### PR TITLE
Fix building pre-compiled wheels

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - wheel
-      - fix-wheel
     tags:
       - '*'
 

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - wheel
+      - fix-wheel
     tags:
       - '*'
 
@@ -32,7 +33,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.4
         env:
           CIBW_BEFORE_BUILD: "pip install -U cmake numpy"
-          CIBW_SKIP: "cp27-* cp35-* *-win32 pp* *-musllinux* *-manylinux_i686"
+          CIBW_SKIP: "cp27-* cp35-* cp36-* *-win32 pp* *-musllinux* *-manylinux_i686"
           CIBW_BUILD_VERBOSITY: 3
 
       - name: Display wheels

--- a/cmake/cmake_extension.py
+++ b/cmake/cmake_extension.py
@@ -40,6 +40,7 @@ try:
                 # -linux_x86_64.whl
                 self.root_is_pure = False
 
+
 except ImportError:
     bdist_wheel = None
 
@@ -74,7 +75,11 @@ class BuildExtension(build_ext):
             extra_cmake_args += " -DBUILD_SHARED_LIBS=ON "
         else:
             extra_cmake_args += " -DBUILD_SHARED_LIBS=OFF "
+        extra_cmake_args += " -DSHERPA_ONNX_ENABLE_CHECK=OFF "
         extra_cmake_args += " -DSHERPA_ONNX_ENABLE_PYTHON=ON "
+        extra_cmake_args += " -DSHERPA_ONNX_ENABLE_PORTAUDIO=OFF "
+        extra_cmake_args += " -DSHERPA_ONNX_ENABLE_C_API=OFF "
+        extra_cmake_args += " -DSHERPA_ONNX_ENABLE_WEBSOCKET=OFF "
 
         if "PYTHON_EXECUTABLE" not in cmake_args:
             print(f"Setting PYTHON_EXECUTABLE to {sys.executable}")


### PR DESCRIPTION
cibuildwheel does not support python 3.6 any more. This PR removes Python 3.6 from CI build.