### PR TITLE
Support resampling

### DIFF
--- a/python-api-examples/speech-recognition-from-microphone-with-endpoint-detection.py
+++ b/python-api-examples/speech-recognition-from-microphone-with-endpoint-detection.py
@@ -100,7 +100,9 @@ def main():
     recognizer = create_recognizer()
     print("Started! Please speak")
 
-    sample_rate = 16000
+    # The model is using 16 kHz, we use 48 kHz here to demonstrate that
+    # sherpa-onnx will do resampling inside.
+    sample_rate = 48000
     samples_per_read = int(0.1 * sample_rate)  # 0.1 second = 100 ms
     last_result = ""
     stream = recognizer.create_stream()

--- a/python-api-examples/speech-recognition-from-microphone.py
+++ b/python-api-examples/speech-recognition-from-microphone.py
@@ -92,9 +92,12 @@ def create_recognizer():
 
 
 def main():
-    print("Started! Please speak")
     recognizer = create_recognizer()
-    sample_rate = 16000
+    print("Started! Please speak")
+
+    # The model is using 16 kHz, we use 48 kHz here to demonstrate that
+    # sherpa-onnx will do resampling inside.
+    sample_rate = 48000
     samples_per_read = int(0.1 * sample_rate)  # 0.1 second = 100 ms
     last_result = ""
     stream = recognizer.create_stream()

--- a/sherpa-onnx/c-api/c-api.h
+++ b/sherpa-onnx/c-api/c-api.h
@@ -115,8 +115,9 @@ void DestoryOnlineStream(SherpaOnnxOnlineStream *stream);
 /// decoding.
 ///
 /// @param stream  A pointer returned by CreateOnlineStream().
-/// @param sample_rate  Sampler rate of the input samples. It has to be 16 kHz
-///                     for models from icefall.
+/// @param sample_rate  Sample rate of the input samples. If it is different
+///                     from config.feat_config.sample_rate, we will do
+///                     resampling inside sherpa-onnx.
 /// @param samples A pointer to a 1-D array containing audio samples.
 ///                The range of samples has to be normalized to [-1, 1].
 /// @param n  Number of elements in the samples array.

--- a/sherpa-onnx/csrc/features.h
+++ b/sherpa-onnx/csrc/features.h
@@ -29,9 +29,11 @@ class FeatureExtractor {
   ~FeatureExtractor();
 
   /**
-     @param sampling_rate The sampling_rate of the input waveform. Should match
-                          the one expected by the feature extractor.
-     @param waveform Pointer to a 1-D array of size n
+     @param sampling_rate The sampling_rate of the input waveform. If it does
+                          not equal to  config.sampling_rate, we will do
+                          resampling inside.
+     @param waveform Pointer to a 1-D array of size n. It must be normalized to
+                     the range [-1, 1].
      @param n Number of entries in waveform
    */
   void AcceptWaveform(int32_t sampling_rate, const float *waveform, int32_t n);

--- a/sherpa-onnx/csrc/online-stream.cc
+++ b/sherpa-onnx/csrc/online-stream.cc
@@ -16,7 +16,7 @@ class OnlineStream::Impl {
   explicit Impl(const FeatureExtractorConfig &config)
       : feat_extractor_(config) {}
 
-  void AcceptWaveform(float sampling_rate, const float *waveform, int32_t n) {
+  void AcceptWaveform(int32_t sampling_rate, const float *waveform, int32_t n) {
     feat_extractor_.AcceptWaveform(sampling_rate, waveform, n);
   }
 
@@ -67,7 +67,7 @@ OnlineStream::OnlineStream(const FeatureExtractorConfig &config /*= {}*/)
 
 OnlineStream::~OnlineStream() = default;
 
-void OnlineStream::AcceptWaveform(float sampling_rate, const float *waveform,
+void OnlineStream::AcceptWaveform(int32_t sampling_rate, const float *waveform,
                                   int32_t n) {
   impl_->AcceptWaveform(sampling_rate, waveform, n);
 }

--- a/sherpa-onnx/csrc/online-stream.h
+++ b/sherpa-onnx/csrc/online-stream.h
@@ -20,12 +20,14 @@ class OnlineStream {
   ~OnlineStream();
 
   /**
-     @param sampling_rate The sampling_rate of the input waveform. Should match
-                          the one expected by the feature extractor.
-     @param waveform Pointer to a 1-D array of size n
+     @param sampling_rate The sampling_rate of the input waveform. If it does
+                          not equal to  config.sampling_rate, we will do
+                          resampling inside.
+     @param waveform Pointer to a 1-D array of size n. It must be normalized to
+                     the range [-1, 1].
      @param n Number of entries in waveform
    */
-  void AcceptWaveform(float sampling_rate, const float *waveform, int32_t n);
+  void AcceptWaveform(int32_t sampling_rate, const float *waveform, int32_t n);
 
   /**
    * InputFinished() tells the class you won't be providing any

--- a/sherpa-onnx/csrc/online-transducer-modified-beam-search-decoder.cc
+++ b/sherpa-onnx/csrc/online-transducer-modified-beam-search-decoder.cc
@@ -76,6 +76,7 @@ OnlineTransducerModifiedBeamSearchDecoder::GetEmptyResult() const {
   std::vector<int64_t> blanks(context_size, blank_id);
   Hypotheses blank_hyp({{blanks, 0}});
   r.hyps = std::move(blank_hyp);
+  r.tokens = std::move(blanks);
   return r;
 }
 

--- a/sherpa-onnx/python/csrc/online-stream.cc
+++ b/sherpa-onnx/python/csrc/online-stream.cc
@@ -8,13 +8,27 @@
 
 namespace sherpa_onnx {
 
+constexpr const char *kAcceptWaveformUsage = R"(
+Process audio samples.
+
+Args:
+  sample_rate:
+    Sample rate of the input samples. If it is different from the one
+    expected by the model, we will do resampling inside.
+  waveform:
+    A 1-D float32 tensor containing audio samples. It must be normalized
+    to the range [-1, 1].
+)";
+
 void PybindOnlineStream(py::module *m) {
   using PyClass = OnlineStream;
   py::class_<PyClass>(*m, "OnlineStream")
-      .def("accept_waveform",
-           [](PyClass &self, float sample_rate, py::array_t<float> waveform) {
-             self.AcceptWaveform(sample_rate, waveform.data(), waveform.size());
-           })
+      .def(
+          "accept_waveform",
+          [](PyClass &self, float sample_rate, py::array_t<float> waveform) {
+            self.AcceptWaveform(sample_rate, waveform.data(), waveform.size());
+          },
+          py::arg("sample_rate"), py::arg("waveform"), kAcceptWaveformUsage)
       .def("input_finished", &PyClass::InputFinished);
 }
 


### PR DESCRIPTION
If the sample rate of the input audio samples is different from the one expected by the model, we do resampling inside sherpa-onnx.

That is, we don't require the input sample rate to be 16 kHz any more.