### PR TITLE
Add alternative URLs for downloading deps

### DIFF
--- a/cmake/asio.cmake
+++ b/cmake/asio.cmake
@@ -2,6 +2,7 @@ function(download_asio)
   include(FetchContent)
 
   set(asio_URL  "https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-24-0.tar.gz")
+  set(asio_URL2  "https://huggingface.co/csukuangfj/sherpa-onnx-cmake-deps/resolve/main/asio-asio-1-24-0.tar.gz")
   set(asio_HASH "SHA256=cbcaaba0f66722787b1a7c33afe1befb3a012b5af3ad7da7ff0f6b8c9b7a8a5b")
 
   # If you don't have access to the Internet,
@@ -22,7 +23,9 @@ function(download_asio)
   endforeach()
 
   FetchContent_Declare(asio
-    URL               ${asio_URL}
+    URL
+      ${asio_URL}
+      ${asio_URL2}
     URL_HASH          ${asio_HASH}
   )
 

--- a/cmake/googletest.cmake
+++ b/cmake/googletest.cmake
@@ -2,6 +2,7 @@ function(download_googltest)
   include(FetchContent)
 
   set(googletest_URL  "https://github.com/google/googletest/archive/refs/tags/v1.13.0.tar.gz")
+  set(googletest_URL2 "https://huggingface.co/csukuangfj/sherpa-onnx-cmake-deps/resolve/main/googletest-1.13.0.tar.gz")
   set(googletest_HASH "SHA256=ad7fdba11ea011c1d925b3289cf4af2c66a352e18d4c7264392fead75e919363")
 
   # If you don't have access to the Internet,
@@ -27,7 +28,9 @@ function(download_googltest)
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
   FetchContent_Declare(googletest
-    URL               ${googletest_URL}
+    URL
+      ${googletest_URL}
+      ${googletest_URL2}
     URL_HASH          ${googletest_HASH}
   )
 

--- a/cmake/kaldi-native-fbank.cmake
+++ b/cmake/kaldi-native-fbank.cmake
@@ -2,6 +2,7 @@ function(download_kaldi_native_fbank)
   include(FetchContent)
 
   set(kaldi_native_fbank_URL  "https://github.com/csukuangfj/kaldi-native-fbank/archive/refs/tags/v1.13.tar.gz")
+  set(kaldi_native_fbank_URL2 "https://huggingface.co/csukuangfj/sherpa-onnx-cmake-deps/resolve/main/kaldi-native-fbank-1.13.tar.gz")
   set(kaldi_native_fbank_HASH "SHA256=1f4d228f9fe3e3e9f92a74a7eecd2489071a03982e4ba6d7c70fc5fa7444df57")
 
   set(KALDI_NATIVE_FBANK_BUILD_TESTS OFF CACHE BOOL "" FORCE)
@@ -26,7 +27,9 @@ function(download_kaldi_native_fbank)
   endforeach()
 
   FetchContent_Declare(kaldi_native_fbank
-    URL               ${kaldi_native_fbank_URL}
+    URL
+      ${kaldi_native_fbank_URL}
+      ${kaldi_native_fbank_URL2}
     URL_HASH          ${kaldi_native_fbank_HASH}
   )
 

--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -11,6 +11,7 @@ function(download_onnxruntime)
       /star-fj/fangjun/download/github/onnxruntime-linux-aarch64-1.14.0.tgz
     )
     set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.14.0/onnxruntime-linux-aarch64-1.14.0.tgz")
+    set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/sherpa-onnx-cmake-deps/resolve/main/onnxruntime-linux-aarch64-1.14.0.tgz")
     set(onnxruntime_HASH "SHA256=9384d2e6e29fed693a4630303902392eead0c41bee5705ccac6d6d34a3d5db86")
   elseif(CMAKE_SYSTEM_NAME STREQUAL Linux AND CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
     # If you don't have access to the Internet,
@@ -24,6 +25,7 @@ function(download_onnxruntime)
     )
 
     set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.14.0/onnxruntime-linux-x64-1.14.0.tgz")
+    set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/sherpa-onnx-cmake-deps/resolve/main/onnxruntime-linux-x64-1.14.0.tgz")
     set(onnxruntime_HASH "SHA256=92bf534e5fa5820c8dffe9de2850f84ed2a1c063e47c659ce09e8c7938aa2090")
     # After downloading, it contains:
     #  ./lib/libonnxruntime.so.1.14.0
@@ -41,6 +43,7 @@ function(download_onnxruntime)
       /tmp/onnxruntime-osx-universal2-1.14.0.tgz
     )
     set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.14.0/onnxruntime-osx-universal2-1.14.0.tgz")
+    set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/sherpa-onnx-cmake-deps/resolve/main/onnxruntime-osx-universal2-1.14.0.tgz")
     set(onnxruntime_HASH "SHA256=348563df91f17a2ac010519f37c3b46fd5b79140974e5c5a90a57e032bb25925")
     # After downloading, it contains:
     #  ./lib/libonnxruntime.1.14.0.dylib
@@ -58,6 +61,7 @@ function(download_onnxruntime)
       /tmp/onnxruntime-win-x64-1.14.0.zip
     )
     set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.14.0/onnxruntime-win-x64-1.14.0.zip")
+    set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/sherpa-onnx-cmake-deps/resolve/main/onnxruntime-win-x64-1.14.0.zip")
     set(onnxruntime_HASH "SHA256=300eafef456748cde2743ee08845bd40ff1bab723697ff934eba6d4ce3519620")
     # After downloading, it contains:
     #  ./lib/onnxruntime.{dll,lib,pdb}
@@ -79,7 +83,9 @@ function(download_onnxruntime)
   endforeach()
 
   FetchContent_Declare(onnxruntime
-    URL               ${onnxruntime_URL}
+    URL
+      ${onnxruntime_URL}
+      ${onnxruntime_URL2}
     URL_HASH          ${onnxruntime_HASH}
   )
 

--- a/cmake/portaudio.cmake
+++ b/cmake/portaudio.cmake
@@ -2,6 +2,7 @@ function(download_portaudio)
   include(FetchContent)
 
   set(portaudio_URL  "http://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz")
+  set(portaudio_URL2 "https://huggingface.co/csukuangfj/sherpa-onnx-cmake-deps/resolve/main/pa_stable_v190700_20210406.tgz")
   set(portaudio_HASH "SHA256=47efbf42c77c19a05d22e627d42873e991ec0c1357219c0d74ce6a2948cb2def")
 
   # If you don't have access to the Internet, please download it to your
@@ -31,7 +32,9 @@ function(download_portaudio)
   endif()
 
   FetchContent_Declare(portaudio
-    URL               ${portaudio_URL}
+    URL
+      ${portaudio_URL}
+      ${portaudio_URL2}
     URL_HASH          ${portaudio_HASH}
   )
 

--- a/cmake/pybind11.cmake
+++ b/cmake/pybind11.cmake
@@ -2,6 +2,7 @@ function(download_pybind11)
   include(FetchContent)
 
   set(pybind11_URL  "https://github.com/pybind/pybind11/archive/refs/tags/v2.10.2.tar.gz")
+  set(pybind11_URL2 "https://huggingface.co/csukuangfj/sherpa-onnx-cmake-deps/resolve/main/pybind11-2.10.2.tar.gz")
   set(pybind11_HASH "SHA256=93bd1e625e43e03028a3ea7389bba5d3f9f2596abc074b068e70f4ef9b1314ae")
 
   # If you don't have access to the Internet,
@@ -22,7 +23,9 @@ function(download_pybind11)
   endforeach()
 
   FetchContent_Declare(pybind11
-    URL               ${pybind11_URL}
+    URL
+      ${pybind11_URL}
+      ${pybind11_URL2}
     URL_HASH          ${pybind11_HASH}
   )
 

--- a/cmake/websocketpp.cmake
+++ b/cmake/websocketpp.cmake
@@ -3,6 +3,7 @@ function(download_websocketpp)
 
   # The latest commit on the develop branch os as 2022-10-22
   set(websocketpp_URL  "https://github.com/zaphoyd/websocketpp/archive/b9aeec6eaf3d5610503439b4fae3581d9aff08e8.zip")
+  set(websocketpp_URL2 "https://huggingface.co/csukuangfj/sherpa-onnx-cmake-deps/resolve/main/websocketpp-b9aeec6eaf3d5610503439b4fae3581d9aff08e8.zip")
   set(websocketpp_HASH "SHA256=1385135ede8191a7fbef9ec8099e3c5a673d48df0c143958216cd1690567f583")
 
   # If you don't have access to the Internet,
@@ -23,7 +24,9 @@ function(download_websocketpp)
   endforeach()
 
   FetchContent_Declare(websocketpp
-    URL               ${websocketpp_URL}
+    URL
+      ${websocketpp_URL}
+      ${websocketpp_URL2}
     URL_HASH          ${websocketpp_HASH}
   )
 


### PR DESCRIPTION
People from China have trouble installing sherpa-onnx because they have difficulty downloading dependencies from GitHub.

This PR adds alternative URLs for downloading dependencies.