### PR TITLE
Add timestamps for streaming ASR.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,8 @@ if(SHERPA_ONNX_ENABLE_WEBSOCKET)
   include(asio)
 endif()
 
+include(json)
+
 add_subdirectory(sherpa-onnx)
 
 if(SHERPA_ONNX_ENABLE_C_API)

--- a/cmake/json.cmake
+++ b/cmake/json.cmake
@@ -1,0 +1,44 @@
+function(download_json)
+  include(FetchContent)
+
+  set(json_URL  "https://github.com/nlohmann/json/archive/refs/tags/v3.11.2.tar.gz")
+  set(json_URL2 "https://huggingface.co/csukuangfj/sherpa-cmake-deps/resolve/main/json-3.11.2.tar.gz")
+  set(json_HASH "SHA256=d69f9deb6a75e2580465c6c4c5111b89c4dc2fa94e3a85fcd2ffcd9a143d9273")
+
+  # If you don't have access to the Internet,
+  # please pre-download json
+  set(possible_file_locations
+    $ENV{HOME}/Downloads/json-3.11.2.tar.gz
+    ${PROJECT_SOURCE_DIR}/json-3.11.2.tar.gz
+    ${PROJECT_BINARY_DIR}/json-3.11.2.tar.gz
+    /tmp/json-3.11.2.tar.gz
+    /star-fj/fangjun/download/github/json-3.11.2.tar.gz
+  )
+
+  foreach(f IN LISTS possible_file_locations)
+    if(EXISTS ${f})
+      set(json_URL  "${f}")
+      file(TO_CMAKE_PATH "${json_URL}" json_URL)
+      set(json_URL2)
+      break()
+    endif()
+  endforeach()
+
+  FetchContent_Declare(json
+    URL
+      ${json_URL}
+      ${json_URL2}
+    URL_HASH          ${json_HASH}
+  )
+
+  FetchContent_GetProperties(json)
+  if(NOT json_POPULATED)
+    message(STATUS "Downloading json from ${json_URL}")
+    FetchContent_Populate(json)
+  endif()
+  message(STATUS "json is downloaded to ${json_SOURCE_DIR}")
+  include_directories(${json_SOURCE_DIR}/include)
+  # Use #include "nlohmann/json.hpp"
+endfunction()
+
+download_json()

--- a/sherpa-onnx/csrc/online-recognizer.h
+++ b/sherpa-onnx/csrc/online-recognizer.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #if __ANDROID_API__ >= 9
 #include "android/asset_manager.h"

--- a/sherpa-onnx/csrc/online-recognizer.h
+++ b/sherpa-onnx/csrc/online-recognizer.h
@@ -22,10 +22,45 @@
 namespace sherpa_onnx {
 
 struct OnlineRecognizerResult {
+  /// Recognition results.
+  /// For English, it consists of space separated words.
+  /// For Chinese, it consists of Chinese words without spaces.
+  /// Example 1: "hello world"
+  /// Example 2: "你好世界"
   std::string text;
 
-  // TODO(fangjun): Add a method to return a json string
-  std::string ToString() const { return text; }
+  /// Decoded results at the token level.
+  /// For instance, for BPE-based models it consists of a list of BPE tokens.
+  std::vector<std::string> tokens;
+
+  /// timestamps.size() == tokens.size()
+  /// timestamps[i] records the time in seconds when tokens[i] is decoded.
+  std::vector<float> timestamps;
+
+  /// ID of this segment
+  /// When an endpoint is detected, it is incremented
+  int32_t segment = 0;
+
+  /// Starting frame of this segment.
+  /// When an endpoint is detected, it will change
+  float start_time = 0;
+
+  /// True if this is the last segment.
+  bool is_final = false;
+
+  /** Return a json string.
+   *
+   * The returned string contains:
+   *   {
+   *     "text": "The recognition result",
+   *     "tokens": [x, x, x],
+   *     "timestamps": [x, x, x],
+   *     "segment": x,
+   *     "start_time": x,
+   *     "is_final": true|false
+   *   }
+   */
+  std::string AsJsonString() const;
 };
 
 struct OnlineRecognizerConfig {

--- a/sherpa-onnx/csrc/online-transducer-decoder.cc
+++ b/sherpa-onnx/csrc/online-transducer-decoder.cc
@@ -34,6 +34,9 @@ OnlineTransducerDecoderResult &OnlineTransducerDecoderResult::operator=(
 
   hyps = other.hyps;
 
+  frame_offset = other.frame_offset;
+  timestamps = other.timestamps;
+
   return *this;
 }
 
@@ -53,6 +56,9 @@ OnlineTransducerDecoderResult &OnlineTransducerDecoderResult::operator=(
   num_trailing_blanks = other.num_trailing_blanks;
   decoder_out = std::move(other.decoder_out);
   hyps = std::move(other.hyps);
+
+  frame_offset = other.frame_offset;
+  timestamps = std::move(other.timestamps);
 
   return *this;
 }

--- a/sherpa-onnx/csrc/online-transducer-decoder.h
+++ b/sherpa-onnx/csrc/online-transducer-decoder.h
@@ -13,11 +13,17 @@
 namespace sherpa_onnx {
 
 struct OnlineTransducerDecoderResult {
+  /// Number of frames after subsampling we have decoded so far
+  int32_t frame_offset = 0;
+
   /// The decoded token IDs so far
   std::vector<int64_t> tokens;
 
   /// number of trailing blank frames decoded so far
   int32_t num_trailing_blanks = 0;
+
+  /// timestamps[i] contains the output frame index where tokens[i] is decoded.
+  std::vector<int32_t> timestamps;
 
   // Cache decoder_out for endpointing
   Ort::Value decoder_out;

--- a/sherpa-onnx/csrc/online-websocket-server-impl.cc
+++ b/sherpa-onnx/csrc/online-websocket-server-impl.cc
@@ -196,7 +196,7 @@ void OnlineWebsocketDecoder::Decode() {
     auto result = recognizer_->GetResult(c->s.get());
 
     asio::post(server_->GetConnectionContext(),
-               [this, hdl = c->hdl, str = result.ToString()]() {
+               [this, hdl = c->hdl, str = result.AsJsonString()]() {
                  server_->Send(hdl, str);
                });
     active_.erase(c->hdl);

--- a/sherpa-onnx/csrc/sherpa-onnx.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx.cc
@@ -102,7 +102,7 @@ for a list of pre-trained models to download.
     recognizer.DecodeStream(s.get());
   }
 
-  std::string text = recognizer.GetResult(s.get()).text;
+  std::string text = recognizer.GetResult(s.get()).AsJsonString();
 
   fprintf(stderr, "Done!\n");
 

--- a/sherpa-onnx/jni/jni.cc
+++ b/sherpa-onnx/jni/jni.cc
@@ -434,7 +434,7 @@ JNIEXPORT jstring JNICALL Java_com_k2fsa_sherpa_onnx_OnlineRecognizer_getResult(
   sherpa_onnx::OnlineStream *s =
       reinterpret_cast<sherpa_onnx::OnlineStream *>(s_ptr);
   sherpa_onnx::OnlineRecognizerResult result = model->GetResult(s);
-  return env->NewStringUTF(result.ToString().c_str());
+  return env->NewStringUTF(result.text.c_str());
 }
 
 SHERPA_ONNX_EXTERN_C


### PR DESCRIPTION
An example output is given below:

# command

```bash
./build/bin/sherpa-onnx \
  ./sherpa-onnx-streaming-zipformer-en-2023-02-21/tokens.txt \
  ./sherpa-onnx-streaming-zipformer-en-2023-02-21/encoder-epoch-99-avg-1.int8.onnx \
  ./sherpa-onnx-streaming-zipformer-en-2023-02-21/decoder-epoch-99-avg-1.int8.onnx \
  ./sherpa-onnx-streaming-zipformer-en-2023-02-21/joiner-epoch-99-avg-1.int8.onnx \
  ./sherpa-onnx-streaming-zipformer-en-2023-02-21/test_wavs/8k.wav
```
# output

```bash
OnlineRecognizerConfig(feat_config=FeatureExtractorConfig(sampling_rate=16000, feature_dim=80), model_config=OnlineTransducerModelConfig(encoder_filename="./sherpa-onnx-streaming-zipformer-en-2023-02-21/encoder-epoch-99-avg-1.int8.onnx", decoder_filename="./sherpa-onnx-streaming-zipformer-en-2023-02-21/decoder-epoch-99-avg-1.int8.onnx", joiner_filename="./sherpa-onnx-streaming-zipformer-en-2023-02-21/joiner-epoch-99-avg-1.int8.onnx", tokens="./sherpa-onnx-streaming-zipformer-en-2023-02-21/tokens.txt", num_threads=2, debug=False), endpoint_config=EndpointConfig(rule1=EndpointRule(must_contain_nonsilence=False, min_trailing_silence=2.4, min_utterance_length=0), rule2=EndpointRule(must_contain_nonsilence=True, min_trailing_silence=1.2, min_utterance_length=0), rule3=EndpointRule(must_contain_nonsilence=False, min_trailing_silence=0, min_utterance_length=20)), enable_endpoint=True, max_active_paths=4, decoding_method="greedy_search")
sampling rate of input file: 8000
wav filename: ./sherpa-onnx-streaming-zipformer-en-2023-02-21/test_wavs/8k.wav
wav duration (s): 4.825
Started
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/features.cc:AcceptWaveform:76 Creating a resampler:
   in_sample_rate: 8000
   output_sample_rate: 16000

Done!
Recognition result for ./sherpa-onnx-streaming-zipformer-en-2023-02-21/test_wavs/8k.wav:
{"is_final":false,"segment":0,"start_time":0.0,"text":" YET THESE THOUGHTS AFFECTED HESTER PRYNNE LESS WITH HOPE THAN APPREHENS","timestamps":"[0.64, 0.76, 0.96, 1.04, 1.24, 1.44, 1.60, 1.68, 1.72, 1.80, 1.84, 2.00, 2.16, 2.28, 2.44, 2.48, 2.68, 2.72, 2.92, 2.96, 3.28, 3.52, 3.68, 3.88, 4.16, 4.28, 4.32, 4.44, 4.64, 4.76]","tokens":[" YE","T"," THE","SE"," THOUGHT","S"," A","FF","E","C","TED"," HE","S","TER"," P","RY","N","NE"," ","LESS"," WITH"," HO","PE"," THAN"," A","PP","RE","HE","N","S"]}
num threads: 2
decoding method: greedy_search
Elapsed seconds: 0.768 s
Real time factor (RTF): 0.768 / 4.825 = 0.159
```