### PR TITLE
ignore style check for files in csharp-api

### DIFF
--- a/sherpa-onnx/csharp-api/CPPLINT.cfg
+++ b/sherpa-onnx/csharp-api/CPPLINT.cfg
@@ -1,0 +1,1 @@
+exclude_files=.*


### PR DESCRIPTION
I am refactoring the csharp-api code and will fix the style issues in a later PR.
