### PR TITLE
Support .netstandard 2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 project(sherpa-onnx)
 
-set(SHERPA_ONNX_VERSION "1.4.7")
+set(SHERPA_ONNX_VERSION "1.4.8")
 
 # Disable warning about
 #

--- a/scripts/dotnet/offline.cs
+++ b/scripts/dotnet/offline.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Text;
 using System;
 
 namespace SherpaOnnx
@@ -116,7 +117,25 @@ namespace SherpaOnnx
     public OfflineRecognizerResult(IntPtr handle)
     {
       Impl impl = (Impl)Marshal.PtrToStructure(handle, typeof(Impl));
-      _text = Marshal.PtrToStringUTF8(impl.Text);
+
+      // PtrToStringUTF8() requires .net standard 2.1
+      // _text = Marshal.PtrToStringUTF8(impl.Text);
+
+      int length = 0;
+
+      unsafe
+      {
+        byte* buffer = (byte*)impl.Text;
+        while (*buffer != 0)
+        {
+          ++buffer;
+        }
+        length = (int)(buffer - (byte*)impl.Text);
+      }
+
+      byte[] stringBuffer = new byte[length];
+      Marshal.Copy(impl.Text, stringBuffer, 0, length);
+      _text = Encoding.UTF8.GetString(stringBuffer);
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/scripts/dotnet/online.cs
+++ b/scripts/dotnet/online.cs
@@ -1,9 +1,10 @@
 ﻿/// Copyright (c)  2023  Xiaomi Corporation (authors: Fangjun Kuang)
 /// Copyright (c)  2023 by manyeyes
 
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using System;
 
 namespace SherpaOnnx
@@ -116,7 +117,24 @@ namespace SherpaOnnx
     public OnlineRecognizerResult(IntPtr handle)
     {
       Impl impl = (Impl)Marshal.PtrToStructure(handle, typeof(Impl));
-      _text = Marshal.PtrToStringUTF8(impl.Text);
+      // PtrToStringUTF8() requires .net standard 2.1
+      // _text = Marshal.PtrToStringUTF8(impl.Text);
+
+      int length = 0;
+
+      unsafe
+      {
+        byte* buffer = (byte*)impl.Text;
+        while (*buffer != 0)
+        {
+          ++buffer;
+        }
+        length = (int)(buffer - (byte*)impl.Text);
+      }
+
+      byte[] stringBuffer = new byte[length];
+      Marshal.Copy(impl.Text, stringBuffer, 0, length);
+      _text = Encoding.UTF8.GetString(stringBuffer);
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/scripts/dotnet/sherpa-onnx.csproj.in
+++ b/scripts/dotnet/sherpa-onnx.csproj.in
@@ -4,7 +4,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <OutputType>Library</OutputType>
     <LangVersion>10.0</LangVersion>
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <RuntimeIdentifiers>linux-x64;osx-x64;win-x64</RuntimeIdentifiers>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>sherpa-onnx</AssemblyName>

--- a/scripts/dotnet/sherpa-onnx.csproj.runtime.in
+++ b/scripts/dotnet/sherpa-onnx.csproj.runtime.in
@@ -3,7 +3,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <RuntimeIdentifier>{{ dotnet_rid }}</RuntimeIdentifier>
     <AssemblyName>sherpa-onnx</AssemblyName>
     <Version>{{ version }}</Version>


### PR DESCRIPTION
`Marshal.PtrToStringUTF8()` requires .netstandard 2.1 and `Marshal.PtrToStringAnsi()` has different behaviors on Unix and Windows:


https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshal.ptrtostringansi?view=net-7.0#definition

> Allocates a managed [String](https://learn.microsoft.com/en-us/dotnet/api/system.string?view=net-7.0) and copies all or part of an unmanaged ANSI (on Windows) or UTF-8 (on Unix) string into it.