### PR TITLE
Fix building wheels on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 project(sherpa-onnx)
 
-set(SHERPA_ONNX_VERSION "1.5.4")
+set(SHERPA_ONNX_VERSION "1.5.5")
 
 # Disable warning about
 #

--- a/cmake/cmake_extension.py
+++ b/cmake/cmake_extension.py
@@ -146,11 +146,11 @@ class BuildExtension(build_ext):
 
         for f in binaries:
             suffix = "" if "dll" in f else suffix
-            src_file = install_dir / 'bin' / (f + suffix)
+            src_file = install_dir / "bin" / (f + suffix)
             if not src_file.is_file():
-              src_file = install_dir / 'lib' / (f + suffix)
+                src_file = install_dir / "lib" / (f + suffix)
             if not src_file.is_file():
-              src_file = install_dir / '..' / (f + suffix)
+                src_file = install_dir / ".." / (f + suffix)
             print(f"Copying {src_file} to {out_bin_dir}/")
             shutil.copy(f"{src_file}", f"{out_bin_dir}/")
 

--- a/cmake/cmake_extension.py
+++ b/cmake/cmake_extension.py
@@ -137,9 +137,23 @@ class BuildExtension(build_ext):
         binaries += ["sherpa-onnx-offline-websocket-server"]
         binaries += ["sherpa-onnx-online-websocket-client"]
 
+        if is_windows():
+            binaries += ["kaldi-native-fbank-core.dll"]
+            binaries += ["sherpa-onnx-c-api.dll"]
+            binaries += ["sherpa-onnx-core.dll"]
+            binaries += ["sherpa-onnx-portaudio.dll"]
+            binaries += ["onnxruntime.dll"]
+
         for f in binaries:
-            src_file = install_dir / "bin" / (f + suffix)
+            suffix = "" if "dll" in f else suffix
+            src_file = install_dir / 'bin' / (f + suffix)
+            if not src_file.is_file():
+              src_file = install_dir / 'lib' / (f + suffix)
+            if not src_file.is_file():
+              src_file = install_dir / '..' / (f + suffix)
             print(f"Copying {src_file} to {out_bin_dir}/")
             shutil.copy(f"{src_file}", f"{out_bin_dir}/")
 
         shutil.rmtree(f"{install_dir}/bin")
+        if is_windows():
+            shutil.rmtree(f"{install_dir}/lib")

--- a/mfc-examples/StreamingSpeechRecognition/StreamingSpeechRecognition.vcxproj
+++ b/mfc-examples/StreamingSpeechRecognition/StreamingSpeechRecognition.vcxproj
@@ -36,7 +36,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>Static</UseOfMfc>

--- a/setup.py
+++ b/setup.py
@@ -54,9 +54,16 @@ def get_binaries_to_install():
     binaries += ["sherpa-onnx-online-websocket-server"]
     binaries += ["sherpa-onnx-offline-websocket-server"]
     binaries += ["sherpa-onnx-online-websocket-client"]
+    if is_windows():
+        binaries += ["kaldi-native-fbank-core.dll"]
+        binaries += ["sherpa-onnx-c-api.dll"]
+        binaries += ["sherpa-onnx-core.dll"]
+        binaries += ["sherpa-onnx-portaudio.dll"]
+        binaries += ["onnxruntime.dll"]
 
     exe = []
     for f in binaries:
+        suffix = "" if 'dll' in f else suffix
         t = bin_dir / (f + suffix)
         exe.append(str(t))
     return exe

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ def get_binaries_to_install():
 
     exe = []
     for f in binaries:
-        suffix = "" if 'dll' in f else suffix
+        suffix = "" if "dll" in f else suffix
         t = bin_dir / (f + suffix)
         exe.append(str(t))
     return exe


### PR DESCRIPTION
There are no `rpath` or `run path` on windows, so we have to copy the required DLLs to the same directory as the the `exe`s.