### PR TITLE
Fix building wheels for Linux

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -21,7 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        # os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +33,8 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.4
         env:
           CIBW_BEFORE_BUILD: "pip install -U cmake numpy"
-          CIBW_SKIP: "cp27-* cp35-* cp36-* *-win32 pp* *-musllinux* *-manylinux_i686"
+          # CIBW_SKIP: "cp27-* cp35-* cp36-* *-win32 pp* *-musllinux* *-manylinux_i686"
+          CIBW_SKIP: "cp27-* cp35-* cp36-* cp37-* cp39-* cp310-* cp311-* *-win32 pp* *-musllinux* *-manylinux_i686"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ENVIRONMENT_LINUX: LD_LIBRARY_PATH='/project/build/bdist.linux-x86_64/wheel/sherpa_onnx/lib'
 
@@ -43,31 +45,51 @@ jobs:
 
           ls -lh ./wheelhouse/*.whl
 
+      - name: Install patchelf
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -q -y patchelf
+          patchelf --help
+
+      - name: Patch wheels
+        shell: bash
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          ls -lh
+          mkdir ./wheels
+          sudo ./scripts/wheel/patch_wheel.py --in-dir ./wheelhouse --out-dir ./wheels
+
+          ls -lh ./wheels/
+          rm -rf ./wheelhouse
+          mv ./wheels ./wheelhouse
+
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
 
-      - name: Publish wheels to PyPI
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install wheel twine setuptools
+      # - name: Publish wheels to PyPI
+      #   env:
+      #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+      #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      #   run: |
+      #     python3 -m pip install --upgrade pip
+      #     python3 -m pip install wheel twine setuptools
+      #
+      #     twine upload ./wheelhouse/*.whl
 
-          twine upload ./wheelhouse/*.whl
-
-      - name: Build sdist
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        shell: bash
-        run: |
-          python3 setup.py sdist
-          ls -l dist/*
-
-      - name: Publish sdist to PyPI
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          twine upload dist/sherpa-onnx-*.tar.gz
+      # - name: Build sdist
+      #   if: ${{ matrix.os == 'ubuntu-latest' }}
+      #   shell: bash
+      #   run: |
+      #     python3 setup.py sdist
+      #     ls -l dist/*
+      #
+      # - name: Publish sdist to PyPI
+      #   if: ${{ matrix.os == 'ubuntu-latest' }}
+      #   env:
+      #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+      #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      #   run: |
+      #     twine upload dist/sherpa-onnx-*.tar.gz

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -21,8 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [ubuntu-latest, windows-latest]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v2
@@ -33,8 +32,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.4
         env:
           CIBW_BEFORE_BUILD: "pip install -U cmake numpy"
-          # CIBW_SKIP: "cp27-* cp35-* cp36-* *-win32 pp* *-musllinux* *-manylinux_i686"
-          CIBW_SKIP: "cp27-* cp35-* cp36-* cp37-* cp39-* cp310-* cp311-* *-win32 pp* *-musllinux* *-manylinux_i686"
+          CIBW_SKIP: "cp27-* cp35-* cp36-* *-win32 pp* *-musllinux* *-manylinux_i686"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ENVIRONMENT_LINUX: LD_LIBRARY_PATH='/project/build/bdist.linux-x86_64/wheel/sherpa_onnx/lib'
 
@@ -42,8 +40,6 @@ jobs:
         shell: bash
         run: |
           ls -lh ./wheelhouse/
-
-          ls -lh ./wheelhouse/*.whl
 
       - name: Install patchelf
         if: matrix.os == 'ubuntu-latest'
@@ -57,7 +53,6 @@ jobs:
         shell: bash
         if: matrix.os == 'ubuntu-latest'
         run: |
-          ls -lh
           mkdir ./wheels
           sudo ./scripts/wheel/patch_wheel.py --in-dir ./wheelhouse --out-dir ./wheels
 
@@ -69,27 +64,27 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
 
-      # - name: Publish wheels to PyPI
-      #   env:
-      #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-      #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      #   run: |
-      #     python3 -m pip install --upgrade pip
-      #     python3 -m pip install wheel twine setuptools
-      #
-      #     twine upload ./wheelhouse/*.whl
+      - name: Publish wheels to PyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install wheel twine setuptools
 
-      # - name: Build sdist
-      #   if: ${{ matrix.os == 'ubuntu-latest' }}
-      #   shell: bash
-      #   run: |
-      #     python3 setup.py sdist
-      #     ls -l dist/*
-      #
-      # - name: Publish sdist to PyPI
-      #   if: ${{ matrix.os == 'ubuntu-latest' }}
-      #   env:
-      #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-      #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      #   run: |
-      #     twine upload dist/sherpa-onnx-*.tar.gz
+          twine upload ./wheelhouse/*.whl
+
+      - name: Build sdist
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        shell: bash
+        run: |
+          python3 setup.py sdist
+          ls -l dist/*
+
+      - name: Publish sdist to PyPI
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          twine upload dist/sherpa-onnx-*.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 project(sherpa-onnx)
 
-set(SHERPA_ONNX_VERSION "1.6.0")
+set(SHERPA_ONNX_VERSION "1.6.1")
 
 # Disable warning about
 #

--- a/scripts/wheel/patch_wheel.py
+++ b/scripts/wheel/patch_wheel.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# Copyright    2023  Xiaomi Corp.        (authors: Fangjun Kuang)
+
+import argparse
+import glob
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--in-dir",
+        type=Path,
+        required=True,
+        help="Input directory.",
+    )
+
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        required=True,
+        help="Output directory.",
+    )
+    return parser.parse_args()
+
+
+def process(out_dir: Path, whl: Path):
+    tmp_dir = out_dir / "tmp"
+    subprocess.check_call(f"unzip {whl} -d {tmp_dir}", shell=True)
+    if "cp37" in str(whl):
+        py_version = "3.7"
+    elif "cp38" in str(whl):
+        py_version = "3.8"
+    elif "cp39" in str(whl):
+        py_version = "3.9"
+    elif "cp310" in str(whl):
+        py_version = "3.10"
+    elif "cp311" in str(whl):
+        py_version = "3.11"
+    else:
+        py_version = "3.12"
+
+    rpath_list = [
+        f"$ORIGIN/../lib/python{py_version}/site-packages/sherpa_onnx/lib",
+        f"$ORIGIN/../lib/python{py_version}/dist-packages/sherpa_onnx/lib",
+        #
+        f"$ORIGIN/../lib/python{py_version}/site-packages/sherpa_onnx/lib64",
+        f"$ORIGIN/../lib/python{py_version}/dist-packages/sherpa_onnx/lib64",
+        #
+        f"$ORIGIN/../lib/python{py_version}/site-packages/sherpa_onnx.libs",
+    ]
+    rpaths = ":".join(rpath_list)
+
+    for filename in glob.glob(
+        f"{tmp_dir}/sherpa_onnx-*data/data/bin/*", recursive=True
+    ):
+        print(filename)
+        existing_rpath = (
+            subprocess.check_output(["patchelf", "--print-rpath", filename])
+            .decode()
+            .strip()
+        )
+        target_rpaths = rpaths + ":" + existing_rpath
+        subprocess.check_call(
+            f"patchelf --force-rpath --set-rpath '{target_rpaths}' {filename}",
+            shell=True,
+        )
+
+    outwheel = Path(shutil.make_archive(whl, "zip", tmp_dir))
+    Path(outwheel).rename(out_dir / whl.name)
+
+    shutil.rmtree(tmp_dir)
+
+
+def main():
+    args = get_args()
+    print(args)
+    in_dir = args.in_dir
+    out_dir = args.out_dir
+    out_dir.mkdir(exist_ok=True, parents=True)
+
+    for whl in in_dir.glob("*.whl"):
+        process(out_dir, whl)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
When using `pip install sherpa-onnx` in a colab notebook, it throws the following error after installation:
<img width="1303" alt="Screenshot 2023-08-07 at 20 14 01" src="https://github.com/k2-fsa/sherpa-onnx/assets/5284924/724c4eee-5955-41d4-9158-f852faf5a2aa">


This PR fixes it by changing the `rpath` of generated binaries.