### PR TITLE
Fix a bug for multilingual ASR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 project(sherpa-onnx)
 
-set(SHERPA_ONNX_VERSION "1.7.8")
+set(SHERPA_ONNX_VERSION "1.7.9")
 
 # Disable warning about
 #

--- a/sherpa-onnx/csrc/offline-whisper-greedy-search-decoder.cc
+++ b/sherpa-onnx/csrc/offline-whisper-greedy-search-decoder.cc
@@ -136,8 +136,10 @@ OfflineWhisperGreedySearchDecoder::Decode(Ort::Value cross_k,
   auto logits_shape = logits.GetTensorTypeAndShapeInfo().GetShape();
   int32_t vocab_size = logits_shape[2];
 
-  int32_t max_token_id = static_cast<int32_t>(std::distance(
-      p_logits, std::max_element(p_logits, p_logits + vocab_size)));
+  const float *p_start = p_logits + (logits_shape[1] - 1) * vocab_size;
+
+  int32_t max_token_id = static_cast<int32_t>(
+      std::distance(p_start, std::max_element(p_start, p_start + vocab_size)));
 
   int32_t n_text_ctx = model_->TextCtx();
 


### PR DESCRIPTION
We should use
```
logits[:, -1, :]
```
for the `sot_sequence`, not `logits[:, 0, :]`.
