### PR TITLE
Catch exception from non-streaming paraformer.

### DIFF
--- a/sherpa-onnx/csrc/offline-recognizer-paraformer-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-paraformer-impl.h
@@ -184,7 +184,14 @@ class OfflineRecognizerParaformerImpl : public OfflineRecognizerImpl {
     // i.e., -23.025850929940457f
     Ort::Value x = PadSequence(model_->Allocator(), features_pointer, 0);
 
-    auto t = model_->Forward(std::move(x), std::move(x_length));
+    std::pair<Ort::Value, Ort::Value> t{nullptr, nullptr};
+    try {
+      t = model_->Forward(std::move(x), std::move(x_length));
+    } catch (const Ort::Exception &ex) {
+      SHERPA_ONNX_LOGE("\n\nCaught exception:\n\n%s\n\nReturn empty result",
+                       ex.what());
+      return;
+    }
 
     auto results = decoder_->Decode(std::move(t.first), std::move(t.second));
 

--- a/sherpa-onnx/csrc/offline-recognizer-paraformer-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-paraformer-impl.h
@@ -188,7 +188,7 @@ class OfflineRecognizerParaformerImpl : public OfflineRecognizerImpl {
     try {
       t = model_->Forward(std::move(x), std::move(x_length));
     } catch (const Ort::Exception &ex) {
-      SHERPA_ONNX_LOGE("\n\nCaught exception:\n\n%s\n\nReturn empty result",
+      SHERPA_ONNX_LOGE("\n\nCaught exception:\n\n%s\n\nReturn an empty result",
                        ex.what());
       return;
     }


### PR DESCRIPTION
To fix the following error for some input waves:
```
2023-09-12 16:36:34.984 sherpa-onnx-offline[64003:6595949] 2023-09-12 16:36:34.984712 
[E:onnxruntime:, sequential_executor.cc:514 ExecuteKernel] 
Non-zero status code returned while running ConstantOfShape node. 
Name:'ConstantOfShape_5489' Status Message: /Users/runner/work/1/s/onnxruntime/core/framework/op_kernel.cc:83 
virtual OrtValue *onnxruntime::OpKernelContext::OutputMLValue(int, const onnxruntime::TensorShape &) 
status.IsOK() was false. Tensor shape cannot contain any negative value

2023-09-12 16:36:34.984 sherpa-onnx-offline[64003:6595949] 2023-09-12 16:36:34.984889 
[E:onnxruntime:, sequential_executor.cc:514 ExecuteKernel] Non-zero status code returned while running Loop node. 
Name:'Loop_5471' Status Message: Non-zero status code returned while running ConstantOfShape node. 
Name:'ConstantOfShape_5489' Status Message: /Users/runner/work/1/s/onnxruntime/core/framework/op_kernel.cc:83 
virtual OrtValue *onnxruntime::OpKernelContext::OutputMLValue(int, const onnxruntime::TensorShape &) 
status.IsOK() was false. Tensor shape cannot contain any negative value
```