### PR TITLE
Fix LogAdd

### DIFF
--- a/sherpa-onnx/csrc/hypothesis.cc
+++ b/sherpa-onnx/csrc/hypothesis.cc
@@ -18,8 +18,10 @@ void Hypotheses::Add(Hypothesis hyp) {
   } else {
     it->second.log_prob = LogAdd<double>()(it->second.log_prob, hyp.log_prob);
 
-    it->second.lm_log_prob =
+    if (it->second.lm_log_prob != 0 && hyp.lm_log_prob != 0){
+      it->second.lm_log_prob =
         LogAdd<double>()(it->second.lm_log_prob, hyp.lm_log_prob);
+    }
   }
 }
 


### PR DESCRIPTION
Using 0 as the initial value,  should not perform addition when both values are 0.  It will trigger a bug in the modified beam search algorithm when the language model is not loaded