### PR TITLE
Fix tokens for byte-level BPE token.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 project(sherpa-onnx)
 
-set(SHERPA_ONNX_VERSION "1.7.15")
+set(SHERPA_ONNX_VERSION "1.7.16")
 
 # Disable warning about
 #

--- a/sherpa-onnx/csrc/symbol-table.cc
+++ b/sherpa-onnx/csrc/symbol-table.cc
@@ -46,6 +46,19 @@ void SymbolTable::Init(std::istream &is) {
       }
     }
 
+    // for byte-level BPE
+    // id 0 is blank, id 1 is sos/eos, id 2 is unk
+    if (id >= 3 && id <= 258 && sym.size() == 6 && sym[0] == '<' &&
+        sym[1] == '0' && sym[2] == 'x' && sym[5] == '>') {
+      std::ostringstream os;
+      os << std::hex << (id - 3);
+
+      if (std::string(sym.data() + 3, sym.data() + 5) == os.str()) {
+        uint8_t i = id - 3;
+        sym = std::string(&i, &i + 1);
+      }
+    }
+
     assert(!sym.empty());
     assert(sym2id_.count(sym) == 0);
     assert(id2sym_.count(id) == 0);


### PR DESCRIPTION
<img width="268" alt="image" src="https://github.com/k2-fsa/sherpa-onnx/assets/5284924/56453e8e-6d7d-4334-8b7e-5e8ef1dad84c">

```
▁ 259
<0xE8> 235
<0x89> 140
<0xBE> 193
```

![image](https://github.com/k2-fsa/sherpa-onnx/assets/5284924/0cc871e8-ca99-4604-b677-a27f38729386)

The bpe.model  and tokens.txt used for testing are from
https://huggingface.co/zrjin/sherpa-onnx-zipformer-multi-zh-hans-2023-9-2/tree/main