### PR TITLE
Added #include <cstdint> to fix gcc 13.2 compilation error.

### DIFF
--- a/sherpa-onnx/csrc/parse-options.h
+++ b/sherpa-onnx/csrc/parse-options.h
@@ -7,6 +7,7 @@
 #ifndef SHERPA_ONNX_CSRC_PARSE_OPTIONS_H_
 #define SHERPA_ONNX_CSRC_PARSE_OPTIONS_H_
 
+#include <cstdint>
 #include <sstream>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
修改gcc13.2下的编译错误。