### PR TITLE
Fix pkg-config for linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,7 @@ if(NOT BUILD_SHARED_LIBS)
   endif()
 
   if(UNIX AND NOT APPLE)
-    set(SHERPA_ONNX_PKG_CONFIG_EXTRA_LIBS "-lstdc++ -lm")
+    set(SHERPA_ONNX_PKG_CONFIG_EXTRA_LIBS "-lstdc++ -lm -pthread -ldl")
   endif()
 endif()
 

--- a/cmake/onnxruntime-linux-x86_64.cmake
+++ b/cmake/onnxruntime-linux-x86_64.cmake
@@ -14,8 +14,8 @@ if(NOT BUILD_SHARED_LIBS)
   message(FATAL_ERROR "This file is for building shared libraries. BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 endif()
 
-set(onnxruntime_URL  "https://huggingface.co/csukuangfj/sherpa-onnx-cmake-deps/resolve/main/onnxruntime-linux-x64-1.16.0.tgz")
-set(onnxruntime_URL2 "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.16.0/onnxruntime-linux-x64-1.16.0.tgz")
+set(onnxruntime_URL   "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.16.0/onnxruntime-linux-x64-1.16.0.tgz")
+set(onnxruntime_URL2  "https://huggingface.co/csukuangfj/sherpa-onnx-cmake-deps/resolve/main/onnxruntime-linux-x64-1.16.0.tgz")
 set(onnxruntime_HASH "SHA256=02bcd1e4fef295dacc3b232774efeaa0a83527f439f29147c3badade4df1f6dc")
 
 # If you don't have access to the Internet,


### PR DESCRIPTION
We need `-pthread -ldl` when link onnxruntime statically on Linux.