### PR TITLE
include cstdint (debian, gcc-13.2)

### DIFF
--- a/sherpa-onnx/csrc/text-utils.cc
+++ b/sherpa-onnx/csrc/text-utils.cc
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
 #include <limits>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
fixes: sherpa-onnx/csrc/text-utils.cc:217:9: error: ‘uint8_t’ does not name a type
