### PR TITLE
Support vits models from piper

### DIFF
--- a/sherpa-onnx/csrc/lexicon.cc
+++ b/sherpa-onnx/csrc/lexicon.cc
@@ -83,8 +83,8 @@ static std::vector<int32_t> ConvertTokensToIds(
 
 Lexicon::Lexicon(const std::string &lexicon, const std::string &tokens,
                  const std::string &punctuations, const std::string &language,
-                 bool debug /*= false*/)
-    : debug_(debug) {
+                 bool debug /*= false*/, bool is_piper /*= false*/)
+    : debug_(debug), is_piper_(is_piper) {
   InitLanguage(language);
 
   {
@@ -103,8 +103,9 @@ Lexicon::Lexicon(const std::string &lexicon, const std::string &tokens,
 #if __ANDROID_API__ >= 9
 Lexicon::Lexicon(AAssetManager *mgr, const std::string &lexicon,
                  const std::string &tokens, const std::string &punctuations,
-                 const std::string &language, bool debug /*= false*/)
-    : debug_(debug) {
+                 const std::string &language, bool debug /*= false*/,
+                 bool is_piper /*= false*/)
+    : debug_(debug), is_piper_(is_piper) {
   InitLanguage(language);
 
   {
@@ -206,6 +207,10 @@ std::vector<int64_t> Lexicon::ConvertTextToTokenIdsEnglish(
   int32_t blank = token2id_.at(" ");
 
   std::vector<int64_t> ans;
+  if (is_piper_) {
+    ans.push_back(token2id_.at("^"));  // sos
+  }
+
   for (const auto &w : words) {
     if (punctuations_.count(w)) {
       ans.push_back(token2id_.at(w));
@@ -225,6 +230,10 @@ std::vector<int64_t> Lexicon::ConvertTextToTokenIdsEnglish(
   if (!ans.empty()) {
     // remove the last blank
     ans.resize(ans.size() - 1);
+  }
+
+  if (is_piper_) {
+    ans.push_back(token2id_.at("$"));  // eos
   }
 
   return ans;

--- a/sherpa-onnx/csrc/lexicon.h
+++ b/sherpa-onnx/csrc/lexicon.h
@@ -24,12 +24,13 @@ class Lexicon {
  public:
   Lexicon(const std::string &lexicon, const std::string &tokens,
           const std::string &punctuations, const std::string &language,
-          bool debug = false);
+          bool debug = false, bool is_piper = false);
 
 #if __ANDROID_API__ >= 9
   Lexicon(AAssetManager *mgr, const std::string &lexicon,
           const std::string &tokens, const std::string &punctuations,
-          const std::string &language, bool debug = false);
+          const std::string &language, bool debug = false,
+          bool is_piper = false);
 #endif
 
   std::vector<int64_t> ConvertTextToTokenIds(const std::string &text) const;
@@ -59,7 +60,7 @@ class Lexicon {
   std::unordered_map<std::string, int32_t> token2id_;
   Language language_;
   bool debug_;
-  //
+  bool is_piper_;
 };
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/offline-tts-vits-model.cc
+++ b/sherpa-onnx/csrc/offline-tts-vits-model.cc
@@ -38,6 +38,107 @@ class OfflineTtsVitsModel::Impl {
 #endif
 
   Ort::Value Run(Ort::Value x, int64_t sid, float speed) {
+    if (is_piper_) {
+      return RunVitsPiper(std::move(x), sid, speed);
+    }
+
+    return RunVits(std::move(x), sid, speed);
+  }
+
+  int32_t SampleRate() const { return sample_rate_; }
+
+  bool AddBlank() const { return add_blank_; }
+
+  std::string Punctuations() const { return punctuations_; }
+  std::string Language() const { return language_; }
+  bool IsPiper() const { return is_piper_; }
+  int32_t NumSpeakers() const { return num_speakers_; }
+
+ private:
+  void Init(void *model_data, size_t model_data_length) {
+    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
+                                           sess_opts_);
+
+    GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
+
+    GetOutputNames(sess_.get(), &output_names_, &output_names_ptr_);
+
+    // get meta data
+    Ort::ModelMetadata meta_data = sess_->GetModelMetadata();
+    if (config_.debug) {
+      std::ostringstream os;
+      os << "---vits model---\n";
+      PrintModelMetadata(os, meta_data);
+      SHERPA_ONNX_LOGE("%s\n", os.str().c_str());
+    }
+
+    Ort::AllocatorWithDefaultOptions allocator;  // used in the macro below
+    SHERPA_ONNX_READ_META_DATA(sample_rate_, "sample_rate");
+    SHERPA_ONNX_READ_META_DATA(add_blank_, "add_blank");
+    SHERPA_ONNX_READ_META_DATA(num_speakers_, "n_speakers");
+    SHERPA_ONNX_READ_META_DATA_STR(punctuations_, "punctuation");
+    SHERPA_ONNX_READ_META_DATA_STR(language_, "language");
+
+    std::string comment;
+    SHERPA_ONNX_READ_META_DATA_STR(comment, "comment");
+    if (comment.find("piper") != std::string::npos) {
+      is_piper_ = true;
+    }
+  }
+
+  Ort::Value RunVitsPiper(Ort::Value x, int64_t sid, float speed) {
+    auto memory_info =
+        Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeDefault);
+
+    std::vector<int64_t> x_shape = x.GetTensorTypeAndShapeInfo().GetShape();
+    if (x_shape[0] != 1) {
+      SHERPA_ONNX_LOGE("Support only batch_size == 1. Given: %d",
+                       static_cast<int32_t>(x_shape[0]));
+      exit(-1);
+    }
+
+    int64_t len = x_shape[1];
+    int64_t len_shape = 1;
+
+    Ort::Value x_length =
+        Ort::Value::CreateTensor(memory_info, &len, 1, &len_shape, 1);
+
+    float noise_scale = config_.vits.noise_scale;
+    float length_scale = config_.vits.length_scale;
+    float noise_scale_w = config_.vits.noise_scale_w;
+
+    if (speed != 1 && speed > 0) {
+      length_scale = 1. / speed;
+    }
+    std::array<float, 3> scales = {noise_scale, length_scale, noise_scale_w};
+
+    int64_t scale_shape = 3;
+
+    Ort::Value scales_tensor = Ort::Value::CreateTensor(
+        memory_info, scales.data(), scales.size(), &scale_shape, 1);
+
+    int64_t sid_shape = 1;
+    Ort::Value sid_tensor =
+        Ort::Value::CreateTensor(memory_info, &sid, 1, &sid_shape, 1);
+
+    std::vector<Ort::Value> inputs;
+    inputs.reserve(4);
+    inputs.push_back(std::move(x));
+    inputs.push_back(std::move(x_length));
+    inputs.push_back(std::move(scales_tensor));
+
+    if (input_names_.size() == 4 && input_names_.back() == "sid") {
+      inputs.push_back(std::move(sid_tensor));
+    }
+
+    auto out =
+        sess_->Run({}, input_names_ptr_.data(), inputs.data(), inputs.size(),
+                   output_names_ptr_.data(), output_names_ptr_.size());
+
+    return std::move(out[0]);
+  }
+
+  Ort::Value RunVits(Ort::Value x, int64_t sid, float speed) {
     auto memory_info =
         Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeDefault);
 
@@ -94,40 +195,6 @@ class OfflineTtsVitsModel::Impl {
     return std::move(out[0]);
   }
 
-  int32_t SampleRate() const { return sample_rate_; }
-
-  bool AddBlank() const { return add_blank_; }
-
-  std::string Punctuations() const { return punctuations_; }
-  std::string Language() const { return language_; }
-  int32_t NumSpeakers() const { return num_speakers_; }
-
- private:
-  void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
-
-    GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
-
-    GetOutputNames(sess_.get(), &output_names_, &output_names_ptr_);
-
-    // get meta data
-    Ort::ModelMetadata meta_data = sess_->GetModelMetadata();
-    if (config_.debug) {
-      std::ostringstream os;
-      os << "---vits model---\n";
-      PrintModelMetadata(os, meta_data);
-      SHERPA_ONNX_LOGE("%s\n", os.str().c_str());
-    }
-
-    Ort::AllocatorWithDefaultOptions allocator;  // used in the macro below
-    SHERPA_ONNX_READ_META_DATA(sample_rate_, "sample_rate");
-    SHERPA_ONNX_READ_META_DATA(add_blank_, "add_blank");
-    SHERPA_ONNX_READ_META_DATA(num_speakers_, "n_speakers");
-    SHERPA_ONNX_READ_META_DATA_STR(punctuations_, "punctuation");
-    SHERPA_ONNX_READ_META_DATA_STR(language_, "language");
-  }
-
  private:
   OfflineTtsModelConfig config_;
   Ort::Env env_;
@@ -147,6 +214,8 @@ class OfflineTtsVitsModel::Impl {
   int32_t num_speakers_;
   std::string punctuations_;
   std::string language_;
+
+  bool is_piper_ = false;
 };
 
 OfflineTtsVitsModel::OfflineTtsVitsModel(const OfflineTtsModelConfig &config)
@@ -174,6 +243,8 @@ std::string OfflineTtsVitsModel::Punctuations() const {
 }
 
 std::string OfflineTtsVitsModel::Language() const { return impl_->Language(); }
+
+bool OfflineTtsVitsModel::IsPiper() const { return impl_->IsPiper(); }
 
 int32_t OfflineTtsVitsModel::NumSpeakers() const {
   return impl_->NumSpeakers();

--- a/sherpa-onnx/csrc/offline-tts-vits-model.h
+++ b/sherpa-onnx/csrc/offline-tts-vits-model.h
@@ -47,6 +47,7 @@ class OfflineTtsVitsModel {
 
   std::string Punctuations() const;
   std::string Language() const;
+  bool IsPiper() const;
   int32_t NumSpeakers() const;
 
  private:


### PR DESCRIPTION
# Usage

I have converted the model `en_US-lessac-medium` from [piper](https://github.com/rhasspy/piper) to sherpa-onnx
and you can find the converted model in the following repo:
https://huggingface.co/csukuangfj/vits-piper-en_US-lessac-medium

If you are interested in how the model is converted, please have a look at the following colab notebook:
https://colab.research.google.com/drive/1PScLJV3sbUUAOiptLO7Ixlzh9XnWWoYZ?usp=sharing

In the following, we describe how to use the converted model with sherpa-onnx

### Download models

```
wget https://huggingface.co/csukuangfj/vits-piper-en_US-lessac-medium/resolve/main/en_US-lessac-medium.onnx

wget https://huggingface.co/csukuangfj/vits-piper-en_US-lessac-medium/resolve/main/lexicon.txt

wget https://huggingface.co/csukuangfj/vits-piper-en_US-lessac-medium/resolve/main/tokens.txt
```

### Build sherpa-onnx

Please use the code from this PR and build sherpa-onnx from source by following
https://k2-fsa.github.io/sherpa/onnx/install/index.html


After building sherpa-onnx, you can use

```
./build/bin/sherpa-onnx-offline-tts \
  --output-filename=./piper.wav \
  --vits-length-scale=0.8 \
  --vits-model=./vits-piper-en_US-lessac-medium/en_US-lessac-medium.onnx \
  --debug=1 \
  --vits-lexicon=./vits-piper-en_US-lessac-medium/lexicon.txt \
  --vits-tokens=./vits-piper-en_US-lessac-medium/tokens.txt \
  "Liliana, the most beautiful and lovely assistant of our team!"
```

It will generate a wave file `./piper.wav`. I have converted it to `mov` and attached it below so that you can listen to it.


https://github.com/k2-fsa/sherpa-onnx/assets/5284924/9eeff6e4-7c93-4821-b271-f1051712afeb


## Your help is needed

Since `piper` provides a lot of pre-trained onnx models, it would be great if you can help convert them to sherpa-onnx.

Unlike `piper`, we don't need to install `piper_phonemize`. We have converted all the words into `lexicon.txt`.