### PR TITLE
Fix reading tokens.txt on Windows

### DIFF
--- a/sherpa-onnx/csrc/lexicon.cc
+++ b/sherpa-onnx/csrc/lexicon.cc
@@ -50,6 +50,8 @@ static std::unordered_map<std::string, int32_t> ReadTokens(std::istream &is) {
       iss >> id;
     }
 
+    // eat the trailing \r\n on windows
+    iss >> std::ws;
     if (!iss.eof()) {
       SHERPA_ONNX_LOGE("Error: %s", line.c_str());
       exit(-1);


### PR DESCRIPTION
```
fangjuns-MacBook-Pro:sherpa-onnx fangjun$ hexdump -c -x -n 10 ./vits-zh-aishell3/tokens.txt
0000000   s   i   l       0  \n   e   o   s
0000000    6973    206c    0a30    6f65    2073
000000a
fangjuns-MacBook-Pro:sherpa-onnx fangjun$ hexdump -c -x -n 10 ~/Downloads/tokens.txt
0000000   s   i   l       0  \r  \n   e   o   s
0000000    6973    206c    0d30    650a    736f
000000a
```

`~/Downloads/tokens.txt` is from a user who downloads it on Windows using git.

This PR handles `\r\n` correctly in case `tokens.txt`  contains `\r\n`.
