### PR TITLE
Remove the 30-second constraint from whisper. 

### DIFF
--- a/.github/scripts/test-offline-whisper.sh
+++ b/.github/scripts/test-offline-whisper.sh
@@ -37,8 +37,8 @@ for name in ${names[@]}; do
   GIT_LFS_SKIP_SMUDGE=1 git clone $repo_url
   pushd $repo
   git lfs pull --include "*.onnx"
-  git lfs pull --include "*.ort"
-  ls -lh *.{onnx,ort}
+  # git lfs pull --include "*.ort"
+  ls -lh *.onnx
   popd
 
   log "test fp32 onnx"
@@ -58,28 +58,6 @@ for name in ${names[@]}; do
     --tokens=$repo/${name}-tokens.txt \
     --whisper-encoder=$repo/${name}-encoder.int8.onnx \
     --whisper-decoder=$repo/${name}-decoder.int8.onnx \
-    --num-threads=2 \
-    $repo/test_wavs/0.wav \
-    $repo/test_wavs/1.wav \
-    $repo/test_wavs/8k.wav
-
-  log "test fp32 ort"
-
-  time $EXE \
-    --tokens=$repo/${name}-tokens.txt \
-    --whisper-encoder=$repo/${name}-encoder.ort \
-    --whisper-decoder=$repo/${name}-decoder.ort \
-    --num-threads=2 \
-    $repo/test_wavs/0.wav \
-    $repo/test_wavs/1.wav \
-    $repo/test_wavs/8k.wav
-
-  log "test int8 ort"
-
-  time $EXE \
-    --tokens=$repo/${name}-tokens.txt \
-    --whisper-encoder=$repo/${name}-encoder.int8.ort \
-    --whisper-decoder=$repo/${name}-decoder.int8.ort \
     --num-threads=2 \
     $repo/test_wavs/0.wav \
     $repo/test_wavs/1.wav \

--- a/.github/scripts/test-offline-whisper.sh
+++ b/.github/scripts/test-offline-whisper.sh
@@ -16,8 +16,12 @@ which $EXE
 names=(
 tiny.en
 base.en
-# small.en
-# medium.en
+small.en
+medium.en
+tiny
+base
+small
+medium
 )
 
 for name in ${names[@]}; do

--- a/.github/scripts/test-offline-whisper.sh
+++ b/.github/scripts/test-offline-whisper.sh
@@ -47,6 +47,7 @@ for name in ${names[@]}; do
     --tokens=$repo/${name}-tokens.txt \
     --whisper-encoder=$repo/${name}-encoder.onnx \
     --whisper-decoder=$repo/${name}-decoder.onnx \
+    --whisper-tail-paddings=500 \
     --num-threads=2 \
     $repo/test_wavs/0.wav \
     $repo/test_wavs/1.wav \
@@ -58,6 +59,7 @@ for name in ${names[@]}; do
     --tokens=$repo/${name}-tokens.txt \
     --whisper-encoder=$repo/${name}-encoder.int8.onnx \
     --whisper-decoder=$repo/${name}-decoder.int8.onnx \
+    --whisper-tail-paddings=500 \
     --num-threads=2 \
     $repo/test_wavs/0.wav \
     $repo/test_wavs/1.wav \

--- a/.github/workflows/export-whisper-to-onnx.yaml
+++ b/.github/workflows/export-whisper-to-onnx.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
+        os: [ubuntu-latest]
         model: ["distil-medium.en", "tiny.en", "base.en", "small.en", "medium.en", "tiny", "base", "small", "medium", "large", "large-v1", "large-v2"]
         python-version: ["3.8"]
 
@@ -52,38 +52,56 @@ jobs:
             ls -lh ~/.cache/whisper
           fi
 
+          src=sherpa-onnx-whisper-${{ matrix.model }}
+
+          mkdir $src
+          cp *.onnx $src/
+          cp *tokens.txt $src
+
+          cd $src
+          mkdir -p test_wavs
+          cd test_wavs
+          wget -q https://huggingface.co/csukuangfj/sherpa-onnx-whisper-medium.en/resolve/main/test_wavs/0.wav
+          wget -q https://huggingface.co/csukuangfj/sherpa-onnx-whisper-medium.en/resolve/main/test_wavs/1.wav
+          wget -q https://huggingface.co/csukuangfj/sherpa-onnx-whisper-medium.en/resolve/main/test_wavs/8k.wav
+          wget -q https://huggingface.co/csukuangfj/sherpa-onnx-whisper-medium.en/resolve/main/test_wavs/trans.txt
+          cd ../..
+          mv $src ../..
+
+          cd ../..
+          echo "--------------------"
+          ls -lh
+          ls -lh $src
+          echo "--------------------"
+
+          tar cjvf ./$src.tar.bz2 $src
+
+      - name: Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./*.tar.bz2
+          overwrite: true
+          repo_name: k2-fsa/sherpa-onnx
+          repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
+          tag: asr-models
+
       - name: Publish ${{ matrix.model }} to huggingface
         shell: bash
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
-          model=${{ matrix.model }}
-
-          cd scripts/whisper
+          src=sherpa-onnx-whisper-${{ matrix.model }}
 
           git config --global user.email "csukuangfj@gmail.com"
           git config --global user.name "Fangjun Kuang"
 
           GIT_LFS_SKIP_SMUDGE=1 git clone https://huggingface.co/csukuangfj/sherpa-onnx-whisper-${{ matrix.model }} huggingface
-          rm huggingface/*.onnx
-          rm huggingface/*.ort
+          rm -rf huggingface/*
 
-          cp -v *.onnx ./huggingface
-          # cp *.ort ./huggingface
-          cp -v *tokens.txt ./huggingface
+          cp -av $src/* ./huggingface/
 
           cd huggingface
-
-          if [[ $model == distil-medium.en ]]; then
-            mkdir -p test_wavs
-            cd test_wavs
-            wget -q https://huggingface.co/csukuangfj/sherpa-onnx-whisper-medium.en/resolve/main/test_wavs/0.wav
-            wget -q https://huggingface.co/csukuangfj/sherpa-onnx-whisper-medium.en/resolve/main/test_wavs/1.wav
-            wget -q https://huggingface.co/csukuangfj/sherpa-onnx-whisper-medium.en/resolve/main/test_wavs/8k.wav
-            wget -q https://huggingface.co/csukuangfj/sherpa-onnx-whisper-medium.en/resolve/main/test_wavs/trans.txt
-            git add .
-            cd ..
-          fi
 
           git status
           ls -lh

--- a/.github/workflows/export-whisper-to-onnx.yaml
+++ b/.github/workflows/export-whisper-to-onnx.yaml
@@ -44,7 +44,7 @@ jobs:
             ls -lh
           fi
           python3 ./export-onnx.py --model ${{ matrix.model }}
-          python3 -m onnxruntime.tools.convert_onnx_models_to_ort --optimization_style=Fixed ./
+          # python3 -m onnxruntime.tools.convert_onnx_models_to_ort --optimization_style=Fixed ./
 
           ls -lh
 
@@ -65,15 +65,17 @@ jobs:
           git config --global user.name "Fangjun Kuang"
 
           GIT_LFS_SKIP_SMUDGE=1 git clone https://huggingface.co/csukuangfj/sherpa-onnx-whisper-${{ matrix.model }} huggingface
+          rm huggingface/*.onnx
+          rm huggingface/*.ort
 
-          cp *.onnx ./huggingface
-          cp *.ort ./huggingface
-          cp *tokens.txt ./huggingface
+          cp -v *.onnx ./huggingface
+          # cp *.ort ./huggingface
+          cp -v *tokens.txt ./huggingface
 
           cd huggingface
 
           if [[ $model == distil-medium.en ]]; then
-            mkdir test_wavs
+            mkdir -p test_wavs
             cd test_wavs
             wget -q https://huggingface.co/csukuangfj/sherpa-onnx-whisper-medium.en/resolve/main/test_wavs/0.wav
             wget -q https://huggingface.co/csukuangfj/sherpa-onnx-whisper-medium.en/resolve/main/test_wavs/1.wav
@@ -86,7 +88,7 @@ jobs:
           git status
           ls -lh
           git lfs track "*.onnx"
-          git lfs track "*.ort"
+          # git lfs track "*.ort"
           git add .
           git commit -m "upload ${{ matrix.model }}"
           git push https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/sherpa-onnx-whisper-${{ matrix.model }} main

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -107,6 +107,16 @@ jobs:
           name: release-static
           path: build/bin/*
 
+      - name: Test offline Whisper
+        shell: bash
+        run: |
+          export PATH=$PWD/build/bin:$PATH
+          export EXE=sherpa-onnx-offline
+
+          readelf -d build/bin/sherpa-onnx-offline
+
+          .github/scripts/test-offline-whisper.sh
+
       - name: Test online CTC
         shell: bash
         run: |
@@ -138,16 +148,6 @@ jobs:
           export EXE=sherpa-onnx
 
           .github/scripts/test-online-paraformer.sh
-
-      - name: Test offline Whisper
-        shell: bash
-        run: |
-          export PATH=$PWD/build/bin:$PATH
-          export EXE=sherpa-onnx-offline
-
-          readelf -d build/bin/sherpa-onnx-offline
-
-          .github/scripts/test-offline-whisper.sh
 
       - name: Test offline transducer
         shell: bash

--- a/.github/workflows/windows-x86.yaml
+++ b/.github/workflows/windows-x86.yaml
@@ -93,13 +93,13 @@ jobs:
 
           .github/scripts/test-online-paraformer.sh
 
-      - name: Test offline Whisper for windows x86
-        shell: bash
-        run: |
-          export PATH=$PWD/build/bin/Release:$PATH
-          export EXE=sherpa-onnx-offline.exe
-
-          .github/scripts/test-offline-whisper.sh
+      # - name: Test offline Whisper for windows x86
+      #   shell: bash
+      #   run: |
+      #     export PATH=$PWD/build/bin/Release:$PATH
+      #     export EXE=sherpa-onnx-offline.exe
+      #
+      #     .github/scripts/test-offline-whisper.sh
 
       - name: Test offline CTC for windows x86
         shell: bash

--- a/scripts/whisper/test.py
+++ b/scripts/whisper/test.py
@@ -258,6 +258,8 @@ def compute_features(filename: str) -> torch.Tensor:
     # We pad 50 frames at the end so that it is able to detect eot
     # You can use another value instead of 50.
     mel = torch.nn.functional.pad(mel, (0, 0, 0, 50), "constant", 0)
+    # Note that if it throws for a multilingual model,
+    # please use a larger value, say 200
 
     target = 3000
     if mel.shape[0] > target:

--- a/scripts/whisper/test.py
+++ b/scripts/whisper/test.py
@@ -259,7 +259,7 @@ def compute_features(filename: str) -> torch.Tensor:
     # You can use another value instead of 50.
     mel = torch.nn.functional.pad(mel, (0, 0, 0, 50), "constant", 0)
     # Note that if it throws for a multilingual model,
-    # please use a larger value, say 200
+    # please use a larger value, say 300
 
     target = 3000
     if mel.shape[0] > target:

--- a/scripts/whisper/test.py
+++ b/scripts/whisper/test.py
@@ -253,8 +253,19 @@ def compute_features(filename: str) -> torch.Tensor:
     log_spec = torch.clamp(features, min=1e-10).log10()
     log_spec = torch.maximum(log_spec, log_spec.max() - 8.0)
     mel = (log_spec + 4.0) / 4.0
+    # mel (T, 80)
+
+    # We pad 50 frames at the end so that it is able to detect eot
+    # You can use another value instead of 50.
+    mel = torch.nn.functional.pad(mel, (0, 0, 0, 50), "constant", 0)
+
     target = 3000
-    mel = torch.nn.functional.pad(mel, (0, 0, 0, target - mel.shape[0]), "constant", 0)
+    if mel.shape[0] > target:
+        mel = mel[:target]
+
+    # We don't need to pad it to 30 seconds now!
+    #  mel = torch.nn.functional.pad(mel, (0, 0, 0, target - mel.shape[0]), "constant", 0)
+
     mel = mel.t().unsqueeze(0)
 
     return mel

--- a/sherpa-onnx/csrc/offline-recognizer-whisper-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-whisper-impl.h
@@ -124,8 +124,8 @@ class OfflineRecognizerWhisperImpl : public OfflineRecognizerImpl {
     // tail_padding_frames so that whisper is able to detect the eot token.
     int32_t tail_padding_frames = 50;
     if (model_->IsMultiLingual()) {
-      // 200 is an experience value. If it throws, please use a larger value.
-      tail_padding_frames = 200;
+      // 300 is an experience value. If it throws, please use a larger value.
+      tail_padding_frames = 300;
     }
 
     int32_t actual_frames =

--- a/sherpa-onnx/csrc/offline-recognizer-whisper-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-whisper-impl.h
@@ -120,9 +120,14 @@ class OfflineRecognizerWhisperImpl : public OfflineRecognizerImpl {
     //
     // You can replace 50 by other values, say, 100.
     //
-    // Since we have removed the 30 seconds contraint, we need
+    // Since we have removed the 30 seconds constraint, we need
     // tail_padding_frames so that whisper is able to detect the eot token.
     int32_t tail_padding_frames = 50;
+    if (model_->IsMultiLingual()) {
+      // 200 is an experience value. If it throws, please use a larger value.
+      tail_padding_frames = 200;
+    }
+
     int32_t actual_frames =
         std::min(num_frames + tail_padding_frames, max_num_frames);
 

--- a/sherpa-onnx/csrc/offline-recognizer-whisper-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-whisper-impl.h
@@ -128,6 +128,10 @@ class OfflineRecognizerWhisperImpl : public OfflineRecognizerImpl {
       tail_padding_frames = 300;
     }
 
+    if (config_.model_config.whisper.tail_paddings > 0) {
+      tail_padding_frames = config_.model_config.whisper.tail_paddings;
+    }
+
     int32_t actual_frames =
         std::min(num_frames + tail_padding_frames, max_num_frames);
 

--- a/sherpa-onnx/csrc/offline-whisper-model-config.cc
+++ b/sherpa-onnx/csrc/offline-whisper-model-config.cc
@@ -32,6 +32,14 @@ void OfflineWhisperModelConfig::Register(ParseOptions *po) {
                "Valid values: transcribe, translate. "
                "Note that for non-multilingual models, it supports "
                "only 'transcribe'");
+
+  po->Register(
+      "whisper-tail-paddings", &tail_paddings,
+      "Suggest value: 50 for English models. 300 for multilingual models. "
+      "Since we have removed the 30-second constraint, we need to add some "
+      "tail padding frames "
+      "so that whisper can detect the eot token. Leave it to -1 to use 50 for "
+      "English models and 300 for multilingual models.");
 }
 
 bool OfflineWhisperModelConfig::Validate() const {
@@ -63,7 +71,8 @@ std::string OfflineWhisperModelConfig::ToString() const {
   os << "encoder=\"" << encoder << "\", ";
   os << "decoder=\"" << decoder << "\", ";
   os << "language=\"" << language << "\", ";
-  os << "task=\"" << task << "\")";
+  os << "task=\"" << task << "\", ";
+  os << "tail_paddings=" << tail_paddings << ")";
 
   return os.str();
 }

--- a/sherpa-onnx/csrc/offline-whisper-model-config.h
+++ b/sherpa-onnx/csrc/offline-whisper-model-config.h
@@ -28,12 +28,26 @@ struct OfflineWhisperModelConfig {
   // Note: For non-multilingual models, it supports only "transcribe"
   std::string task = "transcribe";
 
+  // Number of tail padding frames.
+  //
+  // Since we remove the 30-second constraint, we need to add some paddings
+  // at the end.
+  //
+  // Recommended values:
+  //   - 50 for English models
+  //   - 300 for multilingual models
+  int32_t tail_paddings = -1;
+
   OfflineWhisperModelConfig() = default;
   OfflineWhisperModelConfig(const std::string &encoder,
                             const std::string &decoder,
                             const std::string &language,
-                            const std::string &task)
-      : encoder(encoder), decoder(decoder), language(language), task(task) {}
+                            const std::string &task, int32_t tail_paddings)
+      : encoder(encoder),
+        decoder(decoder),
+        language(language),
+        task(task),
+        tail_paddings(tail_paddings) {}
 
   void Register(ParseOptions *po);
   bool Validate() const;

--- a/sherpa-onnx/python/csrc/offline-whisper-model-config.cc
+++ b/sherpa-onnx/python/csrc/offline-whisper-model-config.cc
@@ -15,13 +15,14 @@ void PybindOfflineWhisperModelConfig(py::module *m) {
   using PyClass = OfflineWhisperModelConfig;
   py::class_<PyClass>(*m, "OfflineWhisperModelConfig")
       .def(py::init<const std::string &, const std::string &,
-                    const std::string &, const std::string &>(),
+                    const std::string &, const std::string &, int32_t>(),
            py::arg("encoder"), py::arg("decoder"), py::arg("language"),
-           py::arg("task"))
+           py::arg("task"), py::arg("tail_paddings") = -1)
       .def_readwrite("encoder", &PyClass::encoder)
       .def_readwrite("decoder", &PyClass::decoder)
       .def_readwrite("language", &PyClass::language)
       .def_readwrite("task", &PyClass::task)
+      .def_readwrite("tail_paddings", &PyClass::tail_paddings)
       .def("__str__", &PyClass::ToString);
 }
 


### PR DESCRIPTION
This PR removes the 30-second constraint for whisper models

In other words, you don't need to pad your audio to 30 seconds. Any duration T <= 30 can be used for whisper models.

You can save computation by removing paddings.

You can find the exported models at
https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models

![Screenshot 2023-12-07 at 14 40 42](https://github.com/k2-fsa/sherpa-onnx/assets/5284924/d7d199cd-a55e-4e6d-8416-13120a304345)
