### PR TITLE
Add missing field for two-pass APK.

### DIFF
--- a/android/SherpaOnnx2Pass/app/src/main/java/com/k2fsa/sherpa/onnx/SherpaOnnx.kt
+++ b/android/SherpaOnnx2Pass/app/src/main/java/com/k2fsa/sherpa/onnx/SherpaOnnx.kt
@@ -25,9 +25,14 @@ data class OnlineParaformerModelConfig(
     var decoder: String = "",
 )
 
+data class OnlineZipformer2CtcModelConfig(
+    var model: String = "",
+)
+
 data class OnlineModelConfig(
     var transducer: OnlineTransducerModelConfig = OnlineTransducerModelConfig(),
     var paraformer: OnlineParaformerModelConfig = OnlineParaformerModelConfig(),
+    var zipformer2Ctc: OnlineZipformer2CtcModelConfig = OnlineZipformer2CtcModelConfig(),
     var tokens: String,
     var numThreads: Int = 1,
     var debug: Boolean = false,

--- a/kotlin-api-examples/.gitignore
+++ b/kotlin-api-examples/.gitignore
@@ -1,3 +1,3 @@
 hs_err*
-main.jar
 vits-zh-aishell3
+*.jar

--- a/kotlin-api-examples/SherpaOnnx2Pass.kt
+++ b/kotlin-api-examples/SherpaOnnx2Pass.kt
@@ -1,0 +1,1 @@
+../android/SherpaOnnx2Pass/app/src/main/java/com/k2fsa/sherpa/onnx/SherpaOnnx.kt

--- a/kotlin-api-examples/run.sh
+++ b/kotlin-api-examples/run.sh
@@ -51,3 +51,21 @@ kotlinc-jvm -include-runtime -d main.jar Main.kt WaveReader.kt SherpaOnnx.kt fak
 ls -lh main.jar
 
 java -Djava.library.path=../build/lib -jar main.jar
+
+# For two-pass
+
+if [ ! -f ./sherpa-onnx-streaming-zipformer-en-20M-2023-02-17/encoder-epoch-99-avg-1.int8.onnx ]; then
+  wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-streaming-zipformer-en-20M-2023-02-17.tar.bz2
+  tar xvf sherpa-onnx-streaming-zipformer-en-20M-2023-02-17.tar.bz2
+  rm sherpa-onnx-streaming-zipformer-en-20M-2023-02-17.tar.bz2
+fi
+
+if [ ! -f ./sherpa-onnx-whisper-tiny.en/tiny.en-encoder.int8.onnx ]; then
+  wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-whisper-tiny.en.tar.bz2
+  tar xvf sherpa-onnx-whisper-tiny.en.tar.bz2
+  rm sherpa-onnx-whisper-tiny.en.tar.bz2
+fi
+
+kotlinc-jvm -include-runtime -d 2pass.jar test-2pass.kt WaveReader.kt SherpaOnnx2Pass.kt faked-asset-manager.kt
+ls -lh 2pass.jar
+java -Djava.library.path=../build/lib -jar 2pass.jar

--- a/kotlin-api-examples/test-2pass.kt
+++ b/kotlin-api-examples/test-2pass.kt
@@ -1,0 +1,49 @@
+package com.k2fsa.sherpa.onnx
+
+fun main() {
+  test2Pass()
+}
+
+fun test2Pass() {
+  val firstPass = createFirstPass()
+  val secondPass = createSecondPass()
+
+  val waveFilename = "./sherpa-onnx-streaming-zipformer-en-20M-2023-02-17/test_wavs/0.wav"
+
+  var objArray = WaveReader.readWaveFromFile(
+      filename = waveFilename,
+  )
+  var samples: FloatArray = objArray[0] as FloatArray
+  var sampleRate: Int = objArray[1] as Int
+
+  firstPass.acceptWaveform(samples, sampleRate = sampleRate)
+  while (firstPass.isReady()) {
+      firstPass.decode()
+  }
+
+  var text = firstPass.text
+  println("First pass text: $text")
+
+  text = secondPass.decode(samples, sampleRate)
+  println("Second pass text: $text")
+}
+
+fun createFirstPass(): SherpaOnnx {
+  val config = OnlineRecognizerConfig(
+      featConfig = getFeatureConfig(sampleRate = 16000, featureDim = 80),
+      modelConfig = getModelConfig(type = 1)!!,
+      endpointConfig = getEndpointConfig(),
+      enableEndpoint = true,
+  )
+
+  return SherpaOnnx(config = config)
+}
+
+fun createSecondPass(): SherpaOnnxOffline {
+  val config = OfflineRecognizerConfig(
+      featConfig = getFeatureConfig(sampleRate = 16000, featureDim = 80),
+      modelConfig = getOfflineModelConfig(type = 2)!!,
+  )
+
+  return SherpaOnnxOffline(config = config)
+}


### PR DESCRIPTION
To fix the following error
```
11964/com.k2fsa.sherpa.onnx A/art: art/runtime/runtime.cc:404] 
Pending exception java.lang.NoSuchFieldError: 
no type "Lcom/k2fsa/sherpa/onnx/OnlineZipformer2CtcModelConfig;" 
found and so no field "zipformer2Ctc" could be found in 
class "Lcom/k2fsa/sherpa/onnx/OnlineModelConfig;" or its superclasses
```

Also, add a test for two-pass.