### PR TITLE
Fix setting speaker ID for Android TTS Engine.

### DIFF
--- a/android/SherpaOnnxTts/app/src/main/java/com/k2fsa/sherpa/onnx/MainActivity.kt
+++ b/android/SherpaOnnxTts/app/src/main/java/com/k2fsa/sherpa/onnx/MainActivity.kt
@@ -184,7 +184,7 @@ class MainActivity : AppCompatActivity() {
         // modelDir = "vits-zh-aishell3"
         // modelName = "vits-aishell3.onnx"
         // ruleFsts = "vits-zh-aishell3/rule.fst"
-        // lexcion = "lexicon.txt"
+        // lexicon = "lexicon.txt"
 
         if (dataDir != null) {
             val newDir = copyDataDir(modelDir)

--- a/android/SherpaOnnxTtsEngine/app/src/main/java/com/k2fsa/sherpa/onnx/tts/engine/MainActivity.kt
+++ b/android/SherpaOnnxTtsEngine/app/src/main/java/com/k2fsa/sherpa/onnx/tts/engine/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -32,6 +33,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.k2fsa.sherpa.onnx.tts.engine.ui.theme.SherpaOnnxTtsEngineTheme
@@ -65,10 +67,14 @@ class MainActivity : ComponentActivity() {
                                 }
                                 var testText by remember { mutableStateOf("") }
 
-                                OutlinedTextField(value = testText,
+                                OutlinedTextField(
+                                    value = testText,
                                     onValueChange = { testText = it },
-                                            label = { Text ("Test text") },
-                                    modifier = Modifier.fillMaxWidth().wrapContentHeight().padding(16.dp),
+                                    label = { Text("Test text") },
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .wrapContentHeight()
+                                        .padding(16.dp),
                                     singleLine = false,
                                 )
 
@@ -76,11 +82,16 @@ class MainActivity : ComponentActivity() {
                                 if (numSpeakers > 1) {
                                     Row {
                                         Text("Speaker ID: (0-${numSpeakers - 1})")
-                                        Slider(
-                                            value = TtsEngine.speakerIdState.value.toFloat(),
-                                            onValueChange = { TtsEngine.speakerId = it.toInt() },
-                                            valueRange = 0.0f..(numSpeakers - 1).toFloat(),
-                                            steps = 1
+                                        OutlinedTextField(
+                                            value = TtsEngine.speakerIdState.value.toString(),
+                                            onValueChange = {
+                                                if (it.isEmpty() || it.isBlank()) {
+                                                    TtsEngine.speakerId = 0
+                                                } else {
+                                                    TtsEngine.speakerId = it.toString().toInt()
+                                                }
+                                            },
+                                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
                                         )
                                     }
                                 }

--- a/android/SherpaOnnxTtsEngine/app/src/main/java/com/k2fsa/sherpa/onnx/tts/engine/TtsEngine.kt
+++ b/android/SherpaOnnxTtsEngine/app/src/main/java/com/k2fsa/sherpa/onnx/tts/engine/TtsEngine.kt
@@ -87,7 +87,7 @@ object TtsEngine {
         // modelDir = "vits-zh-aishell3"
         // modelName = "vits-aishell3.onnx"
         // ruleFsts = "vits-zh-aishell3/rule.fst"
-        // lexcion = "lexicon.txt"
+        // lexicon = "lexicon.txt"
         // lang = "zho"
 
         if (dataDir != null) {

--- a/android/SherpaOnnxTtsEngine/app/src/main/java/com/k2fsa/sherpa/onnx/tts/engine/TtsService.kt
+++ b/android/SherpaOnnxTtsEngine/app/src/main/java/com/k2fsa/sherpa/onnx/tts/engine/TtsService.kt
@@ -81,11 +81,11 @@ class TtsService : TextToSpeechService() {
     override fun onLoadLanguage(_lang: String?, _country: String?, _variant: String?): Int {
         val lang = _lang ?: ""
 
-        if (lang == TtsEngine.lang) {
+        return if (lang == TtsEngine.lang) {
             TtsEngine.createTts(application)
-            return TextToSpeech.LANG_AVAILABLE
+            TextToSpeech.LANG_AVAILABLE
         } else {
-            return TextToSpeech.LANG_NOT_SUPPORTED
+            TextToSpeech.LANG_NOT_SUPPORTED
         }
     }
 


### PR DESCRIPTION
It used a slider to set the speaker ID for the Android TTS engine, and users could only select 3 speakers.

This PR fixes that by using a text field. You can find a screenshot with this PR below:
![image](https://github.com/k2-fsa/sherpa-onnx/assets/5284924/0f831cde-f2ee-4696-84c5-f716e2daa401)
