### PR TITLE
Track token scores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build
 *.zip
 *.tgz
+*.sw?
 onnxruntime-*
 icefall-*
 run.sh

--- a/sherpa-onnx/csrc/hypothesis.h
+++ b/sherpa-onnx/csrc/hypothesis.h
@@ -36,10 +36,12 @@ struct Hypothesis {
 
   // lm_probs[i] contains the lm score for each token in ys.
   // Used only in transducer mofified beam-search.
+  // Elements filled only if LM is used.
   std::vector<float> lm_probs;
 
   // context_scores[i] contains the context-graph score for each token in ys.
   // Used only in transducer mofified beam-search.
+  // Elements filled only if `ContextGraph` is used.
   std::vector<float> context_scores;
 
   // The total score of ys in log space.

--- a/sherpa-onnx/csrc/hypothesis.h
+++ b/sherpa-onnx/csrc/hypothesis.h
@@ -30,7 +30,8 @@ struct Hypothesis {
 
   // The acoustic probability for each token in ys.
   // Used for keyword spotting task.
-  // For transducer mofified beam-search, this is filled with log_posterior scores.
+  // For transducer mofified beam-search and greedy-search,
+  // this is filled with log_posterior scores.
   std::vector<float> ys_probs;
 
   // lm_probs[i] contains the lm score for each token in ys.

--- a/sherpa-onnx/csrc/hypothesis.h
+++ b/sherpa-onnx/csrc/hypothesis.h
@@ -29,8 +29,17 @@ struct Hypothesis {
   std::vector<int32_t> timestamps;
 
   // The acoustic probability for each token in ys.
-  // Only used for keyword spotting task.
+  // Used for keyword spotting task.
+  // For transducer mofified beam-search, this is filled with log_posterior scores.
   std::vector<float> ys_probs;
+
+  // lm_probs[i] contains the lm score for each token in ys.
+  // Used only in transducer mofified beam-search.
+  std::vector<float> lm_probs;
+
+  // context_scores[i] contains the context-graph score for each token in ys.
+  // Used only in transducer mofified beam-search.
+  std::vector<float> context_scores;
 
   // The total score of ys in log space.
   // It contains only acoustic scores

--- a/sherpa-onnx/csrc/online-recognizer-transducer-impl.h
+++ b/sherpa-onnx/csrc/online-recognizer-transducer-impl.h
@@ -69,6 +69,10 @@ static OnlineRecognizerResult Convert(const OnlineTransducerDecoderResult &src,
     r.timestamps.push_back(time);
   }
 
+  r.ys_probs = std::move(src.ys_probs);
+  r.lm_probs = std::move(src.lm_probs);
+  r.context_scores = std::move(src.context_scores);
+
   r.segment = segment;
   r.start_time = frames_since_start * frame_shift_ms / 1000.;
 

--- a/sherpa-onnx/csrc/online-recognizer.cc
+++ b/sherpa-onnx/csrc/online-recognizer.cc
@@ -20,12 +20,12 @@ namespace sherpa_onnx {
 
 /// Helper for `OnlineRecognizerResult::AsJsonString()`
 template<typename T>
-const std::string& VecToString(const std::vector<T>& vec, int32_t precision = 6) {
+std::string VecToString(const std::vector<T>& vec, int32_t precision = 6) {
   std::ostringstream oss;
   oss << std::fixed << std::setprecision(precision);
   oss << "[ ";
   std::string sep = "";
-  for (auto item : vec) {
+  for (const auto& item : vec) {
     oss << sep << item;
     sep = ", ";
   }
@@ -35,13 +35,12 @@ const std::string& VecToString(const std::vector<T>& vec, int32_t precision = 6)
 
 /// Helper for `OnlineRecognizerResult::AsJsonString()`
 template<>  // explicit specialization for T = std::string
-const std::string& VecToString<std::string>(const std::vector<std::string>& vec,
-                                            int32_t) // ignore 2nd arg
-{
+std::string VecToString<std::string>(const std::vector<std::string>& vec,
+                                     int32_t) {  // ignore 2nd arg
   std::ostringstream oss;
   oss << "[ ";
   std::string sep = "";
-  for (auto item : vec) {
+  for (const auto& item : vec) {
     oss << sep << "\"" << item << "\"";
     sep = ", ";
   }
@@ -57,9 +56,10 @@ std::string OnlineRecognizerResult::AsJsonString() const {
   os << "\"timestamps\": " << VecToString(timestamps, 2) << ", ";
   os << "\"ys_probs\": " << VecToString(ys_probs, 6) << ", ";
   os << "\"lm_probs\": " << VecToString(lm_probs, 6) << ", ";
-  os << "\"constext_scores\": " << VecToString(context_scores, 6) << ", ";
+  os << "\"context_scores\": " << VecToString(context_scores, 6) << ", ";
   os << "\"segment\": " << segment << ", ";
-  os << "\"start_time\": " << std::fixed << std::setprecision(2) << start_time  << ", ";
+  os << "\"start_time\": " << std::fixed << std::setprecision(2)
+     << start_time  << ", ";
   os << "\"is_final\": " << (is_final ? "true" : "false");
   os << "}";
   return os.str();

--- a/sherpa-onnx/csrc/online-recognizer.cc
+++ b/sherpa-onnx/csrc/online-recognizer.cc
@@ -21,9 +21,9 @@ namespace sherpa_onnx {
 /// Helper for `OnlineRecognizerResult::AsJsonString()`
 template<typename T>
 const std::string& VecToString(const std::vector<T>& vec, int32_t precision = 6) {
-  std::ostringstrean oss;
+  std::ostringstream oss;
   oss << std::fixed << std::setprecision(precision);
-  oss << "[ " <<
+  oss << "[ ";
   std::string sep = "";
   for (auto item : vec) {
     oss << sep << item;
@@ -35,9 +35,11 @@ const std::string& VecToString(const std::vector<T>& vec, int32_t precision = 6)
 
 /// Helper for `OnlineRecognizerResult::AsJsonString()`
 template<>  // explicit specialization for T = std::string
-const std::string& VecToString<std::string>(const std::vector<T>& vec, int32_t) { // ignore 2nd arg
-  std::ostringstrean oss;
-  oss << "[ " <<
+const std::string& VecToString<std::string>(const std::vector<std::string>& vec,
+                                            int32_t) // ignore 2nd arg
+{
+  std::ostringstream oss;
+  oss << "[ ";
   std::string sep = "";
   for (auto item : vec) {
     oss << sep << "\"" << item << "\"";

--- a/sherpa-onnx/csrc/online-recognizer.cc
+++ b/sherpa-onnx/csrc/online-recognizer.cc
@@ -18,56 +18,48 @@
 
 namespace sherpa_onnx {
 
+/// Helper for `OnlineRecognizerResult::AsJsonString()`
+template<typename T>
+const std::string& VecToString(const std::vector<T>& vec, int32_t precision = 6) {
+  std::ostringstrean oss;
+  oss << std::fixed << std::setprecision(precision);
+  oss << "[ " <<
+  std::string sep = "";
+  for (auto item : vec) {
+    oss << sep << item;
+    sep = ", ";
+  }
+  oss << " ]";
+  return oss.str();
+}
+
+/// Helper for `OnlineRecognizerResult::AsJsonString()`
+template<>  // explicit specialization for T = std::string
+const std::string& VecToString<std::string>(const std::vector<T>& vec, int32_t) { // ignore 2nd arg
+  std::ostringstrean oss;
+  oss << "[ " <<
+  std::string sep = "";
+  for (auto item : vec) {
+    oss << sep << "\"" << item << "\"";
+    sep = ", ";
+  }
+  oss << " ]";
+  return oss.str();
+}
+
 std::string OnlineRecognizerResult::AsJsonString() const {
   std::ostringstream os;
-  os << "{";
-  os << "\"is_final\":" << (is_final ? "true" : "false") << ", ";
-  os << "\"segment\":" << segment << ", ";
-  os << "\"start_time\":" << std::fixed << std::setprecision(2) << start_time
-     << ", ";
-
-  os << "\"text\""
-     << ": ";
-  os << "\"" << text << "\""
-     << ", ";
-
-  os << "\""
-     << "timestamps"
-     << "\""
-     << ": ";
-  os << "[";
-
-  std::string sep = "";
-  for (auto t : timestamps) {
-    os << sep << std::fixed << std::setprecision(2) << t;
-    sep = ", ";
-  }
-  os << "], ";
-
-  os << "\""
-     << "tokens"
-     << "\""
-     << ":";
-  os << "[";
-
-  sep = "";
-  auto oldFlags = os.flags();
-  for (const auto &t : tokens) {
-    if (t.size() == 1 && static_cast<uint8_t>(t[0]) > 0x7f) {
-      const uint8_t *p = reinterpret_cast<const uint8_t *>(t.c_str());
-      os << sep << "\""
-         << "<0x" << std::hex << std::uppercase << static_cast<uint32_t>(p[0])
-         << ">"
-         << "\"";
-      os.flags(oldFlags);
-    } else {
-      os << sep << "\"" << t << "\"";
-    }
-    sep = ", ";
-  }
-  os << "]";
+  os << "{ ";
+  os << "\"text\": " << "\"" << text << "\"" << ", ";
+  os << "\"tokens\": " << VecToString(tokens) << ", ";
+  os << "\"timestamps\": " << VecToString(timestamps, 2) << ", ";
+  os << "\"ys_probs\": " << VecToString(ys_probs, 6) << ", ";
+  os << "\"lm_probs\": " << VecToString(lm_probs, 6) << ", ";
+  os << "\"constext_scores\": " << VecToString(context_scores, 6) << ", ";
+  os << "\"segment\": " << segment << ", ";
+  os << "\"start_time\": " << std::fixed << std::setprecision(2) << start_time  << ", ";
+  os << "\"is_final\": " << (is_final ? "true" : "false");
   os << "}";
-
   return os.str();
 }
 

--- a/sherpa-onnx/csrc/online-recognizer.h
+++ b/sherpa-onnx/csrc/online-recognizer.h
@@ -40,9 +40,9 @@ struct OnlineRecognizerResult {
   /// timestamps[i] records the time in seconds when tokens[i] is decoded.
   std::vector<float> timestamps;
 
-  std::vector<float> ys_probs;
-  std::vector<float> lm_probs;
-  std::vector<float> context_scores;
+  std::vector<float> ys_probs;  //< log-prob scores from ASR model
+  std::vector<float> lm_probs;  //< log-prob scores from language model
+  std::vector<float> context_scores;  //< log-domain scores from "hot-phrase" contextual boosting
 
   /// ID of this segment
   /// When an endpoint is detected, it is incremented
@@ -62,6 +62,9 @@ struct OnlineRecognizerResult {
    *     "text": "The recognition result",
    *     "tokens": [x, x, x],
    *     "timestamps": [x, x, x],
+   *     "ys_probs": [x, x, x],
+   *     "lm_probs": [x, x, x],
+   *     "context_scores": [x, x, x],
    *     "segment": x,
    *     "start_time": x,
    *     "is_final": true|false

--- a/sherpa-onnx/csrc/online-recognizer.h
+++ b/sherpa-onnx/csrc/online-recognizer.h
@@ -42,7 +42,9 @@ struct OnlineRecognizerResult {
 
   std::vector<float> ys_probs;  //< log-prob scores from ASR model
   std::vector<float> lm_probs;  //< log-prob scores from language model
-  std::vector<float> context_scores;  //< log-domain scores from "hot-phrase" contextual boosting
+                                //
+  /// log-domain scores from "hot-phrase" contextual boosting
+  std::vector<float> context_scores;
 
   /// ID of this segment
   /// When an endpoint is detected, it is incremented

--- a/sherpa-onnx/csrc/online-recognizer.h
+++ b/sherpa-onnx/csrc/online-recognizer.h
@@ -40,6 +40,10 @@ struct OnlineRecognizerResult {
   /// timestamps[i] records the time in seconds when tokens[i] is decoded.
   std::vector<float> timestamps;
 
+  std::vector<float> ys_probs;
+  std::vector<float> lm_probs;
+  std::vector<float> context_scores;
+
   /// ID of this segment
   /// When an endpoint is detected, it is incremented
   int32_t segment = 0;

--- a/sherpa-onnx/csrc/online-transducer-decoder.cc
+++ b/sherpa-onnx/csrc/online-transducer-decoder.cc
@@ -37,6 +37,10 @@ OnlineTransducerDecoderResult &OnlineTransducerDecoderResult::operator=(
   frame_offset = other.frame_offset;
   timestamps = other.timestamps;
 
+  ys_probs = other.ys_probs;
+  lm_probs = other.lm_probs;
+  context_scores = other.context_scores;
+
   return *this;
 }
 
@@ -59,6 +63,10 @@ OnlineTransducerDecoderResult &OnlineTransducerDecoderResult::operator=(
 
   frame_offset = other.frame_offset;
   timestamps = std::move(other.timestamps);
+
+  ys_probs = std::move(other.ys_probs);
+  lm_probs = std::move(other.lm_probs);
+  context_scores = std::move(other.context_scores);
 
   return *this;
 }

--- a/sherpa-onnx/csrc/online-transducer-decoder.h
+++ b/sherpa-onnx/csrc/online-transducer-decoder.h
@@ -26,6 +26,10 @@ struct OnlineTransducerDecoderResult {
   /// timestamps[i] contains the output frame index where tokens[i] is decoded.
   std::vector<int32_t> timestamps;
 
+  std::vector<float> ys_probs;
+  std::vector<float> lm_probs;
+  std::vector<float> context_scores;
+
   // Cache decoder_out for endpointing
   Ort::Value decoder_out;
 

--- a/sherpa-onnx/csrc/online-transducer-greedy-search-decoder.cc
+++ b/sherpa-onnx/csrc/online-transducer-greedy-search-decoder.cc
@@ -71,9 +71,11 @@ void OnlineTransducerGreedySearchDecoder::StripLeadingBlanks(
   r->tokens = std::vector<int64_t>(start, end);
 }
 
+
 void OnlineTransducerGreedySearchDecoder::Decode(
     Ort::Value encoder_out,
     std::vector<OnlineTransducerDecoderResult> *result) {
+
   std::vector<int64_t> encoder_out_shape =
       encoder_out.GetTensorTypeAndShapeInfo().GetShape();
 
@@ -97,6 +99,7 @@ void OnlineTransducerGreedySearchDecoder::Decode(
       break;
     }
   }
+
   if (is_batch_decoder_out_cached) {
     auto &r = result->front();
     std::vector<int64_t> decoder_out_shape =
@@ -124,6 +127,7 @@ void OnlineTransducerGreedySearchDecoder::Decode(
       if (blank_penalty_ > 0.0) {
         p_logit[0] -= blank_penalty_;  // assuming blank id is 0
       }
+
       auto y = static_cast<int32_t>(std::distance(
           static_cast<const float *>(p_logit),
           std::max_element(static_cast<const float *>(p_logit),
@@ -138,6 +142,18 @@ void OnlineTransducerGreedySearchDecoder::Decode(
       } else {
         ++r.num_trailing_blanks;
       }
+
+      // export the per-token log scores
+      if (y != 0 && y != unk_id_) {
+        LogSoftmax(p_logit, vocab_size);  // renormalize probabilities,
+                                          // save time by doing it only for
+                                          // emitted symbols
+        float *p_logprob = p_logit;  // rename p_logit as p_logprob,
+                                     // now it contains normalized
+                                     // probability
+        r.ys_probs.push_back(p_logprob[y]);
+      }
+
     }
     if (emitted) {
       Ort::Value decoder_input = model_->BuildDecoderInput(*result);

--- a/sherpa-onnx/csrc/online-transducer-greedy-search-decoder.cc
+++ b/sherpa-onnx/csrc/online-transducer-greedy-search-decoder.cc
@@ -148,12 +148,11 @@ void OnlineTransducerGreedySearchDecoder::Decode(
         LogSoftmax(p_logit, vocab_size);  // renormalize probabilities,
                                           // save time by doing it only for
                                           // emitted symbols
-        float *p_logprob = p_logit;  // rename p_logit as p_logprob,
-                                     // now it contains normalized
-                                     // probability
+        const float *p_logprob = p_logit;  // rename p_logit as p_logprob,
+                                           // now it contains normalized
+                                           // probability
         r.ys_probs.push_back(p_logprob[y]);
       }
-
     }
     if (emitted) {
       Ort::Value decoder_input = model_->BuildDecoderInput(*result);

--- a/sherpa-onnx/csrc/online-transducer-modified-beam-search-decoder.cc
+++ b/sherpa-onnx/csrc/online-transducer-modified-beam-search-decoder.cc
@@ -198,7 +198,7 @@ void OnlineTransducerModifiedBeamSearchDecoder::Decode(
           new_hyp.ys_probs.push_back(y_prob);
 
           float lm_prob = new_hyp.lm_log_prob - prev_lm_log_prob;
-          new_hyp.lm_probs.push_back(lm_probs);
+          new_hyp.lm_probs.push_back(lm_prob);
 
           new_hyp.context_scores.push_back(context_score);
         }

--- a/sherpa-onnx/csrc/online-transducer-modified-beam-search-decoder.cc
+++ b/sherpa-onnx/csrc/online-transducer-modified-beam-search-decoder.cc
@@ -60,7 +60,6 @@ void OnlineTransducerModifiedBeamSearchDecoder::StripLeadingBlanks(
   r->tokens = std::move(tokens);
   r->timestamps = std::move(hyp.timestamps);
 
-
   // export per-token scores
   r->ys_probs = std::move(hyp.ys_probs);
   r->lm_probs = std::move(hyp.lm_probs);
@@ -149,8 +148,6 @@ void OnlineTransducerModifiedBeamSearchDecoder::Decode(
     }
     p_logprob = p_logit;  // we changed p_logprob in the above for loop
 
-    // KarelVesely: Sholud the context score be added already before taking topk tokens ?
-
     for (int32_t b = 0; b != batch_size; ++b) {
       int32_t frame_offset = (*result)[b].frame_offset;
       int32_t start = hyps_row_splits[b];
@@ -190,7 +187,7 @@ void OnlineTransducerModifiedBeamSearchDecoder::Decode(
                            prev_lm_log_prob;  // log_prob only includes the
                                               // score of the transducer
         // export the per-token log scores
-        {
+        if (new_token != 0 && new_token != unk_id_) {
           const Hypothesis& prev_i = prev[hyp_index];
           // subtract 'prev[i]' path scores, which were added before
           // for getting topk tokens
@@ -198,6 +195,9 @@ void OnlineTransducerModifiedBeamSearchDecoder::Decode(
           new_hyp.ys_probs.push_back(y_prob);
 
           float lm_prob = new_hyp.lm_log_prob - prev_lm_log_prob;
+          if (lm_scale_ != 0.0) {
+            lm_prob /= lm_scale_;  // remove lm-scale
+          }
           new_hyp.lm_probs.push_back(lm_prob);
 
           new_hyp.context_scores.push_back(context_score);

--- a/sherpa-onnx/python/csrc/online-recognizer.cc
+++ b/sherpa-onnx/python/csrc/online-recognizer.cc
@@ -37,7 +37,18 @@ static void PybindOnlineRecognizerResult(py::module *m) {
           [](PyClass &self) -> std::vector<float> { return self.lm_probs; })
       .def_property_readonly(
           "context_scores",
-          [](PyClass &self) -> std::vector<float> { return self.context_scores; });
+          [](PyClass &self) -> std::vector<float> { return self.context_scores; })
+       .def_property_readonly(
+          "segment",
+          [](PyClass &self) -> int32_t { return self.segment; })
+       .def_property_readonly(
+          "start_time",
+          [](PyClass &self) -> float { return self.start_time; })
+       .def_property_readonly(
+          "is_final",
+          [](PyClass &self) -> bool { return self.is_final; })
+       .def("as_json_string", &PyClass::AsJsonString,
+            py::call_guard<py::gil_scoped_release>());
 }
 
 static void PybindOnlineRecognizerConfig(py::module *m) {

--- a/sherpa-onnx/python/csrc/online-recognizer.cc
+++ b/sherpa-onnx/python/csrc/online-recognizer.cc
@@ -28,7 +28,16 @@ static void PybindOnlineRecognizerResult(py::module *m) {
           [](PyClass &self) -> float { return self.start_time; })
       .def_property_readonly(
           "timestamps",
-          [](PyClass &self) -> std::vector<float> { return self.timestamps; });
+          [](PyClass &self) -> std::vector<float> { return self.timestamps; })
+      .def_property_readonly(
+          "ys_probs",
+          [](PyClass &self) -> std::vector<float> { return self.ys_probs; })
+      .def_property_readonly(
+          "lm_probs",
+          [](PyClass &self) -> std::vector<float> { return self.lm_probs; })
+      .def_property_readonly(
+          "context_scores",
+          [](PyClass &self) -> std::vector<float> { return self.context_scores; });
 }
 
 static void PybindOnlineRecognizerConfig(py::module *m) {

--- a/sherpa-onnx/python/csrc/online-recognizer.cc
+++ b/sherpa-onnx/python/csrc/online-recognizer.cc
@@ -37,17 +37,16 @@ static void PybindOnlineRecognizerResult(py::module *m) {
           [](PyClass &self) -> std::vector<float> { return self.lm_probs; })
       .def_property_readonly(
           "context_scores",
-          [](PyClass &self) -> std::vector<float> { return self.context_scores; })
-       .def_property_readonly(
+          [](PyClass &self) -> std::vector<float> {
+            return self.context_scores;
+      })
+      .def_property_readonly(
           "segment",
           [](PyClass &self) -> int32_t { return self.segment; })
-       .def_property_readonly(
-          "start_time",
-          [](PyClass &self) -> float { return self.start_time; })
-       .def_property_readonly(
+      .def_property_readonly(
           "is_final",
           [](PyClass &self) -> bool { return self.is_final; })
-       .def("as_json_string", &PyClass::AsJsonString,
+      .def("as_json_string", &PyClass::AsJsonString,
             py::call_guard<py::gil_scoped_release>());
 }
 

--- a/sherpa-onnx/python/sherpa_onnx/online_recognizer.py
+++ b/sherpa-onnx/python/sherpa_onnx/online_recognizer.py
@@ -503,6 +503,9 @@ class OnlineRecognizer(object):
     def get_result(self, s: OnlineStream) -> str:
         return self.recognizer.get_result(s).text.strip()
 
+    def get_result_as_json_string(self, s: OnlineStream) -> str:
+        return self.recognizer.get_result(s).as_json_string()
+
     def tokens(self, s: OnlineStream) -> List[str]:
         return self.recognizer.get_result(s).tokens
 

--- a/sherpa-onnx/python/sherpa_onnx/online_recognizer.py
+++ b/sherpa-onnx/python/sherpa_onnx/online_recognizer.py
@@ -512,6 +512,15 @@ class OnlineRecognizer(object):
     def start_time(self, s: OnlineStream) -> float:
         return self.recognizer.get_result(s).start_time
 
+    def ys_probs(self, s: OnlineStream) -> List[float]:
+        return self.recognizer.get_result(s).ys_probs
+
+    def lm_probs(self, s: OnlineStream) -> List[float]:
+        return self.recognizer.get_result(s).lm_probs
+
+    def context_scores(self, s: OnlineStream) -> List[float]:
+        return self.recognizer.get_result(s).context_scores
+
     def is_endpoint(self, s: OnlineStream) -> bool:
         return self.recognizer.is_endpoint(s)
 


### PR DESCRIPTION
Hello,
I modified the code, so that the per-token scores are accessible via python API 
(ys_probs, lm_probs, context_scores).

This is tracked during the modified beam search decoding of online transduces,
and it is exported for the BestHypothesis.

Would you be interesting in having this functionality in the codebase ?
This can be used as confidences from the client side...

But I did not evaluate it yet, to see how "useful" these numbers are.
I am ready to do changes as well. I'd like to open the discussion...

Best regards
K. Veselý