### PR TITLE
Download ios-onnxruntime from github instead of huggingface.

### DIFF
--- a/build-ios.sh
+++ b/build-ios.sh
@@ -6,34 +6,18 @@ dir=build-ios
 mkdir -p $dir
 cd $dir
 onnxruntime_version=1.16.3
+onnxruntime_dir=ios-onnxruntime/$onnxruntime_version
 
-if [ ! -f ios-onnxruntime/$onnxruntime_version/onnxruntime.xcframework/ios-arm64/onnxruntime.a ]; then
-  if [ ! -d ios-onnxruntime ]; then
-    GIT_LFS_SKIP_SMUDGE=1 git clone https://huggingface.co/csukuangfj/ios-onnxruntime
-  fi
-
-  pushd ios-onnxruntime
-  git pull
-
+if [ ! -f $onnxruntime_dir/onnxruntime.xcframework/ios-arm64/onnxruntime.a ]; then
+  mkdir -p $onnxruntime_dir
+  pushd $onnxruntime_dir
+  rm -f onnxruntime.xcframework-${onnxruntime_version}.tar.bz2
+  wget https://github.com/csukuangfj/onnxruntime-libs/releases/download/v${onnxruntime_version}/onnxruntime.xcframework-${onnxruntime_version}.tar.bz2
+  tar xvf onnxruntime.xcframework-${onnxruntime_version}.tar.bz2
+  rm onnxruntime.xcframework-${onnxruntime_version}.tar.bz2
+  cd ..
   ln -sf $onnxruntime_version/onnxruntime.xcframework .
-  git lfs pull --include $onnxruntime_version/onnxruntime.xcframework/ios-arm64/onnxruntime.a
-  git lfs pull --include $onnxruntime_version/onnxruntime.xcframework/ios-arm64_x86_64-simulator/onnxruntime.a
   popd
-fi
-
-# check filesize
-filesize=$(ls -l ./ios-onnxruntime/$onnxruntime_version/onnxruntime.xcframework/ios-arm64/onnxruntime.a  | tr -s " " " " | cut -d " " -f 5)
-if (( $filesize < 1000 )); then
-  ls -lh ./ios-onnxruntime/onnxruntime.xcframework/ios-arm64/onnxruntime.a
-  echo "Please use: git lfs pull to download ./ios-onnxruntime/$onnxruntime_version/onnxruntime.xcframework/ios-arm64/onnxruntime.a"
-  exit 1
-fi
-
-filesize=$(ls -l ./ios-onnxruntime/$onnxruntime_version/onnxruntime.xcframework/ios-arm64_x86_64-simulator/onnxruntime.a  | tr -s " " " " | cut -d " " -f 5)
-if (( $filesize < 1000 )); then
-  ls -lh ./ios-onnxruntime/$onnxruntime_version/onnxruntime.xcframework/ios-arm64_x86_64-simulator/onnxruntime.a
-  echo "Please use: git lfs pull to download ./ios-onnxruntime/$onnxruntime_version/onnxruntime.xcframework/ios-arm64_x86_64-simulator/onnxruntime.a"
-  exit 1
 fi
 
 # First, for simulator


### PR DESCRIPTION
Users don't need to use `git lfs` to download the ios onnxruntime libs any longer.