### PR TITLE
Use hub.nuaa.cf to replace huggingface URL to download dependencies.

### DIFF
--- a/cmake/onnxruntime-linux-aarch64-static.cmake
+++ b/cmake/onnxruntime-linux-aarch64-static.cmake
@@ -15,7 +15,7 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-linux-aarch64-static_lib-1.17.0.zip")
-set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-linux-aarch64-static_lib-1.17.0.zip")
+set(onnxruntime_URL2 "https://hub.nuaa.cf/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-linux-aarch64-static_lib-1.17.0.zip")
 set(onnxruntime_HASH "SHA256=8be35fa5d4c9cc42075bf90d1a095a44ab6bf4fc7306141aa1169fa49b382cc2")
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-linux-aarch64.cmake
+++ b/cmake/onnxruntime-linux-aarch64.cmake
@@ -14,8 +14,8 @@ if(NOT BUILD_SHARED_LIBS)
   message(FATAL_ERROR "This file is for building shared libraries. BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 endif()
 
-set(onnxruntime_URL "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-linux-aarch64-1.17.0.tgz")
-set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-linux-aarch64-1.17.0.tgz")
+set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-linux-aarch64-1.17.0.tgz")
+set(onnxruntime_URL2 "https://hub.nuaa.cf/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-linux-aarch64-1.17.0.tgz")
 set(onnxruntime_HASH "SHA256=ee5069252f549ef94759b6b60bdf10b2dc2cd71d064a7045dd66a052f956a68b")
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-linux-arm-static.cmake
+++ b/cmake/onnxruntime-linux-arm-static.cmake
@@ -15,7 +15,7 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-linux-arm-static_lib-1.17.0.zip")
-set(onnxruntime_URL  "https://hub.nuaa.cf/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-linux-arm-static_lib-1.17.0.zip")
+set(onnxruntime_URL2 "https://hub.nuaa.cf/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-linux-arm-static_lib-1.17.0.zip")
 set(onnxruntime_HASH "SHA256=36a30732b2ccebdaabfee6e1e4473ce65d90cab12c6d2136874e847baeaa1571")
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-linux-arm-static.cmake
+++ b/cmake/onnxruntime-linux-arm-static.cmake
@@ -15,7 +15,7 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-linux-arm-static_lib-1.17.0.zip")
-set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-linux-arm-static_lib-1.17.0.zip")
+set(onnxruntime_URL  "https://hub.nuaa.cf/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-linux-arm-static_lib-1.17.0.zip")
 set(onnxruntime_HASH "SHA256=36a30732b2ccebdaabfee6e1e4473ce65d90cab12c6d2136874e847baeaa1571")
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-linux-arm.cmake
+++ b/cmake/onnxruntime-linux-arm.cmake
@@ -15,7 +15,7 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 
 set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-linux-arm-1.17.0.zip")
-set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-linux-arm-1.17.0.zip")
+set(onnxruntime_URL2 "https://hub.nuaa.cf/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-linux-arm-1.17.0.zip")
 set(onnxruntime_HASH "SHA256=6bdddba15193336ed26b7fbcc7e487f774cf52c8917899cc5b1d214089e6e855")
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-linux-x86_64-gpu.cmake
+++ b/cmake/onnxruntime-linux-x86_64-gpu.cmake
@@ -19,7 +19,7 @@ if(NOT SHERPA_ONNX_ENABLE_GPU)
 endif()
 
 set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-linux-x64-gpu-1.17.0.tgz")
-set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-linux-x64-gpu-1.17.0.tgz")
+set(onnxruntime_URL2 "https://hub.nuaa.cf/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-linux-x64-gpu-1.17.0.tgz")
 set(onnxruntime_HASH "SHA256=27cfa22af7301868b55220f8733361889286b30be0569a8f46abb63e90342180")
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-linux-x86_64-static.cmake
+++ b/cmake/onnxruntime-linux-x86_64-static.cmake
@@ -15,7 +15,7 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-linux-x64-static_lib-1.17.0-gcc-8.zip")
-set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-linux-x64-static_lib-1.17.0-gcc-8.zip")
+set(onnxruntime_URL2 "https://hub.nuaa.cf/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-linux-x64-static_lib-1.17.0-gcc-8.zip")
 set(onnxruntime_HASH "SHA256=4217302eac0d645b4c2b5fa13d1627c0384d2531615b4a51a52326c01568cc0c")
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-linux-x86_64.cmake
+++ b/cmake/onnxruntime-linux-x86_64.cmake
@@ -15,7 +15,7 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 
 set(onnxruntime_URL   "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-linux-x64-1.17.0.tgz")
-set(onnxruntime_URL2  "https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-linux-x64-1.17.0.tgz")
+set(onnxruntime_URL2  "https://hub.nuaa.cf/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-linux-x64-1.17.0.tgz")
 set(onnxruntime_HASH "SHA256=efc344d54d1969446ff5d3e55b54e205c6579c06333ecf1d34a04215eefae7c6")
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-osx-arm64-static.cmake
+++ b/cmake/onnxruntime-osx-arm64-static.cmake
@@ -13,7 +13,7 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-osx-arm64-static_lib-1.17.0.zip")
-set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-osx-arm64-static_lib-1.17.0.zip")
+set(onnxruntime_URL2 "https://hub.nuaa.cf/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-osx-arm64-static_lib-1.17.0.zip")
 set(onnxruntime_HASH "SHA256=07798f7c91164e6870c438a3a1aeae0768b568bcefd71a3416a4c7a42837e31a")
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-osx-arm64.cmake
+++ b/cmake/onnxruntime-osx-arm64.cmake
@@ -13,7 +13,7 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 
 set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-osx-arm64-1.17.0.tgz")
-set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-osx-arm64-1.17.0.tgz")
+set(onnxruntime_URL2 "https://hub.nuaa.cf/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-osx-arm64-1.17.0.tgz")
 set(onnxruntime_HASH "SHA256=f72a2bcca40e2650756c6b96c69ef031236aaab1b98673e744da4eef0c4bddbd")
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-osx-universal-static.cmake
+++ b/cmake/onnxruntime-osx-universal-static.cmake
@@ -14,7 +14,7 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-osx-universal2-static_lib-1.17.0.zip")
-set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-osx-universal2-static_lib-1.17.0.zip")
+set(onnxruntime_URL2  "https://hub.nuaa.cf/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-osx-universal2-static_lib-1.17.0.zip")
 set(onnxruntime_HASH "SHA256=f5b0367e1be12e8697b34f41a0cec8dc92fc6c445bd5f39865d725e873ad0550")
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-osx-universal.cmake
+++ b/cmake/onnxruntime-osx-universal.cmake
@@ -14,7 +14,7 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 
 set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-osx-universal2-1.17.0.tgz")
-set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-osx-universal2-1.17.0.tgz")
+set(onnxruntime_URL2 "https://hub.nuaa.cf/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-osx-universal2-1.17.0.tgz")
 set(onnxruntime_HASH "SHA256=d6c81efc9be29d504d5f4cc01fec1317861b0ab34f172ad5e6198b486fa43cfd")
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-osx-x86_64-static.cmake
+++ b/cmake/onnxruntime-osx-x86_64-static.cmake
@@ -13,7 +13,7 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-osx-x86_64-static_lib-1.17.0.zip")
-set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-osx-x86_64-static_lib-1.17.0.zip")
+set(onnxruntime_URL2 "https://hub.nuaa.cf/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-osx-x86_64-static_lib-1.17.0.zip")
 set(onnxruntime_HASH "SHA256=280c68f8ebb3d2c6ccb62b07192d888690dfa6e65abe92b97c85cbadd846d931")
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-osx-x86_64.cmake
+++ b/cmake/onnxruntime-osx-x86_64.cmake
@@ -13,7 +13,7 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 
 set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-osx-x86_64-1.17.0.tgz")
-set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-osx-x86_64-1.17.0.tgz")
+set(onnxruntime_URL2 "https://hub.nuaa.cf/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-osx-x86_64-1.17.0.tgz")
 set(onnxruntime_HASH "SHA256=b87b2febef24e5645e13859d176e76473124325a0b1526baf7f68b4aa1eb1b49")
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-win-x64-gpu.cmake
+++ b/cmake/onnxruntime-win-x64-gpu.cmake
@@ -20,7 +20,7 @@ if(NOT SHERPA_ONNX_ENABLE_GPU)
 endif()
 
 set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-win-x64-gpu-1.17.0.zip")
-set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-win-x64-gpu-1.17.0.zip")
+set(onnxruntime_URL2 "https://hub.nuaa.cf/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-win-x64-gpu-1.17.0.zip")
 set(onnxruntime_HASH "SHA256=3c90a38769e2f7bdb088c00410de4895b07b7d53a7c80955f18989775c2a25e7")
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-win-x64-static-debug.cmake
+++ b/cmake/onnxruntime-win-x64-static-debug.cmake
@@ -16,7 +16,7 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-win-x64-static_lib-${CMAKE_BUILD_TYPE}-1.17.0.tar.bz2")
-set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-win-x64-static_lib-${CMAKE_BUILD_TYPE}-1.17.0.tar.bz2")
+set(onnxruntime_URL2 "https://hub.nuaa.cf/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-win-x64-static_lib-${CMAKE_BUILD_TYPE}-1.17.0.tar.bz2")
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
   set(onnxruntime_HASH "SHA256=daef674f160044cf9f4c27d615eaa032f93c4ed6b8d2753bb91b4b37ba40349f")
 elseif(CMAKE_BUILD_TYPE STREQUAL RelWithDebInfo)

--- a/cmake/onnxruntime-win-x64-static.cmake
+++ b/cmake/onnxruntime-win-x64-static.cmake
@@ -20,7 +20,7 @@ if(NOT CMAKE_BUILD_TYPE STREQUAL Release)
 endif()
 
 set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-win-x64-static_lib-1.17.0.tar.bz2")
-set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-win-x64-static_lib-1.17.0.tar.bz2")
+set(onnxruntime_URL2 "https://hub.nuaa.cf/github.com/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-win-x64-static_lib-1.17.0.tar.bz2")
 set(onnxruntime_HASH "SHA256=7ff33b989fbe32546d694284d46653fd4c38f47155105ec14907e6d3cd4b01bb")
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-win-x64.cmake
+++ b/cmake/onnxruntime-win-x64.cmake
@@ -16,7 +16,7 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 
 set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-win-x64-1.17.0.zip")
-set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-win-x64-1.17.0.zip")
+set(onnxruntime_URL2 "https://hub.nuaa.cf/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-win-x64-1.17.0.zip")
 set(onnxruntime_HASH "SHA256=b0436634108c001e2284cb685646047a7b088715b64c05e39ee8a1a8930776a9")
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-win-x86-static-debug.cmake
+++ b/cmake/onnxruntime-win-x86-static-debug.cmake
@@ -17,7 +17,7 @@ endif()
 
 
 set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-win-x86-static_lib-${CMAKE_BUILD_TYPE}-1.17.0.tar.bz2")
-set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-win-x86-static_lib-${CMAKE_BUILD_TYPE}-1.17.0.tar.bz2")
+set(onnxruntime_URL2  "https://hub.nuaa.cf/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-win-x86-static_lib-${CMAKE_BUILD_TYPE}-1.17.0.tar.bz2")
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
   set(onnxruntime_HASH "SHA256=7ebf676b4cae50ae4c203ca54ae2341d7c7aeae66a965a85610b254d24effee3")
 elseif(CMAKE_BUILD_TYPE STREQUAL RelWithDebInfo)

--- a/cmake/onnxruntime-win-x86-static.cmake
+++ b/cmake/onnxruntime-win-x86-static.cmake
@@ -20,7 +20,7 @@ if(NOT CMAKE_BUILD_TYPE STREQUAL Release)
 endif()
 
 set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-win-x86-static_lib-1.17.0.tar.bz2")
-set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-win-x86-static_lib-1.17.0.tar.bz2")
+set(onnxruntime_URL2 "https://hub.nuaa.cf/csukuangfj/onnxruntime-libs/releases/download/v1.17.0/onnxruntime-win-x86-static_lib-1.17.0.tar.bz2")
 set(onnxruntime_HASH "SHA256=3c40c53fef937452bf6cfbac1584875d5627bd908ca731d120642112526c8352")
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-win-x86.cmake
+++ b/cmake/onnxruntime-win-x86.cmake
@@ -16,7 +16,7 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 
 set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-win-x86-1.17.0.zip")
-set(onnxruntime_URL2 "https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-win-x86-1.17.0.zip")
+set(onnxruntime_URL2 "https://hub.nuaa.cf/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-win-x86-1.17.0.zip")
 set(onnxruntime_HASH "SHA256=3f3214f99165d3282cc5647c5a18451aaaaf326599c7e98913ce6c50e50c6463")
 
 # If you don't have access to the Internet,

--- a/cmake/portaudio.cmake
+++ b/cmake/portaudio.cmake
@@ -2,7 +2,7 @@ function(download_portaudio)
   include(FetchContent)
 
   set(portaudio_URL  "http://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz")
-  set(portaudio_URL2 "https://huggingface.co/csukuangfj/sherpa-onnx-cmake-deps/resolve/main/pa_stable_v190700_20210406.tgz")
+  set(portaudio_URL2 "https://hf-mirror.com/csukuangfj/sherpa-onnx-cmake-deps/resolve/main/pa_stable_v190700_20210406.tgz")
   set(portaudio_HASH "SHA256=47efbf42c77c19a05d22e627d42873e991ec0c1357219c0d74ce6a2948cb2def")
 
   # If you don't have access to the Internet, please download it to your

--- a/cmake/pybind11.cmake
+++ b/cmake/pybind11.cmake
@@ -2,7 +2,7 @@ function(download_pybind11)
   include(FetchContent)
 
   set(pybind11_URL  "https://github.com/pybind/pybind11/archive/refs/tags/v2.10.2.tar.gz")
-  set(pybind11_URL2 "https://huggingface.co/csukuangfj/sherpa-onnx-cmake-deps/resolve/main/pybind11-2.10.2.tar.gz")
+  set(pybind11_URL2 "https://hub.nuaa.cf/pybind/pybind11/archive/refs/tags/v2.10.2.tar.gz")
   set(pybind11_HASH "SHA256=93bd1e625e43e03028a3ea7389bba5d3f9f2596abc074b068e70f4ef9b1314ae")
 
   # If you don't have access to the Internet,

--- a/cmake/websocketpp.cmake
+++ b/cmake/websocketpp.cmake
@@ -3,7 +3,7 @@ function(download_websocketpp)
 
   # The latest commit on the develop branch os as 2022-10-22
   set(websocketpp_URL  "https://github.com/zaphoyd/websocketpp/archive/b9aeec6eaf3d5610503439b4fae3581d9aff08e8.zip")
-  set(websocketpp_URL2 "https://huggingface.co/csukuangfj/sherpa-onnx-cmake-deps/resolve/main/websocketpp-b9aeec6eaf3d5610503439b4fae3581d9aff08e8.zip")
+  set(websocketpp_URL2  "https://hub.nuaa.cf/zaphoyd/websocketpp/archive/b9aeec6eaf3d5610503439b4fae3581d9aff08e8.zip")
   set(websocketpp_HASH "SHA256=1385135ede8191a7fbef9ec8099e3c5a673d48df0c143958216cd1690567f583")
 
   # If you don't have access to the Internet,


### PR DESCRIPTION
This is mainly for Chinese users since most of them cannot access Huggingface and some cannot access GitHub.