### PR TITLE
Support Android NNAPI.

### DIFF
--- a/build-android-arm64-v8a.sh
+++ b/build-android-arm64-v8a.sh
@@ -76,8 +76,42 @@ cmake -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake" 
     -DANDROID_ABI="arm64-v8a" \
     -DANDROID_PLATFORM=android-21 ..
 
+# Please use -DANDROID_PLATFORM=android-27 if you want to use Android NNAPI
+
 # make VERBOSE=1 -j4
 make -j4
 make install/strip
 cp -fv $onnxruntime_version/jni/arm64-v8a/libonnxruntime.so install/lib
 rm -rf install/lib/pkgconfig
+
+# To run the generated binaries on Android, please use the following steps.
+#
+#
+# 1. Copy sherpa-onnx and its dependencies to Android
+#
+#   cd build-android-arm64-v8a/install/lib
+#   adb push ./lib*.so /data/local/tmp
+#   cd ../bin
+#   adb push ./sherpa-onnx /data/local/tmp
+#
+# 2. Login into Android
+#
+#   adb shell
+#   cd /data/local/tmp
+#   ./sherpa-onnx
+#
+# which shows the following error log:
+#
+#  CANNOT LINK EXECUTABLE "./sherpa-onnx": library "libsherpa-onnx-core.so" not found: needed by main executable
+#
+# Please run:
+#
+#  export LD_LIBRARY_PATH=$PWD:$LD_LIBRARY_PATH
+#
+# and then you can run:
+#
+#  ./sherpa-onnx
+#
+# It should show the help message of sherpa-onnx.
+#
+# Please use the above approach to copy model files to your phone.

--- a/sherpa-onnx/csrc/provider.cc
+++ b/sherpa-onnx/csrc/provider.cc
@@ -22,6 +22,8 @@ Provider StringToProvider(std::string s) {
     return Provider::kCoreML;
   } else if (s == "xnnpack") {
     return Provider::kXnnpack;
+  } else if (s == "nnapi") {
+    return Provider::kNNAPI;
   } else {
     SHERPA_ONNX_LOGE("Unsupported string: %s. Fallback to cpu", s.c_str());
     return Provider::kCPU;

--- a/sherpa-onnx/csrc/provider.h
+++ b/sherpa-onnx/csrc/provider.h
@@ -17,6 +17,7 @@ enum class Provider {
   kCUDA = 1,     // CUDAExecutionProvider
   kCoreML = 2,   // CoreMLExecutionProvider
   kXnnpack = 3,  // XnnpackExecutionProvider
+  kNNAPI = 4,    // NnapiExecutionProvider
 };
 
 /**


### PR DESCRIPTION
To use Android NNAPI, you need to do the following two steps:

1. Change
https://github.com/k2-fsa/sherpa-onnx/blob/f9db33c9268b20e7bc50c24637fb04bf3fa83e65/build-android-arm64-v8a.sh#L77
to
```
 -DANDROID_PLATFORM=android-27 .. 
```

2. Use `nnapi` instead of `cpu` for the provider.

An example is to change
https://github.com/k2-fsa/sherpa-onnx/blob/f9db33c9268b20e7bc50c24637fb04bf3fa83e65/android/SherpaOnnx/app/src/main/java/com/k2fsa/sherpa/onnx/SherpaOnnx.kt#L40
to
```
 var provider: String = "nnapi", 
```