### PR TITLE
Fix building wheels from source.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,12 @@
+include LICENSE
+include README.md
+include CMakeLists.txt
+recursive-include c-api-examples *.*
+recursive-include sherpa-onnx *.*
+recursive-include cmake *.*
+prune */__pycache__
+prune android
+prune sherpa-onnx/java-api
+prune ios-swift
+prune ios-swiftui
+


### PR DESCRIPTION
With this PR, you can use
```
pip install --no-binary sherpa-onnx sherpa-onnx
```
to install sherpa-onnx from source when we release the next version, i.e., `v1.9.12`.