### PR TITLE
Support Ubuntu 18.04 and CentOS 7

### DIFF
--- a/.github/workflows/build-wheels-aarch64.yaml
+++ b/.github/workflows/build-wheels-aarch64.yaml
@@ -17,13 +17,14 @@ concurrency:
 
 jobs:
   build_wheels_aarch64:
-    name: ${{ matrix.python-version }}
+    name: ${{ matrix.manylinux }} ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python-version: ["cp37", "cp38", "cp39", "cp310", "cp311", "cp312"]
+        manylinux: [manylinux2014, manylinux_2_28]
 
     steps:
       - uses: actions/checkout@v4
@@ -51,7 +52,7 @@ jobs:
           CIBW_SKIP: "cp27-* cp35-* cp36-* *-win32 pp* *-musllinux* *-manylinux_i686"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ARCHS_LINUX: aarch64
-          CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
+          CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/${{ matrix.manylinux }}_aarch64
           # From onnxruntime >= 1.17.0, it drops support for CentOS 7.0 and it supports only manylinux_2_28.
           # manylinux_2_24 is no longer supported
 
@@ -63,7 +64,7 @@ jobs:
           ls -lh ./wheelhouse/*.whl
 
       - name: Publish to huggingface
-        if: matrix.python-version == 'cp38'
+        if: matrix.python-version == 'cp38' && matrix.manylinux == 'manylinux_2_28'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         uses: nick-fields/retry@v3
@@ -93,7 +94,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.python-version }}
+          name: wheel-${{ matrix.python-version }}-${{ matrix.manylinux }}
           path: ./wheelhouse/*.whl
 
       - name: Publish wheels to PyPI

--- a/.github/workflows/build-wheels-linux.yaml
+++ b/.github/workflows/build-wheels-linux.yaml
@@ -17,13 +17,15 @@ concurrency:
 
 jobs:
   build_wheels_linux:
-    name: ${{ matrix.python-version }}
+    name: ${{ matrix.manylinux }} ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python-version: ["cp37", "cp38", "cp39", "cp310", "cp311", "cp312"]
+        manylinux: [manylinux2014, manylinux_2_28]
+
 
     steps:
       - uses: actions/checkout@v4
@@ -46,9 +48,7 @@ jobs:
           CIBW_BUILD: "${{ matrix.python-version}}-* "
           CIBW_SKIP: "cp27-* cp35-* cp36-* *-win32 pp* *-musllinux* *-manylinux_i686"
           CIBW_BUILD_VERBOSITY: 3
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
-          # From onnxruntime >= 1.17.0, it drops support for CentOS 7.0 and it supports only manylinux_2_28.
-          # manylinux_2_24 is no longer supported
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/${{ matrix.manylinux }}_x86_64
 
       - name: Display wheels
         shell: bash
@@ -76,7 +76,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.python-version }}
+          name: wheel-${{ matrix.python-version }}-${{ matrix.manylinux }}
           path: ./wheelhouse/*.whl
 
       - name: Publish to huggingface
@@ -119,14 +119,14 @@ jobs:
           twine upload ./wheelhouse/*.whl
 
       - name: Build sdist
-        if: matrix.python-version == 'cp38'
+        if: matrix.python-version == 'cp38' && matrix.manylinux == 'manylinux_2_28'
         shell: bash
         run: |
           python3 setup.py sdist
           ls -l dist/*
 
       - name: Publish sdist to PyPI
-        if: matrix.python-version == 'cp38'
+        if: matrix.python-version == 'cp38' && matrix.manylinux == 'manylinux_2_28'
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -227,7 +227,7 @@ jobs:
           tar cjvf ${dst}.tar.bz2 $dst
 
       - name: Release pre-compiled binaries and libs for linux x64
-        if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+        if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa' && github.event_name == 'push' && contains(github.ref, 'refs/tags/') && matrix.os == 'ubuntu-20.04' && matrix.gcc_version == '7'
         uses: svenstaro/upload-release-action@v2
         with:
           file_glob: true

--- a/cmake/onnxruntime-linux-aarch64.cmake
+++ b/cmake/onnxruntime-linux-aarch64.cmake
@@ -14,19 +14,19 @@ if(NOT BUILD_SHARED_LIBS)
   message(FATAL_ERROR "This file is for building shared libraries. BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 endif()
 
-set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.17.1/onnxruntime-linux-aarch64-1.17.1.tgz")
-set(onnxruntime_URL2 "https://hub.nuaa.cf/microsoft/onnxruntime/releases/download/v1.17.1/onnxruntime-linux-aarch64-1.17.1.tgz")
-set(onnxruntime_HASH "SHA256=70b6f536bb7ab5961d128e9dbd192368ac1513bffb74fe92f97aac342fbd0ac1")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.17.1/onnxruntime-linux-aarch64-glibc2_17-Release-1.17.1.zip")
+set(onnxruntime_URL2 "https://hub.nuaa.cf/csukuangfj/onnxruntime-libs/releases/download/v1.17.1/onnxruntime-linux-aarch64-glibc2_17-Release-1.17.1.zip")
+set(onnxruntime_HASH "SHA256=2ed01996da79d11ea486f738010bd411096ab91e744306fbd30d09f37e6d43a0")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-linux-aarch64-1.17.1.tgz
-  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-aarch64-1.17.1.tgz
-  ${CMAKE_BINARY_DIR}/onnxruntime-linux-aarch64-1.17.1.tgz
-  /tmp/onnxruntime-linux-aarch64-1.17.1.tgz
-  /star-fj/fangjun/download/github/onnxruntime-linux-aarch64-1.17.1.tgz
+  $ENV{HOME}/Downloads/onnxruntime-linux-aarch64-glibc2_17-Release-1.17.1.zip
+  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-aarch64-glibc2_17-Release-1.17.1.zip
+  ${CMAKE_BINARY_DIR}/onnxruntime-linux-aarch64-glibc2_17-Release-1.17.1.zip
+  /tmp/onnxruntime-linux-aarch64-glibc2_17-Release-1.17.1.zip
+  /star-fj/fangjun/download/github/onnxruntime-linux-aarch64-glibc2_17-Release-1.17.1.zip
 )
 
 foreach(f IN LISTS possible_file_locations)

--- a/cmake/onnxruntime-linux-x86_64.cmake
+++ b/cmake/onnxruntime-linux-x86_64.cmake
@@ -14,19 +14,19 @@ if(NOT BUILD_SHARED_LIBS)
   message(FATAL_ERROR "This file is for building shared libraries. BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 endif()
 
-set(onnxruntime_URL   "https://github.com/microsoft/onnxruntime/releases/download/v1.17.1/onnxruntime-linux-x64-1.17.1.tgz")
-set(onnxruntime_URL2  "https://hub.nuaa.cf/microsoft/onnxruntime/releases/download/v1.17.1/onnxruntime-linux-x64-1.17.1.tgz")
-set(onnxruntime_HASH "SHA256=89b153af88746665909c758a06797175ae366280cbf25502c41eb5955f9a555e")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.17.1/onnxruntime-linux-x64-glibc2_17-Release-1.17.1.zip")
+set(onnxruntime_URL2 "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.17.1/onnxruntime-linux-x64-glibc2_17-Release-1.17.1.zip")
+set(onnxruntime_HASH "SHA256=3cfa5c2c5c21a9401572af5a4cd9d15ed8f6524f10d3b80e5a38676b3a31efe0")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-linux-x64-1.17.1.tgz
-  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-x64-1.17.1.tgz
-  ${CMAKE_BINARY_DIR}/onnxruntime-linux-x64-1.17.1.tgz
-  /tmp/onnxruntime-linux-x64-1.17.1.tgz
-  /star-fj/fangjun/download/github/onnxruntime-linux-x64-1.17.1.tgz
+  $ENV{HOME}/Downloads/onnxruntime-linux-x64-glibc2_17-Release-1.17.1.zip
+  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-x64-glibc2_17-Release-1.17.1.zip
+  ${CMAKE_BINARY_DIR}/onnxruntime-linux-x64-glibc2_17-Release-1.17.1.zip
+  /tmp/onnxruntime-linux-x64-glibc2_17-Release-1.17.1.zip
+  /star-fj/fangjun/download/github/onnxruntime-linux-x64-glibc2_17-Release-1.17.1.zip
 )
 
 foreach(f IN LISTS possible_file_locations)


### PR DESCRIPTION
From onnxruntime >= 1.17.0, the pre-compiled shared lib drops support for CentOS 7.0 and it supports only manylinux_2_28.
However, a lot of users are still using CentOS 7 and ubuntu 18.04. They get errors when running `pip install sherpa-onnx`.

This PR fixes the issue by using self pre-compiled shared onnxruntime lib.