### PR TITLE
Support using T-head-Semi/csi-nn2 for RISC-V

### DIFF
--- a/.github/workflows/riscv64-linux.yaml
+++ b/.github/workflows/riscv64-linux.yaml
@@ -61,7 +61,7 @@ jobs:
         if: steps.cache-qemu.outputs.cache-hit != 'true'
         run: |
           # https://pypi.org/project/xuantie-qemu/#files
-          wget https://files.pythonhosted.org/packages/21/f4/733f29c435987e8bb264a6504c7a4ea4c04d0d431b38a818ab63eef082b9/xuantie_qemu-20230825-py3-none-manylinux1_x86_64.whl
+          wget -q https://files.pythonhosted.org/packages/21/f4/733f29c435987e8bb264a6504c7a4ea4c04d0d431b38a818ab63eef082b9/xuantie_qemu-20230825-py3-none-manylinux1_x86_64.whl
           unzip xuantie_qemu-20230825-py3-none-manylinux1_x86_64.whl
           mkdir -p qemu-install/bin
 
@@ -129,6 +129,7 @@ jobs:
           export PATH=$GITHUB_WORKSPACE/toolchain/bin:$PATH
           export PATH=$GITHUB_WORKSPACE/qemu-install/bin:$PATH
           export QEMU_LD_PREFIX=$GITHUB_WORKSPACE/toolchain/sysroot
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/toolchain/sysroot/lib
 
           ls -lh ./build-riscv64-linux-gnu/bin
 
@@ -143,6 +144,44 @@ jobs:
           echo "----------sherpa-onnx-offline-tts----------"
           qemu-riscv64 ./build-riscv64-linux-gnu/bin/sherpa-onnx-offline-tts --help
           readelf -d ./build-riscv64-linux-gnu/bin/sherpa-onnx-offline-tts
+
+      - name: Test streaming speech recognition
+        shell: bash
+        run: |
+          export PATH=$GITHUB_WORKSPACE/toolchain/bin:$PATH
+          export PATH=$GITHUB_WORKSPACE/qemu-install/bin:$PATH
+          export QEMU_LD_PREFIX=$GITHUB_WORKSPACE/toolchain/sysroot
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/toolchain/sysroot/lib
+
+          wget -q https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-streaming-zipformer-zh-14M-2023-02-23.tar.bz2
+          tar xvf sherpa-onnx-streaming-zipformer-zh-14M-2023-02-23.tar.bz2
+          rm sherpa-onnx-streaming-zipformer-zh-14M-2023-02-23.tar.bz2
+
+          qemu-riscv64 ./build-riscv64-linux-gnu/bin/sherpa-onnx \
+            --tokens=./sherpa-onnx-streaming-zipformer-zh-14M-2023-02-23/tokens.txt \
+            --encoder=./sherpa-onnx-streaming-zipformer-zh-14M-2023-02-23/encoder-epoch-99-avg-1.onnx \
+            --decoder=./sherpa-onnx-streaming-zipformer-zh-14M-2023-02-23/decoder-epoch-99-avg-1.onnx \
+            --joiner=./sherpa-onnx-streaming-zipformer-zh-14M-2023-02-23/joiner-epoch-99-avg-1.onnx \
+            ./sherpa-onnx-streaming-zipformer-zh-14M-2023-02-23/test_wavs/0.wav
+
+      - name: Test offline tts
+        shell: bash
+        run: |
+          export PATH=$GITHUB_WORKSPACE/toolchain/bin:$PATH
+          export PATH=$GITHUB_WORKSPACE/qemu-install/bin:$PATH
+          export QEMU_LD_PREFIX=$GITHUB_WORKSPACE/toolchain/sysroot
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/toolchain/sysroot/lib
+
+          wget -q https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/vits-piper-en_US-lessac-medium.tar.bz2
+          tar xf vits-piper-en_US-lessac-medium.tar.bz2
+          rm vits-piper-en_US-lessac-medium.tar.bz2
+
+          qemu-riscv64 ./build-riscv64-linux-gnu/bin/sherpa-onnx-offline-tts \
+            --vits-model=./vits-piper-en_US-lessac-medium/en_US-lessac-medium.onnx \
+            --vits-data-dir=./vits-piper-en_US-lessac-medium/espeak-ng-data \
+            --vits-tokens=./vits-piper-en_US-lessac-medium/tokens.txt \
+            --output-filename=./liliana-piper-en_US-lessac-medium.wav \
+            'liliana, the most beautiful and lovely assistant of our team!'
 
       - name: Copy files
         shell: bash
@@ -179,6 +218,12 @@ jobs:
         with:
           name: sherpa-onnx-linux-riscv64-shared
           path: sherpa-onnx-*linux-riscv64-shared.tar.bz2
+
+      - uses: actions/upload-artifact@v4
+        if: matrix.lib_type == 'shared'
+        with:
+          name: wave
+          path: ./*.wav
 
       - uses: actions/upload-artifact@v4
         if: matrix.lib_type == 'static'

--- a/.github/workflows/riscv64-linux.yaml
+++ b/.github/workflows/riscv64-linux.yaml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        lib_type: [static, shared]
+        lib_type: [shared] #, static]
 
     steps:
       - uses: actions/checkout@v4
@@ -55,45 +55,35 @@ jobs:
         uses: actions/cache@v4
         with:
           path: qemu-install
-          key: qemu-riscv-install-20240225
-
-      - name: install-qemu-build-deps
-        if: steps.cache-qemu.outputs.cache-hit != 'true'
-        run: |
-          sudo apt-get update
-          sudo apt-get install autoconf automake autotools-dev ninja-build
-
-      - name: checkout-qemu
-        if: steps.cache-qemu.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
-        with:
-          repository: qemu/qemu
-          path: qemu
+          key: qemu-riscv-xuantie-install-20240306
 
       - name: qemu
         if: steps.cache-qemu.outputs.cache-hit != 'true'
         run: |
-          cd qemu
-          ./configure --prefix=$GITHUB_WORKSPACE/qemu-install --target-list=riscv64-linux-user --disable-system
-          make -j2
-          make install
-          ls -lh $GITHUB_WORKSPACE/qemu-install
-          ls -lh $GITHUB_WORKSPACE/qemu-install/bin
+          # https://pypi.org/project/xuantie-qemu/#files
+          wget https://files.pythonhosted.org/packages/21/f4/733f29c435987e8bb264a6504c7a4ea4c04d0d431b38a818ab63eef082b9/xuantie_qemu-20230825-py3-none-manylinux1_x86_64.whl
+          unzip xuantie_qemu-20230825-py3-none-manylinux1_x86_64.whl
+          mkdir -p qemu-install/bin
+
+          cp -v ./qemu/qemu-riscv64 ./qemu-install/bin
 
       - name: cache-toolchain
         id: cache-toolchain
         uses: actions/cache@v4
         with:
           path: toolchain
-          key: riscv64-glibc-ubuntu-20.04-gcc-nightly-2023.10.17-nightly
+          key: Xuantie-900-gcc-linux-5.10.4-glibc-x86_64-V2.6.1-20220906.tar.gz
 
       - name: Download toolchain
         if: steps.cache-toolchain.outputs.cache-hit != 'true'
         shell: bash
         run: |
+          wget -q https://occ-oss-prod.oss-cn-hangzhou.aliyuncs.com/resource//1663142514282/Xuantie-900-gcc-linux-5.10.4-glibc-x86_64-V2.6.1-20220906.tar.gz
+
           mkdir $GITHUB_WORKSPACE/toolchain
-          wget -q https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/2023.10.17/riscv64-glibc-ubuntu-20.04-gcc-nightly-2023.10.17-nightly.tar.gz
-          tar xvf ./riscv64-glibc-ubuntu-20.04-gcc-nightly-2023.10.17-nightly.tar.gz --strip-components 1 -C $GITHUB_WORKSPACE/toolchain
+
+          tar xvf ./Xuantie-900-gcc-linux-5.10.4-glibc-x86_64-V2.6.1-20220906.tar.gz --strip-components 1 -C $GITHUB_WORKSPACE/toolchain
+          ls -lh $GITHUB_WORKSPACE/toolchain/bin
 
       - name: Display toolchain info
         shell: bash

--- a/build-riscv64-linux-gnu.sh
+++ b/build-riscv64-linux-gnu.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -ex
 
 if ! command -v riscv64-unknown-linux-gnu-g++  &> /dev/null; then
   echo "Please install the toolchain first."

--- a/build-riscv64-linux-gnu.sh
+++ b/build-riscv64-linux-gnu.sh
@@ -43,8 +43,8 @@ export CPLUS_INCLUDE_PATH=$PWD/alsa-lib/include:$CPLUS_INCLUDE_PATH
 export SHERPA_ONNX_ALSA_LIB_DIR=$PWD/alsa-lib/src/.libs
 
 if [[ x"$BUILD_SHARED_LIBS" == x"" ]]; then
-  # By default, use static link
-  BUILD_SHARED_LIBS=OFF
+  # By default, use shared libraries
+  BUILD_SHARED_LIBS=ON
 fi
 
 cmake \

--- a/cmake/onnxruntime-linux-riscv64.cmake
+++ b/cmake/onnxruntime-linux-riscv64.cmake
@@ -14,19 +14,20 @@ if(NOT BUILD_SHARED_LIBS)
   message(FATAL_ERROR "This file is for building shared libraries. BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 endif()
 
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.18.0/onnxruntime-linux-riscv64-1.18.0.zip")
-set(onnxruntime_URL2 "https://hub.nuaa.cf/csukuangfj/onnxruntime-libs/releases/download/v1.18.0/onnxruntime-linux-riscv64-1.18.0.zip")
-set(onnxruntime_HASH "SHA256=81a11b54d1d71f4b3161b00cba8576a07594abd218aa5c0d82382960ada06092")
+# set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.18.0/onnxruntime-linux-riscv64-1.18.0.zip")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.14.1/onnxruntime-linux-riscv64-glibc2_17-Release-1.14.1.zip")
+set(onnxruntime_URL  "https://hub.nuaa.cf/csukuangfj/onnxruntime-libs/releases/download/v1.14.1/onnxruntime-linux-riscv64-glibc2_17-Release-1.14.1.zip")
+set(onnxruntime_HASH "SHA256=c2cbc5af081ff82f46640befd85433811486daaf28e702163c6e4e75020fde81")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-linux-riscv64-1.18.0.zip
-  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-riscv64-1.18.0.zip
-  ${CMAKE_BINARY_DIR}/onnxruntime-linux-riscv64-1.18.0.zip
-  /tmp/onnxruntime-linux-riscv64-1.18.0.zip
-  /star-fj/fangjun/download/github/onnxruntime-linux-riscv64-1.18.0.zip
+  $ENV{HOME}/Downloads/onnxruntime-linux-riscv64-glibc2_17-Release-1.14.1.zip
+  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-riscv64-glibc2_17-Release-1.14.1.zip
+  ${CMAKE_BINARY_DIR}/onnxruntime-linux-riscv64-glibc2_17-Release-1.14.1.zip
+  /tmp/onnxruntime-linux-riscv64-glibc2_17-Release-1.14.1.zip
+  /star-fj/fangjun/download/github/onnxruntime-linux-riscv64-glibc2_17-Release-1.14.1.zip
 )
 
 foreach(f IN LISTS possible_file_locations)
@@ -65,7 +66,7 @@ add_library(onnxruntime SHARED IMPORTED)
 
 set_target_properties(onnxruntime PROPERTIES
   IMPORTED_LOCATION ${location_onnxruntime}
-  INTERFACE_INCLUDE_DIRECTORIES "${onnxruntime_SOURCE_DIR}/include/onnxruntime"
+  INTERFACE_INCLUDE_DIRECTORIES "${onnxruntime_SOURCE_DIR}/include/"
 )
 
 file(GLOB onnxruntime_lib_files "${onnxruntime_SOURCE_DIR}/lib/libonnxruntime*")

--- a/cmake/onnxruntime-linux-riscv64.cmake
+++ b/cmake/onnxruntime-linux-riscv64.cmake
@@ -14,7 +14,6 @@ if(NOT BUILD_SHARED_LIBS)
   message(FATAL_ERROR "This file is for building shared libraries. BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 endif()
 
-# set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.18.0/onnxruntime-linux-riscv64-1.18.0.zip")
 set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.14.1/onnxruntime-linux-riscv64-glibc2_17-Release-1.14.1.zip")
 set(onnxruntime_URL2 "https://hub.nuaa.cf/csukuangfj/onnxruntime-libs/releases/download/v1.14.1/onnxruntime-linux-riscv64-glibc2_17-Release-1.14.1.zip")
 set(onnxruntime_HASH "SHA256=c2cbc5af081ff82f46640befd85433811486daaf28e702163c6e4e75020fde81")

--- a/cmake/onnxruntime-linux-riscv64.cmake
+++ b/cmake/onnxruntime-linux-riscv64.cmake
@@ -16,7 +16,7 @@ endif()
 
 # set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.18.0/onnxruntime-linux-riscv64-1.18.0.zip")
 set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.14.1/onnxruntime-linux-riscv64-glibc2_17-Release-1.14.1.zip")
-set(onnxruntime_URL  "https://hub.nuaa.cf/csukuangfj/onnxruntime-libs/releases/download/v1.14.1/onnxruntime-linux-riscv64-glibc2_17-Release-1.14.1.zip")
+set(onnxruntime_URL2 "https://hub.nuaa.cf/csukuangfj/onnxruntime-libs/releases/download/v1.14.1/onnxruntime-linux-riscv64-glibc2_17-Release-1.14.1.zip")
 set(onnxruntime_HASH "SHA256=c2cbc5af081ff82f46640befd85433811486daaf28e702163c6e4e75020fde81")
 
 # If you don't have access to the Internet,


### PR DESCRIPTION
It uses
- https://github.com/T-head-Semi/csi-nn2
- https://github.com/zhangwm-pt/onnxruntime

You can find the pre-compiled onnxruntime lib at 
https://github.com/csukuangfj/onnxruntime-libs/releases/tag/v1.14.1
![Screenshot 2024-03-06 at 17 33 39](https://github.com/k2-fsa/sherpa-onnx/assets/5284924/2d96c1c5-47b9-4852-bd03-0cfd80fe1c03)


---

We can use `qemu-riscv64` in github actions to decode files with a streaming ASR model and a VITS model to convert text to speech.


# Note

This may be the **first** open-source project that supports RISC-V for speech-to-text and text-to-speech with onnxruntime.

# Usage

Please read the [CI test file](https://github.com/k2-fsa/sherpa-onnx/blob/master/.github/workflows/riscv64-linux.yaml) for usage.

We will add doc for it later.