### PR TITLE
Fix a bug in mean calculation of 'ys_probs'

### DIFF
--- a/sherpa-onnx/csrc/transducer-keyword-decoder.cc
+++ b/sherpa-onnx/csrc/transducer-keyword-decoder.cc
@@ -152,7 +152,7 @@ void TransducerKeywordDecoder::Decode(
       if (matched) {
         float ys_prob = 0.0;
         int32_t length = best_hyp.ys_probs.size();
-        for (int32_t i = 1; i <= matched_state->level; ++i) {
+        for (int32_t i = 0; i < matched_state->level; ++i) {
           ys_prob += best_hyp.ys_probs[i];
         }
         ys_prob /= matched_state->level;


### PR DESCRIPTION
A vector variable `best_hyp.ys_probs` contains the probabilities of each token in a matched keyword whose length is `level`.
The code checks if the mean of `best_hyp.ys_probs` is greater than or equal to a threshold.
### Problem
Currently, when calculating the mean, the index ranges from 1 to `level`.
This excludes the first token (at index 0) and includes an undefined value at the end.
In most cases,  this undefined value is zero so the code seems to work fine.
### Solution
Change the index to range  from 0 to `level`-1.