### PR TITLE
Compiler Error and Minor Bug fix

### DIFF
--- a/sherpa-onnx/csrc/audio-tagging-impl.cc
+++ b/sherpa-onnx/csrc/audio-tagging-impl.cc
@@ -25,7 +25,7 @@ std::unique_ptr<AudioTaggingImpl> AudioTaggingImpl::Create(
     return std::make_unique<AudioTaggingCEDImpl>(config);
   }
 
-  SHERPA_ONNX_LOG(
+  SHERPA_ONNX_LOGE(
       "Please specify an audio tagging model! Return a null pointer");
   return nullptr;
 }
@@ -39,7 +39,7 @@ std::unique_ptr<AudioTaggingImpl> AudioTaggingImpl::Create(
     return std::make_unique<AudioTaggingCEDImpl>(mgr, config);
   }
 
-  SHERPA_ONNX_LOG(
+  SHERPA_ONNX_LOGE(
       "Please specify an audio tagging model! Return a null pointer");
   return nullptr;
 }

--- a/sherpa-onnx/csrc/keyword-spotter-transducer-impl.h
+++ b/sherpa-onnx/csrc/keyword-spotter-transducer-impl.h
@@ -307,7 +307,7 @@ class KeywordSpotterTransducerImpl : public KeywordSpotterImpl {
 
   void InitOnlineStream(OnlineStream *stream) const {
     auto r = decoder_->GetEmptyResult();
-    SHERPA_ONNX_CHECK_EQ(r.hyps.size(), 1);
+    SHERPA_ONNX_CHECK_EQ(r.hyps.Size(), 1);
 
     SHERPA_ONNX_CHECK(stream->GetContextGraph() != nullptr);
     r.hyps.begin()->second.context_state = stream->GetContextGraph()->Root();


### PR DESCRIPTION
Found 2 error

Not sure how these were missed/ why they are occurring now
I am on ubuntu machine with g++10 compiler

2 errors

1. Obvious code bug, as Hypothesis class function is having Size() as method
2. Suspecting that SHERPA_ONNX_LOG() function input format is `SHERPA_ONNX_LOG(Type) << "";`



1. 
```
1. /mnt/efs/manickavela/asr_work/trt/sherpa-onnx/sherpa-onnx/csrc/keyword-spotter-transducer-impl.h:310:33: error: ‘class sherpa_onnx::Hypotheses’ has no member named ‘size’; did you mean ‘Size’?
  310 |     SHERPA_ONNX_CHECK_EQ(r.hyps.size(), 1);
      |                                 ^~~~
/mnt/efs/manickavela/asr_work/trt/sherpa-onnx/sherpa-onnx/csrc/log.h:306:5: note: in definition of macro ‘_SHERPA_ONNX_CHECK_OP’
  306 |   ((x)op(y)) ? (void)0                                                         \
      |     ^
```

3.
```
/mnt/efs/manickavela/asr_work/trt/sherpa-onnx/sherpa-onnx/csrc/audio-tagging-impl.cc: In static member function ‘static std::unique_ptr<sherpa_onnx::AudioTaggingImpl> sherpa_onnx::AudioTaggingImpl::Create(const sherpa_onnx::AudioTaggingConfig&)’:
/mnt/efs/manickavela/asr_work/trt/sherpa-onnx/sherpa-onnx/csrc/log.h:321:24: error: expected primary-expression before ‘(’ token
  321 |   ::sherpa_onnx::Logger(__FILE__, SHERPA_ONNX_FUNC, __LINE__, ::sherpa_onnx::x)
      |                        ^
/mnt/efs/manickavela/asr_work/trt/sherpa-onnx/sherpa-onnx/csrc/audio-tagging-impl.cc:28:3: note: in expansion of macro ‘SHERPA_ONNX_LOG’
   28 |   SHERPA_ONNX_LOG(
      |   ^~~~~~~~~~~~~~~
/mnt/efs/manickavela/asr_work/trt/sherpa-onnx/sherpa-onnx/csrc/audio-tagging-impl.cc:29:7: error: expected unqualified-id before string constant
   29 |       "Please specify an audio tagging model! Return a null pointer");
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/efs/manickavela/asr_work/trt/sherpa-onnx/sherpa-onnx/csrc/log.h:321:78: note: in definition of macro ‘SHERPA_ONNX_LOG’
  321 |   ::sherpa_onnx::Logger(__FILE__, SHERPA_ONNX_FUNC, __LINE__, ::sherpa_onnx::x)
```