### PR TITLE
Fix sherpa-onnx-node-version in node examples

### DIFF
--- a/.github/scripts/node-addon/README.md
+++ b/.github/scripts/node-addon/README.md
@@ -7,5 +7,5 @@ for usages.
 
 ||Method|Support multiple threads|Minimum required node version|
 |---|---|---|---|
-|this package| https://github.com/nodejs/node-addon-api | Yes | v10|
+|this package| https://github.com/nodejs/node-addon-api | Yes | v16|
 |https://www.npmjs.com/package/sherpa-onnx| WebAssembly | No | v18|

--- a/.github/workflows/test-nodejs-addon-npm.yaml
+++ b/.github/workflows/test-nodejs-addon-npm.yaml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-11, macos-14, ubuntu-20.04, ubuntu-22.04, windows-latest]
-        node-version: ["16", "17", "18", "19", "21", "22"]
+        node-version: ["10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "21", "22"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-nodejs-addon-npm.yaml
+++ b/.github/workflows/test-nodejs-addon-npm.yaml
@@ -42,8 +42,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, macos-14, ubuntu-20.04, ubuntu-22.04, windows-latest]
-        node-version: ["10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "21", "22"]
+        os: [macos-latest, macos-14, ubuntu-20.04, ubuntu-22.04, windows-latest]
+        node-version: ["16", "17", "18", "19", "21", "22"]
 
     steps:
       - uses: actions/checkout@v4
@@ -73,6 +73,8 @@ jobs:
 
           export DYLD_LIBRARY_PATH=$PWD/node_modules/sherpa-onnx-darwin-x64:$DYLD_LIBRARY_PATH
           export DYLD_LIBRARY_PATH=$PWD/node_modules/sherpa-onnx-darwin-arm64:$DYLD_LIBRARY_PATH
+          export LD_LIBRARY_PATH=$PWD/node_modules/sherpa-onnx-darwin-x64:$DYLD_LIBRARY_PATH
+          export LD_LIBRARY_PATH=$PWD/node_modules/sherpa-onnx-darwin-arm64:$DYLD_LIBRARY_PATH
           export LD_LIBRARY_PATH=$PWD/node_modules/sherpa-onnx-linux-x64:$LD_LIBRARY_PATH
           export LD_LIBRARY_PATH=$PWD/node_modules/sherpa-onnx-linux-arm64:$LD_LIBRARY_PATH
 

--- a/nodejs-addon-examples/README.md
+++ b/nodejs-addon-examples/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Note: You need `Node >= 10`.
+Note: You need `Node >= 16`.
 
 This repo contains examples for NodeJS.
 It uses [node-addon-api](https://github.com/nodejs/node-addon-api) to wrap

--- a/nodejs-addon-examples/package.json
+++ b/nodejs-addon-examples/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "perf_hooks": "*",
     "sherpa-onnx-node": "*"
   }
 }

--- a/nodejs-addon-examples/package.json
+++ b/nodejs-addon-examples/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "sherpa-onnx-node": "*"
+    "sherpa-onnx-node": "^1.0.24"
   }
 }

--- a/nodejs-addon-examples/test_asr_non_streaming_nemo_ctc.js
+++ b/nodejs-addon-examples/test_asr_non_streaming_nemo_ctc.js
@@ -1,6 +1,5 @@
 // Copyright (c)  2024  Xiaomi Corporation
 const sherpa_onnx = require('sherpa-onnx-node');
-const performance = require('perf_hooks').performance;
 
 // Please download test files from
 // https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models
@@ -27,14 +26,14 @@ const waveFilename =
 
 const recognizer = new sherpa_onnx.OfflineRecognizer(config);
 console.log('Started')
-let start = performance.now();
+let start = Date.now();
 const stream = recognizer.createStream();
 const wave = sherpa_onnx.readWave(waveFilename);
 stream.acceptWaveform({sampleRate: wave.sampleRate, samples: wave.samples});
 
 recognizer.decode(stream);
 result = recognizer.getResult(stream)
-let stop = performance.now();
+let stop = Date.now();
 console.log('Done')
 
 const elapsed_seconds = (stop - start) / 1000;

--- a/nodejs-addon-examples/test_asr_non_streaming_paraformer.js
+++ b/nodejs-addon-examples/test_asr_non_streaming_paraformer.js
@@ -1,7 +1,5 @@
 // Copyright (c)  2024  Xiaomi Corporation
 const sherpa_onnx = require('sherpa-onnx-node');
-const performance = require('perf_hooks').performance;
-
 
 // Please download test files from
 // https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models
@@ -26,14 +24,14 @@ const waveFilename =
 
 const recognizer = new sherpa_onnx.OfflineRecognizer(config);
 console.log('Started')
-let start = performance.now();
+let start = Date.now();
 const stream = recognizer.createStream();
 const wave = sherpa_onnx.readWave(waveFilename);
 stream.acceptWaveform({sampleRate: wave.sampleRate, samples: wave.samples});
 
 recognizer.decode(stream);
 result = recognizer.getResult(stream)
-let stop = performance.now();
+let stop = Date.now();
 console.log('Done')
 
 const elapsed_seconds = (stop - start) / 1000;

--- a/nodejs-addon-examples/test_asr_non_streaming_transducer.js
+++ b/nodejs-addon-examples/test_asr_non_streaming_transducer.js
@@ -1,7 +1,5 @@
 // Copyright (c)  2024  Xiaomi Corporation
 const sherpa_onnx = require('sherpa-onnx-node');
-const performance = require('perf_hooks').performance;
-
 
 // Please download test files from
 // https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models
@@ -30,14 +28,14 @@ const waveFilename = './sherpa-onnx-zipformer-en-2023-04-01/test_wavs/1.wav';
 
 const recognizer = new sherpa_onnx.OfflineRecognizer(config);
 console.log('Started')
-let start = performance.now();
+let start = Date.now();
 const stream = recognizer.createStream();
 const wave = sherpa_onnx.readWave(waveFilename);
 stream.acceptWaveform({sampleRate: wave.sampleRate, samples: wave.samples});
 
 recognizer.decode(stream);
 result = recognizer.getResult(stream)
-let stop = performance.now();
+let stop = Date.now();
 console.log('Done')
 
 const elapsed_seconds = (stop - start) / 1000;

--- a/nodejs-addon-examples/test_asr_non_streaming_whisper.js
+++ b/nodejs-addon-examples/test_asr_non_streaming_whisper.js
@@ -1,7 +1,5 @@
 // Copyright (c)  2024  Xiaomi Corporation
 const sherpa_onnx = require('sherpa-onnx-node');
-const performance = require('perf_hooks').performance;
-
 
 // Please download test files from
 // https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models
@@ -26,14 +24,14 @@ const waveFilename = './sherpa-onnx-whisper-tiny.en/test_wavs/0.wav';
 
 const recognizer = new sherpa_onnx.OfflineRecognizer(config);
 console.log('Started')
-let start = performance.now();
+let start = Date.now();
 const stream = recognizer.createStream();
 const wave = sherpa_onnx.readWave(waveFilename);
 stream.acceptWaveform({sampleRate: wave.sampleRate, samples: wave.samples});
 
 recognizer.decode(stream);
 result = recognizer.getResult(stream)
-let stop = performance.now();
+let stop = Date.now();
 console.log('Done')
 
 const elapsed_seconds = (stop - start) / 1000;

--- a/nodejs-addon-examples/test_asr_streaming_ctc.js
+++ b/nodejs-addon-examples/test_asr_streaming_ctc.js
@@ -1,7 +1,5 @@
 // Copyright (c)  2024  Xiaomi Corporation
 const sherpa_onnx = require('sherpa-onnx-node');
-const performance = require('perf_hooks').performance;
-
 
 // Please download test files from
 // https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models
@@ -28,7 +26,7 @@ const waveFilename =
 
 const recognizer = new sherpa_onnx.OnlineRecognizer(config);
 console.log('Started')
-let start = performance.now();
+let start = Date.now();
 const stream = recognizer.createStream();
 const wave = sherpa_onnx.readWave(waveFilename);
 stream.acceptWaveform({sampleRate: wave.sampleRate, samples: wave.samples});
@@ -40,7 +38,7 @@ while (recognizer.isReady(stream)) {
   recognizer.decode(stream);
 }
 result = recognizer.getResult(stream)
-let stop = performance.now();
+let stop = Date.now();
 console.log('Done')
 
 const elapsed_seconds = (stop - start) / 1000;

--- a/nodejs-addon-examples/test_asr_streaming_ctc_hlg.js
+++ b/nodejs-addon-examples/test_asr_streaming_ctc_hlg.js
@@ -1,7 +1,5 @@
 // Copyright (c)  2024  Xiaomi Corporation
 const sherpa_onnx = require('sherpa-onnx-node');
-const performance = require('perf_hooks').performance;
-
 
 // Please download test files from
 // https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models
@@ -31,7 +29,7 @@ const waveFilename =
 
 const recognizer = new sherpa_onnx.OnlineRecognizer(config);
 console.log('Started')
-let start = performance.now();
+let start = Date.now();
 const stream = recognizer.createStream();
 const wave = sherpa_onnx.readWave(waveFilename);
 stream.acceptWaveform({sampleRate: wave.sampleRate, samples: wave.samples});
@@ -43,7 +41,7 @@ while (recognizer.isReady(stream)) {
   recognizer.decode(stream);
 }
 result = recognizer.getResult(stream)
-let stop = performance.now();
+let stop = Date.now();
 console.log('Done')
 
 const elapsed_seconds = (stop - start) / 1000;

--- a/nodejs-addon-examples/test_asr_streaming_paraformer.js
+++ b/nodejs-addon-examples/test_asr_streaming_paraformer.js
@@ -1,7 +1,5 @@
 // Copyright (c)  2024  Xiaomi Corporation
 const sherpa_onnx = require('sherpa-onnx-node');
-const performance = require('perf_hooks').performance;
-
 
 // Please download test files from
 // https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models
@@ -29,7 +27,7 @@ const waveFilename =
 
 const recognizer = new sherpa_onnx.OnlineRecognizer(config);
 console.log('Started')
-let start = performance.now();
+let start = Date.now();
 const stream = recognizer.createStream();
 const wave = sherpa_onnx.readWave(waveFilename);
 stream.acceptWaveform({sampleRate: wave.sampleRate, samples: wave.samples});
@@ -41,7 +39,7 @@ while (recognizer.isReady(stream)) {
   recognizer.decode(stream);
 }
 result = recognizer.getResult(stream)
-let stop = performance.now();
+let stop = Date.now();
 console.log('Done')
 
 const elapsed_seconds = (stop - start) / 1000;

--- a/nodejs-addon-examples/test_asr_streaming_transducer.js
+++ b/nodejs-addon-examples/test_asr_streaming_transducer.js
@@ -1,7 +1,5 @@
 // Copyright (c)  2024  Xiaomi Corporation
 const sherpa_onnx = require('sherpa-onnx-node');
-const performance = require('perf_hooks').performance;
-
 
 // Please download test files from
 // https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models
@@ -32,7 +30,7 @@ const waveFilename =
 
 const recognizer = new sherpa_onnx.OnlineRecognizer(config);
 console.log('Started')
-let start = performance.now();
+let start = Date.now();
 const stream = recognizer.createStream();
 const wave = sherpa_onnx.readWave(waveFilename);
 stream.acceptWaveform({sampleRate: wave.sampleRate, samples: wave.samples});
@@ -44,7 +42,7 @@ while (recognizer.isReady(stream)) {
   recognizer.decode(stream);
 }
 result = recognizer.getResult(stream)
-let stop = performance.now();
+let stop = Date.now();
 console.log('Done')
 
 const elapsed_seconds = (stop - start) / 1000;

--- a/nodejs-addon-examples/test_audio_tagging_ced.js
+++ b/nodejs-addon-examples/test_audio_tagging_ced.js
@@ -38,12 +38,12 @@ const testWaves = [
 console.log('------');
 
 for (let filename of testWaves) {
-  const start = performance.now();
+  const start = Date.now();
   const stream = at.createStream();
   const wave = sherpa_onnx.readWave(filename);
   stream.acceptWaveform({sampleRate: wave.sampleRate, samples: wave.samples});
   const events = at.compute(stream);
-  const stop = performance.now();
+  const stop = Date.now();
 
   const elapsed_seconds = (stop - start) / 1000;
   const duration = wave.samples.length / wave.sampleRate;

--- a/nodejs-addon-examples/test_audio_tagging_zipformer.js
+++ b/nodejs-addon-examples/test_audio_tagging_zipformer.js
@@ -41,12 +41,12 @@ const testWaves = [
 console.log('------');
 
 for (let filename of testWaves) {
-  const start = performance.now();
+  const start = Date.now();
   const stream = at.createStream();
   const wave = sherpa_onnx.readWave(filename);
   stream.acceptWaveform({sampleRate: wave.sampleRate, samples: wave.samples});
   const events = at.compute(stream);
-  const stop = performance.now();
+  const stop = Date.now();
 
   const elapsed_seconds = (stop - start) / 1000;
   const duration = wave.samples.length / wave.sampleRate;

--- a/nodejs-addon-examples/test_keyword_spotter_transducer.js
+++ b/nodejs-addon-examples/test_keyword_spotter_transducer.js
@@ -1,7 +1,5 @@
 // Copyright (c)  2024  Xiaomi Corporation
 const sherpa_onnx = require('sherpa-onnx-node');
-const performance = require('perf_hooks').performance;
-
 
 // Please download test files from
 // https://github.com/k2-fsa/sherpa-onnx/releases/tag/kws-models
@@ -34,7 +32,7 @@ const waveFilename =
 
 const kws = new sherpa_onnx.KeywordSpotter(config);
 console.log('Started')
-let start = performance.now();
+let start = Date.now();
 const stream = kws.createStream();
 const wave = sherpa_onnx.readWave(waveFilename);
 stream.acceptWaveform({sampleRate: wave.sampleRate, samples: wave.samples});
@@ -50,7 +48,7 @@ while (kws.isReady(stream)) {
   }
   kws.decode(stream);
 }
-let stop = performance.now();
+let stop = Date.now();
 
 console.log('Done')
 

--- a/nodejs-addon-examples/test_tts_non_streaming_vits_coqui_de.js
+++ b/nodejs-addon-examples/test_tts_non_streaming_vits_coqui_de.js
@@ -1,6 +1,5 @@
 // Copyright (c)  2024  Xiaomi Corporation
 const sherpa_onnx = require('sherpa-onnx-node');
-const performance = require('perf_hooks').performance;
 
 // please download model files from
 // https://github.com/k2-fsa/sherpa-onnx/releases/tag/tts-models
@@ -24,9 +23,9 @@ const tts = createOfflineTts();
 
 const text = 'Alles hat ein Ende, nur die Wurst hat zwei.'
 
-let start = performance.now();
+let start = Date.now();
 const audio = tts.generate({text: text, sid: 0, speed: 1.0});
-let stop = performance.now();
+let stop = Date.now();
 const elapsed_seconds = (stop - start) / 1000;
 const duration = audio.samples.length / audio.sampleRate;
 const real_time_factor = elapsed_seconds / duration;

--- a/nodejs-addon-examples/test_tts_non_streaming_vits_piper_en.js
+++ b/nodejs-addon-examples/test_tts_non_streaming_vits_piper_en.js
@@ -1,6 +1,5 @@
 // Copyright (c)  2024  Xiaomi Corporation
 const sherpa_onnx = require('sherpa-onnx-node');
-const performance = require('perf_hooks').performance;
 
 // please download model files from
 // https://github.com/k2-fsa/sherpa-onnx/releases/tag/tts-models
@@ -27,9 +26,9 @@ const text =
     'Today as always, men fall into two groups: slaves and free men. Whoever does not have two-thirds of his day for himself, is a slave, whatever he may be: a statesman, a businessman, an official, or a scholar.'
 
 
-let start = performance.now();
+let start = Date.now();
 const audio = tts.generate({text: text, sid: 0, speed: 1.0});
-let stop = performance.now();
+let stop = Date.now();
 const elapsed_seconds = (stop - start) / 1000;
 const duration = audio.samples.length / audio.sampleRate;
 const real_time_factor = elapsed_seconds / duration;

--- a/nodejs-addon-examples/test_tts_non_streaming_vits_zh_aishell3.js
+++ b/nodejs-addon-examples/test_tts_non_streaming_vits_zh_aishell3.js
@@ -1,6 +1,5 @@
 // Copyright (c)  2024  Xiaomi Corporation
 const sherpa_onnx = require('sherpa-onnx-node');
-const performance = require('perf_hooks').performance;
 
 // please download model files from
 // https://github.com/k2-fsa/sherpa-onnx/releases/tag/tts-models
@@ -29,9 +28,9 @@ const tts = createOfflineTts();
 const text =
     '他在长沙出生，长白山长大，去过长江，现在他是一个银行的行长，主管行政工作。有困难，请拨110，或者13020240513。今天是2024年5月13号, 他上个月的工资是12345块钱。'
 
-let start = performance.now();
+let start = Date.now();
 const audio = tts.generate({text: text, sid: 88, speed: 1.0});
-let stop = performance.now();
+let stop = Date.now();
 const elapsed_seconds = (stop - start) / 1000;
 const duration = audio.samples.length / audio.sampleRate;
 const real_time_factor = elapsed_seconds / duration;

--- a/nodejs-addon-examples/test_tts_non_streaming_vits_zh_ll.js
+++ b/nodejs-addon-examples/test_tts_non_streaming_vits_zh_ll.js
@@ -1,6 +1,5 @@
 // Copyright (c)  2024  Xiaomi Corporation
 const sherpa_onnx = require('sherpa-onnx-node');
-const performance = require('perf_hooks').performance;
 
 // please download model files from
 // https://github.com/k2-fsa/sherpa-onnx/releases/tag/tts-models
@@ -29,9 +28,9 @@ const tts = createOfflineTts();
 const text =
     '当夜幕降临，星光点点，伴随着微风拂面，我在静谧中感受着时光的流转，思念如涟漪荡漾，梦境如画卷展开，我与自然融为一体，沉静在这片宁静的美丽之中，感受着生命的奇迹与温柔。2024年5月13号，拨打110或者18920240513。123456块钱。'
 
-let start = performance.now();
+let start = Date.now();
 const audio = tts.generate({text: text, sid: 2, speed: 1.0});
-let stop = performance.now();
+let stop = Date.now();
 const elapsed_seconds = (stop - start) / 1000;
 const duration = audio.samples.length / audio.sampleRate;
 const real_time_factor = elapsed_seconds / duration;


### PR DESCRIPTION
Also, use `Date.now()` to replace `performance.now()` since `performance` is not available in earlier versions of node.