### PR TITLE
Update offline-ctc-greedy-search-decoder.cc

### DIFF
--- a/sherpa-onnx/csrc/offline-ctc-greedy-search-decoder.cc
+++ b/sherpa-onnx/csrc/offline-ctc-greedy-search-decoder.cc
@@ -42,8 +42,8 @@ std::vector<OfflineCtcDecoderResult> OfflineCtcGreedySearchDecoder::Decode(
       if (y != blank_id_ && y != prev_id) {
         r.tokens.push_back(y);
         r.timestamps.push_back(t);
-        prev_id = y;
       }
+      prev_id = y;
     }  // for (int32_t t = 0; ...)
 
     ans.push_back(std::move(r));


### PR DESCRIPTION
Bug fixes.
Z_O_O will be decoded as ZO instead of ZOO.
To fix this, prev_id should update every time.