### PR TITLE
fix: Typo 'maxNumSenetences' in SherpaOnnx.swift

### DIFF
--- a/swift-api-examples/SherpaOnnx.swift
+++ b/swift-api-examples/SherpaOnnx.swift
@@ -657,12 +657,12 @@ func sherpaOnnxOfflineTtsConfig(
   model: SherpaOnnxOfflineTtsModelConfig,
   ruleFsts: String = "",
   ruleFars: String = "",
-  maxNumSenetences: Int = 2
+  maxNumSentences: Int = 2
 ) -> SherpaOnnxOfflineTtsConfig {
   return SherpaOnnxOfflineTtsConfig(
     model: model,
     rule_fsts: toCPointer(ruleFsts),
-    max_num_sentences: Int32(maxNumSenetences),
+    max_num_sentences: Int32(maxNumSentences),
     rule_fars: toCPointer(ruleFars)
   )
 }


### PR DESCRIPTION
Closes #934 