### PR TITLE
store speed in SharedPreferences

### DIFF
--- a/android/SherpaOnnxTtsEngine/app/src/main/java/com/k2fsa/sherpa/onnx/tts/engine/MainActivity.kt
+++ b/android/SherpaOnnxTtsEngine/app/src/main/java/com/k2fsa/sherpa/onnx/tts/engine/MainActivity.kt
@@ -2,6 +2,7 @@
 
 package com.k2fsa.sherpa.onnx.tts.engine
 
+import PreferenceHelper
 import android.media.MediaPlayer
 import android.net.Uri
 import android.os.Bundle
@@ -47,6 +48,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         TtsEngine.createTts(this)
+        val preferenceHelper = PreferenceHelper(this)
         setContent {
             SherpaOnnxTtsEngineTheme {
                 // A surface container using the 'background' color from the theme
@@ -63,7 +65,10 @@ class MainActivity : ComponentActivity() {
                                     Text("Speed " + String.format("%.1f", TtsEngine.speed))
                                     Slider(
                                         value = TtsEngine.speedState.value,
-                                        onValueChange = { TtsEngine.speed = it },
+                                        onValueChange = { 
+                                            TtsEngine.speed = it 
+                                            preferenceHelper.setSpeed(it)
+                                        },
                                         valueRange = 0.2F..3.0F,
                                         modifier = Modifier.fillMaxWidth()
                                     )

--- a/android/SherpaOnnxTtsEngine/app/src/main/java/com/k2fsa/sherpa/onnx/tts/engine/PreferencesHelper.kt
+++ b/android/SherpaOnnxTtsEngine/app/src/main/java/com/k2fsa/sherpa/onnx/tts/engine/PreferencesHelper.kt
@@ -1,0 +1,21 @@
+import android.content.Context
+import android.content.SharedPreferences
+
+class PreferenceHelper(context: Context) {
+
+    private val PREFS_NAME = "com.k2fsa.sherpa.onnx.tts.engine"
+    private val SPEED_KEY = "speed"
+
+    private val sharedPreferences: SharedPreferences =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun setSpeed(value: Float) {
+        val editor = sharedPreferences.edit()
+        editor.putFloat(SPEED_KEY, value)
+        editor.apply()
+    }
+
+    fun getSpeed(): Float {
+        return sharedPreferences.getFloat(SPEED_KEY, 1.0f)
+    }
+}

--- a/android/SherpaOnnxTtsEngine/app/src/main/java/com/k2fsa/sherpa/onnx/tts/engine/TtsEngine.kt
+++ b/android/SherpaOnnxTtsEngine/app/src/main/java/com/k2fsa/sherpa/onnx/tts/engine/TtsEngine.kt
@@ -11,6 +11,7 @@ import com.k2fsa.sherpa.onnx.getOfflineTtsConfig
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
+import PreferenceHelper
 
 object TtsEngine {
     var tts: OfflineTts? = null
@@ -135,6 +136,8 @@ object TtsEngine {
             ruleFsts = ruleFsts ?: "",
             ruleFars = ruleFars ?: ""
         )
+
+        speed = PreferenceHelper(context).getSpeed()
 
         tts = OfflineTts(assetManager = assets, config = config)
     }


### PR DESCRIPTION
Make `tts-engine` on android remember user-defined speed value by storing it  in SharedPreferences. Should solve #973 