### PR TITLE
Fix the alsa-lib version to v1.2.12

### DIFF
--- a/.github/workflows/build-wheels-aarch64.yaml
+++ b/.github/workflows/build-wheels-aarch64.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_BEFORE_ALL: |
-            git clone --depth 1 https://github.com/alsa-project/alsa-lib
+            git clone --depth 1 --branch v1.2.12 https://github.com/alsa-project/alsa-lib
             cd alsa-lib
             ./gitcompile
             cd ..

--- a/.github/workflows/build-wheels-linux.yaml
+++ b/.github/workflows/build-wheels-linux.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_BEFORE_ALL: |
-            git clone --depth 1 https://github.com/alsa-project/alsa-lib
+            git clone --depth 1 --branch v1.2.12 https://github.com/alsa-project/alsa-lib
             cd alsa-lib
             ./gitcompile
             cd ..

--- a/.github/workflows/linux-jni.yaml
+++ b/.github/workflows/linux-jni.yaml
@@ -60,7 +60,7 @@ jobs:
 
               cd /home/runner/work/sherpa-onnx/sherpa-onnx
 
-              git clone --depth 1 https://github.com/alsa-project/alsa-lib
+              git clone --depth 1 --branch v1.2.12 https://github.com/alsa-project/alsa-lib
               pushd alsa-lib
               ./gitcompile
               popd

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -88,7 +88,7 @@ jobs:
 
               cd /home/runner/work/sherpa-onnx/sherpa-onnx
 
-              git clone --depth 1 https://github.com/alsa-project/alsa-lib
+              git clone --depth 1 --branch v1.2.12 https://github.com/alsa-project/alsa-lib
               pushd alsa-lib
               ./gitcompile
               popd

--- a/build-aarch64-linux-gnu.sh
+++ b/build-aarch64-linux-gnu.sh
@@ -23,7 +23,7 @@ cd $dir
 if [ ! -f alsa-lib/src/.libs/libasound.so ]; then
   echo "Start to cross-compile alsa-lib"
   if [ ! -d alsa-lib ]; then
-    git clone --depth 1 https://github.com/alsa-project/alsa-lib
+    git clone --depth 1 --branch v1.2.12 https://github.com/alsa-project/alsa-lib
   fi
   # If it shows:
   #  ./gitcompile: line 79: libtoolize: command not found

--- a/build-arm-linux-gnueabihf.sh
+++ b/build-arm-linux-gnueabihf.sh
@@ -23,7 +23,7 @@ cd $dir
 if [ ! -f alsa-lib/src/.libs/libasound.so ]; then
   echo "Start to cross-compile alsa-lib"
   if [ ! -d alsa-lib ]; then
-    git clone --depth 1 https://github.com/alsa-project/alsa-lib
+    git clone --depth 1 --branch v1.2.12 https://github.com/alsa-project/alsa-lib
   fi
   pushd alsa-lib
   CC=arm-linux-gnueabihf-gcc ./gitcompile --host=arm-linux-gnueabihf

--- a/build-riscv64-linux-gnu.sh
+++ b/build-riscv64-linux-gnu.sh
@@ -26,7 +26,7 @@ cd $dir
 if [ ! -f alsa-lib/src/.libs/libasound.so ]; then
   echo "Start to cross-compile alsa-lib"
   if [ ! -d alsa-lib ]; then
-    git clone --depth 1 https://github.com/alsa-project/alsa-lib
+    git clone --depth 1 --branch v1.2.12 https://github.com/alsa-project/alsa-lib
   fi
   # If it shows:
   #  ./gitcompile: line 79: libtoolize: command not found


### PR DESCRIPTION
To fix the following error
https://github.com/k2-fsa/sherpa-onnx/actions/runs/9624761090/job/26548907449#step:3:741

```
 /opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: seq/.libs/libseq.a(seqmid.o): in function `update_group_ports':
  /project/alsa-lib/src/seq/seqmid.c:672: undefined reference to `strlcat'
  /opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: /project/alsa-lib/src/seq/seqmid.c:673: undefined reference to `strlcat'
  collect2: error: ld returned 1 exit status
```