### PR TITLE
fix a bug for wenet streaming model.

### DIFF
--- a/scripts/wenet/test-onnx-streaming.py
+++ b/scripts/wenet/test-onnx-streaming.py
@@ -143,7 +143,7 @@ def main():
         (model.chunk_size - 1) * model.subsampling_factor + model.right_context + 1
     )
     chunk_length = int(chunk_length)
-    chunk_shift = int(model.required_cache_size)
+    chunk_shift = int(model.chunk_size * model.subsampling_factor)
     print(chunk_length, chunk_shift)
 
     num_frames = x.shape[0]

--- a/sherpa-onnx/csrc/online-wenet-ctc-model.cc
+++ b/sherpa-onnx/csrc/online-wenet-ctc-model.cc
@@ -97,7 +97,9 @@ class OnlineWenetCtcModel::Impl {
            right_context_ + 1;
   }
 
-  int32_t ChunkShift() const { return required_cache_size_; }
+  int32_t ChunkShift() const {
+    return config_.wenet_ctc.chunk_size * subsampling_factor_;
+  }
 
   OrtAllocator *Allocator() const { return allocator_; }
 


### PR DESCRIPTION
The chunk shift was wrong.
See

https://github.com/wenet-e2e/wenet/blob/main/runtime/core/decoder/asr_model.cc#L15

 and

https://github.com/wenet-e2e/wenet/blob/main/runtime/core/decoder/asr_model.cc#L28