### PR TITLE
Fix possible segfault in C API.

### DIFF
--- a/sherpa-onnx/c-api/c-api.cc
+++ b/sherpa-onnx/c-api/c-api.cc
@@ -222,7 +222,7 @@ const SherpaOnnxOnlineRecognizerResult *GetOnlineStreamResult(
     }
     r->tokens_arr = tokens_temp;
 
-    if (!result.timestamps.empty()) {
+    if (!result.timestamps.empty() && result.timestamps.size() == r->count) {
       r->timestamps = new float[r->count];
       std::copy(result.timestamps.begin(), result.timestamps.end(),
                 r->timestamps);
@@ -490,7 +490,7 @@ const SherpaOnnxOfflineRecognizerResult *GetOfflineStreamResult(
     }
     r->tokens_arr = tokens_temp;
 
-    if (!result.timestamps.empty()) {
+    if (!result.timestamps.empty() && result.timestamps.size() == r->count) {
       r->timestamps = new float[r->count];
       std::copy(result.timestamps.begin(), result.timestamps.end(),
                 r->timestamps);


### PR DESCRIPTION
Due to the following lines
https://github.com/k2-fsa/sherpa-onnx/blob/dfca4500aa713cdc9ba1d83fc16f579584c4e8a5/sherpa-onnx/csrc/offline-recognizer-ctc-impl.h#L41-L43

`tokens.size()` is not necessarily equal to `timestamp.size()`.

It causes the following errors without this PR.

https://github.com/k2-fsa/sherpa-onnx/actions/runs/9665724491/job/26663537339#step:15:391
```
free(): invalid next size (fast)
SIGABRT: abort
PC=0x7f8c488969fc m=0 sigcode=18446744073709551610
signal arrived during cgo execution

goroutine 1 gp=0xc0000061c0 m=0 mp=0x5a5900 [syscall]:
runtime.cgocall(0x4b51d0, 0xc000123d08)
	/opt/hostedtoolcache/go/1.22.4/x64/src/runtime/cgocall.go:157 +0x4b fp=0xc000123ce0 sp=0xc000123ca8 pc=0x4082ab
github.com/k2-fsa/sherpa-onnx-go-linux._Cfunc_DestroyOfflineRecognizer(0x21bea00)
	_cgo_gotypes.go:558 +0x3f fp=0xc000123d08 sp=0xc000123ce0 pc=0x487d5f
github.com/k2-fsa/sherpa-onnx-go-linux.DeleteOfflineRecognizer.func1(0x40ef5b?)
	/home/runner/go/pkg/mod/github.com/k2-fsa/sherpa-onnx-go-linux@v1.10.1/sherpa_onnx.go:438 +0x3e fp=0xc000123d48 sp=0xc000123d08 pc=0x4880fe
github.com/k2-fsa/sherpa-onnx-go-linux.DeleteOfflineRecognizer(0xc000408908)
	/home/runner/go/pkg/mod/github.com/k2-fsa/sherpa-onnx-go-linux@v1.10.1/sherpa_onnx.go:438 +0x18 fp=0xc000123d60 sp=0xc000123d48 pc=0x488098
main.main.deferwrap1()

```