### PR TITLE
replace macos-11 with macos-13 for GitHub actions

### DIFF
--- a/.github/workflows/build-wheels-macos-arm64.yaml
+++ b/.github/workflows/build-wheels-macos-arm64.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11]
+        os: [macos-13]
         python-version: ["cp38", "cp39", "cp310", "cp311", "cp312"]
 
     steps:

--- a/.github/workflows/build-wheels-macos-x64.yaml
+++ b/.github/workflows/build-wheels-macos-x64.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11]
+        os: [macos-13]
         python-version: ["cp37", "cp38", "cp39", "cp310", "cp311", "cp312"]
 
     steps:

--- a/.github/workflows/npm-addon-macos.yaml
+++ b/.github/workflows/npm-addon-macos.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, macos-14]
+        os: [macos-13, macos-14]
         python-version: ["3.8"]
 
     steps:

--- a/.github/workflows/run-python-test-macos.yaml
+++ b/.github/workflows/run-python-test-macos.yaml
@@ -41,9 +41,6 @@ jobs:
         # macos-14 is for arm64
         # macos-14-large is for x64
         include:
-          - os: macos-11
-            python-version: "3.7"
-
           - os: macos-13
             python-version: "3.8"
 

--- a/.github/workflows/test-build-wheel.yaml
+++ b/.github/workflows/test-build-wheel.yaml
@@ -50,9 +50,6 @@ jobs:
           - os: ubuntu-22.04
             python-version: "3.12"
 
-          - os: macos-11
-            python-version: "3.7"
-
           - os: macos-12
             python-version: "3.8"
 

--- a/.github/workflows/test-pip-install.yaml
+++ b/.github/workflows/test-pip-install.yaml
@@ -43,9 +43,6 @@ jobs:
           - os: ubuntu-22.04
             python-version: "3.12"
 
-          - os: macos-11
-            python-version: "3.7"
-
           - os: macos-12
             python-version: "3.8"
 


### PR DESCRIPTION
Tests using `macos-11` wait a long time before they can start, so we replace `macos-11` with `macos-13`.