### PR TITLE
Fix releasing dart packages

### DIFF
--- a/flutter/publish.md
+++ b/flutter/publish.md
@@ -1,0 +1,7 @@
+# Note
+
+Before publishing a new version, please first run
+```
+flutter analyze
+```
+to check if there are any issues.

--- a/flutter/sherpa_onnx/lib/src/utils.dart
+++ b/flutter/sherpa_onnx/lib/src/utils.dart
@@ -1,7 +1,6 @@
 // Copyright (c)  2024  Xiaomi Corporation
 import 'dart:convert';
 import 'dart:ffi';
-import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
 

--- a/flutter/sherpa_onnx/pubspec.yaml
+++ b/flutter/sherpa_onnx/pubspec.yaml
@@ -46,6 +46,9 @@ dependencies:
   # sherpa_onnx_ios:
     # path: ../sherpa_onnx_ios
 
+dev_dependencies:
+  flutter_lints: ^3.0.0
+
 flutter:
   plugin:
     platforms:


### PR DESCRIPTION
To fix the following error while publishing dart packages.
https://github.com/csukuangfj/sherpa-onnx/actions/runs/9910954410/job/27385314444#step:7:70

```
Total compressed archive size: 19 KB.
Validating package...
Package validation found the following potential issue:
* `dart analyze` found the following issue(s):
  Analyzing lib, pubspec.yaml...
  
  warning - lib/src/utils.dart:4:8 - Unused import: 'dart:typed_data'. Try removing the import directive. - unused_import
  
  1 issue found.
The server may enforce additional checks.

Package has 1 warning.
```