### PR TITLE
Fix publishing apks to huggingface

### DIFF
--- a/.github/workflows/apk-asr-2pass.yaml
+++ b/.github/workflows/apk-asr-2pass.yaml
@@ -160,14 +160,19 @@ jobs:
             export GIT_LFS_SKIP_SMUDGE=1
             export GIT_CLONE_PROTECTION_ACTIVE=false
 
+            SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+            echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
+
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-apk huggingface
             cd huggingface
             git fetch
             git pull
             git merge -m "merge remote" --ff origin main
 
-            mkdir -p asr-2pass
-            cp -v ../apks/*.apk ./asr-2pass/
+            d=asr-2pass/$SHERPA_ONNX_VERSION
+            mkdir -p $d
+
+            cp -v ../apks/*.apk $d/
             git status
             git lfs track "*.apk"
             git add .

--- a/.github/workflows/apk-asr-2pass.yaml
+++ b/.github/workflows/apk-asr-2pass.yaml
@@ -2,6 +2,8 @@ name: apk-asr-2pass
 
 on:
   push:
+    branches:
+      - apk
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 

--- a/.github/workflows/apk-asr.yaml
+++ b/.github/workflows/apk-asr.yaml
@@ -2,6 +2,8 @@ name: apk-asr
 
 on:
   push:
+    branches:
+      - apk
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 

--- a/.github/workflows/apk-asr.yaml
+++ b/.github/workflows/apk-asr.yaml
@@ -160,14 +160,18 @@ jobs:
             export GIT_LFS_SKIP_SMUDGE=1
             export GIT_CLONE_PROTECTION_ACTIVE=false
 
+            SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+            echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
+
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-apk huggingface
             cd huggingface
             git fetch
             git pull
             git merge -m "merge remote" --ff origin main
 
-            mkdir -p asr
-            cp -v ../apks/*.apk ./asr/
+            d=asr/$SHERPA_ONNX_VERSION
+            mkdir -p $d
+            cp -v ../apks/*.apk $d/
             git status
             git lfs track "*.apk"
             git add .

--- a/.github/workflows/apk-audio-tagging-wearos.yaml
+++ b/.github/workflows/apk-audio-tagging-wearos.yaml
@@ -160,14 +160,18 @@ jobs:
             export GIT_LFS_SKIP_SMUDGE=1
             export GIT_CLONE_PROTECTION_ACTIVE=false
 
+            SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+            echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
+
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-apk huggingface
             cd huggingface
             git fetch
             git pull
             git merge -m "merge remote" --ff origin main
 
-            mkdir -p audio-tagging-wearos
-            cp -v ../apks/*.apk ./audio-tagging-wearos/
+            d=audio-tagging-wearos/$SHERPA_ONNX_VERSION
+            mkdir -p $d
+            cp -v ../apks/*.apk $d/
             git status
             git lfs track "*.apk"
             git add .

--- a/.github/workflows/apk-audio-tagging-wearos.yaml
+++ b/.github/workflows/apk-audio-tagging-wearos.yaml
@@ -2,6 +2,8 @@ name: apk-audio-tagging-wearos
 
 on:
   push:
+    branches:
+      - apk
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 

--- a/.github/workflows/apk-audio-tagging.yaml
+++ b/.github/workflows/apk-audio-tagging.yaml
@@ -2,6 +2,8 @@ name: apk-audio-tagging
 
 on:
   push:
+    branches:
+      - apk
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 

--- a/.github/workflows/apk-kws.yaml
+++ b/.github/workflows/apk-kws.yaml
@@ -157,14 +157,18 @@ jobs:
             export GIT_LFS_SKIP_SMUDGE=1
             export GIT_CLONE_PROTECTION_ACTIVE=false
 
+            SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+            echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
+
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-apk huggingface
             cd huggingface
             git fetch
             git pull
             git merge -m "merge remote" --ff origin main
 
-            mkdir -p kws
-            cp -v ../apks/*.apk ./kws/
+            d=kws/$SHERPA_ONNX_VERSION
+            mkdir -p $d
+            cp -v ../apks/*.apk $d/
             git status
             git lfs track "*.apk"
             git add .

--- a/.github/workflows/apk-kws.yaml
+++ b/.github/workflows/apk-kws.yaml
@@ -2,6 +2,8 @@ name: apk-kws
 
 on:
   push:
+    branches:
+      - apk
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 

--- a/.github/workflows/apk-speaker-identification.yaml
+++ b/.github/workflows/apk-speaker-identification.yaml
@@ -98,14 +98,18 @@ jobs:
             export GIT_LFS_SKIP_SMUDGE=1
             export GIT_CLONE_PROTECTION_ACTIVE=false
 
+            SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+            echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
+
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-apk huggingface
             cd huggingface
             git fetch
             git pull
             git merge -m "merge remote" --ff origin main
 
-            mkdir -p speaker-identification
-            cp -v ../apks/*.apk ./speaker-identification/
+            d=speaker-identification/$SHERPA_ONNX_VERSION
+            mkdir -p $d/
+            cp -v ../apks/*.apk $d/
             git status
             git lfs track "*.apk"
             git add .

--- a/.github/workflows/apk-speaker-identification.yaml
+++ b/.github/workflows/apk-speaker-identification.yaml
@@ -2,6 +2,8 @@ name: apk-speaker-identification
 
 on:
   push:
+    branches:
+      - apk
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 

--- a/.github/workflows/apk-spoken-language-identification.yaml
+++ b/.github/workflows/apk-spoken-language-identification.yaml
@@ -160,14 +160,18 @@ jobs:
             export GIT_LFS_SKIP_SMUDGE=1
             export GIT_CLONE_PROTECTION_ACTIVE=false
 
+            SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+            echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
+
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-apk huggingface
             cd huggingface
             git fetch
             git pull
             git merge -m "merge remote" --ff origin main
 
-            mkdir -p slid
-            cp -v ../apks/*.apk ./slid/
+            d=slid/$SHERPA_ONNX_VERSION
+            mkdir -p $d/
+            cp -v ../apks/*.apk $d/
             git status
             git lfs track "*.apk"
             git add .

--- a/.github/workflows/apk-spoken-language-identification.yaml
+++ b/.github/workflows/apk-spoken-language-identification.yaml
@@ -2,6 +2,8 @@ name: apk-slid
 
 on:
   push:
+    branches:
+      - apk
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 

--- a/.github/workflows/apk-tts-engine.yaml
+++ b/.github/workflows/apk-tts-engine.yaml
@@ -161,14 +161,18 @@ jobs:
             export GIT_LFS_SKIP_SMUDGE=1
             export GIT_CLONE_PROTECTION_ACTIVE=false
 
+            SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+            echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
+
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-apk huggingface
             cd huggingface
             git fetch
             git pull
             git merge -m "merge remote" --ff origin main
 
-            mkdir -p tts-engine-2
-            cp -v ../apks/*.apk ./tts-engine-2/
+            d=tts-engine-new/$SHERPA_ONNX_VERSION
+            mkdir -p $d
+            cp -v ../apks/*.apk $d/
             git status
             git lfs track "*.apk"
             git add .

--- a/.github/workflows/apk-tts-engine.yaml
+++ b/.github/workflows/apk-tts-engine.yaml
@@ -2,6 +2,8 @@ name: apk-tts-engine
 
 on:
   push:
+    branches:
+      - apk
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 

--- a/.github/workflows/apk-tts.yaml
+++ b/.github/workflows/apk-tts.yaml
@@ -2,6 +2,8 @@ name: apk-tts
 
 on:
   push:
+    branches:
+      - apk
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 

--- a/.github/workflows/apk-tts.yaml
+++ b/.github/workflows/apk-tts.yaml
@@ -161,14 +161,18 @@ jobs:
             export GIT_LFS_SKIP_SMUDGE=1
             export GIT_CLONE_PROTECTION_ACTIVE=false
 
+            SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+            echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
+
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-apk huggingface
             cd huggingface
             git fetch
             git pull
             git merge -m "merge remote" --ff origin main
 
-            mkdir -p tts-2
-            cp -v ../apks/*.apk ./tts-2/
+            d=tts-new/$SHERPA_ONNX_VERSION
+            mkdir -p $d
+            cp -v ../apks/*.apk $d/
             git status
             git lfs track "*.apk"
             git add .

--- a/.github/workflows/apk-vad-asr.yaml
+++ b/.github/workflows/apk-vad-asr.yaml
@@ -160,14 +160,18 @@ jobs:
             export GIT_LFS_SKIP_SMUDGE=1
             export GIT_CLONE_PROTECTION_ACTIVE=false
 
+            SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+            echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
+
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-apk huggingface
             cd huggingface
             git fetch
             git pull
             git merge -m "merge remote" --ff origin main
 
-            mkdir -p vad-asr
-            cp -v ../apks/*.apk ./vad-asr/
+            d=vad-asr/$SHERPA_ONNX_VERSION
+            mkdir -p $d
+            cp -v ../apks/*.apk $d/
             git status
             git lfs track "*.apk"
             git add .

--- a/.github/workflows/apk-vad-asr.yaml
+++ b/.github/workflows/apk-vad-asr.yaml
@@ -2,6 +2,8 @@ name: apk-vad-asr
 
 on:
   push:
+    branches:
+      - apk
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 

--- a/.github/workflows/apk-vad.yaml
+++ b/.github/workflows/apk-vad.yaml
@@ -157,14 +157,18 @@ jobs:
             export GIT_LFS_SKIP_SMUDGE=1
             export GIT_CLONE_PROTECTION_ACTIVE=false
 
+            SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+            echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
+
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-apk huggingface
             cd huggingface
             git fetch
             git pull
             git merge -m "merge remote" --ff origin main
 
-            mkdir -p vad
-            cp -v ../apks/*.apk ./vad/
+            d=vad/SHERPA_ONNX_VERSION
+            mkdir -p $d
+            cp -v ../apks/*.apk $d/
             git status
             git lfs track "*.apk"
             git add .

--- a/.github/workflows/apk-vad.yaml
+++ b/.github/workflows/apk-vad.yaml
@@ -2,6 +2,8 @@ name: apk-vad
 
 on:
   push:
+    branches:
+      - apk
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 

--- a/go-api-examples/vad-asr-paraformer/main.go
+++ b/go-api-examples/vad-asr-paraformer/main.go
@@ -15,7 +15,7 @@ func main() {
 	config := sherpa.VadModelConfig{}
 
 	// Please download silero_vad.onnx from
-	// https://github.com/snakers4/silero-vad/blob/master/files/silero_vad.onnx
+	// https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 
 	config.SileroVad.Model = "./silero_vad.onnx"
 	config.SileroVad.Threshold = 0.5

--- a/go-api-examples/vad-asr-paraformer/run.sh
+++ b/go-api-examples/vad-asr-paraformer/run.sh
@@ -3,7 +3,7 @@
 set -ex
 
 if [ ! -f ./silero_vad.onnx ]; then
-  curl -SL -O https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx
+  curl -SL -O https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 fi
 
 if [ ! -f ./sherpa-onnx-paraformer-trilingual-zh-cantonese-en/model.int8.onnx ]; then

--- a/go-api-examples/vad-asr-whisper/main.go
+++ b/go-api-examples/vad-asr-whisper/main.go
@@ -15,7 +15,7 @@ func main() {
 	config := sherpa.VadModelConfig{}
 
 	// Please download silero_vad.onnx from
-	// https://github.com/snakers4/silero-vad/blob/master/files/silero_vad.onnx
+	// https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 
 	config.SileroVad.Model = "./silero_vad.onnx"
 	config.SileroVad.Threshold = 0.5

--- a/go-api-examples/vad-asr-whisper/run.sh
+++ b/go-api-examples/vad-asr-whisper/run.sh
@@ -3,7 +3,7 @@
 set -ex
 
 if [ ! -f ./silero_vad.onnx ]; then
-  curl -SL -O https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx
+  curl -SL -O https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 fi
 
 if [ ! -f ./sherpa-onnx-whisper-tiny.en/tiny.en-encoder.int8.onnx ]; then

--- a/go-api-examples/vad-speaker-identification/main.go
+++ b/go-api-examples/vad-speaker-identification/main.go
@@ -89,7 +89,7 @@ func createVad() *sherpa.VoiceActivityDetector {
 	config := sherpa.VadModelConfig{}
 
 	// Please download silero_vad.onnx from
-	// https://github.com/snakers4/silero-vad/blob/master/files/silero_vad.onnx
+	// https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 
 	config.SileroVad.Model = "./silero_vad.onnx"
 	config.SileroVad.Threshold = 0.5

--- a/go-api-examples/vad-speaker-identification/run.sh
+++ b/go-api-examples/vad-speaker-identification/run.sh
@@ -11,7 +11,7 @@ if [ ! -f ./sr-data/enroll/fangjun-sr-1.wav ]; then
 fi
 
 if [ ! -f ./silero_vad.onnx ]; then
-  curl -SL -O https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx
+  curl -SL -O https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 fi
 
 go mod tidy

--- a/go-api-examples/vad-spoken-language-identification/main.go
+++ b/go-api-examples/vad-spoken-language-identification/main.go
@@ -15,7 +15,7 @@ func main() {
 	config := sherpa.VadModelConfig{}
 
 	// Please download silero_vad.onnx from
-	// https://github.com/snakers4/silero-vad/blob/master/files/silero_vad.onnx
+	// https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 
 	config.SileroVad.Model = "./silero_vad.onnx"
 	config.SileroVad.Threshold = 0.5

--- a/go-api-examples/vad-spoken-language-identification/run.sh
+++ b/go-api-examples/vad-spoken-language-identification/run.sh
@@ -3,7 +3,7 @@
 set -ex
 
 if [ ! -f ./silero_vad.onnx ]; then
-  curl -SL -O https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx
+  curl -SL -O https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 fi
 
 if [ ! -f ./sherpa-onnx-whisper-tiny/tiny-encoder.int8.onnx ]; then

--- a/go-api-examples/vad/main.go
+++ b/go-api-examples/vad/main.go
@@ -13,7 +13,7 @@ func main() {
 	config := sherpa.VadModelConfig{}
 
 	// Please download silero_vad.onnx from
-	// https://github.com/snakers4/silero-vad/blob/master/files/silero_vad.onnx
+	// https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 
 	config.SileroVad.Model = "./silero_vad.onnx"
 	config.SileroVad.Threshold = 0.5

--- a/go-api-examples/vad/run.sh
+++ b/go-api-examples/vad/run.sh
@@ -3,7 +3,7 @@
 set -ex
 
 if [ ! -f ./silero_vad.onnx ]; then
-  curl -SL -O https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx
+  curl -SL -O https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 fi
 
 go mod tidy

--- a/python-api-examples/generate-subtitles.py
+++ b/python-api-examples/generate-subtitles.py
@@ -12,12 +12,12 @@ Supported file formats are those supported by ffmpeg; for instance,
 Note that you need a non-streaming model for this script.
 
 Please visit
-https://github.com/snakers4/silero-vad/blob/master/files/silero_vad.onnx
+https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 to download silero_vad.onnx
 
 For instance,
 
-wget https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx
+wget https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 
 (1) For paraformer
 
@@ -386,7 +386,7 @@ def main():
 
     print("Started!")
 
-    is_silence=False
+    is_silence = False
     # TODO(fangjun): Support multithreads
     while True:
         # *2 because int16_t has two bytes
@@ -394,9 +394,9 @@ def main():
         if not data:
             if is_silence:
                 break
-            is_silence=True
+            is_silence = True
             # The converted audio file does not have a mute data of 1 second or more at the end, which will result in the loss of the last segment data
-            data = np.zeros(1*args.sample_rate,dtype=np.int16)
+            data = np.zeros(1 * args.sample_rate, dtype=np.int16)
 
         samples = np.frombuffer(data, dtype=np.int16)
         samples = samples.astype(np.float32) / 32768

--- a/python-api-examples/speaker-identification-with-vad-dynamic.py
+++ b/python-api-examples/speaker-identification-with-vad-dynamic.py
@@ -18,12 +18,12 @@ Note that `zh` means Chinese, while `en` means English.
 
 (2) Download the VAD model
 Please visit
-https://github.com/snakers4/silero-vad/blob/master/files/silero_vad.onnx
+https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 to download silero_vad.onnx
 
 For instance,
 
-wget https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx
+wget https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 
 (3) Run this script
 

--- a/python-api-examples/speaker-identification-with-vad-non-streaming-asr.py
+++ b/python-api-examples/speaker-identification-with-vad-non-streaming-asr.py
@@ -38,12 +38,12 @@ Note that `zh` means Chinese, while `en` means English.
 
 (3) Download the VAD model
 Please visit
-https://github.com/snakers4/silero-vad/blob/master/files/silero_vad.onnx
+https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 to download silero_vad.onnx
 
 For instance,
 
-wget https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx
+wget https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 
 (4) Please refer to ./generate-subtitles.py
 to download a non-streaming ASR model.

--- a/python-api-examples/speaker-identification-with-vad.py
+++ b/python-api-examples/speaker-identification-with-vad.py
@@ -36,12 +36,12 @@ Note that `zh` means Chinese, while `en` means English.
 
 (3) Download the VAD model
 Please visit
-https://github.com/snakers4/silero-vad/blob/master/files/silero_vad.onnx
+https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 to download silero_vad.onnx
 
 For instance,
 
-wget https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx
+wget https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 
 (4) Run this script
 

--- a/python-api-examples/vad-alsa.py
+++ b/python-api-examples/vad-alsa.py
@@ -55,7 +55,7 @@ def main():
     if not Path(args.silero_vad_model).is_file():
         raise RuntimeError(
             f"{args.silero_vad_model} does not exist. Please download it from "
-            "https://github.com/snakers4/silero-vad/blob/master/files/silero_vad.onnx"
+            "https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx"
         )
 
     device_name = args.device_name

--- a/python-api-examples/vad-microphone.py
+++ b/python-api-examples/vad-microphone.py
@@ -38,7 +38,7 @@ def main():
     if not Path(args.silero_vad_model).is_file():
         raise RuntimeError(
             f"{args.silero_vad_model} does not exist. Please download it from "
-            "https://github.com/snakers4/silero-vad/blob/master/files/silero_vad.onnx"
+            "https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx"
         )
 
     mic_sample_rate = 16000

--- a/python-api-examples/vad-remove-non-speech-segments-alsa.py
+++ b/python-api-examples/vad-remove-non-speech-segments-alsa.py
@@ -14,12 +14,12 @@ python3 ./vad-remove-non-speech-segments-alsa.py \
         --silero-vad-model silero_vad.onnx
 
 Please visit
-https://github.com/snakers4/silero-vad/blob/master/files/silero_vad.onnx
+https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 to download silero_vad.onnx
 
 For instance,
 
-wget https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx
+wget https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 """
 
 import argparse

--- a/python-api-examples/vad-remove-non-speech-segments-from-file.py
+++ b/python-api-examples/vad-remove-non-speech-segments-from-file.py
@@ -13,12 +13,12 @@ python3 ./vad-remove-non-speech-segments-from-file.py \
         output.wav
 
 Please visit
-https://github.com/snakers4/silero-vad/blob/master/files/silero_vad.onnx
+https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 to download silero_vad.onnx
 
 For instance,
 
-wget https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx
+wget https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 """
 
 import argparse

--- a/python-api-examples/vad-remove-non-speech-segments.py
+++ b/python-api-examples/vad-remove-non-speech-segments.py
@@ -11,12 +11,12 @@ python3 ./vad-remove-non-speech-segments.py \
         --silero-vad-model silero_vad.onnx
 
 Please visit
-https://github.com/snakers4/silero-vad/blob/master/files/silero_vad.onnx
+https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 to download silero_vad.onnx
 
 For instance,
 
-wget https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx
+wget https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 """
 
 import argparse

--- a/python-api-examples/vad-with-non-streaming-asr.py
+++ b/python-api-examples/vad-with-non-streaming-asr.py
@@ -51,12 +51,12 @@ to install sherpa-onnx and to download non-streaming pre-trained models
 used in this file.
 
 Please visit
-https://github.com/snakers4/silero-vad/blob/master/files/silero_vad.onnx
+https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 to download silero_vad.onnx
 
 For instance,
 
-wget https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx
+wget https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 """
 import argparse
 import sys

--- a/scripts/apk/build-apk-vad.sh
+++ b/scripts/apk/build-apk-vad.sh
@@ -32,11 +32,11 @@ log "====================x86===================="
 
 mkdir -p apks
 
-log "https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx"
+log "https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx"
 
 # Download the model
 pushd ./android/SherpaOnnxVad/app/src/main/assets/
-wget -c https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx
+wget -c https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 popd
 
 for arch in arm64-v8a armeabi-v7a x86_64 x86; do

--- a/sherpa-onnx/csrc/sherpa-onnx-vad-alsa.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-vad-alsa.cc
@@ -30,10 +30,10 @@ This program shows how to use VAD in sherpa-onnx.
     device_name
 
 Please download silero_vad.onnx from
-https://github.com/snakers4/silero-vad/blob/master/files/silero_vad.onnx
+https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 
 For instance, use
-wget https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx
+wget https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 
 The device name specifies which microphone to use in case there are several
 on your system. You can use

--- a/sherpa-onnx/csrc/sherpa-onnx-vad-microphone-offline-asr.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-vad-microphone-offline-asr.cc
@@ -45,10 +45,10 @@ This program shows how to use a streaming VAD with non-streaming ASR in
 sherpa-onnx.
 
 Please download silero_vad.onnx from
-https://github.com/snakers4/silero-vad/blob/master/files/silero_vad.onnx
+https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 
 For instance, use
-wget https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx
+wget https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 
 Please refer to ./sherpa-onnx-microphone-offline.cc
 to download models for offline ASR.

--- a/sherpa-onnx/csrc/sherpa-onnx-vad-microphone.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-vad-microphone.cc
@@ -49,10 +49,10 @@ This program shows how to use VAD in sherpa-onnx.
     --vad-num-threads=1
 
 Please download silero_vad.onnx from
-https://github.com/snakers4/silero-vad/blob/master/files/silero_vad.onnx
+https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 
 For instance, use
-wget https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx
+wget https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 )usage";
 
   sherpa_onnx::ParseOptions po(kUsageMessage);

--- a/sherpa-onnx/kotlin-api/Vad.kt
+++ b/sherpa-onnx/kotlin-api/Vad.kt
@@ -82,7 +82,7 @@ class Vad(
 }
 
 // Please visit
-// https://github.com/snakers4/silero-vad/blob/master/files/silero_vad.onnx
+// https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 // to download silero_vad.onnx
 // and put it inside the assets/
 // directory


### PR DESCRIPTION
Save APKs for each release in a separate directory.

Huggingface requires that each directory cannot contain more than 1000 files.

Since we have so many tts models and for each model we need to build APKs of 4 different ABIs, 
it is a workaround for the huggingface's constraints by putting them into separate directories for different releases.