### PR TITLE
publish all pre-built wheels to huggingface

### DIFF
--- a/.github/workflows/build-wheels-aarch64.yaml
+++ b/.github/workflows/build-wheels-aarch64.yaml
@@ -99,7 +99,7 @@ jobs:
             SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
             echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
 
-            d=$SHERPA_ONNX_VERSION
+            d=cpu/$SHERPA_ONNX_VERSION
 
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-wheels huggingface
             cd huggingface

--- a/.github/workflows/build-wheels-aarch64.yaml
+++ b/.github/workflows/build-wheels-aarch64.yaml
@@ -81,7 +81,6 @@ jobs:
           mv ./wheels ./wheelhouse
 
       - name: Publish to huggingface
-        if: (matrix.python-version == 'cp38' || matrix.python-version == 'cp39' ) && matrix.manylinux == 'manylinux2014'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         uses: nick-fields/retry@v3
@@ -97,13 +96,20 @@ jobs:
             export GIT_LFS_SKIP_SMUDGE=1
             export GIT_CLONE_PROTECTION_ACTIVE=false
 
+            SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+            echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
+
+            d=$SHERPA_ONNX_VERSION
+
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-wheels huggingface
             cd huggingface
             git fetch
             git pull
             git merge -m "merge remote" --ff origin main
 
-            cp -v ../wheelhouse/*.whl .
+            mkdir -p $d
+
+            cp -v ../wheelhouse/*.whl $d/
 
             git status
             git add .

--- a/.github/workflows/build-wheels-armv7l.yaml
+++ b/.github/workflows/build-wheels-armv7l.yaml
@@ -84,7 +84,6 @@ jobs:
           ls -lh ./wheelhouse/
 
       - name: Publish to huggingface
-        if: matrix.python-version == '3.8'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         uses: nick-fields/retry@v3
@@ -100,13 +99,20 @@ jobs:
             export GIT_LFS_SKIP_SMUDGE=1
             export GIT_CLONE_PROTECTION_ACTIVE=false
 
+            SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+            echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
+
+            d=$SHERPA_ONNX_VERSION
+
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-wheels huggingface
             cd huggingface
             git fetch
             git pull
             git merge -m "merge remote" --ff origin main
 
-            cp -v ../wheelhouse/*.whl .
+            mkdir -p $d
+
+            cp -v ../wheelhouse/*.whl $d/
 
             git status
             git add .

--- a/.github/workflows/build-wheels-armv7l.yaml
+++ b/.github/workflows/build-wheels-armv7l.yaml
@@ -102,7 +102,7 @@ jobs:
             SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
             echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
 
-            d=$SHERPA_ONNX_VERSION
+            d=cpu/$SHERPA_ONNX_VERSION
 
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-wheels huggingface
             cd huggingface

--- a/.github/workflows/build-wheels-linux.yaml
+++ b/.github/workflows/build-wheels-linux.yaml
@@ -80,7 +80,6 @@ jobs:
           path: ./wheelhouse/*.whl
 
       - name: Publish to huggingface
-        if: matrix.python-version == 'cp38'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         uses: nick-fields/retry@v3
@@ -96,13 +95,20 @@ jobs:
             export GIT_LFS_SKIP_SMUDGE=1
             export GIT_CLONE_PROTECTION_ACTIVE=false
 
+            SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+            echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
+
+            d=$SHERPA_ONNX_VERSION
+
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-wheels huggingface
             cd huggingface
             git fetch
             git pull
             git merge -m "merge remote" --ff origin main
 
-            cp -v ../wheelhouse/*.whl .
+            mkdir -p $d
+
+            cp -v ../wheelhouse/*.whl $d/
 
             git status
             git add .

--- a/.github/workflows/build-wheels-linux.yaml
+++ b/.github/workflows/build-wheels-linux.yaml
@@ -98,7 +98,7 @@ jobs:
             SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
             echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
 
-            d=$SHERPA_ONNX_VERSION
+            d=cpu/$SHERPA_ONNX_VERSION
 
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-wheels huggingface
             cd huggingface

--- a/.github/workflows/build-wheels-macos-arm64.yaml
+++ b/.github/workflows/build-wheels-macos-arm64.yaml
@@ -68,7 +68,7 @@ jobs:
             SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
             echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
 
-            d=$SHERPA_ONNX_VERSION
+            d=cpu/$SHERPA_ONNX_VERSION
 
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-wheels huggingface
             cd huggingface

--- a/.github/workflows/build-wheels-macos-arm64.yaml
+++ b/.github/workflows/build-wheels-macos-arm64.yaml
@@ -50,7 +50,6 @@ jobs:
           path: ./wheelhouse/*.whl
 
       - name: Publish to huggingface
-        if: matrix.python-version == 'cp39'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         uses: nick-fields/retry@v3
@@ -66,13 +65,20 @@ jobs:
             export GIT_LFS_SKIP_SMUDGE=1
             export GIT_CLONE_PROTECTION_ACTIVE=false
 
+            SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+            echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
+
+            d=$SHERPA_ONNX_VERSION
+
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-wheels huggingface
             cd huggingface
             git fetch
             git pull
             git merge -m "merge remote" --ff origin main
 
-            cp -v ../wheelhouse/*.whl .
+            mkdir -p $d
+
+            cp -v ../wheelhouse/*.whl $d/
 
             git status
             git add .

--- a/.github/workflows/build-wheels-macos-universal2.yaml
+++ b/.github/workflows/build-wheels-macos-universal2.yaml
@@ -68,7 +68,7 @@ jobs:
             SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
             echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
 
-            d=$SHERPA_ONNX_VERSION
+            d=cpu/$SHERPA_ONNX_VERSION
 
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-wheels huggingface
             cd huggingface

--- a/.github/workflows/build-wheels-macos-universal2.yaml
+++ b/.github/workflows/build-wheels-macos-universal2.yaml
@@ -50,7 +50,6 @@ jobs:
           path: ./wheelhouse/*.whl
 
       - name: Publish to huggingface
-        if: matrix.python-version == 'cp39'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         uses: nick-fields/retry@v3
@@ -66,13 +65,20 @@ jobs:
             export GIT_LFS_SKIP_SMUDGE=1
             export GIT_CLONE_PROTECTION_ACTIVE=false
 
+            SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+            echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
+
+            d=$SHERPA_ONNX_VERSION
+
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-wheels huggingface
             cd huggingface
             git fetch
             git pull
             git merge -m "merge remote" --ff origin main
 
-            cp -v ../wheelhouse/*.whl .
+            mkdir -p $d
+
+            cp -v ../wheelhouse/*.whl $d/
 
             git status
             git add .

--- a/.github/workflows/build-wheels-macos-x64.yaml
+++ b/.github/workflows/build-wheels-macos-x64.yaml
@@ -65,7 +65,6 @@ jobs:
           path: ./wheelhouse/*.whl
 
       - name: Publish to huggingface
-        if: matrix.python-version == 'cp39'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         uses: nick-fields/retry@v3
@@ -81,13 +80,20 @@ jobs:
             export GIT_LFS_SKIP_SMUDGE=1
             export GIT_CLONE_PROTECTION_ACTIVE=false
 
+            SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+            echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
+
+            d=$SHERPA_ONNX_VERSION
+
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-wheels huggingface
             cd huggingface
             git fetch
             git pull
             git merge -m "merge remote" --ff origin main
 
-            cp -v ../wheelhouse/*.whl .
+            mkdir -p $d
+
+            cp -v ../wheelhouse/*.whl $d/
 
             git status
             git add .

--- a/.github/workflows/build-wheels-macos-x64.yaml
+++ b/.github/workflows/build-wheels-macos-x64.yaml
@@ -83,7 +83,7 @@ jobs:
             SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
             echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
 
-            d=$SHERPA_ONNX_VERSION
+            d=cpu/$SHERPA_ONNX_VERSION
 
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-wheels huggingface
             cd huggingface

--- a/.github/workflows/build-wheels-win32.yaml
+++ b/.github/workflows/build-wheels-win32.yaml
@@ -67,7 +67,7 @@ jobs:
             SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
             echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
 
-            d=$SHERPA_ONNX_VERSION
+            d=cpu/$SHERPA_ONNX_VERSION
 
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-wheels huggingface
             cd huggingface

--- a/.github/workflows/build-wheels-win32.yaml
+++ b/.github/workflows/build-wheels-win32.yaml
@@ -49,7 +49,6 @@ jobs:
           path: ./wheelhouse/*.whl
 
       - name: Publish to huggingface
-        if: matrix.python-version == 'cp38'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         uses: nick-fields/retry@v3
@@ -65,13 +64,20 @@ jobs:
             export GIT_LFS_SKIP_SMUDGE=1
             export GIT_CLONE_PROTECTION_ACTIVE=false
 
+            SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+            echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
+
+            d=$SHERPA_ONNX_VERSION
+
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-wheels huggingface
             cd huggingface
             git fetch
             git pull
             git merge -m "merge remote" --ff origin main
 
-            cp -v ../wheelhouse/*.whl .
+            mkdir -p $d
+
+            cp -v ../wheelhouse/*.whl $d/
 
             git status
             git add .

--- a/.github/workflows/build-wheels-win64.yaml
+++ b/.github/workflows/build-wheels-win64.yaml
@@ -73,7 +73,7 @@ jobs:
             SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
             echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
 
-            d=$SHERPA_ONNX_VERSION
+            d=cpu/$SHERPA_ONNX_VERSION
 
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-wheels huggingface
             cd huggingface

--- a/.github/workflows/build-wheels-win64.yaml
+++ b/.github/workflows/build-wheels-win64.yaml
@@ -70,13 +70,20 @@ jobs:
             export GIT_LFS_SKIP_SMUDGE=1
             export GIT_CLONE_PROTECTION_ACTIVE=false
 
+            SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+            echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
+
+            d=$SHERPA_ONNX_VERSION
+
             git clone https://huggingface.co/csukuangfj/sherpa-onnx-wheels huggingface
             cd huggingface
             git fetch
             git pull
             git merge -m "merge remote" --ff origin main
 
-            cp -v ../wheelhouse/*.whl .
+            mkdir -p $d
+
+            cp -v ../wheelhouse/*.whl $d/
 
             git status
             git add .


### PR DESCRIPTION
pypi.org provides only 10GB of free space for open-source projects.

Each new release of sherpa-onnx occupies about 800MB, so we have to delete previous releases otherwise pypi.org refuses to accept new releases due to limited spaces.

To let users install previous versions, we also publish wheels to huggingface and users can find them at

https://k2-fsa.github.io/sherpa/onnx/cpu.html
and
https://k2-fsa.github.io/sherpa/onnx/cpu-cn.html (for users without access to huggingface.co)