### PR TITLE
Provide pre-built wheels with CUDA support.

### DIFF
--- a/.github/workflows/build-wheels-linux-cuda.yaml
+++ b/.github/workflows/build-wheels-linux-cuda.yaml
@@ -23,60 +23,59 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        python-version: ["cp37", "cp38", "cp39", "cp310", "cp311", "cp312"]
-        manylinux: [manylinux2014] #, manylinux_2_28]
+        os: [ubuntu-20.04]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
 
-      # see https://cibuildwheel.readthedocs.io/en/stable/changelog/
-      # for a list of versions
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
-        env:
-          CIBW_BEFORE_ALL: |
-            git clone --depth 1 --branch v1.2.12 https://github.com/alsa-project/alsa-lib
-            cd alsa-lib
-            ./gitcompile
-            cd ..
-            echo "PWD"
-            ls -lh /project/alsa-lib/src/.libs
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-          CIBW_ENVIRONMENT: CPLUS_INCLUDE_PATH=/project/alsa-lib/include:$CPLUS_INCLUDE_PATH SHERPA_ONNX_ALSA_LIB_DIR=/project/alsa-lib/src/.libs LD_LIBRARY_PATH=/project/build/bdist.linux-x86_64/wheel/sherpa_onnx/lib:$SHERPA_ONNX_ALSA_LIB_DIR SHERPA_ONNX_MAKE_ARGS="VERBOSE=1" SHERPA_ONNX_ENABLE_ALSA=1 SHERPA_ONNX_CMAKE_ARGS="-DSHERPA_ONNX_ENABLE_GPU=ON"
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          pip install -U pip wheel setuptools twine
 
-          CIBW_BUILD: "${{ matrix.python-version}}-* "
-          CIBW_SKIP: "cp27-* cp35-* cp36-* *-win32 pp* *-musllinux* *-manylinux_i686"
-          CIBW_BUILD_VERBOSITY: 3
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/${{ matrix.manylinux }}_x86_64
+      - name: Build alsa-lib
+        shell: bash
+        run: |
+          git clone --depth 1 --branch v1.2.12 https://github.com/alsa-project/alsa-lib
+          cd alsa-lib
+          ./gitcompile
+
+      - name: Build sherpa-onnx
+        shell: bash
+        run: |
+          export CPLUS_INCLUDE_PATH=$PWD/alsa-lib/include:$CPLUS_INCLUDE_PATH
+          export SHERPA_ONNX_ALSA_LIB_DIR=$PWD/alsa-lib/src/.libs
+          export LD_LIBRARY_PATH=$SHERPA_ONNX_ALSA_LIB_DIR:$LD_LIBRARY_PATH
+
+          echo "CPLUS_INCLUDE_PATH: $CPLUS_INCLUDE_PATH"
+          ls -lh $PWD/alsa-lib/include
+          echo "---"
+          ls -lh $PWD/alsa-lib/src/.libs
+
+          export SHERPA_ONNX_MAKE_ARGS="VERBOSE=1"
+          export SHERPA_ONNX_ENABLE_ALSA=1
+          export SHERPA_ONNX_CMAKE_ARGS="-DSHERPA_ONNX_ENABLE_GPU=ON"
+
+          python3 setup.py bdist_wheel
+
+          ls -lh dist
+
+          mv dist wheelhouse
 
       - name: Display wheels
         shell: bash
         run: |
           ls -lh ./wheelhouse/
 
-      - name: Install patchelf
-        if: matrix.os == 'ubuntu-latest'
-        shell: bash
-        run: |
-          sudo apt-get update -q
-          sudo apt-get install -q -y patchelf
-          patchelf --help
-
-      - name: Patch wheels
-        shell: bash
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          mkdir ./wheels
-          sudo ./scripts/wheel/patch_wheel.py --in-dir ./wheelhouse --out-dir ./wheels
-
-          ls -lh ./wheels/
-          rm -rf ./wheelhouse
-          mv ./wheels ./wheelhouse
-
       - uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.python-version }}-${{ matrix.manylinux }}
+          name: wheel-cuda-${{ matrix.python-version }}
           path: ./wheelhouse/*.whl
 
       - name: Publish to huggingface

--- a/.github/workflows/build-wheels-linux-cuda.yaml
+++ b/.github/workflows/build-wheels-linux-cuda.yaml
@@ -1,0 +1,116 @@
+name: build-wheels-linux-cuda
+
+on:
+  push:
+    branches:
+      - wheel
+      - wheel-cuda
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
+
+env:
+  SHERPA_ONNX_IS_IN_GITHUB_ACTIONS: 1
+
+concurrency:
+  group: build-wheels-linux-cuda-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_wheels_linux_cuda:
+    name: ${{ matrix.manylinux }} ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["cp37", "cp38", "cp39", "cp310", "cp311", "cp312"]
+        manylinux: [manylinux2014] #, manylinux_2_28]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # see https://cibuildwheel.readthedocs.io/en/stable/changelog/
+      # for a list of versions
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.16.5
+        env:
+          CIBW_BEFORE_ALL: |
+            git clone --depth 1 --branch v1.2.12 https://github.com/alsa-project/alsa-lib
+            cd alsa-lib
+            ./gitcompile
+            cd ..
+            echo "PWD"
+            ls -lh /project/alsa-lib/src/.libs
+
+          CIBW_ENVIRONMENT: CPLUS_INCLUDE_PATH=/project/alsa-lib/include:$CPLUS_INCLUDE_PATH SHERPA_ONNX_ALSA_LIB_DIR=/project/alsa-lib/src/.libs LD_LIBRARY_PATH=/project/build/bdist.linux-x86_64/wheel/sherpa_onnx/lib:$SHERPA_ONNX_ALSA_LIB_DIR SHERPA_ONNX_MAKE_ARGS="VERBOSE=1" SHERPA_ONNX_ENABLE_ALSA=1 SHERPA_ONNX_CMAKE_ARGS="-DSHERPA_ONNX_ENABLE_GPU=ON"
+
+          CIBW_BUILD: "${{ matrix.python-version}}-* "
+          CIBW_SKIP: "cp27-* cp35-* cp36-* *-win32 pp* *-musllinux* *-manylinux_i686"
+          CIBW_BUILD_VERBOSITY: 3
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/${{ matrix.manylinux }}_x86_64
+
+      - name: Display wheels
+        shell: bash
+        run: |
+          ls -lh ./wheelhouse/
+
+      - name: Install patchelf
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -q -y patchelf
+          patchelf --help
+
+      - name: Patch wheels
+        shell: bash
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          mkdir ./wheels
+          sudo ./scripts/wheel/patch_wheel.py --in-dir ./wheelhouse --out-dir ./wheels
+
+          ls -lh ./wheels/
+          rm -rf ./wheelhouse
+          mv ./wheels ./wheelhouse
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-${{ matrix.python-version }}-${{ matrix.manylinux }}
+          path: ./wheelhouse/*.whl
+
+      - name: Publish to huggingface
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 20
+          timeout_seconds: 200
+          shell: bash
+          command: |
+            git config --global user.email "csukuangfj@gmail.com"
+            git config --global user.name "Fangjun Kuang"
+
+            rm -rf huggingface
+            export GIT_LFS_SKIP_SMUDGE=1
+            export GIT_CLONE_PROTECTION_ACTIVE=false
+
+            SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+            echo "SHERPA_ONNX_VERSION $SHERPA_ONNX_VERSION"
+
+            d=cuda/$SHERPA_ONNX_VERSION
+
+            git clone https://huggingface.co/csukuangfj/sherpa-onnx-wheels huggingface
+            cd huggingface
+            git fetch
+            git pull
+            git merge -m "merge remote" --ff origin main
+
+            mkdir -p $d
+
+            cp -v ../wheelhouse/*.whl $d/
+
+            git status
+            git add .
+            git commit -m "add more wheels"
+            git push https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/sherpa-onnx-wheels main

--- a/.github/workflows/build-wheels-linux-cuda.yaml
+++ b/.github/workflows/build-wheels-linux-cuda.yaml
@@ -73,6 +73,23 @@ jobs:
         run: |
           ls -lh ./wheelhouse/
 
+      - name: Install patchelf
+        shell: bash
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -q -y patchelf
+          patchelf --help
+
+      - name: Patch wheels
+        shell: bash
+        run: |
+          mkdir ./wheels
+          sudo ./scripts/wheel/patch_wheel.py --in-dir ./wheelhouse --out-dir ./wheels
+
+          ls -lh ./wheels/
+          rm -rf ./wheelhouse
+          mv ./wheels ./wheelhouse
+
       - uses: actions/upload-artifact@v4
         with:
           name: wheel-cuda-${{ matrix.python-version }}

--- a/.github/workflows/build-wheels-linux.yaml
+++ b/.github/workflows/build-wheels-linux.yaml
@@ -56,7 +56,6 @@ jobs:
           ls -lh ./wheelhouse/
 
       - name: Install patchelf
-        if: matrix.os == 'ubuntu-latest'
         shell: bash
         run: |
           sudo apt-get update -q
@@ -65,7 +64,6 @@ jobs:
 
       - name: Patch wheels
         shell: bash
-        if: matrix.os == 'ubuntu-latest'
         run: |
           mkdir ./wheels
           sudo ./scripts/wheel/patch_wheel.py --in-dir ./wheelhouse --out-dir ./wheels

--- a/.github/workflows/build-wheels-win64-cuda.yaml
+++ b/.github/workflows/build-wheels-win64-cuda.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - wheel
-      - wheel-cuda
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:
@@ -92,13 +91,3 @@ jobs:
             git add .
             git commit -m "add more wheels"
             git push https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/sherpa-onnx-wheels main
-
-      - name: Publish wheels to PyPI
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install wheel twine setuptools
-
-          twine upload ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels-win64-cuda.yaml
+++ b/.github/workflows/build-wheels-win64-cuda.yaml
@@ -1,9 +1,10 @@
-name: build-wheels-linux-cuda
+name: build-wheels-win64-cuda
 
 on:
   push:
     branches:
       - wheel
+      - wheel-cuda
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:
@@ -12,17 +13,17 @@ env:
   SHERPA_ONNX_IS_IN_GITHUB_ACTIONS: 1
 
 concurrency:
-  group: build-wheels-linux-cuda-${{ github.ref }}
+  group: build-wheels-win64-cuda-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build_wheels_linux_cuda:
-    name: ${{ matrix.manylinux }} ${{ matrix.python-version }}
+  build_wheels_win64_cuda:
+    name: ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [windows-2019]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
@@ -33,37 +34,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Python dependencies
+      - name: Build wheels
         shell: bash
         run: |
-          pip install -U pip wheel setuptools twine
+          pip install setuptools wheel
 
-      - name: Build alsa-lib
-        shell: bash
-        run: |
-          git clone --depth 1 --branch v1.2.12 https://github.com/alsa-project/alsa-lib
-          cd alsa-lib
-          ./gitcompile
-
-      - name: Build sherpa-onnx
-        shell: bash
-        run: |
-          export CPLUS_INCLUDE_PATH=$PWD/alsa-lib/include:$CPLUS_INCLUDE_PATH
-          export SHERPA_ONNX_ALSA_LIB_DIR=$PWD/alsa-lib/src/.libs
-          export LD_LIBRARY_PATH=$SHERPA_ONNX_ALSA_LIB_DIR:$LD_LIBRARY_PATH
-
-          echo "CPLUS_INCLUDE_PATH: $CPLUS_INCLUDE_PATH"
-          ls -lh $PWD/alsa-lib/include
-          echo "---"
-          ls -lh $PWD/alsa-lib/src/.libs
-
-          export SHERPA_ONNX_MAKE_ARGS="VERBOSE=1"
-          export SHERPA_ONNX_ENABLE_ALSA=1
           export SHERPA_ONNX_CMAKE_ARGS="-DSHERPA_ONNX_ENABLE_GPU=ON"
 
           python3 setup.py bdist_wheel
 
-          ls -lh dist
+          ls -lh ./dist/
 
           mv dist wheelhouse
 
@@ -72,26 +52,9 @@ jobs:
         run: |
           ls -lh ./wheelhouse/
 
-      - name: Install patchelf
-        shell: bash
-        run: |
-          sudo apt-get update -q
-          sudo apt-get install -q -y patchelf
-          patchelf --help
-
-      - name: Patch wheels
-        shell: bash
-        run: |
-          mkdir ./wheels
-          sudo ./scripts/wheel/patch_wheel.py --in-dir ./wheelhouse --out-dir ./wheels
-
-          ls -lh ./wheels/
-          rm -rf ./wheelhouse
-          mv ./wheels ./wheelhouse
-
       - uses: actions/upload-artifact@v4
         with:
-          name: wheel-cuda-${{ matrix.python-version }}
+          name: wheel-${{ matrix.python-version }}
           path: ./wheelhouse/*.whl
 
       - name: Publish to huggingface
@@ -129,3 +92,13 @@ jobs:
             git add .
             git commit -m "add more wheels"
             git push https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/sherpa-onnx-wheels main
+
+      - name: Publish wheels to PyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install wheel twine setuptools
+
+          twine upload ./wheelhouse/*.whl

--- a/setup.py
+++ b/setup.py
@@ -27,18 +27,21 @@ def get_package_version():
 
     match = re.search(r"set\(SHERPA_ONNX_VERSION (.*)\)", content)
     latest_version = match.group(1).strip('"')
+
+    cmake_args = os.environ.get("SHERPA_ONNX_CMAKE_ARGS", "")
+    extra_version = ""
+    if "-DSHERPA_ONNX_ENABLE_GPU=ON" in cmake_args:
+        extra_version = "+cuda"
+
+    latest_version += extra_version
+
     return latest_version
 
 
 package_name = "sherpa-onnx"
 
 with open("sherpa-onnx/python/sherpa_onnx/__init__.py", "a") as f:
-    cmake_args = os.environ.get("SHERPA_ONNX_CMAKE_ARGS", "")
-    extra_version = ""
-    if "-DSHERPA_ONNX_ENABLE_GPU=ON" in cmake_args:
-        extra_version = "+cuda"
-
-    f.write(f"__version__ = '{get_package_version()}{extra_version}'\n")
+    f.write(f"__version__ = '{get_package_version()}'\n")
 
 
 def get_binaries_to_install():

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import re
 from pathlib import Path
 
@@ -32,7 +33,12 @@ def get_package_version():
 package_name = "sherpa-onnx"
 
 with open("sherpa-onnx/python/sherpa_onnx/__init__.py", "a") as f:
-    f.write(f"__version__ = '{get_package_version()}'\n")
+    cmake_args = os.environ.get("SHERPA_ONNX_CMAKE_ARGS", "")
+    extra_version = ""
+    if "-DSHERPA_ONNX_ENABLE_GPU=ON" in cmake_args:
+        extra_version = "+cuda"
+
+    f.write(f"__version__ = '{get_package_version()}{extra_version}'\n")
 
 
 def get_binaries_to_install():


### PR DESCRIPTION
You can find them at
https://k2-fsa.github.io/sherpa/onnx/cuda.html

<img width="554" alt="Screenshot 2024-07-17 at 22 57 13" src="https://github.com/user-attachments/assets/a5c1f8e8-066c-4d4f-9295-f8bf82ac94e3">


Note that only linux x64 and windows x64 are supported.

---

## Usage
```bash
pip install sherpa-onnx==1.10.16+cuda -f https://k2-fsa.github.io/sherpa/onnx/cuda.html
```

The log is
```
Looking in links: https://k2-fsa.github.io/sherpa/onnx/cuda.html
Collecting sherpa-onnx==1.10.16+cuda
  Downloading https://huggingface.co/csukuangfj/sherpa-onnx-wheels/resolve/main/cuda/1.10.16/sherpa_onnx-1.10.16%2Bcuda-cp310-cp310-linux_x86_64.whl (183.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 183.3/183.3 MB 3.8 MB/s eta 0:00:00
Installing collected packages: sherpa-onnx
Successfully installed sherpa-onnx-1.10.16+cuda
```

```python3
import sherpa_onnx
print(sherpa_onnx.__version__)
```

should print

```
1.10.16+cuda
```