### PR TITLE
Refactor C API to prefix each API with SherpaOnnx.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.19
+
+* Prefix all C API functions with SherpaOnnx
+
 ## 1.10.18
 
 * Fix the case when recognition results contain the symbol `"`. It caused

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(sherpa-onnx)
 # ./nodejs-addon-examples
 # ./dart-api-examples/
 # ./CHANGELOG.md
-set(SHERPA_ONNX_VERSION "1.10.18")
+set(SHERPA_ONNX_VERSION "1.10.19")
 
 # Disable warning about
 #

--- a/c-api-examples/asr-microphone-example/c-api-alsa.cc
+++ b/c-api-examples/asr-microphone-example/c-api-alsa.cc
@@ -190,9 +190,10 @@ int32_t main(int32_t argc, char *argv[]) {
 
   const SherpaOnnxOnlineRecognizer *recognizer =
       SherpaOnnxCreateOnlineRecognizer(&config);
-  const SherpaOnnxOnlineStream *stream = CreateOnlineStream(recognizer);
+  const SherpaOnnxOnlineStream *stream =
+      SherpaOnnxCreateOnlineStream(recognizer);
 
-  const SherpaOnnxDisplay *display = CreateDisplay(50);
+  const SherpaOnnxDisplay *display = SherpaOnnxCreateDisplay(50);
   int32_t segment_id = 0;
 
   const char *device_name = argv[context.index];
@@ -218,17 +219,17 @@ int32_t main(int32_t argc, char *argv[]) {
 
   while (!stop) {
     const std::vector<float> &samples = alsa.Read(chunk);
-    AcceptWaveform(stream, expected_sample_rate, samples.data(),
-                   samples.size());
-    while (IsOnlineStreamReady(recognizer, stream)) {
-      DecodeOnlineStream(recognizer, stream);
+    SherpaOnnxOnlineStreamAcceptWaveform(stream, expected_sample_rate,
+                                         samples.data(), samples.size());
+    while (SherpaOnnxIsOnlineStreamReady(recognizer, stream)) {
+      SherpaOnnxDecodeOnlineStream(recognizer, stream);
     }
 
     const SherpaOnnxOnlineRecognizerResult *r =
-        GetOnlineStreamResult(recognizer, stream);
+        SherpaOnnxGetOnlineStreamResult(recognizer, stream);
 
     std::string text = r->text;
-    DestroyOnlineRecognizerResult(r);
+    SherpaOnnxDestroyOnlineRecognizerResult(r);
 
     if (!text.empty() && last_text != text) {
       last_text = text;
@@ -240,18 +241,18 @@ int32_t main(int32_t argc, char *argv[]) {
       fflush(stderr);
     }
 
-    if (IsEndpoint(recognizer, stream)) {
+    if (SherpaOnnxOnlineStreamIsEndpoint(recognizer, stream)) {
       if (!text.empty()) {
         ++segment_index;
       }
-      Reset(recognizer, stream);
+      SherpaOnnxOnlineStreamReset(recognizer, stream);
     }
   }
 
   // free allocated resources
-  DestroyDisplay(display);
-  DestroyOnlineStream(stream);
-  DestroyOnlineRecognizer(recognizer);
+  SherpaOnnxDestroyDisplay(display);
+  SherpaOnnxDestroyOnlineStream(stream);
+  SherpaOnnxDestroyOnlineRecognizer(recognizer);
   fprintf(stderr, "\n");
 
   return 0;

--- a/c-api-examples/asr-microphone-example/c-api-alsa.cc
+++ b/c-api-examples/asr-microphone-example/c-api-alsa.cc
@@ -189,7 +189,7 @@ int32_t main(int32_t argc, char *argv[]) {
   }
 
   const SherpaOnnxOnlineRecognizer *recognizer =
-      CreateOnlineRecognizer(&config);
+      SherpaOnnxCreateOnlineRecognizer(&config);
   const SherpaOnnxOnlineStream *stream = CreateOnlineStream(recognizer);
 
   const SherpaOnnxDisplay *display = CreateDisplay(50);

--- a/c-api-examples/audio-tagging-c-api.c
+++ b/c-api-examples/audio-tagging-c-api.c
@@ -54,8 +54,8 @@ int32_t main() {
   const SherpaOnnxOfflineStream *stream =
       SherpaOnnxAudioTaggingCreateOfflineStream(tagger);
 
-  AcceptWaveformOffline(stream, wave->sample_rate, wave->samples,
-                        wave->num_samples);
+  SherpaOnnxAcceptWaveformOffline(stream, wave->sample_rate, wave->samples,
+                                  wave->num_samples);
 
   int32_t top_k = 5;
   const SherpaOnnxAudioEvent *const *results =
@@ -71,7 +71,7 @@ int32_t main() {
   fprintf(stderr, "--------------------------------------------------\n");
 
   SherpaOnnxAudioTaggingFreeResults(results);
-  DestroyOfflineStream(stream);
+  SherpaOnnxDestroyOfflineStream(stream);
   SherpaOnnxFreeWave(wave);
   SherpaOnnxDestroyAudioTagging(tagger);
 

--- a/c-api-examples/decode-file-c-api.c
+++ b/c-api-examples/decode-file-c-api.c
@@ -163,7 +163,7 @@ int32_t main(int32_t argc, char *argv[]) {
   }
 
   const SherpaOnnxOnlineRecognizer *recognizer =
-      CreateOnlineRecognizer(&config);
+      SherpaOnnxCreateOnlineRecognizer(&config);
   const SherpaOnnxOnlineStream *stream = CreateOnlineStream(recognizer);
 
   const SherpaOnnxDisplay *display = CreateDisplay(50);

--- a/c-api-examples/decode-file-c-api.c
+++ b/c-api-examples/decode-file-c-api.c
@@ -164,9 +164,10 @@ int32_t main(int32_t argc, char *argv[]) {
 
   const SherpaOnnxOnlineRecognizer *recognizer =
       SherpaOnnxCreateOnlineRecognizer(&config);
-  const SherpaOnnxOnlineStream *stream = CreateOnlineStream(recognizer);
+  const SherpaOnnxOnlineStream *stream =
+      SherpaOnnxCreateOnlineStream(recognizer);
 
-  const SherpaOnnxDisplay *display = CreateDisplay(50);
+  const SherpaOnnxDisplay *display = SherpaOnnxCreateDisplay(50);
   int32_t segment_id = 0;
 
   const char *wav_filename = argv[context.index];
@@ -190,52 +191,53 @@ int32_t main(int32_t argc, char *argv[]) {
         (start + N > wave->num_samples) ? wave->num_samples : (start + N);
     k += N;
 
-    AcceptWaveform(stream, wave->sample_rate, wave->samples + start,
-                   end - start);
-    while (IsOnlineStreamReady(recognizer, stream)) {
-      DecodeOnlineStream(recognizer, stream);
+    SherpaOnnxOnlineStreamAcceptWaveform(stream, wave->sample_rate,
+                                         wave->samples + start, end - start);
+    while (SherpaOnnxIsOnlineStreamReady(recognizer, stream)) {
+      SherpaOnnxDecodeOnlineStream(recognizer, stream);
     }
 
     const SherpaOnnxOnlineRecognizerResult *r =
-        GetOnlineStreamResult(recognizer, stream);
+        SherpaOnnxGetOnlineStreamResult(recognizer, stream);
 
     if (strlen(r->text)) {
       SherpaOnnxPrint(display, segment_id, r->text);
     }
 
-    if (IsEndpoint(recognizer, stream)) {
+    if (SherpaOnnxOnlineStreamIsEndpoint(recognizer, stream)) {
       if (strlen(r->text)) {
         ++segment_id;
       }
-      Reset(recognizer, stream);
+      SherpaOnnxOnlineStreamReset(recognizer, stream);
     }
 
-    DestroyOnlineRecognizerResult(r);
+    SherpaOnnxDestroyOnlineRecognizerResult(r);
   }
 
   // add some tail padding
   float tail_paddings[4800] = {0};  // 0.3 seconds at 16 kHz sample rate
-  AcceptWaveform(stream, wave->sample_rate, tail_paddings, 4800);
+  SherpaOnnxOnlineStreamAcceptWaveform(stream, wave->sample_rate, tail_paddings,
+                                       4800);
 
   SherpaOnnxFreeWave(wave);
 
-  InputFinished(stream);
-  while (IsOnlineStreamReady(recognizer, stream)) {
-    DecodeOnlineStream(recognizer, stream);
+  SherpaOnnxOnlineStreamInputFinished(stream);
+  while (SherpaOnnxIsOnlineStreamReady(recognizer, stream)) {
+    SherpaOnnxDecodeOnlineStream(recognizer, stream);
   }
 
   const SherpaOnnxOnlineRecognizerResult *r =
-      GetOnlineStreamResult(recognizer, stream);
+      SherpaOnnxGetOnlineStreamResult(recognizer, stream);
 
   if (strlen(r->text)) {
     SherpaOnnxPrint(display, segment_id, r->text);
   }
 
-  DestroyOnlineRecognizerResult(r);
+  SherpaOnnxDestroyOnlineRecognizerResult(r);
 
-  DestroyDisplay(display);
-  DestroyOnlineStream(stream);
-  DestroyOnlineRecognizer(recognizer);
+  SherpaOnnxDestroyDisplay(display);
+  SherpaOnnxDestroyOnlineStream(stream);
+  SherpaOnnxDestroyOnlineRecognizer(recognizer);
   fprintf(stderr, "\n");
 
   return 0;

--- a/c-api-examples/sense-voice-c-api.c
+++ b/c-api-examples/sense-voice-c-api.c
@@ -59,7 +59,7 @@ int32_t main() {
   recognizer_config.model_config = offline_model_config;
 
   SherpaOnnxOfflineRecognizer *recognizer =
-      CreateOfflineRecognizer(&recognizer_config);
+      SherpaOnnxCreateOfflineRecognizer(&recognizer_config);
 
   if (recognizer == NULL) {
     fprintf(stderr, "Please check your config!\n");
@@ -67,19 +67,19 @@ int32_t main() {
     return -1;
   }
 
-  SherpaOnnxOfflineStream *stream = CreateOfflineStream(recognizer);
+  SherpaOnnxOfflineStream *stream = SherpaOnnxCreateOfflineStream(recognizer);
 
-  AcceptWaveformOffline(stream, wave->sample_rate, wave->samples,
-                        wave->num_samples);
-  DecodeOfflineStream(recognizer, stream);
+  SherpaOnnxAcceptWaveformOffline(stream, wave->sample_rate, wave->samples,
+                                  wave->num_samples);
+  SherpaOnnxDecodeOfflineStream(recognizer, stream);
   const SherpaOnnxOfflineRecognizerResult *result =
-      GetOfflineStreamResult(stream);
+      SherpaOnnxGetOfflineStreamResult(stream);
 
   fprintf(stderr, "Decoded text: %s\n", result->text);
 
-  DestroyOfflineRecognizerResult(result);
-  DestroyOfflineStream(stream);
-  DestroyOfflineRecognizer(recognizer);
+  SherpaOnnxDestroyOfflineRecognizerResult(result);
+  SherpaOnnxDestroyOfflineStream(stream);
+  SherpaOnnxDestroyOfflineRecognizer(recognizer);
   SherpaOnnxFreeWave(wave);
 
   return 0;

--- a/c-api-examples/speaker-identification-c-api.c
+++ b/c-api-examples/speaker-identification-c-api.c
@@ -37,8 +37,9 @@ static const float *ComputeEmbedding(
   const SherpaOnnxOnlineStream *stream =
       SherpaOnnxSpeakerEmbeddingExtractorCreateStream(ex);
 
-  AcceptWaveform(stream, wave->sample_rate, wave->samples, wave->num_samples);
-  InputFinished(stream);
+  SherpaOnnxOnlineStreamAcceptWaveform(stream, wave->sample_rate, wave->samples,
+                                       wave->num_samples);
+  SherpaOnnxOnlineStreamInputFinished(stream);
 
   if (!SherpaOnnxSpeakerEmbeddingExtractorIsReady(ex, stream)) {
     fprintf(stderr, "The input wave file %s is too short!\n", wav_filename);
@@ -49,7 +50,7 @@ static const float *ComputeEmbedding(
   const float *v =
       SherpaOnnxSpeakerEmbeddingExtractorComputeEmbedding(ex, stream);
 
-  DestroyOnlineStream(stream);
+  SherpaOnnxDestroyOnlineStream(stream);
   SherpaOnnxFreeWave(wave);
 
   // Remeber to free v to avoid memory leak

--- a/c-api-examples/spoken-language-identification-c-api.c
+++ b/c-api-examples/spoken-language-identification-c-api.c
@@ -50,8 +50,8 @@ int32_t main() {
   SherpaOnnxOfflineStream *stream =
       SherpaOnnxSpokenLanguageIdentificationCreateOfflineStream(slid);
 
-  AcceptWaveformOffline(stream, wave->sample_rate, wave->samples,
-                        wave->num_samples);
+  SherpaOnnxAcceptWaveformOffline(stream, wave->sample_rate, wave->samples,
+                                  wave->num_samples);
 
   const SherpaOnnxSpokenLanguageIdentificationResult *result =
       SherpaOnnxSpokenLanguageIdentificationCompute(slid, stream);
@@ -60,7 +60,7 @@ int32_t main() {
   fprintf(stderr, "Detected language: %s\n", result->lang);
 
   SherpaOnnxDestroySpokenLanguageIdentificationResult(result);
-  DestroyOfflineStream(stream);
+  SherpaOnnxDestroyOfflineStream(stream);
   SherpaOnnxFreeWave(wave);
   SherpaOnnxDestroySpokenLanguageIdentification(slid);
 

--- a/c-api-examples/streaming-hlg-decode-file-c-api.c
+++ b/c-api-examples/streaming-hlg-decode-file-c-api.c
@@ -51,9 +51,10 @@ int32_t main() {
     exit(-1);
   }
 
-  const SherpaOnnxOnlineStream *stream = CreateOnlineStream(recognizer);
+  const SherpaOnnxOnlineStream *stream =
+      SherpaOnnxCreateOnlineStream(recognizer);
 
-  const SherpaOnnxDisplay *display = CreateDisplay(50);
+  const SherpaOnnxDisplay *display = SherpaOnnxCreateDisplay(50);
   int32_t segment_id = 0;
 
   const SherpaOnnxWave *wave = SherpaOnnxReadWave(wav_filename);
@@ -76,52 +77,53 @@ int32_t main() {
         (start + N > wave->num_samples) ? wave->num_samples : (start + N);
     k += N;
 
-    AcceptWaveform(stream, wave->sample_rate, wave->samples + start,
-                   end - start);
-    while (IsOnlineStreamReady(recognizer, stream)) {
-      DecodeOnlineStream(recognizer, stream);
+    SherpaOnnxOnlineStreamAcceptWaveform(stream, wave->sample_rate,
+                                         wave->samples + start, end - start);
+    while (SherpaOnnxIsOnlineStreamReady(recognizer, stream)) {
+      SherpaOnnxDecodeOnlineStream(recognizer, stream);
     }
 
     const SherpaOnnxOnlineRecognizerResult *r =
-        GetOnlineStreamResult(recognizer, stream);
+        SherpaOnnxGetOnlineStreamResult(recognizer, stream);
 
     if (strlen(r->text)) {
       SherpaOnnxPrint(display, segment_id, r->text);
     }
 
-    if (IsEndpoint(recognizer, stream)) {
+    if (SherpaOnnxOnlineStreamIsEndpoint(recognizer, stream)) {
       if (strlen(r->text)) {
         ++segment_id;
       }
-      Reset(recognizer, stream);
+      SherpaOnnxOnlineStreamReset(recognizer, stream);
     }
 
-    DestroyOnlineRecognizerResult(r);
+    SherpaOnnxDestroyOnlineRecognizerResult(r);
   }
 
   // add some tail padding
   float tail_paddings[4800] = {0};  // 0.3 seconds at 16 kHz sample rate
-  AcceptWaveform(stream, wave->sample_rate, tail_paddings, 4800);
+  SherpaOnnxOnlineStreamAcceptWaveform(stream, wave->sample_rate, tail_paddings,
+                                       4800);
 
   SherpaOnnxFreeWave(wave);
 
-  InputFinished(stream);
-  while (IsOnlineStreamReady(recognizer, stream)) {
-    DecodeOnlineStream(recognizer, stream);
+  SherpaOnnxOnlineStreamInputFinished(stream);
+  while (SherpaOnnxIsOnlineStreamReady(recognizer, stream)) {
+    SherpaOnnxDecodeOnlineStream(recognizer, stream);
   }
 
   const SherpaOnnxOnlineRecognizerResult *r =
-      GetOnlineStreamResult(recognizer, stream);
+      SherpaOnnxGetOnlineStreamResult(recognizer, stream);
 
   if (strlen(r->text)) {
     SherpaOnnxPrint(display, segment_id, r->text);
   }
 
-  DestroyOnlineRecognizerResult(r);
+  SherpaOnnxDestroyOnlineRecognizerResult(r);
 
-  DestroyDisplay(display);
-  DestroyOnlineStream(stream);
-  DestroyOnlineRecognizer(recognizer);
+  SherpaOnnxDestroyDisplay(display);
+  SherpaOnnxDestroyOnlineStream(stream);
+  SherpaOnnxDestroyOnlineRecognizer(recognizer);
   fprintf(stderr, "\n");
 
   return 0;

--- a/c-api-examples/streaming-hlg-decode-file-c-api.c
+++ b/c-api-examples/streaming-hlg-decode-file-c-api.c
@@ -45,7 +45,7 @@ int32_t main() {
   config.model_config.debug = 0;
   config.ctc_fst_decoder_config.graph = graph;
   const SherpaOnnxOnlineRecognizer *recognizer =
-      CreateOnlineRecognizer(&config);
+      SherpaOnnxCreateOnlineRecognizer(&config);
   if (!recognizer) {
     fprintf(stderr, "Failed to create recognizer");
     exit(-1);

--- a/c-api-examples/whisper-c-api.c
+++ b/c-api-examples/whisper-c-api.c
@@ -59,7 +59,7 @@ int32_t main() {
   recognizer_config.model_config = offline_model_config;
 
   SherpaOnnxOfflineRecognizer *recognizer =
-      CreateOfflineRecognizer(&recognizer_config);
+      SherpaOnnxCreateOfflineRecognizer(&recognizer_config);
 
   if (recognizer == NULL) {
     fprintf(stderr, "Please check your config!\n");
@@ -69,19 +69,19 @@ int32_t main() {
     return -1;
   }
 
-  SherpaOnnxOfflineStream *stream = CreateOfflineStream(recognizer);
+  SherpaOnnxOfflineStream *stream = SherpaOnnxCreateOfflineStream(recognizer);
 
-  AcceptWaveformOffline(stream, wave->sample_rate, wave->samples,
-                        wave->num_samples);
-  DecodeOfflineStream(recognizer, stream);
+  SherpaOnnxAcceptWaveformOffline(stream, wave->sample_rate, wave->samples,
+                                  wave->num_samples);
+  SherpaOnnxDecodeOfflineStream(recognizer, stream);
   const SherpaOnnxOfflineRecognizerResult *result =
-      GetOfflineStreamResult(stream);
+      SherpaOnnxGetOfflineStreamResult(stream);
 
   fprintf(stderr, "Decoded text: %s\n", result->text);
 
-  DestroyOfflineRecognizerResult(result);
-  DestroyOfflineStream(stream);
-  DestroyOfflineRecognizer(recognizer);
+  SherpaOnnxDestroyOfflineRecognizerResult(result);
+  SherpaOnnxDestroyOfflineStream(stream);
+  SherpaOnnxDestroyOfflineRecognizer(recognizer);
   SherpaOnnxFreeWave(wave);
 
   return 0;

--- a/dart-api-examples/keyword-spotter/pubspec.yaml
+++ b/dart-api-examples/keyword-spotter/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.4.0
 
 dependencies:
-  sherpa_onnx: ^1.10.18
+  sherpa_onnx: ^1.10.19
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   path: ^1.9.0

--- a/dart-api-examples/non-streaming-asr/pubspec.yaml
+++ b/dart-api-examples/non-streaming-asr/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  sherpa_onnx: ^1.10.18
+  sherpa_onnx: ^1.10.19
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/streaming-asr/pubspec.yaml
+++ b/dart-api-examples/streaming-asr/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  sherpa_onnx: ^1.10.18
+  sherpa_onnx: ^1.10.19
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/tts/pubspec.yaml
+++ b/dart-api-examples/tts/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  sherpa_onnx: ^1.10.18
+  sherpa_onnx: ^1.10.19
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/vad/pubspec.yaml
+++ b/dart-api-examples/vad/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.4.0
 
 dependencies:
-  sherpa_onnx: ^1.10.18
+  sherpa_onnx: ^1.10.19
   path: ^1.9.0
   args: ^2.5.0
 

--- a/ffmpeg-examples/sherpa-onnx-ffmpeg.c
+++ b/ffmpeg-examples/sherpa-onnx-ffmpeg.c
@@ -317,7 +317,8 @@ int main(int argc, char **argv) {
   config.rule2_min_trailing_silence = 1.2;
   config.rule3_min_utterance_length = 300;
 
-  SherpaOnnxOnlineRecognizer *recognizer = CreateOnlineRecognizer(&config);
+  SherpaOnnxOnlineRecognizer *recognizer =
+      SherpaOnnxCreateOnlineRecognizer(&config);
   SherpaOnnxOnlineStream *stream = CreateOnlineStream(recognizer);
   SherpaOnnxDisplay *display = CreateDisplay(50);
   int32_t segment_id = 0;

--- a/ffmpeg-examples/sherpa-onnx-ffmpeg.c
+++ b/ffmpeg-examples/sherpa-onnx-ffmpeg.c
@@ -224,25 +224,25 @@ static void sherpa_decode_frame(const AVFrame *frame,
   const int16_t *p = (int16_t *)frame->data[0];
 
   if (frame->nb_samples + nb_samples > N) {
-    AcceptWaveform(stream, 16000, samples, nb_samples);
-    while (IsOnlineStreamReady(recognizer, stream)) {
-      DecodeOnlineStream(recognizer, stream);
+    SherpaOnnxOnlineStreamAcceptWaveform(stream, 16000, samples, nb_samples);
+    while (SherpaOnnxIsOnlineStreamReady(recognizer, stream)) {
+      SherpaOnnxDecodeOnlineStream(recognizer, stream);
     }
 
     SherpaOnnxOnlineRecognizerResult *r =
-        GetOnlineStreamResult(recognizer, stream);
+        SherpaOnnxGetOnlineStreamResult(recognizer, stream);
     if (strlen(r->text)) {
       SherpaOnnxPrint(display, *segment_id, r->text);
     }
 
-    if (IsEndpoint(recognizer, stream)) {
+    if (SherpaOnnxOnlineStreamIsEndpoint(recognizer, stream)) {
       if (strlen(r->text)) {
         ++*segment_id;
       }
-      Reset(recognizer, stream);
+      SherpaOnnxOnlineStreamReset(recognizer, stream);
     }
 
-    DestroyOnlineRecognizerResult(r);
+    SherpaOnnxDestroyOnlineRecognizerResult(r);
     nb_samples = 0;
   }
 
@@ -319,8 +319,8 @@ int main(int argc, char **argv) {
 
   SherpaOnnxOnlineRecognizer *recognizer =
       SherpaOnnxCreateOnlineRecognizer(&config);
-  SherpaOnnxOnlineStream *stream = CreateOnlineStream(recognizer);
-  SherpaOnnxDisplay *display = CreateDisplay(50);
+  SherpaOnnxOnlineStream *stream = SherpaOnnxCreateOnlineStream(recognizer);
+  SherpaOnnxDisplay *display = SherpaOnnxCreateDisplay(50);
   int32_t segment_id = 0;
 
   if ((ret = open_input_file(argv[5])) < 0) exit(1);
@@ -376,24 +376,24 @@ int main(int argc, char **argv) {
 
   // add some tail padding
   float tail_paddings[4800] = {0};  // 0.3 seconds at 16 kHz sample rate
-  AcceptWaveform(stream, 16000, tail_paddings, 4800);
-  InputFinished(stream);
+  SherpaOnnxOnlineStreamAcceptWaveform(stream, 16000, tail_paddings, 4800);
+  SherpaOnnxOnlineStreamInputFinished(stream);
 
-  while (IsOnlineStreamReady(recognizer, stream)) {
-    DecodeOnlineStream(recognizer, stream);
+  while (SherpaOnnxIsOnlineStreamReady(recognizer, stream)) {
+    SherpaOnnxDecodeOnlineStream(recognizer, stream);
   }
 
   SherpaOnnxOnlineRecognizerResult *r =
-      GetOnlineStreamResult(recognizer, stream);
+      SherpaOnnxGetOnlineStreamResult(recognizer, stream);
   if (strlen(r->text)) {
     SherpaOnnxPrint(display, segment_id, r->text);
   }
 
-  DestroyOnlineRecognizerResult(r);
+  SherpaOnnxDestroyOnlineRecognizerResult(r);
 
-  DestroyDisplay(display);
-  DestroyOnlineStream(stream);
-  DestroyOnlineRecognizer(recognizer);
+  SherpaOnnxDestroyDisplay(display);
+  SherpaOnnxDestroyOnlineStream(stream);
+  SherpaOnnxDestroyOnlineRecognizer(recognizer);
 
   avfilter_graph_free(&filter_graph);
   avcodec_free_context(&dec_ctx);

--- a/flutter-examples/streaming_asr/pubspec.yaml
+++ b/flutter-examples/streaming_asr/pubspec.yaml
@@ -5,7 +5,7 @@ description: >
 
 publish_to: 'none'
 
-version: 1.10.18
+version: 1.10.19
 
 topics:
   - speech-recognition
@@ -30,7 +30,7 @@ dependencies:
   record: ^5.1.0
   url_launcher: ^6.2.6
 
-  sherpa_onnx: ^1.10.18
+  sherpa_onnx: ^1.10.19
   # sherpa_onnx:
     # path: ../../flutter/sherpa_onnx
 

--- a/flutter-examples/tts/pubspec.yaml
+++ b/flutter-examples/tts/pubspec.yaml
@@ -5,7 +5,7 @@ description: >
 
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.10.18
+version: 1.10.19
 
 environment:
   sdk: '>=3.4.0 <4.0.0'
@@ -17,7 +17,7 @@ dependencies:
   cupertino_icons: ^1.0.6
   path_provider: ^2.1.3
   path: ^1.9.0
-  sherpa_onnx: ^1.10.18
+  sherpa_onnx: ^1.10.19
   url_launcher: ^6.2.6
   audioplayers: ^5.0.0
 

--- a/flutter/sherpa_onnx/lib/src/sherpa_onnx_bindings.dart
+++ b/flutter/sherpa_onnx/lib/src/sherpa_onnx_bindings.dart
@@ -468,32 +468,34 @@ typedef SherpaOnnxCreateOnlineRecognizerNative
 typedef SherpaOnnxCreateOnlineRecognizer
     = SherpaOnnxCreateOnlineRecognizerNative;
 
-typedef DestroyOnlineRecognizerNative = Void Function(
+typedef SherpaOnnxDestroyOnlineRecognizerNative = Void Function(
     Pointer<SherpaOnnxOnlineRecognizer>);
 
-typedef DestroyOnlineRecognizer = void Function(
+typedef SherpaOnnxDestroyOnlineRecognizer = void Function(
     Pointer<SherpaOnnxOnlineRecognizer>);
 
-typedef CreateOnlineStreamNative = Pointer<SherpaOnnxOnlineStream> Function(
-    Pointer<SherpaOnnxOnlineRecognizer>);
+typedef SherpaOnnxCreateOnlineStreamNative = Pointer<SherpaOnnxOnlineStream>
+    Function(Pointer<SherpaOnnxOnlineRecognizer>);
 
-typedef CreateOnlineStream = CreateOnlineStreamNative;
+typedef SherpaOnnxCreateOnlineStream = SherpaOnnxCreateOnlineStreamNative;
 
-typedef CreateOnlineStreamWithHotwordsNative = Pointer<SherpaOnnxOnlineStream>
-    Function(Pointer<SherpaOnnxOnlineRecognizer>, Pointer<Utf8>);
+typedef SherpaOnnxCreateOnlineStreamWithHotwordsNative
+    = Pointer<SherpaOnnxOnlineStream> Function(
+        Pointer<SherpaOnnxOnlineRecognizer>, Pointer<Utf8>);
 
-typedef CreateOnlineStreamWithHotwords = CreateOnlineStreamWithHotwordsNative;
+typedef SherpaOnnxCreateOnlineStreamWithHotwords
+    = SherpaOnnxCreateOnlineStreamWithHotwordsNative;
 
 typedef IsOnlineStreamReadyNative = Int32 Function(
     Pointer<SherpaOnnxOnlineRecognizer>, Pointer<SherpaOnnxOnlineStream>);
 
-typedef IsOnlineStreamReady = int Function(
+typedef SherpaOnnxIsOnlineStreamReady = int Function(
     Pointer<SherpaOnnxOnlineRecognizer>, Pointer<SherpaOnnxOnlineStream>);
 
-typedef DecodeOnlineStreamNative = Void Function(
+typedef SherpaOnnxDecodeOnlineStreamNative = Void Function(
     Pointer<SherpaOnnxOnlineRecognizer>, Pointer<SherpaOnnxOnlineStream>);
 
-typedef DecodeOnlineStream = void Function(
+typedef SherpaOnnxDecodeOnlineStream = void Function(
     Pointer<SherpaOnnxOnlineRecognizer>, Pointer<SherpaOnnxOnlineStream>);
 
 typedef GetOnlineStreamResultAsJsonNative = Pointer<Utf8> Function(
@@ -747,10 +749,11 @@ typedef SherpaOnnxSpeakerEmbeddingExtractorCreateStreamNative
 typedef SherpaOnnxSpeakerEmbeddingExtractorCreateStream
     = SherpaOnnxSpeakerEmbeddingExtractorCreateStreamNative;
 
-typedef DestroyOnlineStreamNative = Void Function(
+typedef SherpaOnnxDestroyOnlineStreamNative = Void Function(
     Pointer<SherpaOnnxOnlineStream>);
 
-typedef DestroyOnlineStream = void Function(Pointer<SherpaOnnxOnlineStream>);
+typedef SherpaOnnxDestroyOnlineStream = void Function(
+    Pointer<SherpaOnnxOnlineStream>);
 
 typedef OnlineStreamAcceptWaveformNative = Void Function(
     Pointer<SherpaOnnxOnlineStream>, Int32, Pointer<Float>, Int32);
@@ -831,15 +834,16 @@ class SherpaOnnxBindings {
 
   static SherpaOnnxCreateOnlineRecognizer? createOnlineRecognizer;
 
-  static DestroyOnlineRecognizer? destroyOnlineRecognizer;
+  static SherpaOnnxDestroyOnlineRecognizer? destroyOnlineRecognizer;
 
-  static CreateOnlineStream? createOnlineStream;
+  static SherpaOnnxCreateOnlineStream? createOnlineStream;
 
-  static CreateOnlineStreamWithHotwords? createOnlineStreamWithHotwords;
+  static SherpaOnnxCreateOnlineStreamWithHotwords?
+      createOnlineStreamWithHotwords;
 
-  static IsOnlineStreamReady? isOnlineStreamReady;
+  static SherpaOnnxIsOnlineStreamReady? isOnlineStreamReady;
 
-  static DecodeOnlineStream? decodeOnlineStream;
+  static SherpaOnnxDecodeOnlineStream? decodeOnlineStream;
 
   static GetOnlineStreamResultAsJson? getOnlineStreamResultAsJson;
 
@@ -907,7 +911,7 @@ class SherpaOnnxBindings {
   static SherpaOnnxSpeakerEmbeddingExtractorDestroyEmbedding?
       speakerEmbeddingExtractorDestroyEmbedding;
 
-  static DestroyOnlineStream? destroyOnlineStream;
+  static SherpaOnnxDestroyOnlineStream? destroyOnlineStream;
 
   static OnlineStreamAcceptWaveform? onlineStreamAcceptWaveform;
 
@@ -956,42 +960,42 @@ class SherpaOnnxBindings {
   static void init(DynamicLibrary dynamicLibrary) {
     createKeywordSpotter ??= dynamicLibrary
         .lookup<NativeFunction<CreateKeywordSpotterNative>>(
-            'CreateKeywordSpotter')
+            'SherpaOnnxCreateKeywordSpotter')
         .asFunction();
 
     destroyKeywordSpotter ??= dynamicLibrary
         .lookup<NativeFunction<DestroyKeywordSpotterNative>>(
-            'DestroyKeywordSpotter')
+            'SherpaOnnxDestroyKeywordSpotter')
         .asFunction();
 
     createKeywordStream ??= dynamicLibrary
         .lookup<NativeFunction<CreateKeywordStreamNative>>(
-            'CreateKeywordStream')
+            'SherpaOnnxCreateKeywordStream')
         .asFunction();
 
     createKeywordStreamWithKeywords ??= dynamicLibrary
         .lookup<NativeFunction<CreateKeywordStreamWithKeywordsNative>>(
-            'CreateKeywordStreamWithKeywords')
+            'SherpaOnnxCreateKeywordStreamWithKeywords')
         .asFunction();
 
     isKeywordStreamReady ??= dynamicLibrary
         .lookup<NativeFunction<IsKeywordStreamReadyNative>>(
-            'IsKeywordStreamReady')
+            'SherpaOnnxIsKeywordStreamReady')
         .asFunction();
 
     decodeKeywordStream ??= dynamicLibrary
         .lookup<NativeFunction<DecodeKeywordStreamNative>>(
-            'DecodeKeywordStream')
+            'SherpaOnnxDecodeKeywordStream')
         .asFunction();
 
     getKeywordResultAsJson ??= dynamicLibrary
         .lookup<NativeFunction<GetKeywordResultAsJsonNative>>(
-            'GetKeywordResultAsJson')
+            'SherpaOnnxGetKeywordResultAsJson')
         .asFunction();
 
     freeKeywordResultJson ??= dynamicLibrary
         .lookup<NativeFunction<FreeKeywordResultJsonNative>>(
-            'FreeKeywordResultJson')
+            'SherpaOnnxFreeKeywordResultJson')
         .asFunction();
 
     createOfflineTts ??= dynamicLibrary
@@ -1033,42 +1037,42 @@ class SherpaOnnxBindings {
 
     createOfflineRecognizer ??= dynamicLibrary
         .lookup<NativeFunction<CreateOfflineRecognizerNative>>(
-            'CreateOfflineRecognizer')
+            'SherpaOnnxCreateOfflineRecognizer')
         .asFunction();
 
     destroyOfflineRecognizer ??= dynamicLibrary
         .lookup<NativeFunction<DestroyOfflineRecognizerNative>>(
-            'DestroyOfflineRecognizer')
+            'SherpaOnnxDestroyOfflineRecognizer')
         .asFunction();
 
     createOfflineStream ??= dynamicLibrary
         .lookup<NativeFunction<CreateOfflineStreamNative>>(
-            'CreateOfflineStream')
+            'SherpaOnnxCreateOfflineStream')
         .asFunction();
 
     destroyOfflineStream ??= dynamicLibrary
         .lookup<NativeFunction<DestroyOfflineStreamNative>>(
-            'DestroyOfflineStream')
+            'SherpaOnnxDestroyOfflineStream')
         .asFunction();
 
     acceptWaveformOffline ??= dynamicLibrary
         .lookup<NativeFunction<AcceptWaveformOfflineNative>>(
-            'AcceptWaveformOffline')
+            'SherpaOnnxAcceptWaveformOffline')
         .asFunction();
 
     decodeOfflineStream ??= dynamicLibrary
         .lookup<NativeFunction<DecodeOfflineStreamNative>>(
-            'DecodeOfflineStream')
+            'SherpaOnnxDecodeOfflineStream')
         .asFunction();
 
     getOfflineStreamResultAsJson ??= dynamicLibrary
         .lookup<NativeFunction<GetOfflineStreamResultAsJsonNative>>(
-            'GetOfflineStreamResultAsJson')
+            'SherpaOnnxGetOfflineStreamResultAsJson')
         .asFunction();
 
     destroyOfflineStreamResultJson ??= dynamicLibrary
         .lookup<NativeFunction<DestroyOfflineStreamResultJsonNative>>(
-            'DestroyOfflineStreamResultJson')
+            'SherpaOnnxDestroyOfflineStreamResultJson')
         .asFunction();
 
     createOnlineRecognizer ??= dynamicLibrary
@@ -1077,44 +1081,46 @@ class SherpaOnnxBindings {
         .asFunction();
 
     destroyOnlineRecognizer ??= dynamicLibrary
-        .lookup<NativeFunction<DestroyOnlineRecognizerNative>>(
-            'DestroyOnlineRecognizer')
+        .lookup<NativeFunction<SherpaOnnxDestroyOnlineRecognizerNative>>(
+            'SherpaOnnxDestroyOnlineRecognizer')
         .asFunction();
 
     createOnlineStream ??= dynamicLibrary
-        .lookup<NativeFunction<CreateOnlineStreamNative>>('CreateOnlineStream')
+        .lookup<NativeFunction<SherpaOnnxCreateOnlineStreamNative>>(
+            'SherpaOnnxCreateOnlineStream')
         .asFunction();
 
     createOnlineStreamWithHotwords ??= dynamicLibrary
-        .lookup<NativeFunction<CreateOnlineStreamWithHotwordsNative>>(
-            'CreateOnlineStreamWithHotwords')
+        .lookup<NativeFunction<SherpaOnnxCreateOnlineStreamWithHotwordsNative>>(
+            'SherpaOnnxCreateOnlineStreamWithHotwords')
         .asFunction();
 
     isOnlineStreamReady ??= dynamicLibrary
-        .lookup<NativeFunction<IsOnlineStreamReadyNative>>(
-            'IsOnlineStreamReady')
+        .lookup<NativeFunction<SherpaOnnxIsOnlineStreamReadyNative>>(
+            'SherpaOnnxIsOnlineStreamReady')
         .asFunction();
 
     decodeOnlineStream ??= dynamicLibrary
-        .lookup<NativeFunction<DecodeOnlineStreamNative>>('DecodeOnlineStream')
+        .lookup<NativeFunction<SherpaOnnxDecodeOnlineStreamNative>>(
+            'SherpaOnnxDecodeOnlineStream')
         .asFunction();
 
     getOnlineStreamResultAsJson ??= dynamicLibrary
         .lookup<NativeFunction<GetOnlineStreamResultAsJsonNative>>(
-            'GetOnlineStreamResultAsJson')
+            'SherpaOnnxGetOnlineStreamResultAsJson')
         .asFunction();
 
     reset ??= dynamicLibrary
-        .lookup<NativeFunction<ResetNative>>('Reset')
+        .lookup<NativeFunction<ResetNative>>('SherpaOnnxOnlineStreamReset')
         .asFunction();
 
     isEndpoint ??= dynamicLibrary
-        .lookup<NativeFunction<IsEndpointNative>>('IsEndpoint')
+        .lookup<NativeFunction<IsEndpointNative>>('SherpaOnnxIsEndpoint')
         .asFunction();
 
     destroyOnlineStreamResultJson ??= dynamicLibrary
         .lookup<NativeFunction<DestroyOnlineStreamResultJsonNative>>(
-            'DestroyOnlineStreamResultJson')
+            'SherpaOnnxDestroyOnlineStreamResultJson')
         .asFunction();
 
     createVoiceActivityDetector ??= dynamicLibrary
@@ -1260,18 +1266,18 @@ class SherpaOnnxBindings {
         .asFunction();
 
     destroyOnlineStream ??= dynamicLibrary
-        .lookup<NativeFunction<DestroyOnlineStreamNative>>(
-            'DestroyOnlineStream')
+        .lookup<NativeFunction<SherpaOnnxDestroyOnlineStreamNative>>(
+            'SherpaOnnxDestroyOnlineStream')
         .asFunction();
 
     onlineStreamAcceptWaveform ??= dynamicLibrary
         .lookup<NativeFunction<OnlineStreamAcceptWaveformNative>>(
-            'AcceptWaveform')
+            'SherpaOnnxOnlineStreamAcceptWaveform')
         .asFunction();
 
     onlineStreamInputFinished ??= dynamicLibrary
         .lookup<NativeFunction<OnlineStreamInputFinishedNative>>(
-            'InputFinished')
+            'SherpaOnnxOnlineStreamInputFinished')
         .asFunction();
 
     speakerEmbeddingExtractorIsReady ??= dynamicLibrary

--- a/flutter/sherpa_onnx/lib/src/sherpa_onnx_bindings.dart
+++ b/flutter/sherpa_onnx/lib/src/sherpa_onnx_bindings.dart
@@ -461,10 +461,12 @@ typedef DestroyOfflineStreamResultJsonNative = Void Function(Pointer<Utf8>);
 
 typedef DestroyOfflineStreamResultJson = void Function(Pointer<Utf8>);
 
-typedef CreateOnlineRecognizerNative = Pointer<SherpaOnnxOnlineRecognizer>
-    Function(Pointer<SherpaOnnxOnlineRecognizerConfig>);
+typedef SherpaOnnxCreateOnlineRecognizerNative
+    = Pointer<SherpaOnnxOnlineRecognizer> Function(
+        Pointer<SherpaOnnxOnlineRecognizerConfig>);
 
-typedef CreateOnlineRecognizer = CreateOnlineRecognizerNative;
+typedef SherpaOnnxCreateOnlineRecognizer
+    = SherpaOnnxCreateOnlineRecognizerNative;
 
 typedef DestroyOnlineRecognizerNative = Void Function(
     Pointer<SherpaOnnxOnlineRecognizer>);
@@ -827,7 +829,7 @@ class SherpaOnnxBindings {
   static GetOfflineStreamResultAsJson? getOfflineStreamResultAsJson;
   static DestroyOfflineStreamResultJson? destroyOfflineStreamResultJson;
 
-  static CreateOnlineRecognizer? createOnlineRecognizer;
+  static SherpaOnnxCreateOnlineRecognizer? createOnlineRecognizer;
 
   static DestroyOnlineRecognizer? destroyOnlineRecognizer;
 
@@ -1070,8 +1072,8 @@ class SherpaOnnxBindings {
         .asFunction();
 
     createOnlineRecognizer ??= dynamicLibrary
-        .lookup<NativeFunction<CreateOnlineRecognizerNative>>(
-            'CreateOnlineRecognizer')
+        .lookup<NativeFunction<SherpaOnnxCreateOnlineRecognizerNative>>(
+            'SherpaOnnxCreateOnlineRecognizer')
         .asFunction();
 
     destroyOnlineRecognizer ??= dynamicLibrary

--- a/flutter/sherpa_onnx/lib/src/sherpa_onnx_bindings.dart
+++ b/flutter/sherpa_onnx/lib/src/sherpa_onnx_bindings.dart
@@ -489,7 +489,7 @@ typedef SherpaOnnxCreateOnlineStreamWithHotwords
 typedef IsOnlineStreamReadyNative = Int32 Function(
     Pointer<SherpaOnnxOnlineRecognizer>, Pointer<SherpaOnnxOnlineStream>);
 
-typedef SherpaOnnxIsOnlineStreamReady = int Function(
+typedef IsOnlineStreamReady = int Function(
     Pointer<SherpaOnnxOnlineRecognizer>, Pointer<SherpaOnnxOnlineStream>);
 
 typedef SherpaOnnxDecodeOnlineStreamNative = Void Function(
@@ -841,7 +841,7 @@ class SherpaOnnxBindings {
   static SherpaOnnxCreateOnlineStreamWithHotwords?
       createOnlineStreamWithHotwords;
 
-  static SherpaOnnxIsOnlineStreamReady? isOnlineStreamReady;
+  static IsOnlineStreamReady? isOnlineStreamReady;
 
   static SherpaOnnxDecodeOnlineStream? decodeOnlineStream;
 
@@ -1096,7 +1096,7 @@ class SherpaOnnxBindings {
         .asFunction();
 
     isOnlineStreamReady ??= dynamicLibrary
-        .lookup<NativeFunction<SherpaOnnxIsOnlineStreamReadyNative>>(
+        .lookup<NativeFunction<IsOnlineStreamReadyNative>>(
             'SherpaOnnxIsOnlineStreamReady')
         .asFunction();
 
@@ -1115,7 +1115,8 @@ class SherpaOnnxBindings {
         .asFunction();
 
     isEndpoint ??= dynamicLibrary
-        .lookup<NativeFunction<IsEndpointNative>>('SherpaOnnxIsEndpoint')
+        .lookup<NativeFunction<IsEndpointNative>>(
+            'SherpaOnnxOnlineStreamIsEndpoint')
         .asFunction();
 
     destroyOnlineStreamResultJson ??= dynamicLibrary

--- a/flutter/sherpa_onnx/pubspec.yaml
+++ b/flutter/sherpa_onnx/pubspec.yaml
@@ -17,7 +17,7 @@ topics:
   - voice-activity-detection
 
 # remember to change the version in ../sherpa_onnx_macos/macos/sherpa_onnx_macos.podspec
-version: 1.10.18
+version: 1.10.19
 
 homepage: https://github.com/k2-fsa/sherpa-onnx
 
@@ -30,23 +30,23 @@ dependencies:
   flutter:
     sdk: flutter
 
-  sherpa_onnx_android: ^1.10.18
+  sherpa_onnx_android: ^1.10.19
   # sherpa_onnx_android:
   #   path: ../sherpa_onnx_android
 
-  sherpa_onnx_macos: ^1.10.18
+  sherpa_onnx_macos: ^1.10.19
   # sherpa_onnx_macos:
   #   path: ../sherpa_onnx_macos
 
-  sherpa_onnx_linux: ^1.10.18
+  sherpa_onnx_linux: ^1.10.19
   # sherpa_onnx_linux:
   #   path: ../sherpa_onnx_linux
     #
-  sherpa_onnx_windows: ^1.10.18
+  sherpa_onnx_windows: ^1.10.19
   # sherpa_onnx_windows:
   #   path: ../sherpa_onnx_windows
 
-  sherpa_onnx_ios: ^1.10.18
+  sherpa_onnx_ios: ^1.10.19
   # sherpa_onnx_ios:
   #   path: ../sherpa_onnx_ios
 

--- a/flutter/sherpa_onnx_ios/ios/sherpa_onnx_ios.podspec
+++ b/flutter/sherpa_onnx_ios/ios/sherpa_onnx_ios.podspec
@@ -7,7 +7,7 @@
 # https://groups.google.com/g/dart-ffi/c/nUATMBy7r0c
 Pod::Spec.new do |s|
   s.name             = 'sherpa_onnx_ios'
-  s.version          = '1.10.18'
+  s.version          = '1.10.19'
   s.summary          = 'A new Flutter FFI plugin project.'
   s.description      = <<-DESC
 A new Flutter FFI plugin project.

--- a/flutter/sherpa_onnx_macos/macos/sherpa_onnx_macos.podspec
+++ b/flutter/sherpa_onnx_macos/macos/sherpa_onnx_macos.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'sherpa_onnx_macos'
-  s.version          = '1.10.18'
+  s.version          = '1.10.19'
   s.summary          = 'sherpa-onnx Flutter FFI plugin project.'
   s.description      = <<-DESC
 sherpa-onnx Flutter FFI plugin project.

--- a/mfc-examples/NonStreamingSpeechRecognition/NonStreamingSpeechRecognitionDlg.cpp
+++ b/mfc-examples/NonStreamingSpeechRecognition/NonStreamingSpeechRecognitionDlg.cpp
@@ -111,7 +111,7 @@ CNonStreamingSpeechRecognitionDlg::CNonStreamingSpeechRecognitionDlg(
 
 CNonStreamingSpeechRecognitionDlg::~CNonStreamingSpeechRecognitionDlg() {
   if (recognizer_) {
-    DestroyOfflineRecognizer(recognizer_);
+    SherpaOnnxDestroyOfflineRecognizer(recognizer_);
     recognizer_ = nullptr;
   }
 }
@@ -256,12 +256,12 @@ void CNonStreamingSpeechRecognitionDlg::OnBnClickedOk() {
     }
     pa_stream_ = nullptr;
 
-    SherpaOnnxOfflineStream *stream = CreateOfflineStream(recognizer_);
+    SherpaOnnxOfflineStream *stream = SherpaOnnxCreateOfflineStream(recognizer_);
 
-    AcceptWaveformOffline(stream, config_.feat_config.sample_rate,
+    SherpaOnnxAcceptWaveformOffline(stream, config_.feat_config.sample_rate,
                           samples_.data(), static_cast<int32_t>(samples_.size()));
-    DecodeOfflineStream(recognizer_, stream);
-    auto r = GetOfflineStreamResult(stream);
+    SherpaOnnxDecodeOfflineStream(recognizer_, stream);
+    auto r = SherpaOnnxGetOfflineStreamResult(stream);
     results_.emplace_back(r->text);
 
     auto str = Utf8ToUtf16(Cat(results_).c_str());
@@ -269,9 +269,9 @@ void CNonStreamingSpeechRecognitionDlg::OnBnClickedOk() {
     my_text_.SetFocus();
     my_text_.SetSel(-1);
 
-    DestroyOfflineRecognizerResult(r);
+    SherpaOnnxDestroyOfflineRecognizerResult(r);
 
-    DestroyOfflineStream(stream);
+    SherpaOnnxDestroyOfflineStream(stream);
     // AfxMessageBox("Stopped", MB_OK);
     my_btn_.SetWindowText(_T("Start"));
     AppendLineToMultilineEditCtrl("\r\nStopped. Please click start and speak");
@@ -417,7 +417,7 @@ void CNonStreamingSpeechRecognitionDlg::InitWhisper() {
   config_.decoding_method = "greedy_search";
   config_.max_active_paths = 4;
 
-  recognizer_ = CreateOfflineRecognizer(&config_);
+  recognizer_ = SherpaOnnxCreateOfflineRecognizer(&config_);
 }
 
 void CNonStreamingSpeechRecognitionDlg::InitParaformer() {
@@ -459,7 +459,7 @@ void CNonStreamingSpeechRecognitionDlg::InitParaformer() {
   config_.decoding_method = "greedy_search";
   config_.max_active_paths = 4;
 
-  recognizer_ = CreateOfflineRecognizer(&config_);
+  recognizer_ = SherpaOnnxCreateOfflineRecognizer(&config_);
 }
 
 void CNonStreamingSpeechRecognitionDlg::InitRecognizer() {
@@ -525,7 +525,7 @@ void CNonStreamingSpeechRecognitionDlg::InitRecognizer() {
   config_.decoding_method = "greedy_search";
   config_.max_active_paths = 4;
 
-  recognizer_ = CreateOfflineRecognizer(&config_);
+  recognizer_ = SherpaOnnxCreateOfflineRecognizer(&config_);
 }
 
 void CNonStreamingSpeechRecognitionDlg::AppendTextToEditCtrl(

--- a/mfc-examples/StreamingSpeechRecognition/StreamingSpeechRecognitionDlg.cpp
+++ b/mfc-examples/StreamingSpeechRecognition/StreamingSpeechRecognitionDlg.cpp
@@ -356,7 +356,7 @@ void CStreamingSpeechRecognitionDlg::InitParaformer() {
   config.model_config.paraformer.encoder = paraformer_encoder.c_str();
   config.model_config.paraformer.decoder = paraformer_decoder.c_str();
 
-  recognizer_ = CreateOnlineRecognizer(&config);
+  recognizer_ = SherpaOnnxCreateOnlineRecognizer(&config);
 }
 
 void CStreamingSpeechRecognitionDlg::InitRecognizer() {
@@ -422,7 +422,7 @@ void CStreamingSpeechRecognitionDlg::InitRecognizer() {
   config.model_config.transducer.decoder = decoder.c_str();
   config.model_config.transducer.joiner = joiner.c_str();
 
-  recognizer_ = CreateOnlineRecognizer(&config);
+  recognizer_ = SherpaOnnxCreateOnlineRecognizer(&config);
 }
 
 // see

--- a/mfc-examples/StreamingSpeechRecognition/StreamingSpeechRecognitionDlg.cpp
+++ b/mfc-examples/StreamingSpeechRecognition/StreamingSpeechRecognitionDlg.cpp
@@ -46,7 +46,7 @@ CStreamingSpeechRecognitionDlg::CStreamingSpeechRecognitionDlg(
 
 CStreamingSpeechRecognitionDlg::~CStreamingSpeechRecognitionDlg() {
   if (recognizer_) {
-    DestroyOnlineRecognizer(recognizer_);
+    SherpaOnnxDestroyOnlineRecognizer(recognizer_);
     recognizer_ = nullptr;
   }
 }
@@ -123,7 +123,7 @@ static int32_t RecordCallback(const void *input_buffer,
 
   auto stream = dlg->stream_;
   if (stream) {
-    AcceptWaveform(stream, 16000, reinterpret_cast<const float *>(input_buffer),
+    SherpaOnnxOnlineStreamAcceptWaveform(stream, 16000, reinterpret_cast<const float *>(input_buffer),
                    frames_per_buffer);
   }
 
@@ -146,11 +146,11 @@ void CStreamingSpeechRecognitionDlg::OnBnClickedOk() {
     started_ = true;
 
     if (stream_) {
-      DestroyOnlineStream(stream_);
+      SherpaOnnxDestroyOnlineStream(stream_);
       stream_ = nullptr;
     }
 
-    stream_ = CreateOnlineStream(recognizer_);
+    stream_ = SherpaOnnxCreateOnlineStream(recognizer_);
 
     PaStreamParameters param;
     param.device = Pa_GetDefaultInputDevice();
@@ -519,13 +519,13 @@ int CStreamingSpeechRecognitionDlg::RunThread() {
 
   std::string last_text;
   while (started_) {
-    while (IsOnlineStreamReady(recognizer_, stream_)) {
-      DecodeOnlineStream(recognizer_, stream_);
+    while (SherpaOnnxIsOnlineStreamReady(recognizer_, stream_)) {
+      SherpaOnnxDecodeOnlineStream(recognizer_, stream_);
     }
 
-    auto r = GetOnlineStreamResult(recognizer_, stream_);
+    auto r = SherpaOnnxGetOnlineStreamResult(recognizer_, stream_);
     std::string text = r->text;
-    DestroyOnlineRecognizerResult(r);
+    SherpaOnnxDestroyOnlineRecognizer(r);
     if (!text.empty() && last_text != text) {
       // CString str;
       // str.Format(_T("%s"), Cat(results, text).c_str());
@@ -535,9 +535,9 @@ int CStreamingSpeechRecognitionDlg::RunThread() {
       my_text_.SetSel(-1);
       last_text = text;
     }
-    int is_endpoint = IsEndpoint(recognizer_, stream_);
+    int is_endpoint = SherpaOnnxOnlineStreamIsEndpoint(recognizer_, stream_);
     if (is_endpoint) {
-      Reset(recognizer_, stream_);
+      SherpaOnnxOnlineStreamReset(recognizer_, stream_);
       if (!text.empty()) {
         results.push_back(std::move(text));
       }

--- a/nodejs-addon-examples/package.json
+++ b/nodejs-addon-examples/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "sherpa-onnx-node": "^1.10.18"
+    "sherpa-onnx-node": "^1.10.19"
   }
 }

--- a/scripts/dart/kws-pubspec.yaml
+++ b/scripts/dart/kws-pubspec.yaml
@@ -9,7 +9,6 @@ environment:
   sdk: ^3.4.0
 
 dependencies:
-  # sherpa_onnx: ^1.10.18
   sherpa_onnx:
     path: ../../flutter/sherpa_onnx
   path: ^1.9.0

--- a/scripts/dart/sherpa-onnx-pubspec.yaml
+++ b/scripts/dart/sherpa-onnx-pubspec.yaml
@@ -17,7 +17,7 @@ topics:
   - voice-activity-detection
 
 # remember to change the version in ../sherpa_onnx_macos/macos/sherpa_onnx.podspec
-version: 1.10.18
+version: 1.10.19
 
 homepage: https://github.com/k2-fsa/sherpa-onnx
 

--- a/scripts/dotnet/KeywordSpotter.cs
+++ b/scripts/dotnet/KeywordSpotter.cs
@@ -13,20 +13,20 @@ namespace SherpaOnnx
     {
         public KeywordSpotter(KeywordSpotterConfig config)
         {
-            IntPtr h = CreateKeywordSpotter(ref config);
+            IntPtr h = SherpaOnnxCreateKeywordSpotter(ref config);
             _handle = new HandleRef(this, h);
         }
 
         public OnlineStream CreateStream()
         {
-            IntPtr p = CreateKeywordStream(_handle.Handle);
+            IntPtr p = SherpaOnnxCreateKeywordStream(_handle.Handle);
             return new OnlineStream(p);
         }
 
         public OnlineStream CreateStream(string keywords)
         {
             byte[] utf8Bytes = Encoding.UTF8.GetBytes(keywords);
-            IntPtr p = CreateKeywordStreamWithKeywords(_handle.Handle, utf8Bytes);
+            IntPtr p = SherpaOnnxCreateKeywordStreamWithKeywords(_handle.Handle, utf8Bytes);
             return new OnlineStream(p);
         }
 
@@ -81,7 +81,7 @@ namespace SherpaOnnx
 
         private void Cleanup()
         {
-            DestroyKeywordSpotter(_handle.Handle);
+            SherpaOnnxDestroyKeywordSpotter(_handle.Handle);
 
             // Don't permit the handle to be used again.
             _handle = new HandleRef(this, IntPtr.Zero);
@@ -90,30 +90,30 @@ namespace SherpaOnnx
         private HandleRef _handle;
 
         [DllImport(Dll.Filename)]
-        private static extern IntPtr CreateKeywordSpotter(ref KeywordSpotterConfig config);
+        private static extern IntPtr SherpaOnnxCreateKeywordSpotter(ref KeywordSpotterConfig config);
 
         [DllImport(Dll.Filename)]
-        private static extern void DestroyKeywordSpotter(IntPtr handle);
+        private static extern void SherpaOnnxDestroyKeywordSpotter(IntPtr handle);
 
         [DllImport(Dll.Filename)]
-        private static extern IntPtr CreateKeywordStream(IntPtr handle);
+        private static extern IntPtr SherpaOnnxCreateKeywordStream(IntPtr handle);
 
         [DllImport(Dll.Filename)]
-        private static extern IntPtr CreateKeywordStreamWithKeywords(IntPtr handle, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I1)] byte[] utf8Keywords);
+        private static extern IntPtr SherpaOnnxCreateKeywordStreamWithKeywords(IntPtr handle, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I1)] byte[] utf8Keywords);
 
-        [DllImport(Dll.Filename, EntryPoint = "IsKeywordStreamReady")]
+        [DllImport(Dll.Filename, EntryPoint = "SherpaOnnxIsKeywordStreamReady")]
         private static extern int IsReady(IntPtr handle, IntPtr stream);
 
-        [DllImport(Dll.Filename, EntryPoint = "DecodeKeywordStream")]
+        [DllImport(Dll.Filename, EntryPoint = "SherpaOnnxDecodeKeywordStream")]
         private static extern void Decode(IntPtr handle, IntPtr stream);
 
-        [DllImport(Dll.Filename, EntryPoint = "DecodeMultipleKeywordStreams")]
+        [DllImport(Dll.Filename, EntryPoint = "SherpaOnnxDecodeMultipleKeywordStreams")]
         private static extern void Decode(IntPtr handle, IntPtr[] streams, int n);
 
-        [DllImport(Dll.Filename, EntryPoint = "GetKeywordResult")]
+        [DllImport(Dll.Filename, EntryPoint = "SherpaOnnxGetKeywordResult")]
         private static extern IntPtr GetResult(IntPtr handle, IntPtr stream);
 
-        [DllImport(Dll.Filename, EntryPoint = "DestroyKeywordResult")]
+        [DllImport(Dll.Filename, EntryPoint = "SherpaOnnxDestroyKeywordResult")]
         private static extern void DestroyResult(IntPtr result);
     }
 }

--- a/scripts/dotnet/OfflineRecognizer.cs
+++ b/scripts/dotnet/OfflineRecognizer.cs
@@ -10,13 +10,13 @@ namespace SherpaOnnx
     {
         public OfflineRecognizer(OfflineRecognizerConfig config)
         {
-            IntPtr h = CreateOfflineRecognizer(ref config);
+            IntPtr h = SherpaOnnxCreateOfflineRecognizer(ref config);
             _handle = new HandleRef(this, h);
         }
 
         public OfflineStream CreateStream()
         {
-            IntPtr p = CreateOfflineStream(_handle.Handle);
+            IntPtr p = SherpaOnnxCreateOfflineStream(_handle.Handle);
             return new OfflineStream(p);
         }
 
@@ -54,7 +54,7 @@ namespace SherpaOnnx
 
         private void Cleanup()
         {
-            DestroyOfflineRecognizer(_handle.Handle);
+            SherpaOnnxDestroyOfflineRecognizer(_handle.Handle);
 
             // Don't permit the handle to be used again.
             _handle = new HandleRef(this, IntPtr.Zero);
@@ -63,18 +63,18 @@ namespace SherpaOnnx
         private HandleRef _handle;
 
         [DllImport(Dll.Filename)]
-        private static extern IntPtr CreateOfflineRecognizer(ref OfflineRecognizerConfig config);
+        private static extern IntPtr SherpaOnnxCreateOfflineRecognizer(ref OfflineRecognizerConfig config);
 
         [DllImport(Dll.Filename)]
-        private static extern void DestroyOfflineRecognizer(IntPtr handle);
+        private static extern void SherpaOnnxDestroyOfflineRecognizer(IntPtr handle);
 
         [DllImport(Dll.Filename)]
-        private static extern IntPtr CreateOfflineStream(IntPtr handle);
+        private static extern IntPtr SherpaOnnxCreateOfflineStream(IntPtr handle);
 
-        [DllImport(Dll.Filename, EntryPoint = "DecodeOfflineStream")]
+        [DllImport(Dll.Filename, EntryPoint = "SherpaOnnxDecodeOfflineStream")]
         private static extern void Decode(IntPtr handle, IntPtr stream);
 
-        [DllImport(Dll.Filename, EntryPoint = "DecodeMultipleOfflineStreams")]
+        [DllImport(Dll.Filename, EntryPoint = "SherpaOnnxDecodeMultipleOfflineStreams")]
         private static extern void Decode(IntPtr handle, IntPtr[] streams, int n);
     }
 

--- a/scripts/dotnet/OfflineStream.cs
+++ b/scripts/dotnet/OfflineStream.cs
@@ -44,7 +44,7 @@ namespace SherpaOnnx
 
         private void Cleanup()
         {
-            DestroyOfflineStream(Handle);
+            SherpaOnnxDestroyOfflineStream(Handle);
 
             // Don't permit the handle to be used again.
             _handle = new HandleRef(this, IntPtr.Zero);
@@ -54,15 +54,15 @@ namespace SherpaOnnx
         public IntPtr Handle => _handle.Handle;
 
         [DllImport(Dll.Filename)]
-        private static extern void DestroyOfflineStream(IntPtr handle);
+        private static extern void SherpaOnnxDestroyOfflineStream(IntPtr handle);
 
-        [DllImport(Dll.Filename, EntryPoint = "AcceptWaveformOffline")]
+        [DllImport(Dll.Filename, EntryPoint = "SherpaOnnxAcceptWaveformOffline")]
         private static extern void AcceptWaveform(IntPtr handle, int sampleRate, float[] samples, int n);
 
-        [DllImport(Dll.Filename, EntryPoint = "GetOfflineStreamResult")]
+        [DllImport(Dll.Filename, EntryPoint = "SherpaOnnxGetOfflineStreamResult")]
         private static extern IntPtr GetResult(IntPtr handle);
 
-        [DllImport(Dll.Filename, EntryPoint = "DestroyOfflineRecognizerResult")]
+        [DllImport(Dll.Filename, EntryPoint = "SherpaOnnxDestroyOfflineRecognizerResult")]
         private static extern void DestroyResult(IntPtr handle);
     }
 

--- a/scripts/dotnet/OnlineRecognizer.cs
+++ b/scripts/dotnet/OnlineRecognizer.cs
@@ -20,7 +20,7 @@ namespace SherpaOnnx
 
         public OnlineStream CreateStream()
         {
-            IntPtr p = CreateOnlineStream(_handle.Handle);
+            IntPtr p = SherpaOnnxCreateOnlineStream(_handle.Handle);
             return new OnlineStream(p);
         }
 
@@ -35,7 +35,7 @@ namespace SherpaOnnx
         /// true.
         public bool IsEndpoint(OnlineStream stream)
         {
-            return IsEndpoint(_handle.Handle, stream.Handle) != 0;
+            return SherpaOnnxOnlineStreamIsEndpoint(_handle.Handle, stream.Handle) != 0;
         }
 
         /// You have to ensure that IsReady(stream) returns true before
@@ -71,7 +71,7 @@ namespace SherpaOnnx
         /// When this method returns, IsEndpoint(stream) will return false.
         public void Reset(OnlineStream stream)
         {
-            Reset(_handle.Handle, stream.Handle);
+            SherpaOnnxOnlineStreamReset(_handle.Handle, stream.Handle);
         }
 
         public void Dispose()
@@ -89,7 +89,7 @@ namespace SherpaOnnx
 
         private void Cleanup()
         {
-            DestroyOnlineRecognizer(_handle.Handle);
+            SherpaOnnxDestroyOnlineRecognizer(_handle.Handle);
 
             // Don't permit the handle to be used again.
             _handle = new HandleRef(this, IntPtr.Zero);
@@ -101,30 +101,30 @@ namespace SherpaOnnx
         private static extern IntPtr SherpaOnnxCreateOnlineRecognizer(ref OnlineRecognizerConfig config);
 
         [DllImport(Dll.Filename)]
-        private static extern void DestroyOnlineRecognizer(IntPtr handle);
+        private static extern void SherpaOnnxDestroyOnlineRecognizer(IntPtr handle);
 
         [DllImport(Dll.Filename)]
-        private static extern IntPtr CreateOnlineStream(IntPtr handle);
+        private static extern IntPtr SherpaOnnxCreateOnlineStream(IntPtr handle);
 
-        [DllImport(Dll.Filename, EntryPoint = "IsOnlineStreamReady")]
+        [DllImport(Dll.Filename, EntryPoint = "SherpaOnnxIsOnlineStreamReady")]
         private static extern int IsReady(IntPtr handle, IntPtr stream);
 
-        [DllImport(Dll.Filename, EntryPoint = "DecodeOnlineStream")]
+        [DllImport(Dll.Filename, EntryPoint = "SherpaOnnxDecodeOnlineStream")]
         private static extern void Decode(IntPtr handle, IntPtr stream);
 
-        [DllImport(Dll.Filename, EntryPoint = "DecodeMultipleOnlineStreams")]
+        [DllImport(Dll.Filename, EntryPoint = "SherpaOnnxDecodeMultipleOnlineStreams")]
         private static extern void Decode(IntPtr handle, IntPtr[] streams, int n);
 
-        [DllImport(Dll.Filename, EntryPoint = "GetOnlineStreamResult")]
+        [DllImport(Dll.Filename, EntryPoint = "SherpaOnnxGetOnlineStreamResult")]
         private static extern IntPtr GetResult(IntPtr handle, IntPtr stream);
 
-        [DllImport(Dll.Filename, EntryPoint = "DestroyOnlineRecognizerResult")]
+        [DllImport(Dll.Filename, EntryPoint = "SherpaOnnxDestroyOnlineRecognizerResult")]
         private static extern void DestroyResult(IntPtr result);
 
         [DllImport(Dll.Filename)]
-        private static extern void Reset(IntPtr handle, IntPtr stream);
+        private static extern void SherpaOnnxOnlineStreamReset(IntPtr handle, IntPtr stream);
 
         [DllImport(Dll.Filename)]
-        private static extern int IsEndpoint(IntPtr handle, IntPtr stream);
+        private static extern int SherpaOnnxOnlineStreamIsEndpoint(IntPtr handle, IntPtr stream);
     }
 }

--- a/scripts/dotnet/OnlineRecognizer.cs
+++ b/scripts/dotnet/OnlineRecognizer.cs
@@ -14,7 +14,7 @@ namespace SherpaOnnx
     {
         public OnlineRecognizer(OnlineRecognizerConfig config)
         {
-            IntPtr h = CreateOnlineRecognizer(ref config);
+            IntPtr h = SherpaOnnxCreateOnlineRecognizer(ref config);
             _handle = new HandleRef(this, h);
         }
 
@@ -98,7 +98,7 @@ namespace SherpaOnnx
         private HandleRef _handle;
 
         [DllImport(Dll.Filename)]
-        private static extern IntPtr CreateOnlineRecognizer(ref OnlineRecognizerConfig config);
+        private static extern IntPtr SherpaOnnxCreateOnlineRecognizer(ref OnlineRecognizerConfig config);
 
         [DllImport(Dll.Filename)]
         private static extern void DestroyOnlineRecognizer(IntPtr handle);

--- a/scripts/dotnet/OnlineStream.cs
+++ b/scripts/dotnet/OnlineStream.cs
@@ -16,12 +16,12 @@ namespace SherpaOnnx
 
         public void AcceptWaveform(int sampleRate, float[] samples)
         {
-            AcceptWaveform(Handle, sampleRate, samples, samples.Length);
+            SherpaOnnxOnlineStreamAcceptWaveform(Handle, sampleRate, samples, samples.Length);
         }
 
         public void InputFinished()
         {
-            InputFinished(Handle);
+            SherpaOnnxOnlineStreamInputFinished(Handle);
         }
 
         ~OnlineStream()
@@ -39,7 +39,7 @@ namespace SherpaOnnx
 
         private void Cleanup()
         {
-            DestroyOnlineStream(Handle);
+            SherpaOnnxDestroyOnlineStream(Handle);
 
             // Don't permit the handle to be used again.
             _handle = new HandleRef(this, IntPtr.Zero);
@@ -49,13 +49,13 @@ namespace SherpaOnnx
         public IntPtr Handle => _handle.Handle;
 
         [DllImport(Dll.Filename)]
-        private static extern void DestroyOnlineStream(IntPtr handle);
+        private static extern void SherpaOnnxDestroyOnlineStream(IntPtr handle);
 
         [DllImport(Dll.Filename)]
-        private static extern void AcceptWaveform(IntPtr handle, int sampleRate, float[] samples, int n);
+        private static extern void SherpaOnnxOnlineStreamAcceptWaveform(IntPtr handle, int sampleRate, float[] samples, int n);
 
         [DllImport(Dll.Filename)]
-        private static extern void InputFinished(IntPtr handle);
+        private static extern void SherpaOnnxOnlineStreamInputFinished(IntPtr handle);
     }
 
 }

--- a/scripts/go/sherpa_onnx.go
+++ b/scripts/go/sherpa_onnx.go
@@ -224,7 +224,7 @@ func NewOnlineRecognizer(config *OnlineRecognizerConfig) *OnlineRecognizer {
 	c.ctc_fst_decoder_config.max_active = C.int(config.CtcFstDecoderConfig.MaxActive)
 
 	recognizer := &OnlineRecognizer{}
-	recognizer.impl = C.CreateOnlineRecognizer(&c)
+	recognizer.impl = C.SherpaOnnxCreateOnlineRecognizer(&c)
 
 	return recognizer
 }

--- a/scripts/go/sherpa_onnx.go
+++ b/scripts/go/sherpa_onnx.go
@@ -151,7 +151,7 @@ type OnlineStream struct {
 
 // Free the internal pointer inside the recognizer to avoid memory leak.
 func DeleteOnlineRecognizer(recognizer *OnlineRecognizer) {
-	C.DestroyOnlineRecognizer(recognizer.impl)
+	C.SherpaOnnxDestroyOnlineRecognizer(recognizer.impl)
 	recognizer.impl = nil
 }
 
@@ -231,7 +231,7 @@ func NewOnlineRecognizer(config *OnlineRecognizerConfig) *OnlineRecognizer {
 
 // Delete the internal pointer inside the stream to avoid memory leak.
 func DeleteOnlineStream(stream *OnlineStream) {
-	C.DestroyOnlineStream(stream.impl)
+	C.SherpaOnnxDestroyOnlineStream(stream.impl)
 	stream.impl = nil
 }
 
@@ -239,7 +239,7 @@ func DeleteOnlineStream(stream *OnlineStream) {
 // the returned stream to avoid memory leak
 func NewOnlineStream(recognizer *OnlineRecognizer) *OnlineStream {
 	stream := &OnlineStream{}
-	stream.impl = C.CreateOnlineStream(recognizer.impl)
+	stream.impl = C.SherpaOnnxCreateOnlineStream(recognizer.impl)
 	return stream
 }
 
@@ -251,7 +251,7 @@ func NewOnlineStream(recognizer *OnlineRecognizer) *OnlineStream {
 //
 // samples contains audio samples. Each sample is in the range [-1, 1]
 func (s *OnlineStream) AcceptWaveform(sampleRate int, samples []float32) {
-	C.AcceptWaveform(s.impl, C.int(sampleRate), (*C.float)(&samples[0]), C.int(len(samples)))
+	C.SherpaOnnxOnlineStreamAcceptWaveform(s.impl, C.int(sampleRate), (*C.float)(&samples[0]), C.int(len(samples)))
 }
 
 // Signal that there will be no incoming audio samples.
@@ -260,7 +260,7 @@ func (s *OnlineStream) AcceptWaveform(sampleRate int, samples []float32) {
 // The main purpose of this function is to flush the remaining audio samples
 // buffered inside for feature extraction.
 func (s *OnlineStream) InputFinished() {
-	C.InputFinished(s.impl)
+	C.SherpaOnnxOnlineStreamInputFinished(s.impl)
 }
 
 // Check whether the stream has enough feature frames for decoding.
@@ -272,7 +272,7 @@ func (s *OnlineStream) InputFinished() {
 //	   recognizer.Decode(s)
 //	}
 func (recognizer *OnlineRecognizer) IsReady(s *OnlineStream) bool {
-	return C.IsOnlineStreamReady(recognizer.impl, s.impl) == 1
+	return C.SherpaOnnxIsOnlineStreamReady(recognizer.impl, s.impl) == 1
 }
 
 // Return true if an endpoint is detected.
@@ -285,14 +285,14 @@ func (recognizer *OnlineRecognizer) IsReady(s *OnlineStream) bool {
 //	   recognizer.Reset(s)
 //	}
 func (recognizer *OnlineRecognizer) IsEndpoint(s *OnlineStream) bool {
-	return C.IsEndpoint(recognizer.impl, s.impl) == 1
+	return C.SherpaOnnxOnlineStreamIsEndpoint(recognizer.impl, s.impl) == 1
 }
 
 // After calling this function, the internal neural network model states
 // are reset and IsEndpoint(s) would return false. GetResult(s) would also
 // return an empty string.
 func (recognizer *OnlineRecognizer) Reset(s *OnlineStream) {
-	C.Reset(recognizer.impl, s.impl)
+	C.SherpaOnnxOnlineStreamReset(recognizer.impl, s.impl)
 }
 
 // Decode the stream. Before calling this function, you have to ensure
@@ -304,7 +304,7 @@ func (recognizer *OnlineRecognizer) Reset(s *OnlineStream) {
 //	  recognizer.Decode(s)
 //	}
 func (recognizer *OnlineRecognizer) Decode(s *OnlineStream) {
-	C.DecodeOnlineStream(recognizer.impl, s.impl)
+	C.SherpaOnnxDecodeOnlineStream(recognizer.impl, s.impl)
 }
 
 // Decode multiple streams in parallel, i.e., in batch.
@@ -316,13 +316,13 @@ func (recognizer *OnlineRecognizer) DecodeStreams(s []*OnlineStream) {
 		ss[i] = v.impl
 	}
 
-	C.DecodeMultipleOnlineStreams(recognizer.impl, &ss[0], C.int(len(s)))
+	C.SherpaOnnxDecodeMultipleOnlineStreams(recognizer.impl, &ss[0], C.int(len(s)))
 }
 
 // Get the current result of stream since the last invoke of Reset()
 func (recognizer *OnlineRecognizer) GetResult(s *OnlineStream) *OnlineRecognizerResult {
-	p := C.GetOnlineStreamResult(recognizer.impl, s.impl)
-	defer C.DestroyOnlineRecognizerResult(p)
+	p := C.SherpaOnnxGetOnlineStreamResult(recognizer.impl, s.impl)
+	defer C.SherpaOnnxDestroyOnlineRecognizerResult(p)
 	result := &OnlineRecognizerResult{}
 	result.Text = C.GoString(p.text)
 
@@ -442,7 +442,7 @@ type OfflineRecognizerResult struct {
 
 // Frees the internal pointer of the recognition to avoid memory leak.
 func DeleteOfflineRecognizer(recognizer *OfflineRecognizer) {
-	C.DestroyOfflineRecognizer(recognizer.impl)
+	C.SherpaOnnxDestroyOfflineRecognizer(recognizer.impl)
 	recognizer.impl = nil
 }
 
@@ -537,14 +537,14 @@ func NewOfflineRecognizer(config *OfflineRecognizerConfig) *OfflineRecognizer {
 	defer C.free(unsafe.Pointer(c.rule_fars))
 
 	recognizer := &OfflineRecognizer{}
-	recognizer.impl = C.CreateOfflineRecognizer(&c)
+	recognizer.impl = C.SherpaOnnxCreateOfflineRecognizer(&c)
 
 	return recognizer
 }
 
 // Frees the internal pointer of the stream to avoid memory leak.
 func DeleteOfflineStream(stream *OfflineStream) {
-	C.DestroyOfflineStream(stream.impl)
+	C.SherpaOnnxDestroyOfflineStream(stream.impl)
 	stream.impl = nil
 }
 
@@ -552,7 +552,7 @@ func DeleteOfflineStream(stream *OfflineStream) {
 // the returned stream to avoid memory leak
 func NewOfflineStream(recognizer *OfflineRecognizer) *OfflineStream {
 	stream := &OfflineStream{}
-	stream.impl = C.CreateOfflineStream(recognizer.impl)
+	stream.impl = C.SherpaOnnxCreateOfflineStream(recognizer.impl)
 	return stream
 }
 
@@ -564,12 +564,12 @@ func NewOfflineStream(recognizer *OfflineRecognizer) *OfflineStream {
 //
 // samples contains the actual audio samples. Each sample is in the range [-1, 1].
 func (s *OfflineStream) AcceptWaveform(sampleRate int, samples []float32) {
-	C.AcceptWaveformOffline(s.impl, C.int(sampleRate), (*C.float)(&samples[0]), C.int(len(samples)))
+	C.SherpaOnnxAcceptWaveformOffline(s.impl, C.int(sampleRate), (*C.float)(&samples[0]), C.int(len(samples)))
 }
 
 // Decode the offline stream.
 func (recognizer *OfflineRecognizer) Decode(s *OfflineStream) {
-	C.DecodeOfflineStream(recognizer.impl, s.impl)
+	C.SherpaOnnxDecodeOfflineStream(recognizer.impl, s.impl)
 }
 
 // Decode multiple streams in parallel, i.e., in batch.
@@ -579,13 +579,13 @@ func (recognizer *OfflineRecognizer) DecodeStreams(s []*OfflineStream) {
 		ss[i] = v.impl
 	}
 
-	C.DecodeMultipleOfflineStreams(recognizer.impl, &ss[0], C.int(len(s)))
+	C.SherpaOnnxDecodeMultipleOfflineStreams(recognizer.impl, &ss[0], C.int(len(s)))
 }
 
 // Get the recognition result of the offline stream.
 func (s *OfflineStream) GetResult() *OfflineRecognizerResult {
-	p := C.GetOfflineStreamResult(s.impl)
-	defer C.DestroyOfflineRecognizerResult(p)
+	p := C.SherpaOnnxGetOfflineStreamResult(s.impl)
+	defer C.SherpaOnnxDestroyOfflineRecognizerResult(p)
 	result := &OfflineRecognizerResult{}
 	result.Text = C.GoString(p.text)
 

--- a/scripts/node-addon-api/src/audio-tagging.cc
+++ b/scripts/node-addon-api/src/audio-tagging.cc
@@ -141,7 +141,7 @@ AudioTaggingCreateOfflineStreamWrapper(const Napi::CallbackInfo &info) {
   return Napi::External<SherpaOnnxOfflineStream>::New(
       env, const_cast<SherpaOnnxOfflineStream *>(stream),
       [](Napi::Env env, SherpaOnnxOfflineStream *stream) {
-        DestroyOfflineStream(stream);
+        SherpaOnnxDestroyOfflineStream(stream);
       });
 }
 

--- a/scripts/node-addon-api/src/keyword-spotting.cc
+++ b/scripts/node-addon-api/src/keyword-spotting.cc
@@ -44,7 +44,7 @@ static Napi::External<SherpaOnnxKeywordSpotter> CreateKeywordSpotterWrapper(
   SHERPA_ONNX_ASSIGN_ATTR_FLOAT(keywords_threshold, keywordsThreshold);
   SHERPA_ONNX_ASSIGN_ATTR_STR(keywords_file, keywordsFile);
 
-  SherpaOnnxKeywordSpotter *kws = CreateKeywordSpotter(&c);
+  SherpaOnnxKeywordSpotter *kws = SherpaOnnxCreateKeywordSpotter(&c);
 
   if (c.model_config.transducer.encoder) {
     delete[] c.model_config.transducer.encoder;
@@ -95,7 +95,7 @@ static Napi::External<SherpaOnnxKeywordSpotter> CreateKeywordSpotterWrapper(
 
   return Napi::External<SherpaOnnxKeywordSpotter>::New(
       env, kws, [](Napi::Env env, SherpaOnnxKeywordSpotter *kws) {
-        DestroyKeywordSpotter(kws);
+        SherpaOnnxDestroyKeywordSpotter(kws);
       });
 }
 
@@ -122,11 +122,11 @@ static Napi::External<SherpaOnnxOnlineStream> CreateKeywordStreamWrapper(
   SherpaOnnxKeywordSpotter *kws =
       info[0].As<Napi::External<SherpaOnnxKeywordSpotter>>().Data();
 
-  SherpaOnnxOnlineStream *stream = CreateKeywordStream(kws);
+  SherpaOnnxOnlineStream *stream = SherpaOnnxCreateKeywordStream(kws);
 
   return Napi::External<SherpaOnnxOnlineStream>::New(
       env, stream, [](Napi::Env env, SherpaOnnxOnlineStream *stream) {
-        DestroyOnlineStream(stream);
+        SherpaOnnxDestroyOnlineStream(stream);
       });
 }
 
@@ -162,7 +162,7 @@ static Napi::Boolean IsKeywordStreamReadyWrapper(
   SherpaOnnxOnlineStream *stream =
       info[1].As<Napi::External<SherpaOnnxOnlineStream>>().Data();
 
-  int32_t is_ready = IsKeywordStreamReady(kws, stream);
+  int32_t is_ready = SherpaOnnxIsKeywordStreamReady(kws, stream);
 
   return Napi::Boolean::New(env, is_ready);
 }
@@ -198,7 +198,7 @@ static void DecodeKeywordStreamWrapper(const Napi::CallbackInfo &info) {
   SherpaOnnxOnlineStream *stream =
       info[1].As<Napi::External<SherpaOnnxOnlineStream>>().Data();
 
-  DecodeKeywordStream(kws, stream);
+  SherpaOnnxDecodeKeywordStream(kws, stream);
 }
 
 static Napi::String GetKeywordResultAsJsonWrapper(
@@ -233,11 +233,11 @@ static Napi::String GetKeywordResultAsJsonWrapper(
   SherpaOnnxOnlineStream *stream =
       info[1].As<Napi::External<SherpaOnnxOnlineStream>>().Data();
 
-  const char *json = GetKeywordResultAsJson(kws, stream);
+  const char *json = SherpaOnnxGetKeywordResultAsJson(kws, stream);
 
   Napi::String s = Napi::String::New(env, json);
 
-  FreeKeywordResultJson(json);
+  SherpaOnnxFreeKeywordResultJson(json);
 
   return s;
 }

--- a/scripts/node-addon-api/src/non-streaming-asr.cc
+++ b/scripts/node-addon-api/src/non-streaming-asr.cc
@@ -202,7 +202,8 @@ CreateOfflineRecognizerWrapper(const Napi::CallbackInfo &info) {
   SHERPA_ONNX_ASSIGN_ATTR_STR(rule_fsts, ruleFsts);
   SHERPA_ONNX_ASSIGN_ATTR_STR(rule_fars, ruleFars);
 
-  SherpaOnnxOfflineRecognizer *recognizer = CreateOfflineRecognizer(&c);
+  SherpaOnnxOfflineRecognizer *recognizer =
+      SherpaOnnxCreateOfflineRecognizer(&c);
 
   if (c.model_config.transducer.encoder) {
     delete[] c.model_config.transducer.encoder;
@@ -306,7 +307,7 @@ CreateOfflineRecognizerWrapper(const Napi::CallbackInfo &info) {
   return Napi::External<SherpaOnnxOfflineRecognizer>::New(
       env, recognizer,
       [](Napi::Env env, SherpaOnnxOfflineRecognizer *recognizer) {
-        DestroyOfflineRecognizer(recognizer);
+        SherpaOnnxDestroyOfflineRecognizer(recognizer);
       });
 }
 
@@ -334,11 +335,11 @@ static Napi::External<SherpaOnnxOfflineStream> CreateOfflineStreamWrapper(
   SherpaOnnxOfflineRecognizer *recognizer =
       info[0].As<Napi::External<SherpaOnnxOfflineRecognizer>>().Data();
 
-  SherpaOnnxOfflineStream *stream = CreateOfflineStream(recognizer);
+  SherpaOnnxOfflineStream *stream = SherpaOnnxCreateOfflineStream(recognizer);
 
   return Napi::External<SherpaOnnxOfflineStream>::New(
       env, stream, [](Napi::Env env, SherpaOnnxOfflineStream *stream) {
-        DestroyOfflineStream(stream);
+        SherpaOnnxDestroyOfflineStream(stream);
       });
 }
 
@@ -405,8 +406,8 @@ static void AcceptWaveformOfflineWrapper(const Napi::CallbackInfo &info) {
   Napi::Float32Array samples = obj.Get("samples").As<Napi::Float32Array>();
   int32_t sample_rate = obj.Get("sampleRate").As<Napi::Number>().Int32Value();
 
-  AcceptWaveformOffline(stream, sample_rate, samples.Data(),
-                        samples.ElementLength());
+  SherpaOnnxAcceptWaveformOffline(stream, sample_rate, samples.Data(),
+                                  samples.ElementLength());
 }
 
 static void DecodeOfflineStreamWrapper(const Napi::CallbackInfo &info) {
@@ -441,7 +442,7 @@ static void DecodeOfflineStreamWrapper(const Napi::CallbackInfo &info) {
   SherpaOnnxOfflineStream *stream =
       info[1].As<Napi::External<SherpaOnnxOfflineStream>>().Data();
 
-  DecodeOfflineStream(recognizer, stream);
+  SherpaOnnxDecodeOfflineStream(recognizer, stream);
 }
 
 static Napi::String GetOfflineStreamResultAsJsonWrapper(
@@ -466,10 +467,10 @@ static Napi::String GetOfflineStreamResultAsJsonWrapper(
   SherpaOnnxOfflineStream *stream =
       info[0].As<Napi::External<SherpaOnnxOfflineStream>>().Data();
 
-  const char *json = GetOfflineStreamResultAsJson(stream);
+  const char *json = SherpaOnnxGetOfflineStreamResultAsJson(stream);
   Napi::String s = Napi::String::New(env, json);
 
-  DestroyOfflineStreamResultJson(json);
+  SherpaOnnxDestroyOfflineStreamResultJson(json);
 
   return s;
 }

--- a/scripts/node-addon-api/src/speaker-identification.cc
+++ b/scripts/node-addon-api/src/speaker-identification.cc
@@ -130,7 +130,7 @@ SpeakerEmbeddingExtractorCreateStreamWrapper(const Napi::CallbackInfo &info) {
   return Napi::External<SherpaOnnxOnlineStream>::New(
       env, const_cast<SherpaOnnxOnlineStream *>(stream),
       [](Napi::Env env, SherpaOnnxOnlineStream *stream) {
-        DestroyOnlineStream(stream);
+        SherpaOnnxDestroyOnlineStream(stream);
       });
 }
 

--- a/scripts/node-addon-api/src/spoken-language-identification.cc
+++ b/scripts/node-addon-api/src/spoken-language-identification.cc
@@ -124,7 +124,7 @@ SpokenLanguageIdentificationCreateOfflineStreamWrapper(
 
   return Napi::External<SherpaOnnxOfflineStream>::New(
       env, stream, [](Napi::Env env, SherpaOnnxOfflineStream *stream) {
-        DestroyOfflineStream(stream);
+        SherpaOnnxDestroyOfflineStream(stream);
       });
 }
 

--- a/scripts/node-addon-api/src/streaming-asr.cc
+++ b/scripts/node-addon-api/src/streaming-asr.cc
@@ -270,7 +270,7 @@ static Napi::External<SherpaOnnxOnlineRecognizer> CreateOnlineRecognizerWrapper(
   return Napi::External<SherpaOnnxOnlineRecognizer>::New(
       env, recognizer,
       [](Napi::Env env, SherpaOnnxOnlineRecognizer *recognizer) {
-        DestroyOnlineRecognizer(recognizer);
+        SherpaOnnxDestroyOnlineRecognizer(recognizer);
       });
 }
 
@@ -298,11 +298,11 @@ static Napi::External<SherpaOnnxOnlineStream> CreateOnlineStreamWrapper(
   SherpaOnnxOnlineRecognizer *recognizer =
       info[0].As<Napi::External<SherpaOnnxOnlineRecognizer>>().Data();
 
-  SherpaOnnxOnlineStream *stream = CreateOnlineStream(recognizer);
+  SherpaOnnxOnlineStream *stream = SherpaOnnxCreateOnlineStream(recognizer);
 
   return Napi::External<SherpaOnnxOnlineStream>::New(
       env, stream, [](Napi::Env env, SherpaOnnxOnlineStream *stream) {
-        DestroyOnlineStream(stream);
+        SherpaOnnxDestroyOnlineStream(stream);
       });
 }
 
@@ -369,7 +369,8 @@ static void AcceptWaveformWrapper(const Napi::CallbackInfo &info) {
   Napi::Float32Array samples = obj.Get("samples").As<Napi::Float32Array>();
   int32_t sample_rate = obj.Get("sampleRate").As<Napi::Number>().Int32Value();
 
-  AcceptWaveform(stream, sample_rate, samples.Data(), samples.ElementLength());
+  SherpaOnnxOnlineStreamAcceptWaveform(stream, sample_rate, samples.Data(),
+                                       samples.ElementLength());
 }
 
 static Napi::Boolean IsOnlineStreamReadyWrapper(
@@ -405,7 +406,7 @@ static Napi::Boolean IsOnlineStreamReadyWrapper(
   SherpaOnnxOnlineStream *stream =
       info[1].As<Napi::External<SherpaOnnxOnlineStream>>().Data();
 
-  int32_t is_ready = IsOnlineStreamReady(recognizer, stream);
+  int32_t is_ready = SherpaOnnxIsOnlineStreamReady(recognizer, stream);
 
   return Napi::Boolean::New(env, is_ready);
 }
@@ -442,7 +443,7 @@ static void DecodeOnlineStreamWrapper(const Napi::CallbackInfo &info) {
   SherpaOnnxOnlineStream *stream =
       info[1].As<Napi::External<SherpaOnnxOnlineStream>>().Data();
 
-  DecodeOnlineStream(recognizer, stream);
+  SherpaOnnxDecodeOnlineStream(recognizer, stream);
 }
 
 static Napi::String GetOnlineStreamResultAsJsonWrapper(
@@ -478,10 +479,10 @@ static Napi::String GetOnlineStreamResultAsJsonWrapper(
   SherpaOnnxOnlineStream *stream =
       info[1].As<Napi::External<SherpaOnnxOnlineStream>>().Data();
 
-  const char *json = GetOnlineStreamResultAsJson(recognizer, stream);
+  const char *json = SherpaOnnxGetOnlineStreamResultAsJson(recognizer, stream);
   Napi::String s = Napi::String::New(env, json);
 
-  DestroyOnlineStreamResultJson(json);
+  SherpaOnnxDestroyOnlineStreamResultJson(json);
 
   return s;
 }
@@ -508,7 +509,7 @@ static void InputFinishedWrapper(const Napi::CallbackInfo &info) {
   SherpaOnnxOnlineStream *stream =
       info[0].As<Napi::External<SherpaOnnxOnlineStream>>().Data();
 
-  InputFinished(stream);
+  SherpaOnnxOnlineStreamInputFinished(stream);
 }
 
 static void ResetOnlineStreamWrapper(const Napi::CallbackInfo &info) {
@@ -543,7 +544,7 @@ static void ResetOnlineStreamWrapper(const Napi::CallbackInfo &info) {
   SherpaOnnxOnlineStream *stream =
       info[1].As<Napi::External<SherpaOnnxOnlineStream>>().Data();
 
-  Reset(recognizer, stream);
+  SherpaOnnxOnlineStreamReset(recognizer, stream);
 }
 
 static Napi::Boolean IsEndpointWrapper(const Napi::CallbackInfo &info) {
@@ -578,7 +579,7 @@ static Napi::Boolean IsEndpointWrapper(const Napi::CallbackInfo &info) {
   SherpaOnnxOnlineStream *stream =
       info[1].As<Napi::External<SherpaOnnxOnlineStream>>().Data();
 
-  int32_t is_endpoint = IsEndpoint(recognizer, stream);
+  int32_t is_endpoint = SherpaOnnxOnlineStreamIsEndpoint(recognizer, stream);
 
   return Napi::Boolean::New(env, is_endpoint);
 }
@@ -603,12 +604,12 @@ static Napi::External<SherpaOnnxDisplay> CreateDisplayWrapper(
   }
   int32_t max_word_per_line = info[0].As<Napi::Number>().Int32Value();
 
-  const SherpaOnnxDisplay *display = CreateDisplay(max_word_per_line);
+  const SherpaOnnxDisplay *display = SherpaOnnxCreateDisplay(max_word_per_line);
 
   return Napi::External<SherpaOnnxDisplay>::New(
       env, const_cast<SherpaOnnxDisplay *>(display),
       [](Napi::Env env, SherpaOnnxDisplay *display) {
-        DestroyDisplay(display);
+        SherpaOnnxDestroyDisplay(display);
       });
 }
 

--- a/scripts/node-addon-api/src/streaming-asr.cc
+++ b/scripts/node-addon-api/src/streaming-asr.cc
@@ -194,7 +194,7 @@ static Napi::External<SherpaOnnxOnlineRecognizer> CreateOnlineRecognizerWrapper(
 
   c.ctc_fst_decoder_config = GetCtcFstDecoderConfig(o);
 
-  SherpaOnnxOnlineRecognizer *recognizer = CreateOnlineRecognizer(&c);
+  SherpaOnnxOnlineRecognizer *recognizer = SherpaOnnxCreateOnlineRecognizer(&c);
 
   if (c.model_config.transducer.encoder) {
     delete[] c.model_config.transducer.encoder;

--- a/sherpa-onnx/c-api/c-api.cc
+++ b/sherpa-onnx/c-api/c-api.cc
@@ -45,7 +45,7 @@ struct SherpaOnnxDisplay {
 
 #define SHERPA_ONNX_OR(x, y) (x ? x : y)
 
-SherpaOnnxOnlineRecognizer *CreateOnlineRecognizer(
+SherpaOnnxOnlineRecognizer *SherpaOnnxCreateOnlineRecognizer(
     const SherpaOnnxOnlineRecognizerConfig *config) {
   sherpa_onnx::OnlineRecognizerConfig recognizer_config;
 

--- a/sherpa-onnx/c-api/c-api.cc
+++ b/sherpa-onnx/c-api/c-api.cc
@@ -130,46 +130,49 @@ SherpaOnnxOnlineRecognizer *SherpaOnnxCreateOnlineRecognizer(
   return recognizer;
 }
 
-void DestroyOnlineRecognizer(const SherpaOnnxOnlineRecognizer *recognizer) {
+void SherpaOnnxDestroyOnlineRecognizer(
+    const SherpaOnnxOnlineRecognizer *recognizer) {
   delete recognizer;
 }
 
-SherpaOnnxOnlineStream *CreateOnlineStream(
+SherpaOnnxOnlineStream *SherpaOnnxCreateOnlineStream(
     const SherpaOnnxOnlineRecognizer *recognizer) {
   SherpaOnnxOnlineStream *stream =
       new SherpaOnnxOnlineStream(recognizer->impl->CreateStream());
   return stream;
 }
 
-SherpaOnnxOnlineStream *CreateOnlineStreamWithHotwords(
+SherpaOnnxOnlineStream *SherpaOnnxCreateOnlineStreamWithHotwords(
     const SherpaOnnxOnlineRecognizer *recognizer, const char *hotwords) {
   SherpaOnnxOnlineStream *stream =
       new SherpaOnnxOnlineStream(recognizer->impl->CreateStream(hotwords));
   return stream;
 }
 
-void DestroyOnlineStream(const SherpaOnnxOnlineStream *stream) {
+void SherpaOnnxDestroyOnlineStream(const SherpaOnnxOnlineStream *stream) {
   delete stream;
 }
 
-void AcceptWaveform(const SherpaOnnxOnlineStream *stream, int32_t sample_rate,
-                    const float *samples, int32_t n) {
+void SherpaOnnxOnlineStreamAcceptWaveform(const SherpaOnnxOnlineStream *stream,
+                                          int32_t sample_rate,
+                                          const float *samples, int32_t n) {
   stream->impl->AcceptWaveform(sample_rate, samples, n);
 }
 
-int32_t IsOnlineStreamReady(const SherpaOnnxOnlineRecognizer *recognizer,
-                            const SherpaOnnxOnlineStream *stream) {
+int32_t SherpaOnnxIsOnlineStreamReady(
+    const SherpaOnnxOnlineRecognizer *recognizer,
+    const SherpaOnnxOnlineStream *stream) {
   return recognizer->impl->IsReady(stream->impl.get());
 }
 
-void DecodeOnlineStream(const SherpaOnnxOnlineRecognizer *recognizer,
-                        const SherpaOnnxOnlineStream *stream) {
+void SherpaOnnxDecodeOnlineStream(const SherpaOnnxOnlineRecognizer *recognizer,
+                                  const SherpaOnnxOnlineStream *stream) {
   recognizer->impl->DecodeStream(stream->impl.get());
 }
 
-void DecodeMultipleOnlineStreams(const SherpaOnnxOnlineRecognizer *recognizer,
-                                 const SherpaOnnxOnlineStream **streams,
-                                 int32_t n) {
+void SherpaOnnxDecodeMultipleOnlineStreams(
+    const SherpaOnnxOnlineRecognizer *recognizer,
+    const SherpaOnnxOnlineStream **streams, int32_t n) {
   std::vector<sherpa_onnx::OnlineStream *> ss(n);
   for (int32_t i = 0; i != n; ++i) {
     ss[i] = streams[i]->impl.get();
@@ -177,7 +180,7 @@ void DecodeMultipleOnlineStreams(const SherpaOnnxOnlineRecognizer *recognizer,
   recognizer->impl->DecodeStreams(ss.data(), n);
 }
 
-const SherpaOnnxOnlineRecognizerResult *GetOnlineStreamResult(
+const SherpaOnnxOnlineRecognizerResult *SherpaOnnxGetOnlineStreamResult(
     const SherpaOnnxOnlineRecognizer *recognizer,
     const SherpaOnnxOnlineStream *stream) {
   sherpa_onnx::OnlineRecognizerResult result =
@@ -241,7 +244,8 @@ const SherpaOnnxOnlineRecognizerResult *GetOnlineStreamResult(
   return r;
 }
 
-void DestroyOnlineRecognizerResult(const SherpaOnnxOnlineRecognizerResult *r) {
+void SherpaOnnxDestroyOnlineRecognizerResult(
+    const SherpaOnnxOnlineRecognizerResult *r) {
   if (r) {
     delete[] r->text;
     delete[] r->json;
@@ -252,7 +256,7 @@ void DestroyOnlineRecognizerResult(const SherpaOnnxOnlineRecognizerResult *r) {
   }
 }
 
-const char *GetOnlineStreamResultAsJson(
+const char *SherpaOnnxGetOnlineStreamResultAsJson(
     const SherpaOnnxOnlineRecognizer *recognizer,
     const SherpaOnnxOnlineStream *stream) {
   sherpa_onnx::OnlineRecognizerResult result =
@@ -264,29 +268,32 @@ const char *GetOnlineStreamResultAsJson(
   return pJson;
 }
 
-void DestroyOnlineStreamResultJson(const char *s) { delete[] s; }
+void SherpaOnnxDestroyOnlineStreamResultJson(const char *s) { delete[] s; }
 
-void Reset(const SherpaOnnxOnlineRecognizer *recognizer,
-           const SherpaOnnxOnlineStream *stream) {
+void SherpaOnnxOnlineStreamReset(const SherpaOnnxOnlineRecognizer *recognizer,
+                                 const SherpaOnnxOnlineStream *stream) {
   recognizer->impl->Reset(stream->impl.get());
 }
 
-void InputFinished(const SherpaOnnxOnlineStream *stream) {
+void SherpaOnnxOnlineStreamInputFinished(const SherpaOnnxOnlineStream *stream) {
   stream->impl->InputFinished();
 }
 
-int32_t IsEndpoint(const SherpaOnnxOnlineRecognizer *recognizer,
-                   const SherpaOnnxOnlineStream *stream) {
+int32_t SherpaOnnxOnlineStreamIsEndpoint(
+    const SherpaOnnxOnlineRecognizer *recognizer,
+    const SherpaOnnxOnlineStream *stream) {
   return recognizer->impl->IsEndpoint(stream->impl.get());
 }
 
-const SherpaOnnxDisplay *CreateDisplay(int32_t max_word_per_line) {
+const SherpaOnnxDisplay *SherpaOnnxCreateDisplay(int32_t max_word_per_line) {
   SherpaOnnxDisplay *ans = new SherpaOnnxDisplay;
   ans->impl = std::make_unique<sherpa_onnx::Display>(max_word_per_line);
   return ans;
 }
 
-void DestroyDisplay(const SherpaOnnxDisplay *display) { delete display; }
+void SherpaOnnxDestroyDisplay(const SherpaOnnxDisplay *display) {
+  delete display;
+}
 
 void SherpaOnnxPrint(const SherpaOnnxDisplay *display, int32_t idx,
                      const char *s) {
@@ -311,7 +318,7 @@ struct SherpaOnnxOfflineStream {
 static sherpa_onnx::OfflineRecognizerConfig convertConfig(
     const SherpaOnnxOfflineRecognizerConfig *config);
 
-SherpaOnnxOfflineRecognizer *CreateOfflineRecognizer(
+SherpaOnnxOfflineRecognizer *SherpaOnnxCreateOfflineRecognizer(
     const SherpaOnnxOfflineRecognizerConfig *config) {
   sherpa_onnx::OfflineRecognizerConfig recognizer_config =
       convertConfig(config);
@@ -438,35 +445,37 @@ void SherpaOnnxOfflineRecognizerSetConfig(
   recognizer->impl->SetConfig(recognizer_config);
 }
 
-void DestroyOfflineRecognizer(SherpaOnnxOfflineRecognizer *recognizer) {
+void SherpaOnnxDestroyOfflineRecognizer(
+    SherpaOnnxOfflineRecognizer *recognizer) {
   delete recognizer;
 }
 
-SherpaOnnxOfflineStream *CreateOfflineStream(
+SherpaOnnxOfflineStream *SherpaOnnxCreateOfflineStream(
     const SherpaOnnxOfflineRecognizer *recognizer) {
   SherpaOnnxOfflineStream *stream =
       new SherpaOnnxOfflineStream(recognizer->impl->CreateStream());
   return stream;
 }
 
-void DestroyOfflineStream(const SherpaOnnxOfflineStream *stream) {
+void SherpaOnnxDestroyOfflineStream(const SherpaOnnxOfflineStream *stream) {
   delete stream;
 }
 
-void AcceptWaveformOffline(const SherpaOnnxOfflineStream *stream,
-                           int32_t sample_rate, const float *samples,
-                           int32_t n) {
+void SherpaOnnxAcceptWaveformOffline(const SherpaOnnxOfflineStream *stream,
+                                     int32_t sample_rate, const float *samples,
+                                     int32_t n) {
   stream->impl->AcceptWaveform(sample_rate, samples, n);
 }
 
-void DecodeOfflineStream(const SherpaOnnxOfflineRecognizer *recognizer,
-                         const SherpaOnnxOfflineStream *stream) {
+void SherpaOnnxDecodeOfflineStream(
+    const SherpaOnnxOfflineRecognizer *recognizer,
+    const SherpaOnnxOfflineStream *stream) {
   recognizer->impl->DecodeStream(stream->impl.get());
 }
 
-void DecodeMultipleOfflineStreams(SherpaOnnxOfflineRecognizer *recognizer,
-                                  SherpaOnnxOfflineStream **streams,
-                                  int32_t n) {
+void SherpaOnnxDecodeMultipleOfflineStreams(
+    SherpaOnnxOfflineRecognizer *recognizer, SherpaOnnxOfflineStream **streams,
+    int32_t n) {
   std::vector<sherpa_onnx::OfflineStream *> ss(n);
   for (int32_t i = 0; i != n; ++i) {
     ss[i] = streams[i]->impl.get();
@@ -474,7 +483,7 @@ void DecodeMultipleOfflineStreams(SherpaOnnxOfflineRecognizer *recognizer,
   recognizer->impl->DecodeStreams(ss.data(), n);
 }
 
-const SherpaOnnxOfflineRecognizerResult *GetOfflineStreamResult(
+const SherpaOnnxOfflineRecognizerResult *SherpaOnnxGetOfflineStreamResult(
     const SherpaOnnxOfflineStream *stream) {
   const sherpa_onnx::OfflineRecognitionResult &result =
       stream->impl->GetResult();
@@ -543,7 +552,7 @@ const SherpaOnnxOfflineRecognizerResult *GetOfflineStreamResult(
   return r;
 }
 
-void DestroyOfflineRecognizerResult(
+void SherpaOnnxDestroyOfflineRecognizerResult(
     const SherpaOnnxOfflineRecognizerResult *r) {
   if (r) {
     delete[] r->text;
@@ -556,7 +565,7 @@ void DestroyOfflineRecognizerResult(
   }
 }
 
-const char *GetOfflineStreamResultAsJson(
+const char *SherpaOnnxGetOfflineStreamResultAsJson(
     const SherpaOnnxOfflineStream *stream) {
   const sherpa_onnx::OfflineRecognitionResult &result =
       stream->impl->GetResult();
@@ -567,7 +576,7 @@ const char *GetOfflineStreamResultAsJson(
   return pJson;
 }
 
-void DestroyOfflineStreamResultJson(const char *s) { delete[] s; }
+void SherpaOnnxDestroyOfflineStreamResultJson(const char *s) { delete[] s; }
 
 // ============================================================
 // For Keyword Spot
@@ -577,7 +586,7 @@ struct SherpaOnnxKeywordSpotter {
   std::unique_ptr<sherpa_onnx::KeywordSpotter> impl;
 };
 
-SherpaOnnxKeywordSpotter *CreateKeywordSpotter(
+SherpaOnnxKeywordSpotter *SherpaOnnxCreateKeywordSpotter(
     const SherpaOnnxKeywordSpotterConfig *config) {
   sherpa_onnx::KeywordSpotterConfig spotter_config;
 
@@ -640,36 +649,37 @@ SherpaOnnxKeywordSpotter *CreateKeywordSpotter(
   return spotter;
 }
 
-void DestroyKeywordSpotter(SherpaOnnxKeywordSpotter *spotter) {
+void SherpaOnnxDestroyKeywordSpotter(SherpaOnnxKeywordSpotter *spotter) {
   delete spotter;
 }
 
-SherpaOnnxOnlineStream *CreateKeywordStream(
+SherpaOnnxOnlineStream *SherpaOnnxCreateKeywordStream(
     const SherpaOnnxKeywordSpotter *spotter) {
   SherpaOnnxOnlineStream *stream =
       new SherpaOnnxOnlineStream(spotter->impl->CreateStream());
   return stream;
 }
 
-SherpaOnnxOnlineStream *CreateKeywordStreamWithKeywords(
+SherpaOnnxOnlineStream *SherpaOnnxCreateKeywordStreamWithKeywords(
     const SherpaOnnxKeywordSpotter *spotter, const char *keywords) {
   SherpaOnnxOnlineStream *stream =
       new SherpaOnnxOnlineStream(spotter->impl->CreateStream(keywords));
   return stream;
 }
 
-int32_t IsKeywordStreamReady(SherpaOnnxKeywordSpotter *spotter,
-                             SherpaOnnxOnlineStream *stream) {
+int32_t SherpaOnnxIsKeywordStreamReady(SherpaOnnxKeywordSpotter *spotter,
+                                       SherpaOnnxOnlineStream *stream) {
   return spotter->impl->IsReady(stream->impl.get());
 }
 
-void DecodeKeywordStream(SherpaOnnxKeywordSpotter *spotter,
-                         SherpaOnnxOnlineStream *stream) {
+void SherpaOnnxDecodeKeywordStream(SherpaOnnxKeywordSpotter *spotter,
+                                   SherpaOnnxOnlineStream *stream) {
   return spotter->impl->DecodeStream(stream->impl.get());
 }
 
-void DecodeMultipleKeywordStreams(SherpaOnnxKeywordSpotter *spotter,
-                                  SherpaOnnxOnlineStream **streams, int32_t n) {
+void SherpaOnnxDecodeMultipleKeywordStreams(SherpaOnnxKeywordSpotter *spotter,
+                                            SherpaOnnxOnlineStream **streams,
+                                            int32_t n) {
   std::vector<sherpa_onnx::OnlineStream *> ss(n);
   for (int32_t i = 0; i != n; ++i) {
     ss[i] = streams[i]->impl.get();
@@ -677,7 +687,7 @@ void DecodeMultipleKeywordStreams(SherpaOnnxKeywordSpotter *spotter,
   spotter->impl->DecodeStreams(ss.data(), n);
 }
 
-const SherpaOnnxKeywordResult *GetKeywordResult(
+const SherpaOnnxKeywordResult *SherpaOnnxGetKeywordResult(
     SherpaOnnxKeywordSpotter *spotter, SherpaOnnxOnlineStream *stream) {
   const sherpa_onnx::KeywordResult &result =
       spotter->impl->GetResult(stream->impl.get());
@@ -742,7 +752,7 @@ const SherpaOnnxKeywordResult *GetKeywordResult(
   return r;
 }
 
-void DestroyKeywordResult(const SherpaOnnxKeywordResult *r) {
+void SherpaOnnxDestroyKeywordResult(const SherpaOnnxKeywordResult *r) {
   if (r) {
     delete[] r->keyword;
     delete[] r->json;
@@ -753,8 +763,8 @@ void DestroyKeywordResult(const SherpaOnnxKeywordResult *r) {
   }
 }
 
-const char *GetKeywordResultAsJson(SherpaOnnxKeywordSpotter *spotter,
-                                   SherpaOnnxOnlineStream *stream) {
+const char *SherpaOnnxGetKeywordResultAsJson(SherpaOnnxKeywordSpotter *spotter,
+                                             SherpaOnnxOnlineStream *stream) {
   const sherpa_onnx::KeywordResult &result =
       spotter->impl->GetResult(stream->impl.get());
 
@@ -765,7 +775,7 @@ const char *GetKeywordResultAsJson(SherpaOnnxKeywordSpotter *spotter,
   return pJson;
 }
 
-void FreeKeywordResultJson(const char *s) { delete[] s; }
+void SherpaOnnxFreeKeywordResultJson(const char *s) { delete[] s; }
 
 // ============================================================
 // For VAD

--- a/sherpa-onnx/c-api/c-api.h
+++ b/sherpa-onnx/c-api/c-api.h
@@ -194,18 +194,18 @@ SHERPA_ONNX_API typedef struct SherpaOnnxOnlineStream SherpaOnnxOnlineStream;
 /// @param config  Config for the recognizer.
 /// @return Return a pointer to the recognizer. The user has to invoke
 //          DestroyOnlineRecognizer() to free it to avoid memory leak.
-SHERPA_ONNX_API SherpaOnnxOnlineRecognizer *CreateOnlineRecognizer(
+SHERPA_ONNX_API SherpaOnnxOnlineRecognizer *SherpaOnnxCreateOnlineRecognizer(
     const SherpaOnnxOnlineRecognizerConfig *config);
 
-/// Free a pointer returned by CreateOnlineRecognizer()
+/// Free a pointer returned by SherpaOnnxCreateOnlineRecognizer()
 ///
-/// @param p A pointer returned by CreateOnlineRecognizer()
+/// @param p A pointer returned by SherpaOnnxCreateOnlineRecognizer()
 SHERPA_ONNX_API void DestroyOnlineRecognizer(
     const SherpaOnnxOnlineRecognizer *recognizer);
 
 /// Create an online stream for accepting wave samples.
 ///
-/// @param recognizer  A pointer returned by CreateOnlineRecognizer()
+/// @param recognizer  A pointer returned by SherpaOnnxCreateOnlineRecognizer()
 /// @return Return a pointer to an OnlineStream. The user has to invoke
 ///         DestroyOnlineStream() to free it to avoid memory leak.
 SHERPA_ONNX_API SherpaOnnxOnlineStream *CreateOnlineStream(
@@ -214,7 +214,7 @@ SHERPA_ONNX_API SherpaOnnxOnlineStream *CreateOnlineStream(
 /// Create an online stream for accepting wave samples with the specified hot
 /// words.
 ///
-/// @param recognizer  A pointer returned by CreateOnlineRecognizer()
+/// @param recognizer  A pointer returned by SherpaOnnxCreateOnlineRecognizer()
 /// @return Return a pointer to an OnlineStream. The user has to invoke
 ///         DestroyOnlineStream() to free it to avoid memory leak.
 SHERPA_ONNX_API SherpaOnnxOnlineStream *CreateOnlineStreamWithHotwords(
@@ -243,7 +243,7 @@ SHERPA_ONNX_API void AcceptWaveform(const SherpaOnnxOnlineStream *stream,
 /// Return 1 if there are enough number of feature frames for decoding.
 /// Return 0 otherwise.
 ///
-/// @param recognizer  A pointer returned by CreateOnlineRecognizer
+/// @param recognizer  A pointer returned by SherpaOnnxCreateOnlineRecognizer
 /// @param stream  A pointer returned by CreateOnlineStream
 SHERPA_ONNX_API int32_t
 IsOnlineStreamReady(const SherpaOnnxOnlineRecognizer *recognizer,
@@ -269,9 +269,9 @@ SHERPA_ONNX_API void DecodeOnlineStream(
 /// Caution: The caller has to ensure each OnlineStream is ready, i.e.,
 /// IsOnlineStreamReady() for that stream should return 1.
 ///
-/// @param recognizer  A pointer returned by CreateOnlineRecognizer()
+/// @param recognizer  A pointer returned by SherpaOnnxCreateOnlineRecognizer()
 /// @param streams  A pointer array containing pointers returned by
-///                 CreateOnlineRecognizer()
+///                 SherpaOnnxCreateOnlineRecognizer()
 /// @param n  Number of elements in the given streams array.
 SHERPA_ONNX_API void DecodeMultipleOnlineStreams(
     const SherpaOnnxOnlineRecognizer *recognizer,
@@ -279,7 +279,7 @@ SHERPA_ONNX_API void DecodeMultipleOnlineStreams(
 
 /// Get the decoding results so far for an OnlineStream.
 ///
-/// @param recognizer A pointer returned by CreateOnlineRecognizer().
+/// @param recognizer A pointer returned by SherpaOnnxCreateOnlineRecognizer().
 /// @param stream A pointer returned by CreateOnlineStream().
 /// @return A pointer containing the result. The user has to invoke
 ///         DestroyOnlineRecognizerResult() to free the returned pointer to
@@ -307,7 +307,7 @@ SHERPA_ONNX_API void DestroyOnlineStreamResultJson(const char *s);
 /// Reset an OnlineStream , which clears the neural network model state
 /// and the state for decoding.
 ///
-/// @param recognizer A pointer returned by CreateOnlineRecognizer().
+/// @param recognizer A pointer returned by SherpaOnnxCreateOnlineRecognizer().
 /// @param stream A pointer returned by CreateOnlineStream
 SHERPA_ONNX_API void Reset(const SherpaOnnxOnlineRecognizer *recognizer,
                            const SherpaOnnxOnlineStream *stream);
@@ -320,7 +320,7 @@ SHERPA_ONNX_API void InputFinished(const SherpaOnnxOnlineStream *stream);
 
 /// Return 1 if an endpoint has been detected.
 ///
-/// @param recognizer A pointer returned by CreateOnlineRecognizer()
+/// @param recognizer A pointer returned by SherpaOnnxCreateOnlineRecognizer()
 /// @param stream A pointer returned by CreateOnlineStream()
 /// @return Return 1 if an endpoint is detected. Return 0 otherwise.
 SHERPA_ONNX_API int32_t IsEndpoint(const SherpaOnnxOnlineRecognizer *recognizer,

--- a/sherpa-onnx/c-api/c-api.h
+++ b/sherpa-onnx/c-api/c-api.h
@@ -193,22 +193,22 @@ SHERPA_ONNX_API typedef struct SherpaOnnxOnlineStream SherpaOnnxOnlineStream;
 
 /// @param config  Config for the recognizer.
 /// @return Return a pointer to the recognizer. The user has to invoke
-//          DestroyOnlineRecognizer() to free it to avoid memory leak.
+//          SherpaOnnxDestroyOnlineRecognizer() to free it to avoid memory leak.
 SHERPA_ONNX_API SherpaOnnxOnlineRecognizer *SherpaOnnxCreateOnlineRecognizer(
     const SherpaOnnxOnlineRecognizerConfig *config);
 
 /// Free a pointer returned by SherpaOnnxCreateOnlineRecognizer()
 ///
 /// @param p A pointer returned by SherpaOnnxCreateOnlineRecognizer()
-SHERPA_ONNX_API void DestroyOnlineRecognizer(
+SHERPA_ONNX_API void SherpaOnnxDestroyOnlineRecognizer(
     const SherpaOnnxOnlineRecognizer *recognizer);
 
 /// Create an online stream for accepting wave samples.
 ///
 /// @param recognizer  A pointer returned by SherpaOnnxCreateOnlineRecognizer()
 /// @return Return a pointer to an OnlineStream. The user has to invoke
-///         DestroyOnlineStream() to free it to avoid memory leak.
-SHERPA_ONNX_API SherpaOnnxOnlineStream *CreateOnlineStream(
+///         SherpaOnnxDestroyOnlineStream() to free it to avoid memory leak.
+SHERPA_ONNX_API SherpaOnnxOnlineStream *SherpaOnnxCreateOnlineStream(
     const SherpaOnnxOnlineRecognizer *recognizer);
 
 /// Create an online stream for accepting wave samples with the specified hot
@@ -216,125 +216,132 @@ SHERPA_ONNX_API SherpaOnnxOnlineStream *CreateOnlineStream(
 ///
 /// @param recognizer  A pointer returned by SherpaOnnxCreateOnlineRecognizer()
 /// @return Return a pointer to an OnlineStream. The user has to invoke
-///         DestroyOnlineStream() to free it to avoid memory leak.
-SHERPA_ONNX_API SherpaOnnxOnlineStream *CreateOnlineStreamWithHotwords(
+///         SherpaOnnxDestroyOnlineStream() to free it to avoid memory leak.
+SHERPA_ONNX_API SherpaOnnxOnlineStream *
+SherpaOnnxCreateOnlineStreamWithHotwords(
     const SherpaOnnxOnlineRecognizer *recognizer, const char *hotwords);
 
 /// Destroy an online stream.
 ///
-/// @param stream A pointer returned by CreateOnlineStream()
-SHERPA_ONNX_API void DestroyOnlineStream(const SherpaOnnxOnlineStream *stream);
+/// @param stream A pointer returned by SherpaOnnxCreateOnlineStream()
+SHERPA_ONNX_API void SherpaOnnxDestroyOnlineStream(
+    const SherpaOnnxOnlineStream *stream);
 
 /// Accept input audio samples and compute the features.
-/// The user has to invoke DecodeOnlineStream() to run the neural network and
-/// decoding.
+/// The user has to invoke SherpaOnnxDecodeOnlineStream() to run the neural
+/// network and decoding.
 ///
-/// @param stream  A pointer returned by CreateOnlineStream().
+/// @param stream  A pointer returned by SherpaOnnxCreateOnlineStream().
 /// @param sample_rate  Sample rate of the input samples. If it is different
 ///                     from config.feat_config.sample_rate, we will do
 ///                     resampling inside sherpa-onnx.
 /// @param samples A pointer to a 1-D array containing audio samples.
 ///                The range of samples has to be normalized to [-1, 1].
 /// @param n  Number of elements in the samples array.
-SHERPA_ONNX_API void AcceptWaveform(const SherpaOnnxOnlineStream *stream,
-                                    int32_t sample_rate, const float *samples,
-                                    int32_t n);
+SHERPA_ONNX_API void SherpaOnnxOnlineStreamAcceptWaveform(
+    const SherpaOnnxOnlineStream *stream, int32_t sample_rate,
+    const float *samples, int32_t n);
 
 /// Return 1 if there are enough number of feature frames for decoding.
 /// Return 0 otherwise.
 ///
 /// @param recognizer  A pointer returned by SherpaOnnxCreateOnlineRecognizer
-/// @param stream  A pointer returned by CreateOnlineStream
+/// @param stream  A pointer returned by SherpaOnnxCreateOnlineStream
 SHERPA_ONNX_API int32_t
-IsOnlineStreamReady(const SherpaOnnxOnlineRecognizer *recognizer,
-                    const SherpaOnnxOnlineStream *stream);
+SherpaOnnxIsOnlineStreamReady(const SherpaOnnxOnlineRecognizer *recognizer,
+                              const SherpaOnnxOnlineStream *stream);
 
 /// Call this function to run the neural network model and decoding.
 //
-/// Precondition for this function: IsOnlineStreamReady() MUST return 1.
+/// Precondition for this function: SherpaOnnxIsOnlineStreamReady() MUST
+/// return 1.
 ///
 /// Usage example:
 ///
-///  while (IsOnlineStreamReady(recognizer, stream)) {
-///     DecodeOnlineStream(recognizer, stream);
+///  while (SherpaOnnxIsOnlineStreamReady(recognizer, stream)) {
+///     SherpaOnnxDecodeOnlineStream(recognizer, stream);
 ///  }
 ///
-SHERPA_ONNX_API void DecodeOnlineStream(
+SHERPA_ONNX_API void SherpaOnnxDecodeOnlineStream(
     const SherpaOnnxOnlineRecognizer *recognizer,
     const SherpaOnnxOnlineStream *stream);
 
-/// This function is similar to DecodeOnlineStream(). It decodes multiple
-/// OnlineStream in parallel.
+/// This function is similar to SherpaOnnxDecodeOnlineStream(). It decodes
+/// multiple OnlineStream in parallel.
 ///
 /// Caution: The caller has to ensure each OnlineStream is ready, i.e.,
-/// IsOnlineStreamReady() for that stream should return 1.
+/// SherpaOnnxIsOnlineStreamReady() for that stream should return 1.
 ///
 /// @param recognizer  A pointer returned by SherpaOnnxCreateOnlineRecognizer()
 /// @param streams  A pointer array containing pointers returned by
 ///                 SherpaOnnxCreateOnlineRecognizer()
 /// @param n  Number of elements in the given streams array.
-SHERPA_ONNX_API void DecodeMultipleOnlineStreams(
+SHERPA_ONNX_API void SherpaOnnxDecodeMultipleOnlineStreams(
     const SherpaOnnxOnlineRecognizer *recognizer,
     const SherpaOnnxOnlineStream **streams, int32_t n);
 
 /// Get the decoding results so far for an OnlineStream.
 ///
 /// @param recognizer A pointer returned by SherpaOnnxCreateOnlineRecognizer().
-/// @param stream A pointer returned by CreateOnlineStream().
+/// @param stream A pointer returned by SherpaOnnxCreateOnlineStream().
 /// @return A pointer containing the result. The user has to invoke
-///         DestroyOnlineRecognizerResult() to free the returned pointer to
-///         avoid memory leak.
-SHERPA_ONNX_API const SherpaOnnxOnlineRecognizerResult *GetOnlineStreamResult(
-    const SherpaOnnxOnlineRecognizer *recognizer,
-    const SherpaOnnxOnlineStream *stream);
+///         SherpaOnnxDestroyOnlineRecognizerResult() to free the returned
+///         pointer to avoid memory leak.
+SHERPA_ONNX_API const SherpaOnnxOnlineRecognizerResult *
+SherpaOnnxGetOnlineStreamResult(const SherpaOnnxOnlineRecognizer *recognizer,
+                                const SherpaOnnxOnlineStream *stream);
 
-/// Destroy the pointer returned by GetOnlineStreamResult().
+/// Destroy the pointer returned by SherpaOnnxGetOnlineStreamResult().
 ///
-/// @param r A pointer returned by GetOnlineStreamResult()
-SHERPA_ONNX_API void DestroyOnlineRecognizerResult(
+/// @param r A pointer returned by SherpaOnnxGetOnlineStreamResult()
+SHERPA_ONNX_API void SherpaOnnxDestroyOnlineRecognizerResult(
     const SherpaOnnxOnlineRecognizerResult *r);
 
 /// Return the result as a json string.
 /// The user has to invoke
-/// DestroyOnlineStreamResultJson()
+/// SherpaOnnxDestroyOnlineStreamResultJson()
 /// to free the returned pointer to avoid memory leak
-SHERPA_ONNX_API const char *GetOnlineStreamResultAsJson(
+SHERPA_ONNX_API const char *SherpaOnnxGetOnlineStreamResultAsJson(
     const SherpaOnnxOnlineRecognizer *recognizer,
     const SherpaOnnxOnlineStream *stream);
 
-SHERPA_ONNX_API void DestroyOnlineStreamResultJson(const char *s);
+SHERPA_ONNX_API void SherpaOnnxDestroyOnlineStreamResultJson(const char *s);
 
-/// Reset an OnlineStream , which clears the neural network model state
-/// and the state for decoding.
+/// SherpaOnnxOnlineStreamReset an OnlineStream , which clears the neural
+/// network model state and the state for decoding.
 ///
 /// @param recognizer A pointer returned by SherpaOnnxCreateOnlineRecognizer().
-/// @param stream A pointer returned by CreateOnlineStream
-SHERPA_ONNX_API void Reset(const SherpaOnnxOnlineRecognizer *recognizer,
-                           const SherpaOnnxOnlineStream *stream);
+/// @param stream A pointer returned by SherpaOnnxCreateOnlineStream
+SHERPA_ONNX_API void SherpaOnnxOnlineStreamReset(
+    const SherpaOnnxOnlineRecognizer *recognizer,
+    const SherpaOnnxOnlineStream *stream);
 
 /// Signal that no more audio samples would be available.
-/// After this call, you cannot call AcceptWaveform() any more.
+/// After this call, you cannot call SherpaOnnxOnlineStreamAcceptWaveform() any
+/// more.
 ///
-/// @param stream A pointer returned by CreateOnlineStream()
-SHERPA_ONNX_API void InputFinished(const SherpaOnnxOnlineStream *stream);
+/// @param stream A pointer returned by SherpaOnnxCreateOnlineStream()
+SHERPA_ONNX_API void SherpaOnnxOnlineStreamInputFinished(
+    const SherpaOnnxOnlineStream *stream);
 
 /// Return 1 if an endpoint has been detected.
 ///
 /// @param recognizer A pointer returned by SherpaOnnxCreateOnlineRecognizer()
-/// @param stream A pointer returned by CreateOnlineStream()
+/// @param stream A pointer returned by SherpaOnnxCreateOnlineStream()
 /// @return Return 1 if an endpoint is detected. Return 0 otherwise.
-SHERPA_ONNX_API int32_t IsEndpoint(const SherpaOnnxOnlineRecognizer *recognizer,
-                                   const SherpaOnnxOnlineStream *stream);
+SHERPA_ONNX_API int32_t
+SherpaOnnxOnlineStreamIsEndpoint(const SherpaOnnxOnlineRecognizer *recognizer,
+                                 const SherpaOnnxOnlineStream *stream);
 
 // for displaying results on Linux/macOS.
 SHERPA_ONNX_API typedef struct SherpaOnnxDisplay SherpaOnnxDisplay;
 
-/// Create a display object. Must be freed using DestroyDisplay to avoid
-/// memory leak.
-SHERPA_ONNX_API const SherpaOnnxDisplay *CreateDisplay(
+/// Create a display object. Must be freed using SherpaOnnxDestroyDisplay to
+/// avoid memory leak.
+SHERPA_ONNX_API const SherpaOnnxDisplay *SherpaOnnxCreateDisplay(
     int32_t max_word_per_line);
 
-SHERPA_ONNX_API void DestroyDisplay(const SherpaOnnxDisplay *display);
+SHERPA_ONNX_API void SherpaOnnxDestroyDisplay(const SherpaOnnxDisplay *display);
 
 /// Print the result.
 SHERPA_ONNX_API void SherpaOnnxPrint(const SherpaOnnxDisplay *display,
@@ -431,8 +438,9 @@ SHERPA_ONNX_API typedef struct SherpaOnnxOfflineStream SherpaOnnxOfflineStream;
 
 /// @param config  Config for the recognizer.
 /// @return Return a pointer to the recognizer. The user has to invoke
-//          DestroyOfflineRecognizer() to free it to avoid memory leak.
-SHERPA_ONNX_API SherpaOnnxOfflineRecognizer *CreateOfflineRecognizer(
+//          SherpaOnnxDestroyOfflineRecognizer() to free it to avoid memory
+//          leak.
+SHERPA_ONNX_API SherpaOnnxOfflineRecognizer *SherpaOnnxCreateOfflineRecognizer(
     const SherpaOnnxOfflineRecognizerConfig *config);
 
 /// @param config  Config for the recognizer.
@@ -440,31 +448,31 @@ SHERPA_ONNX_API void SherpaOnnxOfflineRecognizerSetConfig(
     const SherpaOnnxOfflineRecognizer *recognizer,
     const SherpaOnnxOfflineRecognizerConfig *config);
 
-/// Free a pointer returned by CreateOfflineRecognizer()
+/// Free a pointer returned by SherpaOnnxCreateOfflineRecognizer()
 ///
-/// @param p A pointer returned by CreateOfflineRecognizer()
-SHERPA_ONNX_API void DestroyOfflineRecognizer(
+/// @param p A pointer returned by SherpaOnnxCreateOfflineRecognizer()
+SHERPA_ONNX_API void SherpaOnnxDestroyOfflineRecognizer(
     SherpaOnnxOfflineRecognizer *recognizer);
 
 /// Create an offline stream for accepting wave samples.
 ///
-/// @param recognizer  A pointer returned by CreateOfflineRecognizer()
+/// @param recognizer  A pointer returned by SherpaOnnxCreateOfflineRecognizer()
 /// @return Return a pointer to an OfflineStream. The user has to invoke
-///         DestroyOfflineStream() to free it to avoid memory leak.
-SHERPA_ONNX_API SherpaOnnxOfflineStream *CreateOfflineStream(
+///         SherpaOnnxDestroyOfflineStream() to free it to avoid memory leak.
+SHERPA_ONNX_API SherpaOnnxOfflineStream *SherpaOnnxCreateOfflineStream(
     const SherpaOnnxOfflineRecognizer *recognizer);
 
 /// Destroy an offline stream.
 ///
-/// @param stream A pointer returned by CreateOfflineStream()
-SHERPA_ONNX_API void DestroyOfflineStream(
+/// @param stream A pointer returned by SherpaOnnxCreateOfflineStream()
+SHERPA_ONNX_API void SherpaOnnxDestroyOfflineStream(
     const SherpaOnnxOfflineStream *stream);
 
 /// Accept input audio samples and compute the features.
-/// The user has to invoke DecodeOfflineStream() to run the neural network and
-/// decoding.
+/// The user has to invoke SherpaOnnxDecodeOfflineStream() to run the neural
+/// network and decoding.
 ///
-/// @param stream  A pointer returned by CreateOfflineStream().
+/// @param stream  A pointer returned by SherpaOnnxCreateOfflineStream().
 /// @param sample_rate  Sample rate of the input samples. If it is different
 ///                     from config.feat_config.sample_rate, we will do
 ///                     resampling inside sherpa-onnx.
@@ -473,30 +481,30 @@ SHERPA_ONNX_API void DestroyOfflineStream(
 /// @param n  Number of elements in the samples array.
 ///
 /// @caution: For each offline stream, please invoke this function only once!
-SHERPA_ONNX_API void AcceptWaveformOffline(
+SHERPA_ONNX_API void SherpaOnnxAcceptWaveformOffline(
     const SherpaOnnxOfflineStream *stream, int32_t sample_rate,
     const float *samples, int32_t n);
 /// Decode an offline stream.
 ///
-/// We assume you have invoked AcceptWaveformOffline() for the given stream
-/// before calling this function.
+/// We assume you have invoked SherpaOnnxAcceptWaveformOffline() for the given
+/// stream before calling this function.
 ///
-/// @param recognizer A pointer returned by CreateOfflineRecognizer().
-/// @param stream A pointer returned by CreateOfflineStream()
-SHERPA_ONNX_API void DecodeOfflineStream(
+/// @param recognizer A pointer returned by SherpaOnnxCreateOfflineRecognizer().
+/// @param stream A pointer returned by SherpaOnnxCreateOfflineStream()
+SHERPA_ONNX_API void SherpaOnnxDecodeOfflineStream(
     const SherpaOnnxOfflineRecognizer *recognizer,
     const SherpaOnnxOfflineStream *stream);
 
 /// Decode a list offline streams in parallel.
 ///
-/// We assume you have invoked AcceptWaveformOffline() for each stream
+/// We assume you have invoked SherpaOnnxAcceptWaveformOffline() for each stream
 /// before calling this function.
 ///
-/// @param recognizer A pointer returned by CreateOfflineRecognizer().
+/// @param recognizer A pointer returned by SherpaOnnxCreateOfflineRecognizer().
 /// @param streams A pointer pointer array containing pointers returned
-///                by CreateOfflineStream().
+///                by SherpaOnnxCreateOfflineStream().
 /// @param n Number of entries in the given streams.
-SHERPA_ONNX_API void DecodeMultipleOfflineStreams(
+SHERPA_ONNX_API void SherpaOnnxDecodeMultipleOfflineStreams(
     SherpaOnnxOfflineRecognizer *recognizer, SherpaOnnxOfflineStream **streams,
     int32_t n);
 
@@ -538,30 +546,30 @@ SHERPA_ONNX_API typedef struct SherpaOnnxOfflineRecognizerResult {
 
 /// Get the result of the offline stream.
 ///
-/// We assume you have called DecodeOfflineStream() or
-/// DecodeMultipleOfflineStreams() with the given stream before calling
-/// this function.
+/// We assume you have called SherpaOnnxDecodeOfflineStream() or
+/// SherpaOnnxDecodeMultipleOfflineStreams() with the given stream before
+/// calling this function.
 ///
-/// @param stream A pointer returned by CreateOfflineStream().
+/// @param stream A pointer returned by SherpaOnnxCreateOfflineStream().
 /// @return Return a pointer to the result. The user has to invoke
-///         DestroyOnlineRecognizerResult() to free the returned pointer to
-///         avoid memory leak.
-SHERPA_ONNX_API const SherpaOnnxOfflineRecognizerResult *GetOfflineStreamResult(
-    const SherpaOnnxOfflineStream *stream);
+///         SherpaOnnxDestroyOnlineRecognizerResult() to free the returned
+///         pointer to avoid memory leak.
+SHERPA_ONNX_API const SherpaOnnxOfflineRecognizerResult *
+SherpaOnnxGetOfflineStreamResult(const SherpaOnnxOfflineStream *stream);
 
-/// Destroy the pointer returned by GetOfflineStreamResult().
+/// Destroy the pointer returned by SherpaOnnxGetOfflineStreamResult().
 ///
-/// @param r A pointer returned by GetOfflineStreamResult()
-SHERPA_ONNX_API void DestroyOfflineRecognizerResult(
+/// @param r A pointer returned by SherpaOnnxGetOfflineStreamResult()
+SHERPA_ONNX_API void SherpaOnnxDestroyOfflineRecognizerResult(
     const SherpaOnnxOfflineRecognizerResult *r);
 
 /// Return the result as a json string.
-/// The user has to use DestroyOfflineStreamResultJson()
+/// The user has to use SherpaOnnxDestroyOfflineStreamResultJson()
 /// to free the returned pointer to avoid memory leak
-SHERPA_ONNX_API const char *GetOfflineStreamResultAsJson(
+SHERPA_ONNX_API const char *SherpaOnnxGetOfflineStreamResultAsJson(
     const SherpaOnnxOfflineStream *stream);
 
-SHERPA_ONNX_API void DestroyOfflineStreamResultJson(const char *s);
+SHERPA_ONNX_API void SherpaOnnxDestroyOfflineStreamResultJson(const char *s);
 
 // ============================================================
 // For Keyword Spot
@@ -618,82 +626,86 @@ SHERPA_ONNX_API typedef struct SherpaOnnxKeywordSpotter
 
 /// @param config  Config for the keyword spotter.
 /// @return Return a pointer to the spotter. The user has to invoke
-///         DestroyKeywordSpotter() to free it to avoid memory leak.
-SHERPA_ONNX_API SherpaOnnxKeywordSpotter *CreateKeywordSpotter(
+///         SherpaOnnxDestroyKeywordSpotter() to free it to avoid memory leak.
+SHERPA_ONNX_API SherpaOnnxKeywordSpotter *SherpaOnnxCreateKeywordSpotter(
     const SherpaOnnxKeywordSpotterConfig *config);
 
-/// Free a pointer returned by CreateKeywordSpotter()
+/// Free a pointer returned by SherpaOnnxCreateKeywordSpotter()
 ///
-/// @param p A pointer returned by CreateKeywordSpotter()
-SHERPA_ONNX_API void DestroyKeywordSpotter(SherpaOnnxKeywordSpotter *spotter);
+/// @param p A pointer returned by SherpaOnnxCreateKeywordSpotter()
+SHERPA_ONNX_API void SherpaOnnxDestroyKeywordSpotter(
+    SherpaOnnxKeywordSpotter *spotter);
 
 /// Create an online stream for accepting wave samples.
 ///
-/// @param spotter A pointer returned by CreateKeywordSpotter()
+/// @param spotter A pointer returned by SherpaOnnxCreateKeywordSpotter()
 /// @return Return a pointer to an OnlineStream. The user has to invoke
-///         DestroyOnlineStream() to free it to avoid memory leak.
-SHERPA_ONNX_API SherpaOnnxOnlineStream *CreateKeywordStream(
+///         SherpaOnnxDestroyOnlineStream() to free it to avoid memory leak.
+SHERPA_ONNX_API SherpaOnnxOnlineStream *SherpaOnnxCreateKeywordStream(
     const SherpaOnnxKeywordSpotter *spotter);
 
 /// Create an online stream for accepting wave samples with the specified hot
 /// words.
 ///
-/// @param spotter A pointer returned by CreateKeywordSpotter()
+/// @param spotter A pointer returned by SherpaOnnxCreateKeywordSpotter()
 /// @param keywords A pointer points to the keywords that you set
 /// @return Return a pointer to an OnlineStream. The user has to invoke
-///         DestroyOnlineStream() to free it to avoid memory leak.
-SHERPA_ONNX_API SherpaOnnxOnlineStream *CreateKeywordStreamWithKeywords(
+///         SherpaOnnxDestroyOnlineStream() to free it to avoid memory leak.
+SHERPA_ONNX_API SherpaOnnxOnlineStream *
+SherpaOnnxCreateKeywordStreamWithKeywords(
     const SherpaOnnxKeywordSpotter *spotter, const char *keywords);
 
 /// Return 1 if there are enough number of feature frames for decoding.
 /// Return 0 otherwise.
 ///
-/// @param spotter A pointer returned by CreateKeywordSpotter
-/// @param stream  A pointer returned by CreateKeywordStream
-SHERPA_ONNX_API int32_t IsKeywordStreamReady(SherpaOnnxKeywordSpotter *spotter,
-                                             SherpaOnnxOnlineStream *stream);
+/// @param spotter A pointer returned by SherpaOnnxCreateKeywordSpotter
+/// @param stream  A pointer returned by SherpaOnnxCreateKeywordStream
+SHERPA_ONNX_API int32_t SherpaOnnxIsKeywordStreamReady(
+    SherpaOnnxKeywordSpotter *spotter, SherpaOnnxOnlineStream *stream);
 
 /// Call this function to run the neural network model and decoding.
 //
-/// Precondition for this function: IsKeywordStreamReady() MUST return 1.
-SHERPA_ONNX_API void DecodeKeywordStream(SherpaOnnxKeywordSpotter *spotter,
-                                         SherpaOnnxOnlineStream *stream);
+/// Precondition for this function: SherpaOnnxIsKeywordStreamReady() MUST
+/// return 1.
+SHERPA_ONNX_API void SherpaOnnxDecodeKeywordStream(
+    SherpaOnnxKeywordSpotter *spotter, SherpaOnnxOnlineStream *stream);
 
-/// This function is similar to DecodeKeywordStream(). It decodes multiple
-/// OnlineStream in parallel.
+/// This function is similar to SherpaOnnxDecodeKeywordStream(). It decodes
+/// multiple OnlineStream in parallel.
 ///
 /// Caution: The caller has to ensure each OnlineStream is ready, i.e.,
-/// IsKeywordStreamReady() for that stream should return 1.
+/// SherpaOnnxIsKeywordStreamReady() for that stream should return 1.
 ///
-/// @param spotter A pointer returned by CreateKeywordSpotter()
+/// @param spotter A pointer returned by SherpaOnnxCreateKeywordSpotter()
 /// @param streams  A pointer array containing pointers returned by
-///                 CreateKeywordStream()
+///                 SherpaOnnxCreateKeywordStream()
 /// @param n  Number of elements in the given streams array.
-SHERPA_ONNX_API void DecodeMultipleKeywordStreams(
+SHERPA_ONNX_API void SherpaOnnxDecodeMultipleKeywordStreams(
     SherpaOnnxKeywordSpotter *spotter, SherpaOnnxOnlineStream **streams,
     int32_t n);
 
 /// Get the decoding results so far for an OnlineStream.
 ///
-/// @param spotter A pointer returned by CreateKeywordSpotter().
-/// @param stream A pointer returned by CreateKeywordStream().
+/// @param spotter A pointer returned by SherpaOnnxCreateKeywordSpotter().
+/// @param stream A pointer returned by SherpaOnnxCreateKeywordStream().
 /// @return A pointer containing the result. The user has to invoke
-///         DestroyKeywordResult() to free the returned pointer to
+///         SherpaOnnxDestroyKeywordResult() to free the returned pointer to
 ///         avoid memory leak.
-SHERPA_ONNX_API const SherpaOnnxKeywordResult *GetKeywordResult(
+SHERPA_ONNX_API const SherpaOnnxKeywordResult *SherpaOnnxGetKeywordResult(
     SherpaOnnxKeywordSpotter *spotter, SherpaOnnxOnlineStream *stream);
 
-/// Destroy the pointer returned by GetKeywordResult().
+/// Destroy the pointer returned by SherpaOnnxGetKeywordResult().
 ///
-/// @param r A pointer returned by GetKeywordResult()
-SHERPA_ONNX_API void DestroyKeywordResult(const SherpaOnnxKeywordResult *r);
+/// @param r A pointer returned by SherpaOnnxGetKeywordResult()
+SHERPA_ONNX_API void SherpaOnnxDestroyKeywordResult(
+    const SherpaOnnxKeywordResult *r);
 
-// the user has to call FreeKeywordResultJson() to free the returned pointer
-// to avoid memory leak
-SHERPA_ONNX_API const char *GetKeywordResultAsJson(
+// the user has to call SherpaOnnxFreeKeywordResultJson() to free the returned
+// pointer to avoid memory leak
+SHERPA_ONNX_API const char *SherpaOnnxGetKeywordResultAsJson(
     SherpaOnnxKeywordSpotter *spotter, SherpaOnnxOnlineStream *stream);
 
-SHERPA_ONNX_API void FreeKeywordResultJson(const char *s);
+SHERPA_ONNX_API void SherpaOnnxFreeKeywordResultJson(const char *s);
 
 // ============================================================
 // For VAD
@@ -979,7 +991,7 @@ SherpaOnnxCreateSpokenLanguageIdentification(
 SHERPA_ONNX_API void SherpaOnnxDestroySpokenLanguageIdentification(
     const SherpaOnnxSpokenLanguageIdentification *slid);
 
-// The user has to invoke DestroyOfflineStream()
+// The user has to invoke SherpaOnnxDestroyOfflineStream()
 // to free the returned pointer to avoid memory leak
 SHERPA_ONNX_API SherpaOnnxOfflineStream *
 SherpaOnnxSpokenLanguageIdentificationCreateOfflineStream(
@@ -1029,8 +1041,8 @@ SHERPA_ONNX_API void SherpaOnnxDestroySpeakerEmbeddingExtractor(
 SHERPA_ONNX_API int32_t SherpaOnnxSpeakerEmbeddingExtractorDim(
     const SherpaOnnxSpeakerEmbeddingExtractor *p);
 
-// The user has to invoke DestroyOnlineStream() to free the returned pointer
-// to avoid memory leak
+// The user has to invoke SherpaOnnxDestroyOnlineStream() to free the returned
+// pointer to avoid memory leak
 SHERPA_ONNX_API const SherpaOnnxOnlineStream *
 SherpaOnnxSpeakerEmbeddingExtractorCreateStream(
     const SherpaOnnxSpeakerEmbeddingExtractor *p);
@@ -1239,7 +1251,7 @@ SHERPA_ONNX_API const SherpaOnnxAudioTagging *SherpaOnnxCreateAudioTagging(
 SHERPA_ONNX_API void SherpaOnnxDestroyAudioTagging(
     const SherpaOnnxAudioTagging *tagger);
 
-// The user has to invoke DestroyOfflineStream()
+// The user has to invoke SherpaOnnxDestroyOfflineStream()
 // to free the returned pointer to avoid memory leak
 SHERPA_ONNX_API const SherpaOnnxOfflineStream *
 SherpaOnnxAudioTaggingCreateOfflineStream(const SherpaOnnxAudioTagging *tagger);

--- a/swift-api-examples/SherpaOnnx.swift
+++ b/swift-api-examples/SherpaOnnx.swift
@@ -227,7 +227,7 @@ class SherpaOnnxRecognizer {
   init(
     config: UnsafePointer<SherpaOnnxOnlineRecognizerConfig>!
   ) {
-    recognizer = CreateOnlineRecognizer(config)
+    recognizer = SherpaOnnxCreateOnlineRecognizer(config)
     stream = CreateOnlineStream(recognizer)
   }
 

--- a/swift-api-examples/SherpaOnnx.swift
+++ b/swift-api-examples/SherpaOnnx.swift
@@ -213,7 +213,7 @@ class SherpaOnnxOnlineRecongitionResult {
 
   deinit {
     if let result {
-      DestroyOnlineRecognizerResult(result)
+      SherpaOnnxDestroyOnlineRecognizerResult(result)
     }
   }
 }
@@ -228,16 +228,16 @@ class SherpaOnnxRecognizer {
     config: UnsafePointer<SherpaOnnxOnlineRecognizerConfig>!
   ) {
     recognizer = SherpaOnnxCreateOnlineRecognizer(config)
-    stream = CreateOnlineStream(recognizer)
+    stream = SherpaOnnxCreateOnlineStream(recognizer)
   }
 
   deinit {
     if let stream {
-      DestroyOnlineStream(stream)
+      SherpaOnnxDestroyOnlineStream(stream)
     }
 
     if let recognizer {
-      DestroyOnlineRecognizer(recognizer)
+      SherpaOnnxDestroyOnlineRecognizer(recognizer)
     }
   }
 
@@ -248,22 +248,22 @@ class SherpaOnnxRecognizer {
   ///   - sampleRate: Sample rate of the input audio samples. Must match
   ///                 the one expected by the model.
   func acceptWaveform(samples: [Float], sampleRate: Int = 16000) {
-    AcceptWaveform(stream, Int32(sampleRate), samples, Int32(samples.count))
+    SherpaOnnxOnlineStreamAcceptWaveform(stream, Int32(sampleRate), samples, Int32(samples.count))
   }
 
   func isReady() -> Bool {
-    return IsOnlineStreamReady(recognizer, stream) == 1 ? true : false
+    return SherpaOnnxIsOnlineStreamReady(recognizer, stream) == 1 ? true : false
   }
 
   /// If there are enough number of feature frames, it invokes the neural
   /// network computation and decoding. Otherwise, it is a no-op.
   func decode() {
-    DecodeOnlineStream(recognizer, stream)
+    SherpaOnnxDecodeOnlineStream(recognizer, stream)
   }
 
   /// Get the decoding results so far
   func getResult() -> SherpaOnnxOnlineRecongitionResult {
-    let result: UnsafePointer<SherpaOnnxOnlineRecognizerResult>? = GetOnlineStreamResult(
+    let result: UnsafePointer<SherpaOnnxOnlineRecognizerResult>? = SherpaOnnxGetOnlineStreamResult(
       recognizer, stream)
     return SherpaOnnxOnlineRecongitionResult(result: result)
   }
@@ -275,15 +275,15 @@ class SherpaOnnxRecognizer {
   /// the given hotWords appended to the default hotwords.
   func reset(hotwords: String? = nil) {
     guard let words = hotwords, !words.isEmpty else {
-      Reset(recognizer, stream)
+      SherpaOnnxOnlineStreamReset(recognizer, stream)
       return
     }
 
     words.withCString { cString in
-      let newStream = CreateOnlineStreamWithHotwords(recognizer, cString)
+      let newStream = SherpaOnnxCreateOnlineStreamWithHotwords(recognizer, cString)
       // lock while release and replace stream
       objc_sync_enter(self)
-      DestroyOnlineStream(stream)
+      SherpaOnnxDestroyOnlineStream(stream)
       stream = newStream
       objc_sync_exit(self)
     }
@@ -292,12 +292,12 @@ class SherpaOnnxRecognizer {
   /// Signal that no more audio samples would be available.
   /// After this call, you cannot call acceptWaveform() any more.
   func inputFinished() {
-    InputFinished(stream)
+    SherpaOnnxOnlineStreamInputFinished(stream)
   }
 
   /// Return true is an endpoint has been detected.
   func isEndpoint() -> Bool {
-    return IsEndpoint(recognizer, stream) == 1 ? true : false
+    return SherpaOnnxOnlineStreamIsEndpoint(recognizer, stream) == 1 ? true : false
   }
 }
 
@@ -469,7 +469,7 @@ class SherpaOnnxOfflineRecongitionResult {
 
   deinit {
     if let result {
-      DestroyOfflineRecognizerResult(result)
+      SherpaOnnxDestroyOfflineRecognizerResult(result)
     }
   }
 }
@@ -481,12 +481,12 @@ class SherpaOnnxOfflineRecognizer {
   init(
     config: UnsafePointer<SherpaOnnxOfflineRecognizerConfig>!
   ) {
-    recognizer = CreateOfflineRecognizer(config)
+    recognizer = SherpaOnnxCreateOfflineRecognizer(config)
   }
 
   deinit {
     if let recognizer {
-      DestroyOfflineRecognizer(recognizer)
+      SherpaOnnxDestroyOfflineRecognizer(recognizer)
     }
   }
 
@@ -497,16 +497,17 @@ class SherpaOnnxOfflineRecognizer {
   ///   - sampleRate: Sample rate of the input audio samples. Must match
   ///                 the one expected by the model.
   func decode(samples: [Float], sampleRate: Int = 16000) -> SherpaOnnxOfflineRecongitionResult {
-    let stream: OpaquePointer! = CreateOfflineStream(recognizer)
+    let stream: OpaquePointer! = SherpaOnnxCreateOfflineStream(recognizer)
 
-    AcceptWaveformOffline(stream, Int32(sampleRate), samples, Int32(samples.count))
+    SherpaOnnxAcceptWaveformOffline(stream, Int32(sampleRate), samples, Int32(samples.count))
 
-    DecodeOfflineStream(recognizer, stream)
+    SherpaOnnxDecodeOfflineStream(recognizer, stream)
 
-    let result: UnsafePointer<SherpaOnnxOfflineRecognizerResult>? = GetOfflineStreamResult(
-      stream)
+    let result: UnsafePointer<SherpaOnnxOfflineRecognizerResult>? =
+      SherpaOnnxGetOfflineStreamResult(
+        stream)
 
-    DestroyOfflineStream(stream)
+    SherpaOnnxDestroyOfflineStream(stream)
 
     return SherpaOnnxOfflineRecongitionResult(result: result)
   }
@@ -852,14 +853,14 @@ class SherpaOnnxSpokenLanguageIdentificationWrapper {
     -> SherpaOnnxSpokenLanguageIdentificationResultWrapper
   {
     let stream: OpaquePointer! = SherpaOnnxSpokenLanguageIdentificationCreateOfflineStream(slid)
-    AcceptWaveformOffline(stream, Int32(sampleRate), samples, Int32(samples.count))
+    SherpaOnnxAcceptWaveformOffline(stream, Int32(sampleRate), samples, Int32(samples.count))
 
     let result: UnsafePointer<SherpaOnnxSpokenLanguageIdentificationResult>? =
       SherpaOnnxSpokenLanguageIdentificationCompute(
         slid,
         stream)
 
-    DestroyOfflineStream(stream)
+    SherpaOnnxDestroyOfflineStream(stream)
     return SherpaOnnxSpokenLanguageIdentificationResultWrapper(result: result)
   }
 }
@@ -900,7 +901,7 @@ class SherpaOnnxKeywordResultWrapper {
 
   deinit {
     if let result {
-      DestroyKeywordResult(result)
+      SherpaOnnxDestroyKeywordResult(result)
     }
   }
 }
@@ -933,34 +934,34 @@ class SherpaOnnxKeywordSpotterWrapper {
   init(
     config: UnsafePointer<SherpaOnnxKeywordSpotterConfig>!
   ) {
-    spotter = CreateKeywordSpotter(config)
-    stream = CreateKeywordStream(spotter)
+    spotter = SherpaOnnxCreateKeywordSpotter(config)
+    stream = SherpaOnnxCreateKeywordStream(spotter)
   }
 
   deinit {
     if let stream {
-      DestroyOnlineStream(stream)
+      SherpaOnnxDestroyOnlineStream(stream)
     }
 
     if let spotter {
-      DestroyKeywordSpotter(spotter)
+      SherpaOnnxDestroyKeywordSpotter(spotter)
     }
   }
 
   func acceptWaveform(samples: [Float], sampleRate: Int = 16000) {
-    AcceptWaveform(stream, Int32(sampleRate), samples, Int32(samples.count))
+    SherpaOnnxOnlineStreamAcceptWaveform(stream, Int32(sampleRate), samples, Int32(samples.count))
   }
 
   func isReady() -> Bool {
-    return IsKeywordStreamReady(spotter, stream) == 1 ? true : false
+    return SherpaOnnxIsKeywordStreamReady(spotter, stream) == 1 ? true : false
   }
 
   func decode() {
-    DecodeKeywordStream(spotter, stream)
+    SherpaOnnxDecodeKeywordStream(spotter, stream)
   }
 
   func getResult() -> SherpaOnnxKeywordResultWrapper {
-    let result: UnsafePointer<SherpaOnnxKeywordResult>? = GetKeywordResult(
+    let result: UnsafePointer<SherpaOnnxKeywordResult>? = SherpaOnnxGetKeywordResult(
       spotter, stream)
     return SherpaOnnxKeywordResultWrapper(result: result)
   }
@@ -968,7 +969,7 @@ class SherpaOnnxKeywordSpotterWrapper {
   /// Signal that no more audio samples would be available.
   /// After this call, you cannot call acceptWaveform() any more.
   func inputFinished() {
-    InputFinished(stream)
+    SherpaOnnxOnlineStreamInputFinished(stream)
   }
 }
 

--- a/wasm/asr/CMakeLists.txt
+++ b/wasm/asr/CMakeLists.txt
@@ -9,22 +9,22 @@ endif()
 set(exported_functions
   MyPrint
   # online ASR
-  AcceptWaveform
-  CreateOnlineStream
-  DecodeOnlineStream
-  DestroyOfflineStreamResultJson
-  DestroyOnlineRecognizer
-  DestroyOnlineRecognizerResult
-  DestroyOnlineStream
-  DestroyOnlineStreamResultJson
-  GetOfflineStreamResultAsJson
-  GetOnlineStreamResult
-  GetOnlineStreamResultAsJson
-  InputFinished
-  IsEndpoint
-  IsOnlineStreamReady
-  Reset
   SherpaOnnxCreateOnlineRecognizer
+  SherpaOnnxCreateOnlineStream
+  SherpaOnnxDecodeOnlineStream
+  SherpaOnnxDestroyOfflineStreamResultJson
+  SherpaOnnxDestroyOnlineRecognizer
+  SherpaOnnxDestroyOnlineRecognizerResult
+  SherpaOnnxDestroyOnlineStream
+  SherpaOnnxDestroyOnlineStreamResultJson
+  SherpaOnnxGetOfflineStreamResultAsJson
+  SherpaOnnxGetOnlineStreamResult
+  SherpaOnnxGetOnlineStreamResultAsJson
+  SherpaOnnxIsOnlineStreamReady
+  SherpaOnnxOnlineStreamAcceptWaveform
+  SherpaOnnxOnlineStreamInputFinished
+  SherpaOnnxOnlineStreamIsEndpoint
+  SherpaOnnxOnlineStreamReset
   #
 )
 set(mangled_exported_functions)

--- a/wasm/asr/CMakeLists.txt
+++ b/wasm/asr/CMakeLists.txt
@@ -10,7 +10,6 @@ set(exported_functions
   MyPrint
   # online ASR
   AcceptWaveform
-  CreateOnlineRecognizer
   CreateOnlineStream
   DecodeOnlineStream
   DestroyOfflineStreamResultJson
@@ -25,6 +24,7 @@ set(exported_functions
   IsEndpoint
   IsOnlineStreamReady
   Reset
+  SherpaOnnxCreateOnlineRecognizer
   #
 )
 set(mangled_exported_functions)

--- a/wasm/asr/sherpa-onnx-asr.js
+++ b/wasm/asr/sherpa-onnx-asr.js
@@ -869,7 +869,7 @@ class OfflineStream {
 
   free() {
     if (this.handle) {
-      this.Module._DestroyOfflineStream(this.handle);
+      this.Module._SherpaOnnxDestroyOfflineStream(this.handle);
       this.handle = null;
     }
   }
@@ -882,7 +882,7 @@ class OfflineStream {
     const pointer =
         this.Module._malloc(samples.length * samples.BYTES_PER_ELEMENT);
     this.Module.HEAPF32.set(samples, pointer / samples.BYTES_PER_ELEMENT);
-    this.Module._AcceptWaveformOffline(
+    this.Module._SherpaOnnxAcceptWaveformOffline(
         this.handle, sampleRate, pointer, samples.length);
     this.Module._free(pointer);
   }
@@ -892,7 +892,7 @@ class OfflineRecognizer {
   constructor(configObj, Module) {
     this.config = configObj;
     const config = initSherpaOnnxOfflineRecognizerConfig(configObj, Module);
-    const handle = Module._CreateOfflineRecognizer(config.ptr);
+    const handle = Module._SherpaOnnxCreateOfflineRecognizer(config.ptr);
     freeConfig(config, Module);
 
     this.handle = handle;
@@ -900,24 +900,25 @@ class OfflineRecognizer {
   }
 
   free() {
-    this.Module._DestroyOfflineRecognizer(this.handle);
+    this.Module._SherpaOnnxDestroyOfflineRecognizer(this.handle);
     this.handle = 0
   }
 
   createStream() {
-    const handle = this.Module._CreateOfflineStream(this.handle);
+    const handle = this.Module._SherpaOnnxCreateOfflineStream(this.handle);
     return new OfflineStream(handle, this.Module);
   }
 
   decode(stream) {
-    this.Module._DecodeOfflineStream(this.handle, stream.handle);
+    this.Module._SherpaOnnxDecodeOfflineStream(this.handle, stream.handle);
   }
 
   getResult(stream) {
-    const r = this.Module._GetOfflineStreamResultAsJson(stream.handle);
+    const r =
+        this.Module._SherpaOnnxGetOfflineStreamResultAsJson(stream.handle);
     const jsonStr = this.Module.UTF8ToString(r);
     const ans = JSON.parse(jsonStr);
-    this.Module._DestroyOfflineStreamResultJson(r);
+    this.Module._SherpaOnnxDestroyOfflineStreamResultJson(r);
 
     return ans;
   }
@@ -933,7 +934,7 @@ class OnlineStream {
 
   free() {
     if (this.handle) {
-      this.Module._DestroyOnlineStream(this.handle);
+      this.Module._SherpaOnnxDestroyOnlineStream(this.handle);
       this.handle = null;
       this.Module._free(this.pointer);
       this.pointer = null;
@@ -954,12 +955,12 @@ class OnlineStream {
     }
 
     this.Module.HEAPF32.set(samples, this.pointer / samples.BYTES_PER_ELEMENT);
-    this.Module._AcceptWaveform(
+    this.Module._SherpaOnnxOnlineStreamAcceptWaveform(
         this.handle, sampleRate, this.pointer, samples.length);
   }
 
   inputFinished() {
-    this.Module._InputFinished(this.handle);
+    this.Module._SherpaOnnxOnlineStreamInputFinished(this.handle);
   }
 };
 
@@ -967,7 +968,7 @@ class OnlineRecognizer {
   constructor(configObj, Module) {
     this.config = configObj;
     const config = initSherpaOnnxOnlineRecognizerConfig(configObj, Module)
-    const handle = Module._CreateOnlineRecognizer(config.ptr);
+    const handle = Module._SherpaOnnxCreateOnlineRecognizer(config.ptr);
 
     freeConfig(config, Module);
 
@@ -976,37 +977,39 @@ class OnlineRecognizer {
   }
 
   free() {
-    this.Module._DestroyOnlineRecognizer(this.handle);
+    this.Module._SherpaOnnxDestroyOnlineRecognizer(this.handle);
     this.handle = 0
   }
 
   createStream() {
-    const handle = this.Module._CreateOnlineStream(this.handle);
+    const handle = this.Module._SherpaOnnxCreateOnlineStream(this.handle);
     return new OnlineStream(handle, this.Module);
   }
 
   isReady(stream) {
-    return this.Module._IsOnlineStreamReady(this.handle, stream.handle) == 1;
+    return this.Module._SherpaOnnxIsOnlineStreamReady(
+               this.handle, stream.handle) == 1;
   }
 
   decode(stream) {
-    this.Module._DecodeOnlineStream(this.handle, stream.handle);
+    this.Module._SherpaOnnxDecodeOnlineStream(this.handle, stream.handle);
   }
 
   isEndpoint(stream) {
-    return this.Module._IsEndpoint(this.handle, stream.handle) == 1;
+    return this.Module._SherpaOnnxOnlineStreamIsEndpoint(
+               this.handle, stream.handle) == 1;
   }
 
   reset(stream) {
-    this.Module._Reset(this.handle, stream.handle);
+    this.Module._SherpaOnnxOnlineStreamReset(this.handle, stream.handle);
   }
 
   getResult(stream) {
-    const r =
-        this.Module._GetOnlineStreamResultAsJson(this.handle, stream.handle);
+    const r = this.Module._SherpaOnnxGetOnlineStreamResultAsJson(
+        this.handle, stream.handle);
     const jsonStr = this.Module.UTF8ToString(r);
     const ans = JSON.parse(jsonStr);
-    this.Module._DestroyOnlineStreamResultJson(r);
+    this.Module._SherpaOnnxDestroyOnlineStreamResultJson(r);
 
     return ans;
   }

--- a/wasm/kws/CMakeLists.txt
+++ b/wasm/kws/CMakeLists.txt
@@ -8,15 +8,15 @@ if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/assets/decoder-epoch-12-avg-2-chunk-1
 endif()
 
 set(exported_functions
-        AcceptWaveform
-        CreateKeywordSpotter
-        DestroyKeywordSpotter
-        CreateKeywordStream
-        DecodeKeywordStream
-        GetKeywordResult
-        DestroyKeywordResult
-        IsKeywordStreamReady
-        InputFinished
+  SherpaOnnxCreateKeywordSpotter
+  SherpaOnnxCreateKeywordStream
+  SherpaOnnxDecodeKeywordStream
+  SherpaOnnxDestroyKeywordResult
+  SherpaOnnxDestroyKeywordSpotter
+  SherpaOnnxGetKeywordResult
+  SherpaOnnxIsKeywordStreamReady
+  SherpaOnnxOnlineStreamAcceptWaveform
+  SherpaOnnxOnlineStreamInputFinished
 )
 set(mangled_exported_functions)
 foreach(x IN LISTS exported_functions)

--- a/wasm/kws/sherpa-onnx-kws.js
+++ b/wasm/kws/sherpa-onnx-kws.js
@@ -189,7 +189,7 @@ class Stream {
 
   free() {
     if (this.handle) {
-      this.Module._DestroyOnlineKwsStream(this.handle);
+      this.Module._SherpaOnnxDestroyOnlineStream(this.handle);
       this.handle = null;
       this.Module._free(this.pointer);
       this.pointer = null;
@@ -210,12 +210,12 @@ class Stream {
     }
 
     this.Module.HEAPF32.set(samples, this.pointer / samples.BYTES_PER_ELEMENT);
-    this.Module._AcceptWaveform(
+    this.Module._SherpaOnnxOnlineStreamAcceptWaveform(
         this.handle, sampleRate, this.pointer, samples.length);
   }
 
   inputFinished() {
-    this.Module._InputFinished(this.handle);
+    this.Module._SherpaOnnxOnlineStreamInputFinished(this.handle);
   }
 };
 
@@ -223,7 +223,7 @@ class Kws {
   constructor(configObj, Module) {
     this.config = configObj;
     let config = initKwsConfig(configObj, Module)
-    let handle = Module._CreateKeywordSpotter(config.ptr);
+    let handle = Module._SherpaOnnxCreateKeywordSpotter(config.ptr);
 
     freeConfig(config, Module);
 
@@ -232,28 +232,30 @@ class Kws {
   }
 
   free() {
-    this.Module._DestroyKeywordSpotter(this.handle);
+    this.Module._SherpaOnnxDestroyKeywordSpotter(this.handle);
     this.handle = 0
   }
 
   createStream() {
-    let handle = this.Module._CreateKeywordStream(this.handle);
+    let handle = this.Module._SherpaOnnxCreateKeywordStream(this.handle);
     return new Stream(handle, this.Module);
   }
 
   isReady(stream) {
-    return this.Module._IsKeywordStreamReady(this.handle, stream.handle) === 1;
+    return this.Module._SherpaOnnxIsKeywordStreamReady(
+               this.handle, stream.handle) == 1;
   }
 
   decode(stream) {
-    return this.Module._DecodeKeywordStream(this.handle, stream.handle);
+    return this.Module._SherpaOnnxDecodeKeywordStream(
+        this.handle, stream.handle);
   }
 
   getResult(stream) {
-    let r = this.Module._GetKeywordResult(this.handle, stream.handle);
+    let r = this.Module._SherpaOnnxGetKeywordResult(this.handle, stream.handle);
     let jsonPtr = this.Module.getValue(r + 24, 'i8*');
     let json = this.Module.UTF8ToString(jsonPtr);
-    this.Module._DestroyKeywordResult(r);
+    this.Module._SherpaOnnxDestroyKeywordResult(r);
     return JSON.parse(json);
   }
 }

--- a/wasm/nodejs/CMakeLists.txt
+++ b/wasm/nodejs/CMakeLists.txt
@@ -14,7 +14,6 @@ set(exported_functions
   SherpaOnnxOfflineTtsSampleRate
   SherpaOnnxWriteWave
   # streaming asr
-  IsEndpoint
   SherpaOnnxCreateOnlineRecognizer
   SherpaOnnxCreateOnlineStream
   SherpaOnnxDecodeOnlineStream
@@ -27,6 +26,7 @@ set(exported_functions
   SherpaOnnxIsOnlineStreamReady
   SherpaOnnxOnlineStreamAcceptWaveform
   SherpaOnnxOnlineStreamInputFinished
+  SherpaOnnxOnlineStreamIsEndpoint
   SherpaOnnxOnlineStreamReset
   # non-streaming ASR
   PrintOfflineRecognizerConfig

--- a/wasm/nodejs/CMakeLists.txt
+++ b/wasm/nodejs/CMakeLists.txt
@@ -14,41 +14,41 @@ set(exported_functions
   SherpaOnnxOfflineTtsSampleRate
   SherpaOnnxWriteWave
   # streaming asr
-  AcceptWaveform
-  CreateOnlineStream
-  DecodeOnlineStream
-  DestroyOnlineRecognizer
-  DestroyOnlineRecognizerResult
-  DestroyOnlineStream
-  DestroyOnlineStreamResultJson
-  GetOnlineStreamResult
-  GetOnlineStreamResultAsJson
-  InputFinished
   IsEndpoint
-  IsOnlineStreamReady
-  Reset
   SherpaOnnxCreateOnlineRecognizer
+  SherpaOnnxCreateOnlineStream
+  SherpaOnnxDecodeOnlineStream
+  SherpaOnnxDestroyOnlineRecognizer
+  SherpaOnnxDestroyOnlineRecognizerResult
+  SherpaOnnxDestroyOnlineStream
+  SherpaOnnxDestroyOnlineStreamResultJson
+  SherpaOnnxGetOnlineStreamResult
+  SherpaOnnxGetOnlineStreamResultAsJson
+  SherpaOnnxIsOnlineStreamReady
+  SherpaOnnxOnlineStreamAcceptWaveform
+  SherpaOnnxOnlineStreamInputFinished
+  SherpaOnnxOnlineStreamReset
   # non-streaming ASR
-  AcceptWaveformOffline
-  CreateOfflineRecognizer
-  CreateOfflineStream
-  DecodeMultipleOfflineStreams
-  DecodeOfflineStream
-  DestroyOfflineRecognizer
-  DestroyOfflineRecognizerResult
-  DestroyOfflineStream
-  DestroyOfflineStreamResultJson
-  GetOfflineStreamResult
-  GetOfflineStreamResultAsJson
   PrintOfflineRecognizerConfig
+  SherpaOnnxAcceptWaveformOffline
+  SherpaOnnxCreateOfflineRecognizer
+  SherpaOnnxCreateOfflineStream
+  SherpaOnnxDecodeMultipleOfflineStreams
+  SherpaOnnxDecodeOfflineStream
+  SherpaOnnxDestroyOfflineRecognizer
+  SherpaOnnxDestroyOfflineRecognizerResult
+  SherpaOnnxDestroyOfflineStream
+  SherpaOnnxDestroyOfflineStreamResultJson
+  SherpaOnnxGetOfflineStreamResult
+  SherpaOnnxGetOfflineStreamResultAsJson
   # online kws
-  CreateKeywordSpotter
-  DestroyKeywordSpotter
-  CreateKeywordStream
-  DecodeKeywordStream
-  GetKeywordResult
-  DestroyKeywordResult
-  IsKeywordStreamReady
+  SherpaOnnxCreateKeywordSpotter
+  SherpaOnnxCreateKeywordStream
+  SherpaOnnxDecodeKeywordStream
+  SherpaOnnxDestroyKeywordResult
+  SherpaOnnxDestroyKeywordSpotter
+  SherpaOnnxGetKeywordResult
+  SherpaOnnxIsKeywordStreamReady
 )
 
 

--- a/wasm/nodejs/CMakeLists.txt
+++ b/wasm/nodejs/CMakeLists.txt
@@ -15,7 +15,6 @@ set(exported_functions
   SherpaOnnxWriteWave
   # streaming asr
   AcceptWaveform
-  CreateOnlineRecognizer
   CreateOnlineStream
   DecodeOnlineStream
   DestroyOnlineRecognizer
@@ -28,6 +27,7 @@ set(exported_functions
   IsEndpoint
   IsOnlineStreamReady
   Reset
+  SherpaOnnxCreateOnlineRecognizer
   # non-streaming ASR
   AcceptWaveformOffline
   CreateOfflineRecognizer


### PR DESCRIPTION
So that there are no symbol conflicts when using sherpa-onnx in another project.