### PR TITLE
Fix copying asset files for flutter examples.

### DIFF
--- a/flutter-examples/streaming_asr/lib/utils.dart
+++ b/flutter-examples/streaming_asr/lib/utils.dart
@@ -14,8 +14,9 @@ Future<String> copyAssetFile(String src, [String? dst]) async {
   final target = join(directory.path, dst);
   bool exists = await new File(target).exists();
 
-  if (!exists) {
-    final data = await rootBundle.load(src);
+  final data = await rootBundle.load(src);
+
+  if (!exists || File(target).lengthSync() != data.lengthInBytes) {
     final List<int> bytes =
         data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes);
     await File(target).writeAsBytes(bytes);

--- a/flutter-examples/tts/lib/utils.dart
+++ b/flutter-examples/tts/lib/utils.dart
@@ -45,8 +45,8 @@ Future<String> copyAssetFile(String src, [String? dst]) async {
   final target = p.join(directory.path, dst);
   bool exists = await new File(target).exists();
 
-  if (!exists) {
-    final data = await rootBundle.load(src);
+  final data = await rootBundle.load(src);
+  if (!exists || File(target).lengthSync() != data.lengthInBytes) {
     final List<int> bytes =
         data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes);
     await (await File(target).create(recursive: true)).writeAsBytes(bytes);


### PR DESCRIPTION
If the target file exists but has a different file size, we need to copy the source file to the target file.