### PR TITLE
addition of blank_penalty config in online_recognizer

### DIFF
--- a/scripts/go/sherpa_onnx.go
+++ b/scripts/go/sherpa_onnx.go
@@ -129,6 +129,7 @@ type OnlineRecognizerConfig struct {
 	Rule3MinUtteranceLength float32
 	HotwordsFile            string
 	HotwordsScore           float32
+	BlankPenalty            float32
 	CtcFstDecoderConfig     OnlineCtcFstDecoderConfig
 	RuleFsts                string
 	RuleFars                string
@@ -212,6 +213,7 @@ func NewOnlineRecognizer(config *OnlineRecognizerConfig) *OnlineRecognizer {
 	defer C.free(unsafe.Pointer(c.hotwords_file))
 
 	c.hotwords_score = C.float(config.HotwordsScore)
+	c.blank_penalty = C.float(config.BlankPenalty)
 
 	c.rule_fsts = C.CString(config.RuleFsts)
 	defer C.free(unsafe.Pointer(c.rule_fsts))
@@ -421,6 +423,7 @@ type OfflineRecognizerConfig struct {
 	MaxActivePaths int
 	HotwordsFile   string
 	HotwordsScore  float32
+	BlankPenalty   float32
 	RuleFsts       string
 	RuleFars       string
 }
@@ -529,6 +532,8 @@ func NewOfflineRecognizer(config *OfflineRecognizerConfig) *OfflineRecognizer {
 	defer C.free(unsafe.Pointer(c.hotwords_file))
 
 	c.hotwords_score = C.float(config.HotwordsScore)
+
+	c.blank_penalty = C.float(config.BlankPenalty)
 
 	c.rule_fsts = C.CString(config.RuleFsts)
 	defer C.free(unsafe.Pointer(c.rule_fsts))

--- a/sherpa-onnx/c-api/c-api.cc
+++ b/sherpa-onnx/c-api/c-api.cc
@@ -105,6 +105,8 @@ SherpaOnnxOnlineRecognizer *SherpaOnnxCreateOnlineRecognizer(
   recognizer_config.hotwords_score =
       SHERPA_ONNX_OR(config->hotwords_score, 1.5);
 
+  recognizer_config.blank_penalty = SHERPA_ONNX_OR(config->blank_penalty, 0.0);
+
   recognizer_config.ctc_fst_decoder_config.graph =
       SHERPA_ONNX_OR(config->ctc_fst_decoder_config.graph, "");
   recognizer_config.ctc_fst_decoder_config.max_active =

--- a/sherpa-onnx/c-api/c-api.h
+++ b/sherpa-onnx/c-api/c-api.h
@@ -142,6 +142,7 @@ SHERPA_ONNX_API typedef struct SherpaOnnxOnlineRecognizerConfig {
 
   /// Bonus score for each token in hotwords.
   float hotwords_score;
+  float blank_penalty;
 
   SherpaOnnxOnlineCtcFstDecoderConfig ctc_fst_decoder_config;
   const char *rule_fsts;


### PR DESCRIPTION
Added support for the blank_penalty config parameter in the  Go module to match the existing Python implementation. 