### PR TITLE
Exclude .DS_Store files from flutter tts assets

### DIFF
--- a/flutter-examples/tts/generate-asset-list.py
+++ b/flutter-examples/tts/generate-asset-list.py
@@ -21,6 +21,7 @@ def main():
         ".sh",
         "*.md",
         "MODEL_CARD",
+        ".DS_Store",
     ]
     sep = "    "
     ss = []


### PR DESCRIPTION
To avoid the following case
![37d14768e5aaa546ce61280ed62d329a](https://github.com/user-attachments/assets/bc01d981-3f80-40dd-b030-6f3055916ac2)


Users don't need to manually exclude `.DS_Store` files on macOS.