### PR TITLE
Fix swift example for generating subtitles.

### DIFF
--- a/swift-api-examples/generate-subtitles.swift
+++ b/swift-api-examples/generate-subtitles.swift
@@ -179,6 +179,7 @@ func run() {
     vad.acceptWaveform(samples: [Float](array[offset..<end]))
   }
 
+  vad.flush()
   var index: Int = 0
   while !vad.isEmpty() {
     let s = vad.front()


### PR DESCRIPTION
We need to invoke vad.flush() at the end.