### PR TITLE
Fix running MeloTTS models on GPU.

### DIFF
--- a/scripts/melo-tts/export-onnx.py
+++ b/scripts/melo-tts/export-onnx.py
@@ -229,7 +229,7 @@ def main():
 
     torch_model = ModelWrapper(model)
 
-    opset_version = 13
+    opset_version = 18
     x = torch.randint(low=0, high=10, size=(60,), dtype=torch.int64)
     print(x.shape)
     x_lengths = torch.tensor([x.size(0)], dtype=torch.int64)


### PR DESCRIPTION
We need to use opset 18 to export the model to onnx.

We have updated the released model to use opset 18.

![Screenshot 2024-09-26 at 16 50 34](https://github.com/user-attachments/assets/3294d230-dd58-4481-9e3c-ec51e795fbb5)
