### PR TITLE
docs(nodejs-addon-examples): add guide for pnpm user

### DIFF
--- a/nodejs-addon-examples/README.md
+++ b/nodejs-addon-examples/README.md
@@ -12,41 +12,32 @@ Note: [../nodejs-examples](../nodejs-examples) uses WebAssembly to wrap
 Before you continue, please first run
 
 ```bash
-npm install
+npm install # or pnpm install
 
 # For macOS x64
+## With npm
 export DYLD_LIBRARY_PATH=$PWD/node_modules/sherpa-onnx-darwin-x64:$DYLD_LIBRARY_PATH
+## With pnpm
+export DYLD_LIBRARY_PATH=$PWD/node_modules/.pnpm/sherpa-onnx-node@<REPLACE-THIS-WITH-THE-INSTALLED-VERSION>/node_modules/sherpa-onnx-darwin-x64:$DYLD_LIBRARY_PATH
 
 # For macOS arm64
+## With npm
 export DYLD_LIBRARY_PATH=$PWD/node_modules/sherpa-onnx-darwin-arm64:$DYLD_LIBRARY_PATH
+## With pnpm
+export DYLD_LIBRARY_PATH=$PWD/node_modules/.pnpm/sherpa-onnx-node@<REPLACE-THIS-WITH-THE-INSTALLED-VERSION>/node_modules/sherpa-onnx-darwin-arm64:$DYLD_LIBRARY_PATH
 
 # For Linux x64
+## With npm
 export LD_LIBRARY_PATH=$PWD/node_modules/sherpa-onnx-linux-x64:$LD_LIBRARY_PATH
+## With pnpm
+export LD_LIBRARY_PATH=$PWD/node_modules/.pnpm/sherpa-onnx-node@<REPLACE-THIS-WITH-THE-INSTALLED-VERSION>/node_modules/sherpa-onnx-linux-x64:$LD_LIBRARY_PATH
 
 # For Linux arm64, e.g., Raspberry Pi 4
+## With npm
 export LD_LIBRARY_PATH=$PWD/node_modules/sherpa-onnx-linux-arm64:$LD_LIBRARY_PATH
+## With pnpm
+export LD_LIBRARY_PATH=$PWD/node_modules/.pnpm/sherpa-onnx-node@<REPLACE-THIS-WITH-THE-INSTALLED-VERSION>/node_modules/sherpa-onnx-linux-arm64:$LD_LIBRARY_PATH
 ```
-
-For [pnpm](https://pnpm.io/) users, should add following section to `package.json`:
-
-```json
-{
-    // ...
-    "optionalDependencies": {
-        // ...
-        "sherpa-onnx-darwin-arm64": "^1.10.27",
-        "sherpa-onnx-darwin-x64": "^1.10.27",
-        "sherpa-onnx-linux-x64": "^1.10.27",
-        "sherpa-onnx-linux-arm64": "^1.10.27",
-        "sherpa-onnx-win-x64": "^1.10.27",
-        "sherpa-onnx-win-ia32": "^1.10.27",
-        // ...
-    },
-    //...
-}
-```
-
-You can replace the version to same as `sherpa-onnx-node` in `dependencies`.
 
 # Examples
 

--- a/nodejs-addon-examples/README.md
+++ b/nodejs-addon-examples/README.md
@@ -27,6 +27,27 @@ export LD_LIBRARY_PATH=$PWD/node_modules/sherpa-onnx-linux-x64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$PWD/node_modules/sherpa-onnx-linux-arm64:$LD_LIBRARY_PATH
 ```
 
+For [pnpm](https://pnpm.io/) users, should add following section to `package.json`:
+
+```json
+{
+    // ...
+    "optionalDependencies": {
+        // ...
+        "sherpa-onnx-darwin-arm64": "^1.10.27",
+        "sherpa-onnx-darwin-x64": "^1.10.27",
+        "sherpa-onnx-linux-x64": "^1.10.27",
+        "sherpa-onnx-linux-arm64": "^1.10.27",
+        "sherpa-onnx-win-x64": "^1.10.27",
+        "sherpa-onnx-win-ia32": "^1.10.27",
+        // ...
+    },
+    //...
+}
+```
+
+You can replace the version to same as `sherpa-onnx-node` in `dependencies`.
+
 # Examples
 
 The following tables list the examples in this folder.

--- a/scripts/node-addon-api/lib/addon.js
+++ b/scripts/node-addon-api/lib/addon.js
@@ -1,4 +1,5 @@
 const os = require('os');
+const path = require('path');
 
 // Package name triggered spam for sherpa-onnx-win32-x64
 // so we have renamed it to sherpa-onnx-win-x64
@@ -25,6 +26,14 @@ for (const p of possible_paths) {
 }
 
 if (!found) {
+  let addon_path = `${process.env.PWD}/node_modules/sherpa-onnx-${platform_arch}`;
+  const pnpmIndex = __dirname.indexOf(`node_modules${path.sep}.pnpm`);
+  if (pnpmIndex !== -1) {
+    const parts = __dirname.slice(pnpmIndex).split(path.sep);
+    parts.pop();
+    addon_path = `${process.env.PWD}/${parts.join('/')}/sherpa-onnx-${platform_arch}`;
+  }
+
   let msg = `Could not find sherpa-onnx-node. Tried\n\n  ${
       possible_paths.join('\n  ')}\n`
   if (os.platform() == 'darwin' &&
@@ -34,8 +43,7 @@ if (!found) {
     msg +=
         'Please remeber to set the following environment variable and try again:\n';
 
-    msg += `export DYLD_LIBRARY_PATH=${
-        process.env.PWD}/node_modules/sherpa-onnx-${platform_arch}`;
+    msg += `export DYLD_LIBRARY_PATH=${addon_path}`;
 
     msg += ':$DYLD_LIBRARY_PATH\n';
   }
@@ -47,8 +55,7 @@ if (!found) {
     msg +=
         'Please remeber to set the following environment variable and try again:\n';
 
-    msg += `export LD_LIBRARY_PATH=${
-        process.env.PWD}/node_modules/sherpa-onnx-${platform_arch}`;
+    msg += `export LD_LIBRARY_PATH=${addon_path}`;
 
     msg += ':$LD_LIBRARY_PATH\n';
   }


### PR DESCRIPTION
For example, pnpm will install the `sherpa-onnx-linux-x64` at `node_modules/.pnpm/sherpa-onnx-linux-x64@1.10.27`, so the addon.js can not find `sherpa-onnx.node`.