### PR TITLE
fix "log10" compile error by import CMATH lib

### DIFF
--- a/sherpa-onnx/csrc/offline-whisper-model.cc
+++ b/sherpa-onnx/csrc/offline-whisper-model.cc
@@ -9,6 +9,7 @@
 #include <tuple>
 #include <unordered_map>
 #include <utility>
+#include <cmath>
 
 #include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"

--- a/sherpa-onnx/csrc/offline-whisper-model.cc
+++ b/sherpa-onnx/csrc/offline-whisper-model.cc
@@ -5,11 +5,11 @@
 #include "sherpa-onnx/csrc/offline-whisper-model.h"
 
 #include <algorithm>
+#include <cmath>
 #include <string>
 #include <tuple>
 #include <unordered_map>
 #include <utility>
-#include <cmath>
 
 #include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"


### PR DESCRIPTION
在进行 RISCV 运行的 sherpa-onnx 交叉编译的过程中，执行 ./build-riscv64-linux-gnu.sh 脚本的时候出现了
error: 'log10' is not a member of 'std'
在 sherpa-onnx/sherpa-onnx/csrc/offline-whisper-model.cc 文件中导入 <cmath> 库解决