### PR TITLE
Fix building node-addon for Windows x86.

### DIFF
--- a/scripts/node-addon-api/src/non-streaming-speaker-diarization.cc
+++ b/scripts/node-addon-api/src/non-streaming-speaker-diarization.cc
@@ -238,11 +238,12 @@ static Napi::Array OfflineSpeakerDiarizationProcessWrapper(
 
   for (int32_t i = 0; i != num_segments; ++i) {
     Napi::Object obj = Napi::Object::New(env);
+
     obj.Set(Napi::String::New(env, "start"), segments[i].start);
     obj.Set(Napi::String::New(env, "end"), segments[i].end);
     obj.Set(Napi::String::New(env, "speaker"), segments[i].speaker);
 
-    ans[i] = obj;
+    ans.Set(i, obj);
   }
 
   SherpaOnnxOfflineSpeakerDiarizationDestroySegment(segments);


### PR DESCRIPTION
To fix the following errors on Windows x86:
https://github.com/csukuangfj/sherpa-onnx/actions/runs/11514071976/job/32051958194#step:9:140

```
  1>Checking Build System
  Building Custom Rule D:/a/sherpa-onnx/sherpa-onnx/scripts/node-addon-api/CMakeLists.txt
  audio-tagging.cc
  keyword-spotting.cc
  non-streaming-asr.cc
  non-streaming-speaker-diarization.cc
D:\a\sherpa-onnx\sherpa-onnx\scripts\node-addon-api\src\non-streaming-speaker-diarization.cc(245,10): error C2666: 'Napi::Object::operator []': 3 overloads have similar conversions [D:\a\sherpa-onnx\sherpa-onnx\scripts\node-addon-api\build\sherpa-onnx.vcxproj]
D:\a\sherpa-onnx\sherpa-onnx\scripts\node-addon-api\node_modules\node-addon-api\napi-inl.h(942,22): message : could be 'Napi::Value Napi::Object::operator [](uint32_t) const' [D:\a\sherpa-onnx\sherpa-onnx\scripts\node-addon-api\build\sherpa-onnx.vcxproj]
D:\a\sherpa-onnx\sherpa-onnx\scripts\node-addon-api\node_modules\node-addon-api\napi-inl.h(938,22): message : or       'Napi::Value Napi::Object::operator [](const std::string &) const' [D:\a\sherpa-onnx\sherpa-onnx\scripts\node-addon-api\build\sherpa-onnx.vcxproj]
D:\a\sherpa-onnx\sherpa-onnx\scripts\node-addon-api\node_modules\node-addon-api\napi-inl.h(934,22): message : or       'Napi::Value Napi::Object::operator [](const char *) const' [D:\a\sherpa-onnx\sherpa-onnx\scripts\node-addon-api\build\sherpa-onnx.vcxproj]
D:\a\sherpa-onnx\sherpa-onnx\scripts\node-addon-api\node_modules\node-addon-api\napi-inl.h(930,49): message : or       'Napi::Object::PropertyLValue<uint32_t> Napi::Object::operator [](uint32_t)' [D:\a\sherpa-onnx\sherpa-onnx\scripts\node-addon-api\build\sherpa-onnx.vcxproj]
D:\a\sherpa-onnx\sherpa-onnx\scripts\node-addon-api\node_modules\node-addon-api\napi-inl.h(926,52): message : or       'Napi::Object::PropertyLValue<std::string> Napi::Object::operator [](const std::string &)' [D:\a\sherpa-onnx\sherpa-onnx\scripts\node-addon-api\build\sherpa-onnx.vcxproj]
D:\a\sherpa-onnx\sherpa-onnx\scripts\node-addon-api\node_modules\node-addon-api\napi-inl.h(922,52): message : or       'Napi::Object::PropertyLValue<std::string> Napi::Object::operator [](const char *)' [D:\a\sherpa-onnx\sherpa-onnx\scripts\node-addon-api\build\sherpa-onnx.vcxproj]
D:\a\sherpa-onnx\sherpa-onnx\scripts\node-addon-api\src\non-streaming-speaker-diarization.cc(245,10): message : or       'built-in C++ operator[(napi_value, int)' [D:\a\sherpa-onnx\sherpa-onnx\scripts\node-addon-api\build\sherpa-onnx.vcxproj]
D:\a\sherpa-onnx\sherpa-onnx\scripts\node-addon-api\src\non-streaming-speaker-diarization.cc(245,10): message : while trying to match the argument list '(Napi::Array, int32_t)' [D:\a\sherpa-onnx\sherpa-onnx\scripts\node-addon-api\build\sherpa-onnx.vcxproj]
  non-streaming-tts.cc
```