### PR TITLE
Fix VS target architecture variable x64 Configure error.

### DIFF
--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -71,7 +71,7 @@ function(download_onnxruntime)
   elseif(WIN32)
     message(STATUS "CMAKE_VS_PLATFORM_NAME: ${CMAKE_VS_PLATFORM_NAME}")
 
-    if(CMAKE_VS_PLATFORM_NAME STREQUAL Win32 OR CMAKE_VS_PLATFORM_NAME STREQUAL win32)
+    if(CMAKE_VS_PLATFORM_NAME STREQUAL Win32 OR CMAKE_VS_PLATFORM_NAME STREQUAL x64)
       if(BUILD_SHARED_LIBS)
         include(onnxruntime-win-x86)
       else()


### PR DESCRIPTION
## Why do this change?
The possibilities for the CMAKE_VS_PLATFORM_NAME variable are:
`x64`, `ARM64`, or `Win32`, `ARM`, `ARM64EC`
(And this value is case sensitive)
![6537ffdd1f01681875bde7aeeaf614b9](https://github.com/user-attachments/assets/af24c6f3-4e64-4c31-9889-e9b19f62e623)

The current implementation will not enter the correct logic when the variable is equal to x64.

cmake document reference:
https://cmake.org/cmake/help/latest/variable/CMAKE_GENERATOR_PLATFORM.html#visual-studio-platform-selection

Similar implementations for other repositories:
https://github.com/unknownv2/CoreHook.Host/blob/9ae818c62646caed2dad18957903b96080fbc156/CMakeLists.txt#L15
