### PR TITLE
Reduce vad-sense-voice example code.

### DIFF
--- a/c-api-examples/vad-sense-voice-c-api.c
+++ b/c-api-examples/vad-sense-voice-c-api.c
@@ -99,15 +99,15 @@ int32_t main() {
 
   int32_t window_size = vadConfig.silero_vad.window_size;
   int32_t i = 0;
-  int32_t excess_size = wave->num_samples % window_size;
-  int32_t total_size = wave->num_samples + excess_size;
+  int is_loop = 1;
 
-  while (i <= total_size) {
-    if (i < total_size) {
+  while (is_loop) {
+    if (i + window_size < wave->num_samples) {
       SherpaOnnxVoiceActivityDetectorAcceptWaveform(vad, wave->samples + i,
                                                     window_size);
     } else {
       SherpaOnnxVoiceActivityDetectorFlush(vad);
+      is_loop = 0;
     }
 
     while (!SherpaOnnxVoiceActivityDetectorEmpty(vad)) {

--- a/c-api-examples/vad-sense-voice-c-api.c
+++ b/c-api-examples/vad-sense-voice-c-api.c
@@ -102,7 +102,7 @@ int32_t main() {
   int32_t excess_size = wave->num_samples % window_size;
   int32_t total_size = wave->num_samples + excess_size;
 
-  while (i < total_size) {
+  while (i <= total_size) {
     if (i < total_size) {
       SherpaOnnxVoiceActivityDetectorAcceptWaveform(vad, wave->samples + i,
                                                     window_size);

--- a/c-api-examples/vad-sense-voice-c-api.c
+++ b/c-api-examples/vad-sense-voice-c-api.c
@@ -99,11 +99,16 @@ int32_t main() {
 
   int32_t window_size = vadConfig.silero_vad.window_size;
   int32_t i = 0;
+  int32_t excess_size = wave->num_samples % window_size;
+  int32_t total_size = wave->num_samples + excess_size;
 
-  while (i + window_size < wave->num_samples) {
-    SherpaOnnxVoiceActivityDetectorAcceptWaveform(vad, wave->samples + i,
-                                                  window_size);
-    i += window_size;
+  while (i < total_size) {
+    if (i < total_size) {
+      SherpaOnnxVoiceActivityDetectorAcceptWaveform(vad, wave->samples + i,
+                                                    window_size);
+    } else {
+      SherpaOnnxVoiceActivityDetectorFlush(vad);
+    }
 
     while (!SherpaOnnxVoiceActivityDetectorEmpty(vad)) {
       const SherpaOnnxSpeechSegment *segment =
@@ -132,36 +137,7 @@ int32_t main() {
       SherpaOnnxDestroySpeechSegment(segment);
       SherpaOnnxVoiceActivityDetectorPop(vad);
     }
-  }
-
-  SherpaOnnxVoiceActivityDetectorFlush(vad);
-
-  while (!SherpaOnnxVoiceActivityDetectorEmpty(vad)) {
-    const SherpaOnnxSpeechSegment *segment =
-        SherpaOnnxVoiceActivityDetectorFront(vad);
-
-    const SherpaOnnxOfflineStream *stream =
-        SherpaOnnxCreateOfflineStream(recognizer);
-
-    SherpaOnnxAcceptWaveformOffline(stream, wave->sample_rate, segment->samples,
-                                    segment->n);
-
-    SherpaOnnxDecodeOfflineStream(recognizer, stream);
-
-    const SherpaOnnxOfflineRecognizerResult *result =
-        SherpaOnnxGetOfflineStreamResult(stream);
-
-    float start = segment->start / 16000.0f;
-    float duration = segment->n / 16000.0f;
-    float stop = start + duration;
-
-    fprintf(stderr, "%.3f -- %.3f: %s\n", start, stop, result->text);
-
-    SherpaOnnxDestroyOfflineRecognizerResult(result);
-    SherpaOnnxDestroyOfflineStream(stream);
-
-    SherpaOnnxDestroySpeechSegment(segment);
-    SherpaOnnxVoiceActivityDetectorPop(vad);
+    i += window_size;
   }
 
   SherpaOnnxDestroyOfflineRecognizer(recognizer);

--- a/c-api-examples/vad-sense-voice-c-api.c
+++ b/c-api-examples/vad-sense-voice-c-api.c
@@ -99,15 +99,15 @@ int32_t main() {
 
   int32_t window_size = vadConfig.silero_vad.window_size;
   int32_t i = 0;
-  int is_loop = 1;
+  int is_eof = 0;
 
-  while (is_loop) {
+  while (!is_eof) {
     if (i + window_size < wave->num_samples) {
       SherpaOnnxVoiceActivityDetectorAcceptWaveform(vad, wave->samples + i,
                                                     window_size);
     } else {
       SherpaOnnxVoiceActivityDetectorFlush(vad);
-      is_loop = 0;
+      is_eof = 1;
     }
 
     while (!SherpaOnnxVoiceActivityDetectorEmpty(vad)) {


### PR DESCRIPTION
The current code uses a repeated while loop code (two sections of while) to process the tail data.
```c
while(..) {
}
while(..) {
}
```
And the optimized early calculation of total_size can circulate less each calculation amount and improve efficiency.
So I reduce sherpa-onnx/c-api-examples/vad-sense-voice-c-api.c some codes.