### PR TITLE
Use xcframework for Flutter iOS plugin. 

### DIFF
--- a/.github/workflows/release-dart-package.yaml
+++ b/.github/workflows/release-dart-package.yaml
@@ -481,11 +481,8 @@ jobs:
       - name: Copy pre-built libs
         shell: bash
         run: |
-          echo "----ios-arm64----"
-          cp -v build-ios-shared/ios-arm64/libsherpa-onnx-c-api.dylib flutter/sherpa_onnx_ios/ios/
-          cp -v build-ios-shared/ios-onnxruntime/onnxruntime.xcframework/ios-arm64/onnxruntime.a flutter/sherpa_onnx_ios/ios/libonnxruntime.a
-
-          ls -lh flutter/sherpa_onnx_ios/ios/libonnxruntime.a
+          echo "----ios arm64 and arm64_x64_simulator----"
+          cp -av build-ios-shared/sherpa_onnx.xcframework flutter/sherpa_onnx_ios/ios/
 
           mv -v flutter/sherpa_onnx_ios /tmp/to_be_published
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 1.10.31
+
+* Publish pre-built wheels for Python 3.13 (#1485)
+* Publish pre-built macos xcframework (#1490)
+* Fix reading tokens.txt on Windows. (#1497)
+* Add two-pass ASR Android APKs for Moonshine models. (#1499)
+* Support building GPU-capable sherpa-onnx on Linux aarch64. (#1500)
+* Publish pre-built wheels with CUDA support for Linux aarch64. (#1507)
+* Export the English TTS model from MeloTTS (#1509)
+* Add Lazarus example for Moonshine models. (#1532)
+* Add isolate_tts demo (#1529)
+* Add WebAssembly example for VAD + Moonshine models. (#1535)
+* Add Android APK for streaming Paraformer ASR (#1538)
+* Support static build for windows arm64. (#1539)
+* Use xcframework for Flutter iOS plugin to support iOS simulators.
+
 ## 1.10.30
 
 * Fix building node-addon for Windows x86. (#1469)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,9 @@ set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
 project(sherpa-onnx)
 
 # Remember to update
-# ./nodejs-addon-examples
-# ./dart-api-examples/
 # ./CHANGELOG.md
-set(SHERPA_ONNX_VERSION "1.10.30")
+# ./new-release.sh
+set(SHERPA_ONNX_VERSION "1.10.31")
 
 # Disable warning about
 #

--- a/build-ios-shared.sh
+++ b/build-ios-shared.sh
@@ -76,6 +76,8 @@ if [[ ! -f build/simulator_x86_64/install/lib/libsherpa-onnx-c-api.dylib ]]; the
     -B build/simulator_x86_64
 
   cmake --build build/simulator_x86_64 -j 4 --target install
+else
+  echo "Skip building for simulator (x86_64)"
 fi
 
 echo "Building for simulator (arm64)"
@@ -107,6 +109,8 @@ if [[ ! -f build/simulator_arm64/install/lib/libsherpa-onnx-c-api.dylib ]]; then
     -B build/simulator_arm64
 
   cmake --build build/simulator_arm64 -j 4 --target install
+else
+  echo "Skip building for simulator (arm64)"
 fi
 
 echo "Building for arm64"
@@ -140,11 +144,149 @@ if [[ ! -f build/os64/install/lib/libsherpa-onnx-c-api.dylib ]]; then
     -B build/os64
 
   cmake --build build/os64 -j 4 --target install
+else
+  echo "Skip building for arm64"
 fi
 
 echo "Collect dynamic libraries "
 mkdir -p ios-arm64 ios-arm64-simulator ios-x86_64-simulator
 
 cp -v ./build/os64/install/lib/libsherpa-onnx-c-api.dylib ios-arm64/
-cp -v ./build/simulator_arm64/install/lib/libsherpa-onnx-c-api.dylib ios-arm64-simulator
-cp -v .//build/simulator_x86_64/install/lib/libsherpa-onnx-c-api.dylib ios-x86_64-simulator
+cp -v ./build/simulator_arm64/install/lib/libsherpa-onnx-c-api.dylib ios-arm64-simulator/
+cp -v .//build/simulator_x86_64/install/lib/libsherpa-onnx-c-api.dylib ios-x86_64-simulator/
+
+# see https://github.com/k2-fsa/sherpa-onnx/issues/1172#issuecomment-2439662662
+rm -rf ios-arm64_x86_64-simulator
+mkdir ios-arm64_x86_64-simulator
+
+lipo \
+  -create \
+    ios-arm64-simulator/libsherpa-onnx-c-api.dylib \
+    ios-x86_64-simulator/libsherpa-onnx-c-api.dylib \
+  -output \
+    ios-arm64_x86_64-simulator/libsherpa-onnx-c-api.dylib
+
+pushd ios-arm64
+rm -rf sherpa_onnx.framework
+mkdir sherpa_onnx.framework
+
+lipo \
+  -create \
+    libsherpa-onnx-c-api.dylib \
+  -output \
+    sherpa_onnx
+
+mv sherpa_onnx sherpa_onnx.framework/
+cd sherpa_onnx.framework
+
+install_name_tool \
+  -change @rpath/libsherpa-onnx-c-api.dylib @rpath/sherpa_onnx.framework/sherpa_onnx \
+  sherpa_onnx
+
+install_name_tool \
+  -id "@rpath/sherpa_onnx.framework/sherpa_onnx" \
+  sherpa_onnx
+
+chmod +x sherpa_onnx
+popd
+
+pushd ios-arm64_x86_64-simulator
+rm -rf sherpa_onnx.framework
+mkdir sherpa_onnx.framework
+
+lipo \
+  -create \
+    libsherpa-onnx-c-api.dylib \
+  -output \
+    sherpa_onnx
+
+mv sherpa_onnx sherpa_onnx.framework/
+cd sherpa_onnx.framework
+install_name_tool \
+  -change @rpath/libsherpa-onnx-c-api.dylib @rpath/sherpa_onnx.framework/sherpa_onnx \
+  sherpa_onnx
+
+install_name_tool \
+  -id "@rpath/sherpa_onnx.framework/sherpa_onnx" \
+  sherpa_onnx
+
+chmod +x sherpa_onnx
+popd
+
+for d in ios-arm64_x86_64-simulator ios-arm64; do
+  dst=$d/sherpa_onnx.framework
+
+  # The Info.plist is modified from
+  # https://github.com/Spicely/flutter_openim_sdk_ffi/blob/main/ios/openim_sdk_ffi.framework/Info.plist
+  cat >$dst/Info.plist <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>sherpa_onnx</string>
+	<key>DTSDKName</key>
+	<string>iphoneos17.0</string>
+	<key>DTXcode</key>
+	<string>1501</string>
+	<key>DTSDKBuild</key>
+	<string>21A326</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>BuildMachineOSBuild</key>
+	<string>23B81</string>
+	<key>DTPlatformName</key>
+	<string>iphoneos</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.10.30</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleExecutable</key>
+	<string>sherpa_onnx</string>
+	<key>DTCompiler</key>
+	<string>com.apple.compilers.llvm.clang.1_0</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+	<key>MinimumOSVersion</key>
+	<string>12.0</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.k2fsa.sherpa.onnx</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>DTPlatformVersion</key>
+	<string>17.0</string>
+	<key>DTXcodeBuild</key>
+	<string>15A507</string>
+	<key>DTPlatformBuild</key>
+	<string>21A326</string>
+</dict>
+</plist>
+EOF
+done
+
+rm -rf sherpa_onnx.xcframework
+xcodebuild -create-xcframework \
+  -framework ios-arm64/sherpa_onnx.framework \
+  -framework ios-arm64_x86_64-simulator/sherpa_onnx.framework \
+  -output sherpa_onnx.xcframework
+
+cd sherpa_onnx.xcframework
+echo "PWD: $PWD"
+ls -lh
+echo "---"
+ls -lh */*

--- a/build-ios-shared.sh
+++ b/build-ios-shared.sh
@@ -242,7 +242,7 @@ for d in ios-arm64_x86_64-simulator ios-arm64; do
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.10.30</string>
+	<string>1.10.31</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
 		<string>iPhoneOS</string>

--- a/dart-api-examples/add-punctuations/pubspec.yaml
+++ b/dart-api-examples/add-punctuations/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.10.30
+  sherpa_onnx: ^1.10.31
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/audio-tagging/pubspec.yaml
+++ b/dart-api-examples/audio-tagging/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.10.30
+  sherpa_onnx: ^1.10.31
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/keyword-spotter/pubspec.yaml
+++ b/dart-api-examples/keyword-spotter/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.10.30
+  sherpa_onnx: ^1.10.31
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   path: ^1.9.0

--- a/dart-api-examples/non-streaming-asr/pubspec.yaml
+++ b/dart-api-examples/non-streaming-asr/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  sherpa_onnx: ^1.10.30
+  sherpa_onnx: ^1.10.31
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/speaker-diarization/pubspec.yaml
+++ b/dart-api-examples/speaker-diarization/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.10.30
+  sherpa_onnx: ^1.10.31
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   path: ^1.9.0

--- a/dart-api-examples/speaker-identification/pubspec.yaml
+++ b/dart-api-examples/speaker-identification/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.10.30
+  sherpa_onnx: ^1.10.31
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/streaming-asr/pubspec.yaml
+++ b/dart-api-examples/streaming-asr/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  sherpa_onnx: ^1.10.30
+  sherpa_onnx: ^1.10.31
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/tts/pubspec.yaml
+++ b/dart-api-examples/tts/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  sherpa_onnx: ^1.10.30
+  sherpa_onnx: ^1.10.31
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/vad-with-non-streaming-asr/pubspec.yaml
+++ b/dart-api-examples/vad-with-non-streaming-asr/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.10.30
+  sherpa_onnx: ^1.10.31
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/vad/pubspec.yaml
+++ b/dart-api-examples/vad/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.10.30
+  sherpa_onnx: ^1.10.31
   path: ^1.9.0
   args: ^2.5.0
 

--- a/flutter-examples/README.md
+++ b/flutter-examples/README.md
@@ -136,14 +136,16 @@ flutter create --platforms ios ./
 Connect your iPhone to the computer, and run `flutter devices`, which will print:
 
 ```bash
-Found 3 connected devices:
-  iPhone (mobile) • 00008030-001064212E85802E • ios            • iOS 16.3 20D47
-  macOS (desktop) • macos                     • darwin-x64     • macOS 13.1 22C65 darwin-x64
-  Chrome (web)    • chrome                    • web-javascript • Google Chrome 126.0.6478.127
+Found 4 connected devices:
+  iPhone 14 (mobile) • 634110C4-168D-408F-A938-D7FC62222579 • ios            • com.apple.CoreSimulator.SimRuntime.iOS-16-2 (simulator)
+  iPhone (mobile)    • 00008030-001064212E85802E            • ios            • iOS 16.3 20D47
+  macOS (desktop)    • macos                                • darwin-x64     • macOS 13.1 22C65 darwin-x64
+  Chrome (web)       • chrome                               • web-javascript • Google Chrome 126.0.6478.127
 
 No wireless devices were found.
 
 Run "flutter emulators" to list and start any available device emulators.
+(E.g., flutter emulators --launch ios)
 
 If you expected another device to be detected, please run "flutter doctor" to diagnose potential issues. You may also try increasing the time to wait
 for connected devices with the "--device-timeout" flag. Visit https://flutter.dev/setup/ for troubleshooting tips.

--- a/flutter-examples/streaming_asr/pubspec.yaml
+++ b/flutter-examples/streaming_asr/pubspec.yaml
@@ -5,7 +5,7 @@ description: >
 
 publish_to: 'none'
 
-version: 1.10.30
+version: 1.10.31
 
 topics:
   - speech-recognition
@@ -31,7 +31,7 @@ dependencies:
   record: ^5.1.0
   url_launcher: ^6.2.6
 
-  sherpa_onnx: ^1.10.30
+  sherpa_onnx: ^1.10.31
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
 

--- a/flutter-examples/tts/lib/model.dart
+++ b/flutter-examples/tts/lib/model.dart
@@ -79,16 +79,17 @@ Future<sherpa_onnx.OfflineTts> createOfflineTts() async {
   // Example 7
   // https://github.com/k2-fsa/sherpa-onnx/releases/tag/tts-models
   // https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/vits-melo-tts-zh_en.tar.bz2
-  modelDir = 'vits-melo-tts-zh_en';
-  modelName = 'model.onnx';
-  lexicon = 'lexicon.txt';
-  dictDir = 'vits-melo-tts-zh_en/dict';
+  // modelDir = 'vits-melo-tts-zh_en';
+  // modelName = 'model.onnx';
+  // lexicon = 'lexicon.txt';
+  // dictDir = 'vits-melo-tts-zh_en/dict';
 
   // ============================================================
   // Please don't change the remaining part of this function
   // ============================================================
   if (modelName == '') {
-    throw Exception('You are supposed to select a model by changing the code before you run the app');
+    throw Exception(
+        'You are supposed to select a model by changing the code before you run the app');
   }
 
   final Directory directory = await getApplicationDocumentsDirectory();

--- a/flutter-examples/tts/pubspec.yaml
+++ b/flutter-examples/tts/pubspec.yaml
@@ -5,7 +5,7 @@ description: >
 
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.10.30
+version: 1.10.31
 
 environment:
   sdk: ">=2.17.0 <4.0.0"
@@ -18,7 +18,7 @@ dependencies:
   cupertino_icons: ^1.0.6
   path_provider: ^2.1.3
   path: ^1.9.0
-  sherpa_onnx: ^1.10.30
+  sherpa_onnx: ^1.10.31
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   url_launcher: 6.2.6

--- a/flutter/sherpa_onnx/lib/sherpa_onnx.dart
+++ b/flutter/sherpa_onnx/lib/sherpa_onnx.dart
@@ -25,11 +25,19 @@ String? _path;
 // https://github.com/flutter/codelabs/blob/main/ffigen_codelab/step_05/lib/ffigen_app.dart
 // https://api.flutter.dev/flutter/dart-io/Platform-class.html
 final DynamicLibrary _dylib = () {
-  if (Platform.isMacOS || Platform.isIOS) {
+  if (Platform.isMacOS) {
     if (_path == null) {
       return DynamicLibrary.open('libsherpa-onnx-c-api.dylib');
     } else {
       return DynamicLibrary.open('$_path/libsherpa-onnx-c-api.dylib');
+    }
+  }
+
+  if (Platform.isIOS) {
+    if (_path == null) {
+      return DynamicLibrary.open('sherpa_onnx.framework/sherpa_onnx');
+    } else {
+      return DynamicLibrary.open('$_path/sherpa_onnx.framework/sherpa_onnx');
     }
   }
 

--- a/flutter/sherpa_onnx/pubspec.yaml
+++ b/flutter/sherpa_onnx/pubspec.yaml
@@ -17,7 +17,7 @@ topics:
   - voice-activity-detection
 
 # remember to change the version in ../sherpa_onnx_macos/macos/sherpa_onnx_macos.podspec
-version: 1.10.30
+version: 1.10.31
 
 homepage: https://github.com/k2-fsa/sherpa-onnx
 
@@ -30,23 +30,23 @@ dependencies:
   flutter:
     sdk: flutter
 
-  sherpa_onnx_android: ^1.10.30
+  sherpa_onnx_android: ^1.10.31
   # sherpa_onnx_android:
   #   path: ../sherpa_onnx_android
 
-  sherpa_onnx_macos: ^1.10.30
+  sherpa_onnx_macos: ^1.10.31
   # sherpa_onnx_macos:
   #   path: ../sherpa_onnx_macos
 
-  sherpa_onnx_linux: ^1.10.30
+  sherpa_onnx_linux: ^1.10.31
   # sherpa_onnx_linux:
   #   path: ../sherpa_onnx_linux
 
-  sherpa_onnx_windows: ^1.10.30
+  sherpa_onnx_windows: ^1.10.31
   # sherpa_onnx_windows:
   #   path: ../sherpa_onnx_windows
 
-  sherpa_onnx_ios: ^1.10.30
+  sherpa_onnx_ios: ^1.10.31
   # sherpa_onnx_ios:
   #   path: ../sherpa_onnx_ios
 

--- a/flutter/sherpa_onnx_ios/ios/sherpa_onnx_ios.podspec
+++ b/flutter/sherpa_onnx_ios/ios/sherpa_onnx_ios.podspec
@@ -23,7 +23,8 @@ A new Flutter FFI plugin project.
   s.source           = { :path => '.' }
   s.dependency 'Flutter'
   s.platform = :ios, '12.0'
-  s.ios.vendored_libraries = '*.dylib', '*.a'
+  s.preserve_paths = 'sherpa_onnx.xcframework/**/*'
+  s.vendored_frameworks = 'sherpa_onnx.xcframework'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = {

--- a/flutter/sherpa_onnx_ios/ios/sherpa_onnx_ios.podspec
+++ b/flutter/sherpa_onnx_ios/ios/sherpa_onnx_ios.podspec
@@ -7,7 +7,7 @@
 # https://groups.google.com/g/dart-ffi/c/nUATMBy7r0c
 Pod::Spec.new do |s|
   s.name             = 'sherpa_onnx_ios'
-  s.version          = '1.10.30'
+  s.version          = '1.10.31'
   s.summary          = 'A new Flutter FFI plugin project.'
   s.description      = <<-DESC
 A new Flutter FFI plugin project.

--- a/flutter/sherpa_onnx_macos/macos/sherpa_onnx_macos.podspec
+++ b/flutter/sherpa_onnx_macos/macos/sherpa_onnx_macos.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'sherpa_onnx_macos'
-  s.version          = '1.10.30'
+  s.version          = '1.10.31'
   s.summary          = 'sherpa-onnx Flutter FFI plugin project.'
   s.description      = <<-DESC
 sherpa-onnx Flutter FFI plugin project.

--- a/new-release.sh
+++ b/new-release.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+sed -i.bak 's/1\.10\.29/1\.10\.30/g' ./build-ios-shared.sh
 find flutter -name *.yaml -type f -exec sed -i.bak 's/1\.10\.29/1\.10\.30/g' {} \;
 find dart-api-examples -name *.yaml -type f -exec sed -i.bak 's/1\.10\.29/1\.10\.30/g' {} \;
 find flutter-examples -name *.yaml -type f -exec sed -i.bak 's/1\.10\.29/1\.10\.30/g' {} \;

--- a/new-release.sh
+++ b/new-release.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-sed -i.bak 's/1\.10\.29/1\.10\.30/g' ./build-ios-shared.sh
-find flutter -name *.yaml -type f -exec sed -i.bak 's/1\.10\.29/1\.10\.30/g' {} \;
-find dart-api-examples -name *.yaml -type f -exec sed -i.bak 's/1\.10\.29/1\.10\.30/g' {} \;
-find flutter-examples -name *.yaml -type f -exec sed -i.bak 's/1\.10\.29/1\.10\.30/g' {} \;
-find flutter -name *.podspec -type f -exec sed -i.bak 's/1\.10\.29/1\.10\.30/g' {} \;
-find nodejs-addon-examples -name package.json -type f -exec sed -i.bak 's/1\.10\.29/1\.10\.30/g' {} \;
+sed -i.bak 's/1\.10\.30/1\.10\.31/g' ./build-ios-shared.sh
+find flutter -name *.yaml -type f -exec sed -i.bak 's/1\.10\.30/1\.10\.31/g' {} \;
+find dart-api-examples -name *.yaml -type f -exec sed -i.bak 's/1\.10\.30/1\.10\.31/g' {} \;
+find flutter-examples -name *.yaml -type f -exec sed -i.bak 's/1\.10\.30/1\.10\.31/g' {} \;
+find flutter -name *.podspec -type f -exec sed -i.bak 's/1\.10\.30/1\.10\.31/g' {} \;
+find nodejs-addon-examples -name package.json -type f -exec sed -i.bak 's/1\.10\.30/1\.10\.31/g' {} \;

--- a/nodejs-addon-examples/package.json
+++ b/nodejs-addon-examples/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "sherpa-onnx-node": "^1.10.30"
+    "sherpa-onnx-node": "^1.10.31"
   }
 }


### PR DESCRIPTION
Fixes #1172 

Screenshot of running `./build-ios-shared.sh`
<img width="1134" alt="Screenshot 2024-11-16 at 16 37 58" src="https://github.com/user-attachments/assets/6c0ea846-896e-4ade-aff4-55d3b918c564">


You can see that the xcframework contains pre-built libs for both iOS (arm64) and iOS simulators (arm64 + x86_64)