### PR TITLE
[Not for commit] Use onnxruntime 1.16.3 for Linux x86_64 GPU.

### DIFF
--- a/cmake/onnxruntime-linux-x86_64-gpu.cmake
+++ b/cmake/onnxruntime-linux-x86_64-gpu.cmake
@@ -19,19 +19,19 @@ if(NOT SHERPA_ONNX_ENABLE_GPU)
 endif()
 
 
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.17.1/onnxruntime-linux-x64-gpu-1.17.1-patched.zip")
-set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-linux-x64-gpu-1.17.1-patched.zip")
+set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.16.3/onnxruntime-linux-x64-gpu-1.16.3.tgz")
+set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-linux-x64-gpu-1.16.3.tgz")
 set(onnxruntime_HASH "SHA256=1261de176e8d9d4d2019f8fa8c732c6d11494f3c6e73168ab6d2cc0903f22551")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-linux-x64-gpu-1.17.1-patched.zip
-  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-x64-gpu-1.17.1-patched.zip
-  ${CMAKE_BINARY_DIR}/onnxruntime-linux-x64-gpu-1.17.1-patched.zip
-  /tmp/onnxruntime-linux-x64-gpu-1.17.1-patched.zip
-  /star-fj/fangjun/download/github/onnxruntime-linux-x64-gpu-1.17.1-patched.zip
+  $ENV{HOME}/Downloads/onnxruntime-linux-x64-gpu-1.16.3.tgz
+  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-x64-gpu-1.16.3.tgz
+  ${CMAKE_BINARY_DIR}/onnxruntime-linux-x64-gpu-1.16.3.tgz
+  /tmp/onnxruntime-linux-x64-gpu-1.16.3.tgz
+  /star-fj/fangjun/download/github/onnxruntime-linux-x64-gpu-1.16.3.tgz
 )
 
 foreach(f IN LISTS possible_file_locations)

--- a/cmake/onnxruntime-linux-x86_64-gpu.cmake
+++ b/cmake/onnxruntime-linux-x86_64-gpu.cmake
@@ -21,7 +21,7 @@ endif()
 
 set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.16.3/onnxruntime-linux-x64-gpu-1.16.3.tgz")
 set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-linux-x64-gpu-1.16.3.tgz")
-set(onnxruntime_HASH "SHA256=1261de176e8d9d4d2019f8fa8c732c6d11494f3c6e73168ab6d2cc0903f22551")
+set(onnxruntime_HASH "SHA256=bbdc33367c056029b3ac0c042cbca2236b8f59a3a53b4daf23432ef1d8bf52de")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.


### PR DESCRIPTION
Since `onnxruntime >= 1.17` requires `glibc >=2.28`, which does not support CentOS 7, this commit shows how to use a different version of onnxruntime to build sherpa-onnx.