### PR TITLE
Fix: export-onnx.py(expected all tensors to be on the same device)

### DIFF
--- a/scripts/sense-voice/export-onnx.py
+++ b/scripts/sense-voice/export-onnx.py
@@ -119,7 +119,7 @@ def display_params(params):
 
 
 def main():
-    model, params = SenseVoiceSmall.from_pretrained(model="iic/SenseVoiceSmall")
+    model, params = SenseVoiceSmall.from_pretrained(model="iic/SenseVoiceSmall", device="cpu")
     display_params(params)
 
     generate_tokens(params)


### PR DESCRIPTION
由于[SenseVoiceSmall.from_pretrained()](https://github.com/FunAudioLLM/SenseVoice/blob/5780ace4ea4a1b3e72f21d1632aa5ced23176dca/model.py#L651)
调用的[funasr.auto.auto_model.AutoModel.build_model()](https://github.com/modelscope/FunASR/blob/d4f13c2e444f972b272273bce76b05f52f5164aa/funasr/auto/auto_model.py#L182)默认device是cuda
(在cuda available的环境中)
```python
device = kwargs.get("device", "cuda")
if not torch.cuda.is_available() or kwargs.get("ngpu", 1) == 0:
    device = "cpu"
    kwargs["batch_size"] = 1
kwargs["device"] = device
```
而export-onnx.py里的tensor默认都是cpu, 导致
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu
所以直接在加载model的时候指定cpu