### PR TITLE
Add iOS example for Kokoro TTS

### DIFF
--- a/ios-swiftui/SherpaOnnxTts/SherpaOnnxTts/ViewModel.swift
+++ b/ios-swiftui/SherpaOnnxTts/SherpaOnnxTts/ViewModel.swift
@@ -160,12 +160,34 @@ func getTtsFor_matcha_icefall_zh_baker() -> SherpaOnnxOfflineTtsWrapper {
   return SherpaOnnxOfflineTtsWrapper(config: &config)
 }
 
+func getTtsFor_kokoro_en_v0_19() -> SherpaOnnxOfflineTtsWrapper {
+  // please see https://k2-fsa.github.io/sherpa/onnx/tts/pretrained_models/kokoro.html#kokoro-en-v0-19-english-11-speakers
+
+  let model = getResource("model", "onnx")
+  let voices = getResource("voices", "bin")
+
+  // tokens.txt
+  let tokens = getResource("tokens", "txt")
+
+  // in this case, we don't need lexicon.txt
+  let dataDir = resourceURL(to: "espeak-ng-data")
+
+  let kokoro = sherpaOnnxOfflineTtsKokoroModelConfig(
+    model: model, voices: voices, tokens: tokens, dataDir: dataDir)
+  let modelConfig = sherpaOnnxOfflineTtsModelConfig(kokoro: kokoro)
+  var config = sherpaOnnxOfflineTtsConfig(model: modelConfig)
+
+  return SherpaOnnxOfflineTtsWrapper(config: &config)
+}
+
 func createOfflineTts() -> SherpaOnnxOfflineTtsWrapper {
   // Please enable only one of them
 
+  return getTtsFor_kokoro_en_v0_19()
+
   // return getTtsFor_matcha_icefall_zh_baker()
 
-  return getTtsFor_en_US_amy_low()
+  // return getTtsFor_en_US_amy_low()
 
   // return getTtsForVCTK()
 


### PR DESCRIPTION
# Steps to run it on the iOS simulator inside xcode

## 1. Download and build the code
```bash
mkdir -p ~/open-source/
cd ~/open-source
git clone https://github.com/k2-fsa/sherpa-onnx
cd sherpa-onnx
./build-ios.sh
```

## 2. Download the tts model
Please refer to
https://k2-fsa.github.io/sherpa/onnx/tts/pretrained_models/kokoro.html#kokoro-en-v0-19-english-11-speakers
to download models.
```bash
mkdir -p ~/open-source/icefall-models
cd ~/open-source/icefall-models

wget https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/kokoro-en-v0_19.tar.bz2
tar xf kokoro-en-v0_19.tar.bz2
rm kokoro-en-v0_19.tar.bz2
```

Note that you can put model files anywhere you like. We use `~/open-source/icefall-models` as an example

## 3. Start xcode

Start xcode and open the project
https://github.com/k2-fsa/sherpa-onnx/tree/master/ios-swiftui/SherpaOnnxTts

<img width="1348" alt="Screenshot 2025-01-20 at 12 46 13" src="https://github.com/user-attachments/assets/b3bcd56d-1061-4cb4-9f1b-84821d5cb185" />


## 4. Add the TTS model to the project

<img width="1350" alt="Screenshot 2025-01-20 at 12 47 28" src="https://github.com/user-attachments/assets/c257ea13-b231-4820-b94b-71b2fd667904" />

<img width="1324" alt="Screenshot 2025-01-20 at 12 48 41" src="https://github.com/user-attachments/assets/61877219-38c6-4f2d-925d-6644e1ce9295" />

<img width="784" alt="Screenshot 2025-01-20 at 12 49 53" src="https://github.com/user-attachments/assets/4fc27ba0-ba97-44b9-90ae-de3a8588b6bc" />

## 5. Check model files and run it

<img width="1327" alt="Screenshot 2025-01-20 at 12 52 07" src="https://github.com/user-attachments/assets/db412c51-d954-4592-92aa-2fcf5dde1914" />

<img width="1357" alt="Screenshot 2025-01-20 at 12 52 33" src="https://github.com/user-attachments/assets/f99bab9c-8e19-4e4c-9e35-e4551c3f4fbf" />


----

The version of xcode I am using is
<img width="534" alt="Screenshot 2025-01-20 at 12 54 01" src="https://github.com/user-attachments/assets/40b40fcf-e283-4904-b6e8-96a1aa8ce0a4" />


