### PR TITLE
Fix `dither` binding in Pybind11 to ensure independence from `high_freq` in `FeatureExtractorConfig`

### DIFF
--- a/sherpa-onnx/python/csrc/features.cc
+++ b/sherpa-onnx/python/csrc/features.cc
@@ -19,7 +19,7 @@ static void PybindFeatureExtractorConfig(py::module *m) {
       .def_readwrite("feature_dim", &PyClass::feature_dim)
       .def_readwrite("low_freq", &PyClass::low_freq)
       .def_readwrite("high_freq", &PyClass::high_freq)
-      .def_readwrite("dither", &PyClass::high_freq)
+      .def_readwrite("dither", &PyClass::dither)
       .def("__str__", &PyClass::ToString);
 }
 


### PR DESCRIPTION
This PR fixes the incorrect binding of the dither attribute in the FeatureExtractorConfig Pybind11 bindings. Previously, dither was mistakenly bound to the high_freq member variable, causing unexpected behavior where changes to one attribute affected the other.

The fix updates the Pybind11 binding to correctly map dither to its own member variable, ensuring that dither and high_freq are independent properties in Python