### PR TITLE
Reduce vad-moonshine-c-api example code.

### DIFF
--- a/c-api-examples/vad-moonshine-c-api.c
+++ b/c-api-examples/vad-moonshine-c-api.c
@@ -98,12 +98,16 @@ int32_t main() {
 
   int32_t window_size = vadConfig.silero_vad.window_size;
   int32_t i = 0;
+  int is_eof = 0;
 
-  while (i + window_size < wave->num_samples) {
-    SherpaOnnxVoiceActivityDetectorAcceptWaveform(vad, wave->samples + i,
-                                                  window_size);
-    i += window_size;
-
+  while (!is_eof) {
+    if (i + window_size < wave->num_samples) {
+      SherpaOnnxVoiceActivityDetectorAcceptWaveform(vad, wave->samples + i,
+                                                    window_size);
+    } else {
+      SherpaOnnxVoiceActivityDetectorFlush(vad);
+      is_eof = 1;
+    }
     while (!SherpaOnnxVoiceActivityDetectorEmpty(vad)) {
       const SherpaOnnxSpeechSegment *segment =
           SherpaOnnxVoiceActivityDetectorFront(vad);
@@ -131,36 +135,7 @@ int32_t main() {
       SherpaOnnxDestroySpeechSegment(segment);
       SherpaOnnxVoiceActivityDetectorPop(vad);
     }
-  }
-
-  SherpaOnnxVoiceActivityDetectorFlush(vad);
-
-  while (!SherpaOnnxVoiceActivityDetectorEmpty(vad)) {
-    const SherpaOnnxSpeechSegment *segment =
-        SherpaOnnxVoiceActivityDetectorFront(vad);
-
-    const SherpaOnnxOfflineStream *stream =
-        SherpaOnnxCreateOfflineStream(recognizer);
-
-    SherpaOnnxAcceptWaveformOffline(stream, wave->sample_rate, segment->samples,
-                                    segment->n);
-
-    SherpaOnnxDecodeOfflineStream(recognizer, stream);
-
-    const SherpaOnnxOfflineRecognizerResult *result =
-        SherpaOnnxGetOfflineStreamResult(stream);
-
-    float start = segment->start / 16000.0f;
-    float duration = segment->n / 16000.0f;
-    float stop = start + duration;
-
-    fprintf(stderr, "%.3f -- %.3f: %s\n", start, stop, result->text);
-
-    SherpaOnnxDestroyOfflineRecognizerResult(result);
-    SherpaOnnxDestroyOfflineStream(stream);
-
-    SherpaOnnxDestroySpeechSegment(segment);
-    SherpaOnnxVoiceActivityDetectorPop(vad);
+    i += window_size;
   }
 
   SherpaOnnxDestroyOfflineRecognizer(recognizer);


### PR DESCRIPTION
Reduce vad-moonshine-c-api example code.

The current code uses a repeated while loop code (two sections of while) to process the tail data.
```cpp
while(..) {
}
while(..) {
}
```

And the optimized early calculation of total_size can circulate less each calculation amount and improve efficiency.

So I reduce sherpa-onnx/c-api-examples/vad-moonshine-c-api.c some codes.

The PR like this: https://github.com/k2-fsa/sherpa-onnx/pull/1510

The screenshot is test results after modification in my pc.
![圖片](https://github.com/user-attachments/assets/e6493314-f819-4adc-87ac-6fc01a8778da)


