### PR TITLE
Fix publishing wheels

### DIFF
--- a/.github/workflows/build-wheels-aarch64.yaml
+++ b/.github/workflows/build-wheels-aarch64.yaml
@@ -123,6 +123,6 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install wheel twine setuptools
+          python3 -m pip install wheel twine==5.0.0 setuptools
 
           twine upload ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels-armv7l.yaml
+++ b/.github/workflows/build-wheels-armv7l.yaml
@@ -129,6 +129,6 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install wheel twine setuptools
+          python3 -m pip install wheel twine==5.0.0 setuptools
 
           twine upload ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels-linux-cuda.yaml
+++ b/.github/workflows/build-wheels-linux-cuda.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Python dependencies
         shell: bash
         run: |
-          pip install -U pip wheel setuptools twine
+          pip install -U pip wheel setuptools twine==5.0.0
 
       - name: Build alsa-lib
         shell: bash

--- a/.github/workflows/build-wheels-linux.yaml
+++ b/.github/workflows/build-wheels-linux.yaml
@@ -118,7 +118,7 @@ jobs:
         shell: bash
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install wheel twine setuptools
+          python3 -m pip install wheel twine==5.0.0 setuptools
 
           twine upload ./wheelhouse/*.whl
 

--- a/.github/workflows/build-wheels-macos-arm64.yaml
+++ b/.github/workflows/build-wheels-macos-arm64.yaml
@@ -95,6 +95,6 @@ jobs:
           fi
 
           python3 -m pip install $opts --upgrade pip
-          python3 -m pip install $opts wheel twine setuptools
+          python3 -m pip install $opts wheel twine==5.0.0 setuptools
 
           twine upload ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels-macos-universal2.yaml
+++ b/.github/workflows/build-wheels-macos-universal2.yaml
@@ -89,6 +89,6 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python3 -m pip install --break-system-packages --upgrade pip
-          python3 -m pip install --break-system-packages wheel twine setuptools
+          python3 -m pip install --break-system-packages wheel twine==5.0.0 setuptools
 
           twine upload ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels-macos-x64.yaml
+++ b/.github/workflows/build-wheels-macos-x64.yaml
@@ -110,6 +110,6 @@ jobs:
           fi
 
           python3 -m pip install $opts --upgrade pip
-          python3 -m pip install $opts wheel twine setuptools
+          python3 -m pip install $opts wheel twine==5.0.0 setuptools
 
           twine upload ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels-win32.yaml
+++ b/.github/workflows/build-wheels-win32.yaml
@@ -88,6 +88,6 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install wheel twine setuptools
+          python3 -m pip install wheel twine==5.0.0 setuptools
 
           twine upload ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels-win64.yaml
+++ b/.github/workflows/build-wheels-win64.yaml
@@ -94,6 +94,6 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install wheel twine setuptools
+          python3 -m pip install wheel twine==5.0.0 setuptools
 
           twine upload ./wheelhouse/*.whl


### PR DESCRIPTION
To fix the following error
```
Uploading distributions to https://upload.pypi.org/legacy/
ERROR    InvalidDistribution: Invalid distribution metadata: dynamic introduced
         in metadata version 2.2, not 2.1 
```