### PR TITLE
Fix: Prepend 0 to tokenization to prevent word skipping for Kokoro.

### DIFF
--- a/sherpa-onnx/csrc/piper-phonemize-lexicon.cc
+++ b/sherpa-onnx/csrc/piper-phonemize-lexicon.cc
@@ -163,6 +163,8 @@ static std::vector<std::vector<int64_t>> PiperPhonemesToIdsKokoro(
   std::vector<int64_t> current;
   current.reserve(phonemes.size());
 
+  current.push_back(0);
+
   for (auto p : phonemes) {
     if (token2id.count(p)) {
       if (current.size() > max_len - 1) {


### PR DESCRIPTION
Addressed issue Skipping words #1777

In the original code they have a 0 in front and behind. Currently it only has it behind so I added it to the front also. Here is the original code:
https://huggingface.co/hexgrad/kLegacy/blob/d0acca3b0748cae52e0a14a28ad03515002ff22f/v0.19/kokoro.py#L117