### PR TITLE
Fix passing gb2312 encoded strings to tts on Windows

### DIFF
--- a/sherpa-onnx/csrc/offline-tts.cc
+++ b/sherpa-onnx/csrc/offline-tts.cc
@@ -96,6 +96,8 @@ OfflineTts::~OfflineTts() = default;
 GeneratedAudio OfflineTts::Generate(
     const std::string &text, int64_t sid /*=0*/, float speed /*= 1.0*/,
     GeneratedAudioCallback callback /*= nullptr*/) const {
+  // uint8_t sss[] = {0xc4, 0xe3, 0xba, 0xc3};
+  // std::string text(sss, &sss[0] + 4);
 #if !defined(_WIN32)
   return impl_->Generate(text, sid, speed, std::move(callback));
 #else
@@ -109,7 +111,7 @@ GeneratedAudio OfflineTts::Generate(
           "Detected GB2312 encoded string! Converting it to UTF8.");
       printed = true;
     }
-    return impl_->Generate(text, sid, speed, std::move(callback));
+    return impl_->Generate(utf8_text, sid, speed, std::move(callback));
   } else {
     SHERPA_ONNX_LOGE(
         "Non UTF8 encoded string is received. You would not get expected "

--- a/sherpa-onnx/csrc/offline-tts.cc
+++ b/sherpa-onnx/csrc/offline-tts.cc
@@ -96,8 +96,6 @@ OfflineTts::~OfflineTts() = default;
 GeneratedAudio OfflineTts::Generate(
     const std::string &text, int64_t sid /*=0*/, float speed /*= 1.0*/,
     GeneratedAudioCallback callback /*= nullptr*/) const {
-  // uint8_t sss[] = {0xc4, 0xe3, 0xba, 0xc3};
-  // std::string text(sss, &sss[0] + 4);
 #if !defined(_WIN32)
   return impl_->Generate(text, sid, speed, std::move(callback));
 #else

--- a/sherpa-onnx/csrc/text-utils.cc
+++ b/sherpa-onnx/csrc/text-utils.cc
@@ -6,6 +6,7 @@
 #include "sherpa-onnx/csrc/text-utils.h"
 
 #include <algorithm>
+#include <iostream>
 #include <cassert>
 #include <cctype>
 #include <cstdint>
@@ -565,7 +566,7 @@ bool IsUtf8(const std::string &text) {
       continue;
     }
 
-    return false
+    return false;
   }
 
   return true;
@@ -596,25 +597,30 @@ bool IsGB2312(const std::string &text) {
 #if defined(_WIN32)
 std::string Gb2312ToUtf8(const std::string &text) {
   // https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar
+// 936 is from https://learn.microsoft.com/en-us/windows/win32/intl/code-page-identifiers
   int32_t num_wchars =
-      MultiByteToWideChar(CP_GB2312, 0, text.c_str(), -1, nullptr, 0);
+      MultiByteToWideChar(936, 0, text.c_str(), -1, nullptr, 0);
+SHERPA_ONNX_LOGE("num of wchars: %d", num_wchars);
   if (num_wchars == 0) {
     return {};
   }
 
-  std::wstring wstr(num_wchars) MultiByteToWideChar(CP_GB2312, 0, text.c_str(),
-                                                    -1, wstr.data(), num_chars);
-
+  std::wstring wstr;
+  wstr.resize(num_wchars);
+  MultiByteToWideChar(936, 0, text.c_str(),
+                                                    -1, wstr.data(), num_wchars);
   // https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte
   int32_t num_chars = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, nullptr,
                                           0, nullptr, nullptr);
+SHERPA_ONNX_LOGE("num of chars: %d", num_chars);
   if (num_chars == 0) {
     return {};
   }
 
-  std::string ans(num_chars);
+  std::string ans(num_chars, 0);
   WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, ans.data(), num_chars,
                       nullptr, nullptr);
+std::cout << "ans: " << ans.size() << "--->" << ans << "\n";
 
   return ans;
 }

--- a/sherpa-onnx/csrc/text-utils.cc
+++ b/sherpa-onnx/csrc/text-utils.cc
@@ -598,8 +598,9 @@ bool IsGB2312(const std::string &text) {
 std::string Gb2312ToUtf8(const std::string &text) {
   // https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar
 // 936 is from https://learn.microsoft.com/en-us/windows/win32/intl/code-page-identifiers
+// GB2312 -> 936
   int32_t num_wchars =
-      MultiByteToWideChar(936, 0, text.c_str(), -1, nullptr, 0);
+      MultiByteToWideChar(936, 0, text.c_str(), text.size(), nullptr, 0);
 SHERPA_ONNX_LOGE("num of wchars: %d", num_wchars);
   if (num_wchars == 0) {
     return {};
@@ -608,7 +609,7 @@ SHERPA_ONNX_LOGE("num of wchars: %d", num_wchars);
   std::wstring wstr;
   wstr.resize(num_wchars);
   MultiByteToWideChar(936, 0, text.c_str(),
-                                                    -1, wstr.data(), num_wchars);
+                                                    text.size(), wstr.data(), num_wchars);
   // https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte
   int32_t num_chars = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, nullptr,
                                           0, nullptr, nullptr);

--- a/sherpa-onnx/csrc/text-utils.cc
+++ b/sherpa-onnx/csrc/text-utils.cc
@@ -6,7 +6,6 @@
 #include "sherpa-onnx/csrc/text-utils.h"
 
 #include <algorithm>
-#include <iostream>
 #include <cassert>
 #include <cctype>
 #include <cstdint>
@@ -597,23 +596,23 @@ bool IsGB2312(const std::string &text) {
 #if defined(_WIN32)
 std::string Gb2312ToUtf8(const std::string &text) {
   // https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar
-// 936 is from https://learn.microsoft.com/en-us/windows/win32/intl/code-page-identifiers
-// GB2312 -> 936
+  // 936 is from
+  // https://learn.microsoft.com/en-us/windows/win32/intl/code-page-identifiers
+  // GB2312 -> 936
   int32_t num_wchars =
       MultiByteToWideChar(936, 0, text.c_str(), text.size(), nullptr, 0);
-SHERPA_ONNX_LOGE("num of wchars: %d", num_wchars);
+  SHERPA_ONNX_LOGE("num of wchars: %d", num_wchars);
   if (num_wchars == 0) {
     return {};
   }
 
   std::wstring wstr;
   wstr.resize(num_wchars);
-  MultiByteToWideChar(936, 0, text.c_str(),
-                                                    text.size(), wstr.data(), num_wchars);
+  MultiByteToWideChar(936, 0, text.c_str(), text.size(), wstr.data(),
+                      num_wchars);
   // https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte
   int32_t num_chars = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, nullptr,
                                           0, nullptr, nullptr);
-SHERPA_ONNX_LOGE("num of chars: %d", num_chars);
   if (num_chars == 0) {
     return {};
   }
@@ -621,7 +620,6 @@ SHERPA_ONNX_LOGE("num of chars: %d", num_chars);
   std::string ans(num_chars, 0);
   WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, ans.data(), num_chars,
                       nullptr, nullptr);
-std::cout << "ans: " << ans.size() << "--->" << ans << "\n";
 
   return ans;
 }

--- a/sherpa-onnx/csrc/text-utils.h
+++ b/sherpa-onnx/csrc/text-utils.h
@@ -127,6 +127,18 @@ void ToLowerCase(std::string *in_out);
 std::string RemoveInvalidUtf8Sequences(const std::string &text,
                                        bool show_debug_msg = false);
 
+// Return true if text contains valid utf8 sequence.
+// Return false otherwise
+bool IsUtf8(const std::string &text);
+
+// Return true if text contains valid gb2312 encoded sequence
+// Return false otherwise
+bool IsGB2312(const std::string &text);
+
+#if defined(_WIN32)
+std::string Gb2312ToUtf8(const std::string &text);
+#endif
+
 }  // namespace sherpa_onnx
 
 #endif  // SHERPA_ONNX_CSRC_TEXT_UTILS_H_


### PR DESCRIPTION
Chinese users usually have the strings encoded in GB2312 on Windows, not in UTF8. 
This PR converts GB2312 encoded strings to UTF8 encoding.