### PR TITLE
OfflineRecognizer supports create stream with hotwords

### DIFF
--- a/sherpa-onnx/c-api/c-api.cc
+++ b/sherpa-onnx/c-api/c-api.cc
@@ -533,6 +533,13 @@ const SherpaOnnxOfflineStream *SherpaOnnxCreateOfflineStream(
   return stream;
 }
 
+const SherpaOnnxOfflineStream *SherpaOnnxCreateOfflineStreamWithHotwords(
+    const SherpaOnnxOfflineRecognizer *recognizer, const char *hotwords) {
+  SherpaOnnxOfflineStream *stream =
+      new SherpaOnnxOfflineStream(recognizer->impl->CreateStream(hotwords));
+  return stream;
+}
+
 void SherpaOnnxDestroyOfflineStream(const SherpaOnnxOfflineStream *stream) {
   delete stream;
 }

--- a/sherpa-onnx/c-api/c-api.h
+++ b/sherpa-onnx/c-api/c-api.h
@@ -484,6 +484,16 @@ SHERPA_ONNX_API void SherpaOnnxDestroyOfflineRecognizer(
 SHERPA_ONNX_API const SherpaOnnxOfflineStream *SherpaOnnxCreateOfflineStream(
     const SherpaOnnxOfflineRecognizer *recognizer);
 
+/// Create an offline stream for accepting wave samples with the specified hot
+/// words.
+///
+/// @param recognizer  A pointer returned by SherpaOnnxCreateOfflineRecognizer()
+/// @return Return a pointer to an OfflineStream. The user has to invoke
+///         SherpaOnnxDestroyOfflineStream() to free it to avoid memory leak.
+SHERPA_ONNX_API const SherpaOnnxOfflineStream *
+SherpaOnnxCreateOfflineStreamWithHotwords(
+    const SherpaOnnxOfflineRecognizer *recognizer, const char *hotwords);
+
 /// Destroy an offline stream.
 ///
 /// @param stream A pointer returned by SherpaOnnxCreateOfflineStream()

--- a/sherpa-onnx/c-api/cxx-api.cc
+++ b/sherpa-onnx/c-api/cxx-api.cc
@@ -266,8 +266,13 @@ void OfflineRecognizer::Destroy(const SherpaOnnxOfflineRecognizer *p) const {
 }
 
 OfflineStream OfflineRecognizer::CreateStream() const {
-  auto p = SherpaOnnxCreateOfflineStream(p_);
-  return OfflineStream{p};
+  auto s = SherpaOnnxCreateOfflineStream(p_);
+  return OfflineStream{s};
+}
+
+OfflineStream OfflineRecognizer::CreateStream(const std::string &hotwords) const {
+  auto s = SherpaOnnxCreateOfflineStreamWithHotwords(p_, hotwords.c_str());
+  return OfflineStream{s};
 }
 
 void OfflineRecognizer::Decode(const OfflineStream *s) const {

--- a/sherpa-onnx/c-api/cxx-api.h
+++ b/sherpa-onnx/c-api/cxx-api.h
@@ -301,6 +301,8 @@ class SHERPA_ONNX_API OfflineRecognizer
 
   OfflineStream CreateStream() const;
 
+  OfflineStream CreateStream(const std::string &hotwords) const;
+
   void Decode(const OfflineStream *s) const;
 
   void Decode(const OfflineStream *ss, int32_t n) const;


### PR DESCRIPTION
Add the hotwords parameter when creating a stream to the offline recognizer in the C and C++ APIs.