### PR TITLE
Disable strict hotword matching mode for offline transducer

### DIFF
--- a/sherpa-onnx/csrc/offline-transducer-modified-beam-search-decoder.cc
+++ b/sherpa-onnx/csrc/offline-transducer-modified-beam-search-decoder.cc
@@ -138,7 +138,9 @@ OfflineTransducerModifiedBeamSearchDecoder::Decode(
           new_hyp.timestamps.push_back(t);
           if (context_graphs[i] != nullptr) {
             auto context_res =
-                context_graphs[i]->ForwardOneStep(context_state, new_token, strict_hotword_mode_);
+                context_graphs[i]->ForwardOneStep(context_state,
+                  new_token,
+                  false /* non-strict mode */);
             context_score = std::get<0>(context_res);
             new_hyp.context_state = std::get<1>(context_res);
           }

--- a/sherpa-onnx/csrc/offline-transducer-modified-beam-search-decoder.cc
+++ b/sherpa-onnx/csrc/offline-transducer-modified-beam-search-decoder.cc
@@ -138,7 +138,7 @@ OfflineTransducerModifiedBeamSearchDecoder::Decode(
           new_hyp.timestamps.push_back(t);
           if (context_graphs[i] != nullptr) {
             auto context_res =
-                context_graphs[i]->ForwardOneStep(context_state, new_token);
+                context_graphs[i]->ForwardOneStep(context_state, new_token, strict_hotword_mode_);
             context_score = std::get<0>(context_res);
             new_hyp.context_state = std::get<1>(context_res);
           }

--- a/sherpa-onnx/csrc/offline-transducer-modified-beam-search-decoder.h
+++ b/sherpa-onnx/csrc/offline-transducer-modified-beam-search-decoder.h
@@ -20,15 +20,13 @@ class OfflineTransducerModifiedBeamSearchDecoder
                                              OfflineLM *lm,
                                              int32_t max_active_paths,
                                              float lm_scale, int32_t unk_id,
-                                             float blank_penalty,
-                                             bool strict_hotword_mode = false)
+                                             float blank_penalty)
       : model_(model),
         lm_(lm),
         max_active_paths_(max_active_paths),
         lm_scale_(lm_scale),
         unk_id_(unk_id),
-        blank_penalty_(blank_penalty),
-        strict_hotword_mode_(strict_hotword_mode) {}
+        blank_penalty_(blank_penalty) {}
 
   std::vector<OfflineTransducerDecoderResult> Decode(
       Ort::Value encoder_out, Ort::Value encoder_out_length,
@@ -42,7 +40,6 @@ class OfflineTransducerModifiedBeamSearchDecoder
   float lm_scale_;  // used only when lm_ is not nullptr
   int32_t unk_id_;
   float blank_penalty_;
-  bool strict_hotword_mode_ = false;
 };
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/offline-transducer-modified-beam-search-decoder.h
+++ b/sherpa-onnx/csrc/offline-transducer-modified-beam-search-decoder.h
@@ -20,13 +20,15 @@ class OfflineTransducerModifiedBeamSearchDecoder
                                              OfflineLM *lm,
                                              int32_t max_active_paths,
                                              float lm_scale, int32_t unk_id,
-                                             float blank_penalty)
+                                             float blank_penalty,
+                                             bool strict_hotword_mode = false)
       : model_(model),
         lm_(lm),
         max_active_paths_(max_active_paths),
         lm_scale_(lm_scale),
         unk_id_(unk_id),
-        blank_penalty_(blank_penalty) {}
+        blank_penalty_(blank_penalty),
+        strict_hotword_mode_(strict_hotword_mode) {}
 
   std::vector<OfflineTransducerDecoderResult> Decode(
       Ort::Value encoder_out, Ort::Value encoder_out_length,
@@ -40,6 +42,7 @@ class OfflineTransducerModifiedBeamSearchDecoder
   float lm_scale_;  // used only when lm_ is not nullptr
   int32_t unk_id_;
   float blank_penalty_;
+  bool strict_hotword_mode_ = false;
 };
 
 }  // namespace sherpa_onnx


### PR DESCRIPTION
I noticed that for offline transducer strict_mode is True when traversing ContextGraph, but for online non-strict mode is used (see #638 ).

What is the rationale behind this?

In my testing, when using strict_mode the decoder sometimes "gets stuck" in the final state of the hotword graph, penalizing all tokens after the hotword. In other words, if we have sentence "he is my friend" and hotwords list contains "he", then sometimes decoder output is just "he" and remainder of the sentence is truncated. This is typically happens if weight is too large, but I would still consider such behaviour undesirable for ASR (not keyword spotter). 

This PR proposes to disable strict hotword matching mode for offline transducer. 
Also it introduces new variable, so that later this mode can be made configurable. 