### PR TITLE
Export FireRedASR to ONNX

### DIFF
--- a/.github/workflows/export-fire-red-asr.yaml
+++ b/.github/workflows/export-fire-red-asr.yaml
@@ -1,0 +1,119 @@
+name: export-fire-red-asr-to-onnx
+
+on:
+  push:
+    branches:
+      - export-fire-red-asr
+
+  workflow_dispatch:
+
+concurrency:
+  group: export-fire-red-asr-to-onnx-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  export-fire-red-asr-to-onnx:
+    if: github.repository_owner == 'k2-fsa' || github.repository_owner == 'csukuangfj'
+    name: export FireRedAsr ${{ matrix.version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.10"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          pip install "numpy<=1.26.4" onnx==1.16.0 onnxruntime==1.17.1
+
+      - name: Download exported ONNX model from ModelScope
+        env:
+          MS_TOKEN: ${{ secrets.MODEL_SCOPE_GIT_TOKEN }}
+        shell: bash
+        run: |
+          git clone https://oauth2:${MS_TOKEN}@www.modelscope.cn/csukuangfj/sherpa-onnx-fire-red-asr-large-zh_en-2025-02-16.git ms
+          ls -lh ms
+
+
+      - name: Collect results
+        shell: bash
+        run: |
+          src=ms
+          d=sherpa-onnx-fire-red-asr-large-zh_en-2025-02-16
+          mkdir $d
+
+          mv -v $src/*.onnx $d
+          cp -v $src/README.md $d
+          cp -v $src/tokens.txt $d
+          cp -av $src/test_wavs $d
+
+          ls -lh $d/
+          tar cjfv $d.tar.bz2 $d
+
+          ls -lh $d.tar.bz2
+          rm -rf ms
+
+      - name: Publish to huggingface ${{ matrix.version }}
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 20
+          timeout_seconds: 200
+          shell: bash
+          command: |
+            git config --global user.email "csukuangfj@gmail.com"
+            git config --global user.name "Fangjun Kuang"
+
+            rm -rf huggingface
+            export GIT_LFS_SKIP_SMUDGE=1
+            export GIT_CLONE_PROTECTION_ACTIVE=false
+
+            src=sherpa-onnx-fire-red-asr-large-zh_en-2025-02-16
+
+            git clone https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/$src huggingface
+            cd huggingface
+            rm -rf ./*
+            git fetch
+            git pull
+
+            cp -av ../$src/* ./
+
+            git lfs track "*.onnx"
+            git add .
+
+            ls -lh
+
+            git status
+
+            git commit -m "add models"
+            git push https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/$src main || true
+
+      - name: Release
+        if: github.repository_owner == 'csukuangfj'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./*.tar.bz2
+          overwrite: true
+          repo_name: k2-fsa/sherpa-onnx
+          repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
+          tag: asr-models
+
+      - name: Release
+        if: github.repository_owner == 'k2-fsa'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./*.tar.bz2
+          overwrite: true
+          tag: asr-models

--- a/.github/workflows/mfc.yaml
+++ b/.github/workflows/mfc.yaml
@@ -138,7 +138,7 @@ jobs:
           file: ./mfc-examples/${{ matrix.arch }}/Release/sherpa-onnx-non-streaming-*.exe
 
       - name: Release pre-compiled binaries and libs for Windows ${{ matrix.arch }}
-        if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+        if: (github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa') && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         uses: svenstaro/upload-release-action@v2
         with:
           file_glob: true


### PR DESCRIPTION
See also https://github.com/FireRedTeam/FireRedASR
and
https://huggingface.co/FireRedTeam/FireRedASR-AED-L/tree/main

Note it supports both Chinese and English.

The **Large** version is quite large. See the exported onnx model files below:
```
total 1.7G
-rw-r--r-- 1 runner docker  188 Feb 16 08:46 README.md
-rw-r--r-- 1 runner docker 425M Feb 16 08:45 decoder.int8.onnx
-rw-r--r-- 1 runner docker 1.3G Feb 16 08:46 encoder.int8.onnx
drwxr-xr-x 2 runner docker 4.0K Feb 16 08:45 test_wavs
-rw-r--r-- 1 runner docker  70K Feb 16 08:46 tokens.txt
```

You can download it from
https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models

<img width="1293" alt="Screenshot 2025-02-16 at 16 52 28" src="https://github.com/user-attachments/assets/5006f10e-9846-4607-9663-33f6d32583c8" />


We will open-source the export code once the `xs` version of the model from
https://github.com/FireRedTeam/FireRedASR
is open-sourced.