### PR TITLE
speaker-identification-with-vad-non-streaming-asr.py Lack of support for sense_voice.

### DIFF
--- a/python-api-examples/speaker-identification-with-vad-non-streaming-asr.py
+++ b/python-api-examples/speaker-identification-with-vad-non-streaming-asr.py
@@ -317,6 +317,23 @@ def create_recognizer(args) -> sherpa_onnx.OfflineRecognizer:
             task=args.whisper_task,
             tail_paddings=args.whisper_tail_paddings,
         )
+    elif args.sense_voice:
+        assert len(args.wenet_ctc) == 0, args.wenet_ctc
+        assert len(args.whisper_encoder) == 0, args.whisper_encoder
+        assert len(args.whisper_decoder) == 0, args.whisper_decoder
+        assert len(args.moonshine_preprocessor) == 0, args.moonshine_preprocessor
+        assert len(args.moonshine_encoder) == 0, args.moonshine_encoder
+        assert len(args.moonshine_uncached_decoder) == 0, args.moonshine_uncached_decoder
+        assert len(args.moonshine_cached_decoder) == 0, args.moonshine_cached_decoder
+
+        assert_file_exists(args.sense_voice)
+        recognizer = sherpa_onnx.OfflineRecognizer.from_sense_voice(
+            model=args.sense_voice,
+            tokens=args.tokens,
+            num_threads=args.num_threads,
+            use_itn=True,
+            debug=args.debug,
+        )
     else:
         raise ValueError("Please specify at least one model")
 

--- a/python-api-examples/speaker-identification-with-vad-non-streaming-asr.py
+++ b/python-api-examples/speaker-identification-with-vad-non-streaming-asr.py
@@ -185,6 +185,13 @@ def register_non_streaming_asr_model_args(parser):
         help="Feature dimension. Must match the one expected by the model",
     )
 
+    parser.add_argument(
+        "--sense-voice",
+        default="",
+        type=str,
+        help="Path to whisper encoder model",
+    )
+
 
 def get_args():
     parser = argparse.ArgumentParser(
@@ -318,14 +325,6 @@ def create_recognizer(args) -> sherpa_onnx.OfflineRecognizer:
             tail_paddings=args.whisper_tail_paddings,
         )
     elif args.sense_voice:
-        assert len(args.wenet_ctc) == 0, args.wenet_ctc
-        assert len(args.whisper_encoder) == 0, args.whisper_encoder
-        assert len(args.whisper_decoder) == 0, args.whisper_decoder
-        assert len(args.moonshine_preprocessor) == 0, args.moonshine_preprocessor
-        assert len(args.moonshine_encoder) == 0, args.moonshine_encoder
-        assert len(args.moonshine_uncached_decoder) == 0, args.moonshine_uncached_decoder
-        assert len(args.moonshine_cached_decoder) == 0, args.moonshine_cached_decoder
-
         assert_file_exists(args.sense_voice)
         recognizer = sherpa_onnx.OfflineRecognizer.from_sense_voice(
             model=args.sense_voice,

--- a/python-api-examples/speaker-identification-with-vad-non-streaming-asr.py
+++ b/python-api-examples/speaker-identification-with-vad-non-streaming-asr.py
@@ -189,7 +189,7 @@ def register_non_streaming_asr_model_args(parser):
         "--sense-voice",
         default="",
         type=str,
-        help="Path to whisper encoder model",
+        help="Path to sense voice model",
     )
 
 


### PR DESCRIPTION
Fix that speaker-identification-with-vad-non-streaming-asr.py does not support the sense_voice ASR model. (#1883)
![image](https://github.com/user-attachments/assets/a08e0ab5-ecef-441a-a56c-1e5c0c1a315e)
