### PR TITLE
Fix kokoro lexicon.

### DIFF
--- a/scripts/kokoro/v1.0/run.sh
+++ b/scripts/kokoro/v1.0/run.sh
@@ -110,9 +110,14 @@ if [ ! -f ./tokens.txt ]; then
   ./generate_tokens.py
 fi
 
-if [ ! -f ./lexicon.txt ]; then
+if [ ! -f ./lexicon-zh.txt ]; then
   ./generate_lexicon.py
 fi
+
+grep '还钱' ./lexicon-zh.txt
+sed -i.bak 's/还钱 x a i/还钱 x w a/' ./lexicon-zh.txt
+rm -v ./lexicon-zh.txt.bak
+grep '还钱' ./lexicon-zh.txt
 
 if [ ! -f ./voices.bin ]; then
   ./generate_voices_bin.py


### PR DESCRIPTION
还钱 is mispronounced.