### PR TITLE
Add onnxruntime 1.18.1 for Linux aarch64 GPU

### DIFF
--- a/.github/workflows/aarch64-linux-gnu-shared.yaml
+++ b/.github/workflows/aarch64-linux-gnu-shared.yaml
@@ -44,6 +44,9 @@ jobs:
             gpu: ON
             onnxruntime_version: "1.16.0"
           - os: ubuntu-22.04-arm
+            gpu: ON
+            onnxruntime_version: "1.18.1"
+          - os: ubuntu-22.04-arm
             gpu: OFF
             onnxruntime_version: ""
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,8 @@ option(SHERPA_ONNX_USE_PRE_INSTALLED_ONNXRUNTIME_IF_AVAILABLE "True to use pre-i
 option(SHERPA_ONNX_ENABLE_SANITIZER "Whether to enable ubsan and asan" OFF)
 option(SHERPA_ONNX_BUILD_C_API_EXAMPLES "Whether to enable C API examples" ON)
 
-set(SHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION "1.11.0" CACHE STRING "Used only for Linux ARM64 GPU. If you use Jetson nano b01, then please set it to 1.11.0. If you use Jetson Orin NX, then set it to 1.16.0")
+set(SHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION "1.11.0" CACHE STRING "Used only for Linux ARM64 GPU. If you use Jetson nano b01, then please set it to 1.11.0. If you use Jetson Orin NX, then set it to 1.16.0.If you use NVIDIA Jetson Orin Nano Engineering Reference Developer Kit
+Super - Jetpack 6.2 [L4T 36.4.3], then set it to 1.18.1")
 
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")

--- a/build-aarch64-linux-gnu.sh
+++ b/build-aarch64-linux-gnu.sh
@@ -20,6 +20,14 @@
 #       export SHERPA_ONNX_ENABLE_GPU=ON
 #       export SHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION=1.16.0
 #       ./build-aarch64-linux-gnu.sh
+#
+#   (d) For NVIDIA Jetson Orin Nano Engineering Reference Developer Kit Super
+#       Jetpack 6.2 [L4T 36.4.3] (CUDA 12.6)
+#
+#       export SHERPA_ONNX_ENABLE_GPU=ON
+#       export SHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION=1.18.1
+#       ./build-aarch64-linux-gnu.sh
+
 
 if command -v aarch64-none-linux-gnu-gcc  &> /dev/null; then
   ln -svf $(which aarch64-none-linux-gnu-gcc) ./aarch64-linux-gnu-gcc

--- a/cmake/onnxruntime-linux-aarch64-gpu.cmake
+++ b/cmake/onnxruntime-linux-aarch64-gpu.cmake
@@ -27,6 +27,11 @@ to cmake (You need to make sure CUDA 10.2 is available on your board).
 If you use Jetson Orin NX, then please pass
    -DSHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION=1.16.0
 to cmake (You need to make sure CUDA 11.4 is available on your board).
+
+If you use NVIDIA Jetson Orin Nano Engineering Reference Developer Kit
+Super - Jetpack 6.2 [L4T 36.4.3], then please pass
+   -DSHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION=1.18.1
+to cmake (You need to make sure CUDA 12.6 is available on your board).
 ")
 
 set(v ${SHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION})
@@ -36,8 +41,14 @@ set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/
 
 if(v STREQUAL "1.11.0")
   set(onnxruntime_HASH "SHA256=36eded935551e23aead09d4173bdf0bd1e7b01fdec15d77f97d6e34029aa60d7")
-else()
+elseif(v STREQUAL "1.16.0")
   set(onnxruntime_HASH "SHA256=4c09d5acf2c2682b4eab1dc2f1ad98fc1fde5f5f1960063e337983ba59379a4b")
+elseif(v STREQUAL "1.18.1")
+  set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.18.1/onnxruntime-linux-aarch64-gpu-cuda12-1.18.1.tar.bz2")
+  set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-linux-aarch64-gpu-cuda12-1.18.1.tar.bz2")
+  set(onnxruntime_HASH "SHA256=1e91064ec13a6fabb6b670da8a2da4f369c1dbd50a5be77a879b2473e7afc0a6")
+else()
+  message(FATAL_ERROR "Unuspported onnxruntime version ${v} for Linux aarch64")
 endif()
 
 # If you don't have access to the Internet,


### PR DESCRIPTION
See also https://github.com/k2-fsa/sherpa-onnx/pull/1630


The pre-built onnxruntime libs are provided by the community using the following command:

```bash
./build.sh --build_shared_lib --config Release --update \
  --build --parallel --use_cuda \
  --cuda_home /usr/local/cuda \
  --cudnn_home /usr/lib/aarch64-linux-gnu 2>&1 | tee my-log.txt
```

See also https://github.com/microsoft/onnxruntime/discussions/11226

info about the board:

```
Software part of jetson-stats 4.3.1 - (c) 2024, Raffaello Bonghi
Model: NVIDIA Jetson Orin Nano Engineering Reference Developer Kit Super - Jetpack 6.2 [L4T 36.4.3]
NV Power Mode[1]: 25W
Serial Number: [XXX Show with: jetson_release -s XXX]
Hardware:
 - P-Number: p3767-0003
 - Module: NVIDIA Jetson Orin Nano (8GB ram)
Platform:
 - Distribution: Ubuntu 22.04 Jammy Jellyfish
 - Release: 5.15.148-tegra
jtop:
 - Version: 4.3.1
 - Service: Active
Libraries:
 - CUDA: 12.6.68
 - cuDNN: 9.3.0.75
 - TensorRT: 10.3.0.30
 - VPI: 3.2.4
 - Vulkan: 1.3.204
 - OpenCV: 4.8.0 - with CUDA: NO
```

Build logs are attached below
[build_log.txt](https://github.com/user-attachments/files/18938196/build_log.txt)

---

You can try the pre-built binaries and libs for v1.10.45 at
https://huggingface.co/csukuangfj/sherpa-onnx-libs/blob/main/aarch64/sherpa-onnx-v1.10.45-linux-aarch64-shared-gpu-onnxruntime-1.18.1.tar.bz2

<img width="1324" alt="Screenshot 2025-02-24 at 16 11 15" src="https://github.com/user-attachments/assets/9a804ffa-2763-440d-b7df-8cd895d156ac" />
