### PR TITLE
fix: AddPunct panic

### DIFF
--- a/scripts/go/sherpa_onnx.go
+++ b/scripts/go/sherpa_onnx.go
@@ -1483,7 +1483,7 @@ func DeleteOfflinePunc(punc *OfflinePunctuation) {
 
 func (punc *OfflinePunctuation) AddPunct(text string) string {
 	p := C.SherpaOfflinePunctuationAddPunct(punc.impl, C.CString(text))
-	defer C.free(unsafe.Pointer(p))
+	defer C.SherpaOfflinePunctuationFreeText(p)
 
 	text_with_punct := C.GoString(p)
 


### PR DESCRIPTION
D:\a\sherpa-onnx\sherpa-onnx\sherpa-onnx\c-api\c-api.cc:SherpaOnnxCreateOfflinePunctuation:1792 OfflinePunctuationConfig(model=OfflinePunctuationModelConfig(ct_transformer="./sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12/model.onnx", num_threads=1, debug=True, provider="cpu"))

D:\a\sherpa-onnx\sherpa-onnx\sherpa-onnx\csrc\offline-ct-transformer-model.cc:Init:117 
vocab_size: 272727
num_punctuations: 6
punctuations: <unk> _ ， 。 ？ 、 


2025/02/25 17:33:43.565918 ----------
2025/02/25 17:33:45.584163 Input text: 这是
Exception 0xc0000005 0x0 0xffffffffffffffff 0x7ffb9b95744b
PC=0x7ffb9b95744b
signal arrived during external code execution

runtime.cgocall(0x1a71c0, 0xc000029d50)
	D:/go/go1.24.0/src/runtime/cgocall.go:167 +0x3e fp=0xc000029d28 sp=0xc000029cc0 pc=0x16793e
github.com/k2-fsa/sherpa-onnx-go-windows._Cfunc_free(0x14f80404c40)
	_cgo_gotypes.go:1835 +0x45 fp=0xc000029d50 sp=0xc000029d28 pc=0x1a5185
github.com/k2-fsa/sherpa-onnx-go-windows.(*OfflinePunctuation).AddPunct.(*OfflinePunctuation).AddPunct.func2.func3()
	D:/go_workspacenew/pkg/mod/github.com/k2-fsa/sherpa-onnx-go-windows@v1.10.41/sherpa_onnx.go:1441 +0x35 fp=0xc000029d88 sp=0xc000029d50 pc=0x1a56d5
github.com/k2-fsa/sherpa-onnx-go-windows.(*OfflinePunctuation).AddPunct(0xc00001e480?, {0x1dc51d?, 0x2?})
	D:/go_workspacenew/pkg/mod/github.com/k2-fsa/sherpa-onnx-go-windows@v1.10.41/sherpa_onnx.go:1445 +0xde fp=0xc000029e00 sp=0xc000029d88 pc=0x1a563e
main.main()
	D:/go_workspacenew/src/go_code/sftest/sherpa-onnx-master/add-punctuation/main.go:33 +0x2c9 fp=0xc000029f50 sp=0xc000029e00 pc=0x1a5ac9
runtime.main()
	D:/go/go1.24.0/src/runtime/proc.go:283 +0x27d fp=0xc000029fe0 sp=0xc000029f50 pc=0x13c1dd
runtime.goexit({})
	D:/go/go1.24.0/src/runtime/asm_amd64.s:1700 +0x1 fp=0xc000029fe8 sp=0xc000029fe0 pc=0x16f8a1

goroutine 2 gp=0xc0000028c0 m=nil [force gc (idle)]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
	D:/go/go1.24.0/src/runtime/proc.go:435 +0xce fp=0xc00004dfa8 sp=0xc00004df88 pc=0x1697ce
runtime.goparkunlock(...)
	D:/go/go1.24.0/src/runtime/proc.go:441
runtime.forcegchelper()
	D:/go/go1.24.0/src/runtime/proc.go:348 +0xb8 fp=0xc00004dfe0 sp=0xc00004dfa8 pc=0x13c4f8
runtime.goexit({})
	D:/go/go1.24.0/src/runtime/asm_amd64.s:1700 +0x1 fp=0xc00004dfe8 sp=0xc00004dfe0 pc=0x16f8a1
created by runtime.init.7 in goroutine 1
	D:/go/go1.24.0/src/runtime/proc.go:336 +0x1a

goroutine 3 gp=0xc000002c40 m=nil [GC sweep wait]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
	D:/go/go1.24.0/src/runtime/proc.go:435 +0xce fp=0xc00004ff80 sp=0xc00004ff60 pc=0x1697ce
runtime.goparkunlock(...)
	D:/go/go1.24.0/src/runtime/proc.go:441
runtime.bgsweep(0xc000010780)
	D:/go/go1.24.0/src/runtime/mgcsweep.go:276 +0x94 fp=0xc00004ffc8 sp=0xc00004ff80 pc=0x1265b4
runtime.gcenable.gowrap1()
	D:/go/go1.24.0/src/runtime/mgc.go:204 +0x25 fp=0xc00004ffe0 sp=0xc00004ffc8 pc=0x11ac45
runtime.goexit({})
	D:/go/go1.24.0/src/runtime/asm_amd64.s:1700 +0x1 fp=0xc00004ffe8 sp=0xc00004ffe0 pc=0x16f8a1
created by runtime.gcenable in goroutine 1
	D:/go/go1.24.0/src/runtime/mgc.go:204 +0x66

goroutine 4 gp=0xc000002e00 m=nil [GC scavenge wait]:
runtime.gopark(0xc000010780?, 0x204ea0?, 0x1?, 0x0?, 0xc000002e00?)
	D:/go/go1.24.0/src/runtime/proc.go:435 +0xce fp=0xc000061f78 sp=0xc000061f58 pc=0x1697ce
runtime.goparkunlock(...)
	D:/go/go1.24.0/src/runtime/proc.go:441
runtime.(*scavengerState).park(0x2927c0)
	D:/go/go1.24.0/src/runtime/mgcscavenge.go:425 +0x49 fp=0xc000061fa8 sp=0xc000061f78 pc=0x124069
runtime.bgscavenge(0xc000010780)
	D:/go/go1.24.0/src/runtime/mgcscavenge.go:653 +0x3c fp=0xc000061fc8 sp=0xc000061fa8 pc=0x1245dc
runtime.gcenable.gowrap2()
	D:/go/go1.24.0/src/runtime/mgc.go:205 +0x25 fp=0xc000061fe0 sp=0xc000061fc8 pc=0x11abe5
runtime.goexit({})
	D:/go/go1.24.0/src/runtime/asm_amd64.s:1700 +0x1 fp=0xc000061fe8 sp=0xc000061fe0 pc=0x16f8a1
created by runtime.gcenable in goroutine 1
	D:/go/go1.24.0/src/runtime/mgc.go:205 +0xa5

goroutine 5 gp=0xc000003340 m=nil [finalizer wait]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
	D:/go/go1.24.0/src/runtime/proc.go:435 +0xce fp=0xc000063e30 sp=0xc000063e10 pc=0x1697ce
runtime.runfinq()
	D:/go/go1.24.0/src/runtime/mfinal.go:196 +0x107 fp=0xc000063fe0 sp=0xc000063e30 pc=0x119c47
runtime.goexit({})
	D:/go/go1.24.0/src/runtime/asm_amd64.s:1700 +0x1 fp=0xc000063fe8 sp=0xc000063fe0 pc=0x16f8a1
created by runtime.createfing in goroutine 1
	D:/go/go1.24.0/src/runtime/mfinal.go:166 +0x3d
rax     0x14f80400280
rbx     0x420a019008606801
rcx     0x49b0
rdx     0x14f80404c40
rdi     0x0
rsi     0x14fb7ef0000
rbp     0x0
rsp     0x3e60fffaf0
r8      0x280efa88
r9      0x0
r10     0xc00008c030
r11     0xffffffffffffffff
r12     0x0
r13     0x14f80404c40
r14     0x14f80404c30
r15     0x1
rip     0x7ffb9b95744b
rflags  0x10202
cs      0x33
fs      0x53
gs      0x2b

Process finished with the exit code 2


调用offline加标点的时候崩溃，自己写cgo调用c-api.h把defer C.free(unsafe.Pointer(p))改成defer C.SherpaOfflinePunctuationFreeText(p)就正常。