### PR TITLE
c-api add wave write to buffer.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ kokoro-multi-lang-v1_0
 sherpa-onnx-fire-red-asr-large-zh_en-2025-02-16
 cmake-build-debug
 README-DEV.txt
+
+##clion
+.idea

--- a/sherpa-onnx/c-api/c-api.cc
+++ b/sherpa-onnx/c-api/c-api.cc
@@ -1337,6 +1337,16 @@ int32_t SherpaOnnxWriteWave(const float *samples, int32_t n,
   return sherpa_onnx::WriteWave(filename, sample_rate, samples, n);
 }
 
+int64_t SherpaOnnxWaveFileSize(int32_t n_samples) {
+  return sherpa_onnx::WaveFileSize(n_samples);
+}
+
+SHERPA_ONNX_API void SherpaOnnxWriteWaveToBuffer(const float *samples,
+                                                 int32_t n, int32_t sample_rate,
+                                                 char *buffer) {
+  sherpa_onnx::WriteWave(buffer, sample_rate, samples, n);
+}
+
 const SherpaOnnxWave *SherpaOnnxReadWave(const char *filename) {
   int32_t sample_rate = -1;
   bool is_ok = false;

--- a/sherpa-onnx/c-api/c-api.h
+++ b/sherpa-onnx/c-api/c-api.h
@@ -1049,6 +1049,18 @@ SHERPA_ONNX_API int32_t SherpaOnnxWriteWave(const float *samples, int32_t n,
                                             int32_t sample_rate,
                                             const char *filename);
 
+// the amount of bytes needed to store a wave file which contains a
+// single channel and has 16-bit samples.
+SHERPA_ONNX_API int64_t SherpaOnnxWaveFileSize(int32_t n_samples);
+
+// Similar to SherpaOnnxWriteWave , it writes wave to allocated  buffer;
+//
+// in some case (http tts api return wave binary file, server do not need to
+// write wave to fs)
+SHERPA_ONNX_API void SherpaOnnxWriteWaveToBuffer(const float *samples,
+                                                 int32_t n, int32_t sample_rate,
+                                                 char *buffer);
+
 SHERPA_ONNX_API typedef struct SherpaOnnxWave {
   // samples normalized to the range [-1, 1]
   const float *samples;

--- a/sherpa-onnx/csrc/wave-reader.cc
+++ b/sherpa-onnx/csrc/wave-reader.cc
@@ -315,7 +315,9 @@ std::vector<float> ReadWaveImpl(std::istream &is, int32_t *sampling_rate,
 std::vector<float> ReadWave(const std::string &filename, int32_t *sampling_rate,
                             bool *is_ok) {
   std::ifstream is(filename, std::ifstream::binary);
-  return ReadWave(is, sampling_rate, is_ok);
+  auto samples = ReadWave(is, sampling_rate, is_ok);
+  is.close();
+  return samples;
 }
 
 std::vector<float> ReadWave(std::istream &is, int32_t *sampling_rate,

--- a/sherpa-onnx/csrc/wave-reader.cc
+++ b/sherpa-onnx/csrc/wave-reader.cc
@@ -315,9 +315,7 @@ std::vector<float> ReadWaveImpl(std::istream &is, int32_t *sampling_rate,
 std::vector<float> ReadWave(const std::string &filename, int32_t *sampling_rate,
                             bool *is_ok) {
   std::ifstream is(filename, std::ifstream::binary);
-  auto samples = ReadWave(is, sampling_rate, is_ok);
-  is.close();
-  return samples;
+  return ReadWave(is, sampling_rate, is_ok);
 }
 
 std::vector<float> ReadWave(std::istream &is, int32_t *sampling_rate,

--- a/sherpa-onnx/csrc/wave-writer.cc
+++ b/sherpa-onnx/csrc/wave-writer.cc
@@ -84,10 +84,8 @@ bool WriteWave(const std::string &filename, int32_t sampling_rate,
   os << buffer;
   if (!os) {
     SHERPA_ONNX_LOGE("Write %s failed", filename.c_str());
-    os.close();
     return false;
   }
-  os.close();
   return true;
 }
 

--- a/sherpa-onnx/csrc/wave-writer.cc
+++ b/sherpa-onnx/csrc/wave-writer.cc
@@ -4,6 +4,7 @@
 
 #include "sherpa-onnx/csrc/wave-writer.h"
 
+#include <cstring>
 #include <fstream>
 #include <string>
 #include <vector>

--- a/sherpa-onnx/csrc/wave-writer.h
+++ b/sherpa-onnx/csrc/wave-writer.h
@@ -22,6 +22,11 @@ namespace sherpa_onnx {
 bool WriteWave(const std::string &filename, int32_t sampling_rate,
                const float *samples, int32_t n);
 
+void WriteWave(char *buffer, int32_t sampling_rate, const float *samples,
+               int32_t n);
+
+int64_t WaveFileSize(int32_t n_samples);
+
 }  // namespace sherpa_onnx
 
 #endif  // SHERPA_ONNX_CSRC_WAVE_WRITER_H_


### PR DESCRIPTION
in same case , the api can be useful :
- a tts server which  sent  wave  output to its client  and  not  do not need to save a tmp file to filesystem。
