### PR TITLE
Export vocos to sherpa-onnx

### DIFF
--- a/.github/workflows/export-vocos.yaml
+++ b/.github/workflows/export-vocos.yaml
@@ -1,0 +1,111 @@
+name: export-vocos-to-onnx
+
+on:
+  push:
+    branches:
+      - export-vocos
+
+  workflow_dispatch:
+
+concurrency:
+  group: export-vocos-to-onnx-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  export-vocos-to-onnx:
+    if: github.repository_owner == 'k2-fsa' || github.repository_owner == 'csukuangfj'
+    name: export vocos ${{ matrix.version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.10"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          pip install "numpy<=1.26.4" onnx==1.16.0 onnxruntime==1.17.1 soundfile piper_phonemize -f https://k2-fsa.github.io/icefall/piper_phonemize.html kaldi_native_fbank
+
+      - name: Run
+        shell: bash
+        run: |
+          cd scripts/vocos
+          ./run.sh
+          ls -lh
+
+      - name: Collect results
+        shell: bash
+        run: |
+          cp -v scripts/vocos/vocos-22khz-univ.onnx .
+          cp -v scripts/vocos/*.wav .
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: generated-waves
+          path: ./*.wav
+
+      - name: Publish to huggingface
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 20
+          timeout_seconds: 200
+          shell: bash
+          command: |
+            git config --global user.email "csukuangfj@gmail.com"
+            git config --global user.name "Fangjun Kuang"
+
+            rm -rf huggingface
+            export GIT_LFS_SKIP_SMUDGE=1
+            export GIT_CLONE_PROTECTION_ACTIVE=false
+
+            git clone https://csukuangfj:$HF_TOKEN@huggingface.co/k2-fsa/sherpa-onnx-models huggingface
+            cd huggingface
+            git fetch
+            git pull
+
+            d=vocoder-models
+            mkdir -p $d
+
+            cp -a ../vocos-22khz-univ.onnx $d/
+
+            git lfs track "*.onnx"
+            git add .
+
+            ls -lh
+
+            git status
+
+            git commit -m "add models"
+            git push https://csukuangfj:$HF_TOKEN@huggingface.co/k2-fsa/sherpa-onnx-models main || true
+
+      - name: Release
+        if: github.repository_owner == 'csukuangfj'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./*.onnx
+          overwrite: true
+          repo_name: k2-fsa/sherpa-onnx
+          repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
+          tag: vocoder-models
+
+      - name: Release
+        if: github.repository_owner == 'k2-fsa'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./*.onnx
+          overwrite: true
+          tag: vocoder-models
+

--- a/scripts/vocos/README.md
+++ b/scripts/vocos/README.md
@@ -1,0 +1,5 @@
+# Introduction
+
+This folder contains script to export the ONNX model from
+https://huggingface.co/BSC-LT
+to sherpa-onnx

--- a/scripts/vocos/add_meta_data.py
+++ b/scripts/vocos/add_meta_data.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Copyright    2025  Xiaomi Corp.        (authors: Fangjun Kuang)
+
+
+import argparse
+
+import onnx
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--in-model", type=str, required=True, help="input onnx model")
+
+    parser.add_argument(
+        "--out-model", type=str, required=True, help="output onnx model"
+    )
+
+    return parser.parse_args()
+
+
+def main():
+    args = get_args()
+    print(args.in_model, args.out_model)
+
+    model = onnx.load(args.in_model)
+
+    meta_data = {
+        "model_type": "vocos",
+        "model_filename": "mel_spec_22khz_univ.onnx",
+        "sample_rate": 22050,
+        "version": 1,
+        "model_author": "BSC-LT",
+        "maintainer": "k2-fsa",
+        "n_fft": 1024,
+        "hop_length": 256,
+        "win_length": 1024,
+        "window_type": "hann",
+        "center": 1,
+        "pad_mode": "reflect",
+        "normalized": 0,
+        "url1": "https://huggingface.co/BSC-LT/vocos-mel-22khz",
+        "url2": "https://github.com/gemelo-ai/vocos",
+    }
+
+    print(model.metadata_props)
+
+    while len(model.metadata_props):
+        model.metadata_props.pop()
+
+    for key, value in meta_data.items():
+        meta = model.metadata_props.add()
+        meta.key = key
+        meta.value = str(value)
+    print("--------------------")
+
+    print(model.metadata_props)
+
+    onnx.save(model, args.out_model)
+
+    print(f"Saved to {args.out_model}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/vocos/run.sh
+++ b/scripts/vocos/run.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if [ ! -f mel_spec_22khz_univ.onnx ]; then
+  curl -SL -O https://huggingface.co/BSC-LT/vocos-mel-22khz/resolve/main/mel_spec_22khz_univ.onnx
+fi
+
+if [ ! -f ./vocos-22khz-univ.onnx ]; then
+  python3 ./add_meta_data.py --in-model ./mel_spec_22khz_univ.onnx --out-model ./vocos-22khz-univ.onnx
+fi
+
+# The following is for testing
+if [ ! -f ./matcha-icefall-en_US-ljspeech/tokens.txt ]; then
+  curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/matcha-icefall-en_US-ljspeech.tar.bz2
+  tar xf matcha-icefall-en_US-ljspeech.tar.bz2
+  rm matcha-icefall-en_US-ljspeech.tar.bz2
+fi
+
+if [ ! -f ./hifigan_v2.onnx ]; then
+  curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/vocoder-models/hifigan_v2.onnx
+fi
+
+python3 ./test.py
+ls -lh

--- a/scripts/vocos/test.py
+++ b/scripts/vocos/test.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+
+import kaldi_native_fbank as knf
+import numpy as np
+import onnxruntime as ort
+import soundfile as sf
+import torch
+
+try:
+    from piper_phonemize import phonemize_espeak
+except Exception as ex:
+    raise RuntimeError(
+        f"{ex}\nPlease run\n"
+        "pip install piper_phonemize -f https://k2-fsa.github.io/icefall/piper_phonemize.html"
+    )
+
+
+class OnnxVocosModel:
+    def __init__(
+        self,
+        filename: str,
+    ):
+        session_opts = ort.SessionOptions()
+        session_opts.inter_op_num_threads = 1
+        session_opts.intra_op_num_threads = 1
+
+        self.session_opts = session_opts
+        self.model = ort.InferenceSession(
+            filename,
+            sess_options=self.session_opts,
+            providers=["CPUExecutionProvider"],
+        )
+
+        for i in self.model.get_inputs():
+            print(i)
+
+        print("-----")
+
+        for i in self.model.get_outputs():
+            print(i)
+
+    def __call__(self, x: torch.tensor):
+        assert x.ndim == 3, x.shape
+        assert x.shape[0] == 1, x.shape
+
+        mag, x, y = self.model.run(
+            [
+                self.model.get_outputs()[0].name,
+                self.model.get_outputs()[1].name,
+                self.model.get_outputs()[2].name,
+            ],
+            {
+                self.model.get_inputs()[0].name: x.numpy(),
+            },
+        )
+        # audio: (batch_size, num_samples)
+
+        return mag, x, y
+
+
+class OnnxHifiGANModel:
+    def __init__(
+        self,
+        filename: str,
+    ):
+        session_opts = ort.SessionOptions()
+        session_opts.inter_op_num_threads = 1
+        session_opts.intra_op_num_threads = 1
+
+        self.session_opts = session_opts
+        self.model = ort.InferenceSession(
+            filename,
+            sess_options=self.session_opts,
+            providers=["CPUExecutionProvider"],
+        )
+
+        for i in self.model.get_inputs():
+            print(i)
+
+        print("-----")
+
+        for i in self.model.get_outputs():
+            print(i)
+
+    def __call__(self, x: torch.tensor):
+        assert x.ndim == 3, x.shape
+        assert x.shape[0] == 1, x.shape
+
+        audio = self.model.run(
+            [self.model.get_outputs()[0].name],
+            {
+                self.model.get_inputs()[0].name: x.numpy(),
+            },
+        )[0]
+        # audio: (batch_size, num_samples)
+
+        return torch.from_numpy(audio)
+
+
+def load_tokens(filename):
+    token2id = dict()
+    with open(filename, encoding="utf-8") as f:
+        for line in f:
+            fields = line.strip().split()
+            if len(fields) == 1:
+                t = " "
+                idx = int(fields[0])
+            else:
+                t, idx = line.strip().split()
+            token2id[t] = int(idx)
+    return token2id
+
+
+class OnnxModel:
+    def __init__(
+        self,
+        filename: str,
+        tokens: str,
+    ):
+        self.token2id = load_tokens(tokens)
+        session_opts = ort.SessionOptions()
+        session_opts.inter_op_num_threads = 1
+        session_opts.intra_op_num_threads = 2
+
+        self.session_opts = session_opts
+        self.model = ort.InferenceSession(
+            filename,
+            sess_options=self.session_opts,
+            providers=["CPUExecutionProvider"],
+        )
+
+        print(f"{self.model.get_modelmeta().custom_metadata_map}")
+        metadata = self.model.get_modelmeta().custom_metadata_map
+        self.sample_rate = int(metadata["sample_rate"])
+
+        for i in self.model.get_inputs():
+            print(i)
+
+        print("-----")
+
+        for i in self.model.get_outputs():
+            print(i)
+
+    def __call__(self, x: torch.tensor):
+        assert x.ndim == 2, x.shape
+        assert x.shape[0] == 1, x.shape
+
+        x_lengths = torch.tensor([x.shape[1]], dtype=torch.int64)
+        print("x_lengths", x_lengths)
+        print("x", x.shape)
+
+        noise_scale = torch.tensor([1.0], dtype=torch.float32)
+        length_scale = torch.tensor([1.0], dtype=torch.float32)
+
+        mel = self.model.run(
+            [self.model.get_outputs()[0].name],
+            {
+                self.model.get_inputs()[0].name: x.numpy(),
+                self.model.get_inputs()[1].name: x_lengths.numpy(),
+                self.model.get_inputs()[2].name: noise_scale.numpy(),
+                self.model.get_inputs()[3].name: length_scale.numpy(),
+            },
+        )[0]
+        # mel: (batch_size, feat_dim, num_frames)
+
+        return torch.from_numpy(mel)
+
+
+def main():
+    am = OnnxModel(
+        filename="./matcha-icefall-en_US-ljspeech/model-steps-3.onnx",
+        tokens="./matcha-icefall-en_US-ljspeech/tokens.txt",
+    )
+    vocoder = OnnxHifiGANModel("./hifigan_v2.onnx")
+    vocos = OnnxVocosModel("./mel_spec_22khz_univ.onnx")
+
+    text = "how are you doing"
+    tokens_list = phonemize_espeak(text, "en-us")
+    print(tokens_list)
+    tokens = []
+    for t in tokens_list:
+        tokens.extend(t)
+
+    token_ids = []
+    for t in tokens:
+        if t not in am.token2id:
+            print(f"Skip OOV '{t}'")
+            continue
+        token_ids.append(am.token2id[t])
+
+    print(tokens)
+    print(token_ids)
+
+    token_ids2 = [am.token2id["_"]] * (len(token_ids) * 2 + 1)
+    token_ids2[1::2] = token_ids
+    token_ids = token_ids2
+    x = torch.tensor(token_ids, dtype=torch.int64).unsqueeze(0)
+    mel = am(x)
+    print("mel", mel.shape)
+    # mel:(1, 80, 78)
+
+    mag, x, y = vocos(mel)
+    print(mag.shape)
+    print(x.shape)
+    print(y.shape)
+    stft_result = knf.StftResult(
+        real=(mag * x)[0].transpose().reshape(-1).tolist(),
+        imag=(mag * y)[0].transpose().reshape(-1).tolist(),
+        num_frames=mag.shape[2],
+    )
+    config = knf.StftConfig(
+        n_fft=1024,
+        hop_length=256,
+        win_length=1024,
+        window_type="hann",
+        center=True,
+        pad_mode="reflect",
+        normalized=False,
+    )
+    istft = knf.IStft(config)
+    audio = istft(stft_result)
+    audio = np.array(audio)
+    #  audio = audio / 2
+    print(np.max(audio), np.min(audio))
+    sf.write("vocos.wav", np.array(audio, dtype=np.float32), am.sample_rate, "PCM_16")
+
+    audio = vocoder(mel).squeeze().numpy()
+    print("audio", audio.shape)
+    print(np.max(audio), np.min(audio))
+
+    sample_rate = am.sample_rate
+    sf.write("hifigan-v2.wav", audio, sample_rate, "PCM_16")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
You can download it from https://github.com/k2-fsa/sherpa-onnx/releases/tag/vocoder-models

<img width="1270" alt="Screenshot 2025-03-17 at 09 05 45" src="https://github.com/user-attachments/assets/53714a09-7a12-481f-8595-c006a9c19c40" />


# Comparison with hifigan v2

| | Hifigan V2|vocos|
|---|---|---|
|onnx file size| 3.58 MB |51.4MB|
|CPU RTF|0.071|0.038| 


The RTF is tested on my MacBook pro
<img width="283" alt="Screenshot 2025-03-17 at 09 08 52" src="https://github.com/user-attachments/assets/d95ea396-1f25-41a4-9efc-24e3c5d4203f" />

using [scripts/vocos/test.py](https://github.com/k2-fsa/sherpa-onnx/blob/vocoder-models/scripts/vocos/run.sh). The log output is
```
{'language': 'English', 'voice': 'en-us', 'pad_id': '0', 'model_type': 'matcha-tts', 'has_espeak': '1', 'jieba': '0', 'sample_rate': '22050', 'maintainer': 'k2-fsa', 'n_speakers': '1', 'model_author': 'icefall', 'version': '1', 'dataset_url': 'https://keithito.com/LJ-Speech-Dataset/', 'use_eos_bos': '1', 'dataset': 'LJ Speech', 'num_ode_steps': '3'}
----------matcha----------
NodeArg(name='x', type='tensor(int64)', shape=['N', 'L'])
NodeArg(name='x_length', type='tensor(int64)', shape=['N'])
NodeArg(name='noise_scale', type='tensor(float)', shape=[1])
NodeArg(name='length_scale', type='tensor(float)', shape=[1])
-----
NodeArg(name='mel', type='tensor(float)', shape=['N', 80, 'L'])

----------hifigan----------
NodeArg(name='mel', type='tensor(float)', shape=['N', 80, 'L'])
-----
NodeArg(name='audio', type='tensor(float)', shape=['N', 'L'])

----------vocos----------
NodeArg(name='mels', type='tensor(float)', shape=['batch_size', 80, 'time'])
-----
NodeArg(name='mag', type='tensor(float)', shape=['Clipmag_dim_0', 'Clipmag_dim_1', 'Clipmag_dim_2'])
NodeArg(name='x', type='tensor(float)', shape=['Clipmag_dim_0', 'Cosx_dim_1', 'Clipmag_dim_2'])
NodeArg(name='y', type='tensor(float)', shape=['Clipmag_dim_0', 'Cosx_dim_1', 'Clipmag_dim_2'])

[['t', 'ə', 'd', 'ˈ', 'e', 'ɪ', ' ', 'æ', 'z', ' ', 'ˈ', 'ɔ', 'ː', 'l', 'w', 'e', 'ɪ', 'z', ',', ' ', 'm', 'ˈ', 'ɛ', 'n', ' ', 'f', 'ˈ', 'ɔ', 'ː', 'l', ' ', 'ˌ', 'ɪ', 'n', 't', 'ʊ', ' ', 't', 'ˈ', 'u', 'ː', ' ', 'ɡ', 'ɹ', 'ˈ', 'u', 'ː', 'p', 's', ':', ' ', 's', 'l', 'ˈ', 'e', 'ɪ', 'v', 'z', ' ', 'æ', 'n', 'd', ' ', 'f', 'ɹ', 'ˈ', 'i', 'ː', ' ', 'm', 'ˈ', 'ɛ', 'n', '.'], ['h', 'u', 'ː', 'ˈ', 'ɛ', 'v', 'ɚ', ' ', 'd', 'ʌ', 'z', 'n', 'ˌ', 'ɑ', 'ː', 't', ' ', 'h', 'æ', 'v', ' ', 't', 'ˈ', 'u', 'ː', 'θ', 'ˈ', 'ɜ', 'ː', 'd', 'z', ' ', 'ʌ', 'v', ' ', 'h', 'ɪ', 'z', ' ', 'd', 'ˈ', 'e', 'ɪ', ' ', 'f', 'ɔ', 'ː', 'ɹ', ' ', 'h', 'ɪ', 'm', 's', 'ˈ', 'ɛ', 'l', 'f', ',', ' ', 'ɪ', 'z', ' ', 'ɐ', ' ', 's', 'l', 'ˈ', 'e', 'ɪ', 'v', ',', ' ', 'w', 'ʌ', 't', 'ˈ', 'ɛ', 'v', 'ɚ', ' ', 'h', 'i', 'ː', ' ', 'm', 'ˈ', 'e', 'ɪ', ' ', 'b', 'ˈ', 'i', 'ː', ':', ' ', 'ɐ', ' ', 's', 't', 'ˈ', 'e', 'ɪ', 't', 's', 'm', 'ə', 'n', ',', ' ', 'ɐ', ' ', 'b', 'ˈ', 'ɪ', 'z', 'n', 'ə', 's', 'm', 'ə', 'n', ',', ' ', 'ɐ', 'n', ' ', 'ə', 'f', 'ˈ', 'ɪ', 'ʃ', 'ə', 'l', ',', ' ', 'ɔ', 'ː', 'ɹ', ' ', 'ɐ', ' ', 's', 'k', 'ˈ', 'ɑ', 'ː', 'l', 'ɚ', '.']]
mel (1, 80, 1334)
vocos max/min 0.6310729384422302 -0.5137452483177185
hifigan max/min 0.5375503 -0.42614767
Audio duration for vocos 15.476 s
Audio duration for hifigan 15.488 s
Mean audio duration: 15.482 s
RTF for acoustic model 0.069
RTF for vocos 0.038
RTF for hifigan 0.071
```

The generated waves are given below
(text is
```
  "Today as always, men fall into two groups: slaves and free men. 
Whoever does not have two-thirds of his day for himself, is a slave, 
whatever he may be: a statesman, a businessman, an official, or a scholar."
```
)


https://github.com/user-attachments/assets/e90baa1d-7cf3-4ed0-9856-fd471185d773


https://github.com/user-attachments/assets/5b91be05-a19c-426a-912c-3d5e085cd578








