### PR TITLE
Support cuda12 and cudnn8 for Linux aarch64.

### DIFF
--- a/.github/workflows/aarch64-linux-gnu-shared.yaml
+++ b/.github/workflows/aarch64-linux-gnu-shared.yaml
@@ -234,7 +234,7 @@ jobs:
           file: sherpa-onnx-*linux-aarch64*.tar.bz2
 
       - name: Release pre-compiled binaries and libs for aarch64 linux
-        # if: github.repository_owner == 'csukuangfj' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+        if: github.repository_owner == 'csukuangfj' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         uses: svenstaro/upload-release-action@v2
         with:
           file_glob: true

--- a/.github/workflows/aarch64-linux-gnu-shared.yaml
+++ b/.github/workflows/aarch64-linux-gnu-shared.yaml
@@ -45,6 +45,9 @@ jobs:
             onnxruntime_version: "1.16.0"
           - os: ubuntu-22.04-arm
             gpu: ON
+            onnxruntime_version: "1.18.0"
+          - os: ubuntu-22.04-arm
+            gpu: ON
             onnxruntime_version: "1.18.1"
           - os: ubuntu-22.04-arm
             gpu: OFF
@@ -231,7 +234,7 @@ jobs:
           file: sherpa-onnx-*linux-aarch64*.tar.bz2
 
       - name: Release pre-compiled binaries and libs for aarch64 linux
-        if: github.repository_owner == 'csukuangfj' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+        # if: github.repository_owner == 'csukuangfj' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         uses: svenstaro/upload-release-action@v2
         with:
           file_glob: true
@@ -239,7 +242,7 @@ jobs:
           file: sherpa-onnx-*linux-aarch64*.tar.bz2
           # repo_name: k2-fsa/sherpa-onnx
           # repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
-          # tag: v1.10.42
+          # tag: v1.11.1
 
       - name: Test offline Moonshine
         if: matrix.build_type != 'Debug'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,7 @@ option(SHERPA_ONNX_ENABLE_SANITIZER "Whether to enable ubsan and asan" OFF)
 option(SHERPA_ONNX_BUILD_C_API_EXAMPLES "Whether to enable C API examples" ON)
 option(SHERPA_ONNX_ENABLE_RKNN "Whether to build for RKNN NPU " OFF)
 
-set(SHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION "1.11.0" CACHE STRING "Used only for Linux ARM64 GPU. If you use Jetson nano b01, then please set it to 1.11.0. If you use Jetson Orin NX, then set it to 1.16.0.If you use NVIDIA Jetson Orin Nano Engineering Reference Developer Kit
-Super - Jetpack 6.2 [L4T 36.4.3], then set it to 1.18.1")
+set(SHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION "1.11.0" CACHE STRING "Used only for Linux ARM64 GPU. Set to 1.11.0 if you use CUDA 10.2 and cudnn8. Set it to 1.16.0 if you use CUDA 11.4 and cudnn8. Set it to 1.18.0 if you use CUDA 12.2 and cudnn8. Set it to 1.18.1 if you use CUDA 12.6 and cudnn9")
 
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")

--- a/build-aarch64-linux-gnu.sh
+++ b/build-aarch64-linux-gnu.sh
@@ -27,6 +27,12 @@
 #       export SHERPA_ONNX_ENABLE_GPU=ON
 #       export SHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION=1.18.1
 #       ./build-aarch64-linux-gnu.sh
+#
+#   (e) For  NVIDIA Jetson Orin NX (16GB ram) with CUDA 12.2, cudnn8
+#
+#       export SHERPA_ONNX_ENABLE_GPU=ON
+#       export SHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION=1.18.0
+#       ./build-aarch64-linux-gnu.sh
 
 
 if command -v aarch64-none-linux-gnu-gcc  &> /dev/null; then

--- a/cmake/onnxruntime-linux-aarch64-gpu.cmake
+++ b/cmake/onnxruntime-linux-aarch64-gpu.cmake
@@ -43,6 +43,10 @@ if(v STREQUAL "1.11.0")
   set(onnxruntime_HASH "SHA256=36eded935551e23aead09d4173bdf0bd1e7b01fdec15d77f97d6e34029aa60d7")
 elseif(v STREQUAL "1.16.0")
   set(onnxruntime_HASH "SHA256=4c09d5acf2c2682b4eab1dc2f1ad98fc1fde5f5f1960063e337983ba59379a4b")
+elseif(v STREQUAL "1.18.0")
+  set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.18.0/onnxruntime-linux-aarch64-gpu-cuda12.2-cudnn8.9.4-trt8.6.2-1.18.0.tar.bz2")
+  set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-linux-aarch64-gpu-cuda12.2-cudnn8.9.4-trt8.6.2-1.18.0.tar.bz2")
+  set(onnxruntime_HASH "SHA256=da437a69be982fc28ca7d60d0c5ccce2f48d027fa888cc76458cdc05410f4e2d")
 elseif(v STREQUAL "1.18.1")
   set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.18.1/onnxruntime-linux-aarch64-gpu-cuda12-1.18.1.tar.bz2")
   set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-linux-aarch64-gpu-cuda12-1.18.1.tar.bz2")
@@ -60,6 +64,18 @@ set(possible_file_locations
   ${CMAKE_BINARY_DIR}/onnxruntime-linux-aarch64-gpu-${v}.tar.bz2
   /tmp/onnxruntime-linux-aarch64-gpu-${v}.tar.bz2
   /star-fj/fangjun/download/github/onnxruntime-linux-aarch64-gpu-${v}.tar.bz2
+  #
+  $ENV{HOME}/Downloads/onnxruntime-linux-aarch64-gpu-cuda12.2-cudnn8.9.4-trt8.6.2-${v}.tar.bz2
+  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-aarch64-gpu-cuda12.2-cudnn8.9.4-trt8.6.2-${v}.tar.bz2
+  ${CMAKE_BINARY_DIR}/onnxruntime-linux-aarch64-gpu-cuda12.2-cudnn8.9.4-trt8.6.2-${v}.tar.bz2
+  /tmp/onnxruntime-linux-aarch64-gpu-cuda12.2-cudnn8.9.4-trt8.6.2-${v}.tar.bz2
+  /star-fj/fangjun/download/github/onnxruntime-linux-aarch64-gpu-cuda12.2-cudnn8.9.4-trt8.6.2-${v}.tar.bz2
+  #
+  $ENV{HOME}/Downloads/onnxruntime-linux-aarch64-gpu-cuda12-${v}.tar.bz2
+  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-aarch64-gpu-cuda12-${v}.tar.bz2
+  ${CMAKE_BINARY_DIR}/onnxruntime-linux-aarch64-gpu-cuda12-${v}.tar.bz2
+  /tmp/onnxruntime-linux-aarch64-gpu-cuda12-${v}.tar.bz2
+  /star-fj/fangjun/download/github/onnxruntime-linux-aarch64-gpu-cuda12-${v}.tar.bz2
 )
 
 foreach(f IN LISTS possible_file_locations)


### PR DESCRIPTION
See also https://github.com/k2-fsa/sherpa-onnx/pull/1914

Info about the board used to build the onnxruntime
```
Software part of jetson-stats 4.2.4 - (c) 2024, Raffaello Bonghi
Jetpack： 6.0 [L4T 36.3.0]
Hardware:
 - P-Number: p3767-0000
 - Module: NVIDIA Jetson Orin NX (16GB ram)
Platform:
 - Distribution: Ubuntu 22.04 Jammy Jellyfish
 - Release: 5.15.136-tegra
jtop:
 - Version: 4.2.4
 - Service: Active
Libraries:
 - CUDA: 12.2.140
 - cuDNN: 8.9.4.25
 - TensorRT: 8.6.2.3
 - VPI: 3.1.5
 - Vulkan: 1.3.204
 - OpenCV: 4.8.0 - with CUDA: NO
```

Thanks to @litao-zhx for providing the pre-built onnxruntime libs.

---

You can download pre-built sherpa-onnx libs at
https://github.com/k2-fsa/sherpa-onnx/releases/tag/v1.11.1

<img width="1329" alt="Screenshot 2025-03-19 at 11 17 41" src="https://github.com/user-attachments/assets/01ba4493-6979-4e33-a45f-0b7269dde4ce" />
