### PR TITLE
Add LODR support to online and offline recognizers

### DIFF
--- a/sherpa-onnx/csrc/CMakeLists.txt
+++ b/sherpa-onnx/csrc/CMakeLists.txt
@@ -23,6 +23,7 @@ set(sources
   hypothesis.cc
   keyword-spotter-impl.cc
   keyword-spotter.cc
+  lodr-fst.cc
   offline-ctc-fst-decoder-config.cc
   offline-ctc-fst-decoder.cc
   offline-ctc-greedy-search-decoder.cc

--- a/sherpa-onnx/csrc/hypothesis.h
+++ b/sherpa-onnx/csrc/hypothesis.h
@@ -12,9 +12,11 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <memory>
 
 #include "onnxruntime_cxx_api.h"  // NOLINT
 #include "sherpa-onnx/csrc/context-graph.h"
+#include "sherpa-onnx/csrc/lodr-fst.h"
 #include "sherpa-onnx/csrc/math.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"
 
@@ -61,6 +63,9 @@ struct Hypothesis {
   // the nn lm states
   std::vector<CopyableOrtValue> nn_lm_states;
 
+  // the LODR states
+  std::shared_ptr<LODRStateCost> lodr_state;
+
   const ContextState *context_state;
 
   // TODO(fangjun): Make it configurable
@@ -72,7 +77,8 @@ struct Hypothesis {
   Hypothesis() = default;
   Hypothesis(const std::vector<int64_t> &ys, double log_prob,
              const ContextState *context_state = nullptr)
-      : ys(ys), log_prob(log_prob), context_state(context_state) {}
+      : ys(ys), log_prob(log_prob), context_state(context_state),
+        lodr_state(nullptr) {}
 
   double TotalLogProb() const { return log_prob + lm_log_prob; }
 

--- a/sherpa-onnx/csrc/lodr-fst.cc
+++ b/sherpa-onnx/csrc/lodr-fst.cc
@@ -1,0 +1,200 @@
+// sherpa-onnx/csrc/lodr-fst.cc
+//
+// Contains code copied from icefall/utils/ngram_lm.py
+// Copyright (c)  2023 Xiaomi Corporation
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include "sherpa-onnx/csrc/lodr-fst.h"
+#include "sherpa-onnx/csrc/log.h"
+#include "sherpa-onnx/csrc/hypothesis.h"
+
+namespace sherpa_onnx {
+
+LODRFST::LODRFST(const std::string &fst_path) {
+  fst_ = std::unique_ptr<fst::StdConstFst>(
+    CastOrConvertToConstFst(fst::StdVectorFst::Read(fst_path)));
+}
+
+std::vector<std::tuple<int, float>> LODRFST::process_backoff_arcs(
+    int state, float cost) {
+  std::vector<std::tuple<int, float>> ans;
+  auto next = next_states_costs_no_backoff(state, backoff_id);
+  if (!next.has_value()) {
+    return ans;
+  }
+  auto [next_state, next_cost] = next.value();
+  ans.emplace_back(next_state, next_cost + cost);
+  auto recursive_result = process_backoff_arcs(next_state, next_cost + cost);
+  ans.insert(ans.end(), recursive_result.begin(), recursive_result.end());
+  return ans;
+}
+
+std::optional<std::tuple<int, float>> LODRFST::next_states_costs_no_backoff(
+    int state, int label) {
+  fst::ArcIterator<fst::StdConstFst> arc_iter(*fst_, state);
+  int num_arcs = fst_->NumArcs(state);
+
+  int left = 0, right = num_arcs - 1;
+  while (left <= right) {
+    int mid = (left + right) / 2;
+    arc_iter.Seek(mid);
+    auto arc = arc_iter.Value();
+    if (arc.ilabel < label) {
+      left = mid + 1;
+    } else if (arc.ilabel > label) {
+      right = mid - 1;
+    } else {
+      return std::make_tuple(arc.nextstate, arc.weight.Value());
+    }
+  }
+  return std::nullopt;
+}
+
+std::pair<std::vector<int>, std::vector<float>> LODRFST::get_next_states_costs(
+    int state, int label) {
+  std::vector<int> states = {state};
+  std::vector<float> costs = {0};
+
+  auto extra_states_costs = process_backoff_arcs(state, 0);
+  for (const auto& [s, c] : extra_states_costs) {
+    states.push_back(s);
+    costs.push_back(c);
+  }
+
+  std::vector<int> next_states;
+  std::vector<float> next_costs;
+  for (size_t i = 0; i < states.size(); ++i) {
+    auto next = next_states_costs_no_backoff(states[i], label);
+    if (next.has_value()) {
+      auto [ns, nc] = next.value();
+      next_states.push_back(ns);
+      next_costs.push_back(costs[i] + nc);
+    }
+  }
+
+  return std::make_pair(next_states, next_costs);
+}
+
+void LODRFST::ComputeScore(float scale, Hypothesis *hyp, int32_t offset) {
+  if (scale == 0) {
+    return;
+  }
+
+  using Weight = typename fst::StdArc::Weight;
+  using Arc = fst::StdArc;
+
+  // Step 1: Convert the input text into an FST
+  fst::StdVectorFst ys = YsToFst(hyp->ys, offset);
+
+  // Step 2: Compose the input text with the rule FST
+  fst::StdVectorFst composed_fst;
+  fst::Compose(ys, *fst_, &composed_fst);
+
+  // Step 3: Get the best path from the composed FST
+  fst::StdVectorFst score_fst;
+  fst::ShortestPath(composed_fst, &score_fst, 1);
+
+  // Step 4: Compute the total weight (i.e. score of the hypothesis)
+  Weight total_weight = Weight::One();
+  auto s = score_fst.Start();
+  if (s == fst::kNoStateId) {
+    // this is an empty FST
+    SHERPA_ONNX_LOG("Empty FST after scoring hyp with LODR! Mismatched FST?");
+    return;
+  }
+  while (score_fst.Final(s) == Weight::Zero()) {
+    fst::ArcIterator<fst::Fst<Arc>> aiter(score_fst, s);
+    if (aiter.Done()) {
+      // not reached final.
+      SHERPA_ONNX_LOG("LODR FST failed to reach final state. Mismatched FST?");
+      return;
+    }
+
+    const auto &arc = aiter.Value();
+
+    total_weight = Times(total_weight, arc.weight);
+
+    s = arc.nextstate;
+    if (s == fst::kNoStateId) {
+      SHERPA_ONNX_LOG("Transition to invalid state in LODR FST");
+      return;
+    }
+
+    aiter.Next();
+    if (!aiter.Done()) {
+      // not a linear FST
+      SHERPA_ONNX_LOG("Error in applying LODR FST. Not a linear FST?");
+      return;
+    }
+  }
+
+  if (score_fst.Final(s) != Weight::Zero()) {
+    total_weight = Times(total_weight, score_fst.Final(s));
+  }
+
+  // Update the hyp score
+  hyp->log_prob += scale * total_weight.Value();
+}
+
+fst::StdVectorFst LODRFST::YsToFst(
+    const std::vector<int64_t> &ys, int32_t offset) {
+  using Weight = typename fst::StdArc::Weight;
+  using Arc = fst::StdArc;
+
+  fst::StdVectorFst ans;
+  ans.ReserveStates(ys.size());
+
+  auto s = ans.AddState();
+  ans.SetStart(s);
+  for (size_t i = offset; i < ys.size(); ++i) {
+    const auto nextstate = ans.AddState();
+    ans.AddArc(s, Arc(ys[i], ys[i], Weight::One(), nextstate));
+    s = nextstate;
+  }
+
+  ans.SetFinal(s, Weight::One());
+
+  return ans;
+}
+
+LODRStateCost::LODRStateCost(
+    LODRFST* fst, std::unordered_map<int, float> state_cost)
+    : fst_(fst) {
+  if (state_cost.empty()) {
+    state_cost_[0] = 0.0;
+  } else {
+    state_cost_ = state_cost;
+  }
+}
+
+LODRStateCost LODRStateCost::forward_one_step(int label) {
+  std::unordered_map<int, float> state_cost;
+  for (const auto& [s, c] : state_cost_) {
+    auto [next_states, next_costs] = fst_->get_next_states_costs(s, label);
+    for (size_t i = 0; i < next_states.size(); ++i) {
+      int ns = next_states[i];
+      float nc = next_costs[i];
+      if (state_cost.find(ns) == state_cost.end()) {
+        state_cost[ns] = std::numeric_limits<float>::infinity();
+      }
+      state_cost[ns] = std::min(state_cost[ns], c + nc);
+    }
+  }
+  return LODRStateCost(fst_, state_cost);
+}
+
+float LODRStateCost::lm_score() const {
+  if (state_cost_.empty()) {
+    return -std::numeric_limits<float>::infinity();
+  }
+  auto min_cost = std::min_element(state_cost_.begin(), state_cost_.end(),
+                                   [](const auto& a, const auto& b) {
+                                     return a.second < b.second;
+                                   });
+  return -min_cost->second;
+}
+
+}  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/lodr-fst.h
+++ b/sherpa-onnx/csrc/lodr-fst.h
@@ -1,0 +1,66 @@
+// sherpa-onnx/csrc/lodr-fst.h
+//
+// Contains code copied from icefall/utils/ngram_lm.py
+// Copyright (c)  2023 Xiaomi Corporation
+
+
+#ifndef SHERPA_ONNX_CSRC_LODR_FST_H_
+#define SHERPA_ONNX_CSRC_LODR_FST_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <optional>
+#include <tuple>
+#include <unordered_map>
+#include <limits>
+#include <algorithm>
+#include <utility>
+
+#include "kaldifst/csrc/kaldi-fst-io.h"
+
+namespace sherpa_onnx {
+
+class Hypothesis;
+
+class LODRFST {
+ public:
+  explicit LODRFST(const std::string &fst_path);
+
+  std::pair<std::vector<int>, std::vector<float>> get_next_states_costs(
+    int state, int label);
+
+  void ComputeScore(float scale, Hypothesis *hyp, int32_t offset);
+
+ private:
+  fst::StdVectorFst YsToFst(const std::vector<int64_t> &ys, int32_t offset);
+
+  std::vector<std::tuple<int, float>> process_backoff_arcs(
+    int state, float cost);
+
+  std::optional<std::tuple<int, float>> next_states_costs_no_backoff(
+    int state, int label);
+
+
+  int backoff_id;
+  std::unique_ptr<fst::StdConstFst> fst_;
+};
+
+class LODRStateCost {
+ public:
+  explicit LODRStateCost(
+    LODRFST* fst,
+    std::unordered_map<int, float> state_cost = {});
+
+  LODRStateCost forward_one_step(int label);
+
+  float lm_score() const;
+
+ private:
+  LODRFST* fst_;
+  std::unordered_map<int, float> state_cost_;
+};
+
+}  // namespace sherpa_onnx
+
+#endif  // SHERPA_ONNX_CSRC_LODR_FST_H_

--- a/sherpa-onnx/csrc/offline-lm-config.cc
+++ b/sherpa-onnx/csrc/offline-lm-config.cc
@@ -18,6 +18,8 @@ void OfflineLMConfig::Register(ParseOptions *po) {
                "Number of threads to run the neural network of LM model");
   po->Register("lm-provider", &lm_provider,
                "Specify a provider to LM model use: cpu, cuda, coreml");
+  po->Register("lodr-fst", &lodr_fst, "Path to LODR FST model.");
+  po->Register("lodr-scale", &lodr_scale, "LODR scale.");
 }
 
 bool OfflineLMConfig::Validate() const {
@@ -34,7 +36,9 @@ std::string OfflineLMConfig::ToString() const {
 
   os << "OfflineLMConfig(";
   os << "model=\"" << model << "\", ";
-  os << "scale=" << scale << ")";
+  os << "scale=" << scale << ", ";
+  os << "lodr_scale=" << lodr_scale << ", ";
+  os << "lodr_fst=\"" << lodr_fst << "\")";
 
   return os.str();
 }

--- a/sherpa-onnx/csrc/offline-lm-config.h
+++ b/sherpa-onnx/csrc/offline-lm-config.h
@@ -19,14 +19,21 @@ struct OfflineLMConfig {
   int32_t lm_num_threads = 1;
   std::string lm_provider = "cpu";
 
+  // LODR
+  std::string lodr_fst = "";
+  float lodr_scale = 0.01;
+
   OfflineLMConfig() = default;
 
   OfflineLMConfig(const std::string &model, float scale, int32_t lm_num_threads,
-                  const std::string &lm_provider)
+                  const std::string &lm_provider, const std::string &lodr_fst,
+                  float lodr_scale)
       : model(model),
         scale(scale),
         lm_num_threads(lm_num_threads),
-        lm_provider(lm_provider) {}
+        lm_provider(lm_provider),
+        lodr_fst(lodr_fst),
+        lodr_scale(lodr_scale) {}
 
   void Register(ParseOptions *po);
   bool Validate() const;

--- a/sherpa-onnx/csrc/offline-lm.cc
+++ b/sherpa-onnx/csrc/offline-lm.cc
@@ -17,6 +17,7 @@
 #include "rawfile/raw_file_manager.h"
 #endif
 
+#include "sherpa-onnx/csrc/lodr-fst.h"
 #include "sherpa-onnx/csrc/offline-rnn-lm.h"
 
 namespace sherpa_onnx {
@@ -74,11 +75,17 @@ void OfflineLM::ComputeLMScore(float scale, int32_t context_size,
   }
   auto negative_loglike = Rescore(std::move(x), std::move(x_lens));
   const float *p_nll = negative_loglike.GetTensorData<float>();
+  // We scale LODR scale with LM scale to replicate Icefall code
+  auto lodr_scale = config_.lodr_scale * scale;
   for (auto &h : *hyps) {
     for (auto &t : h) {
       // Use -scale here since we want to change negative loglike to loglike.
       t.second.lm_log_prob = -scale * (*p_nll);
       ++p_nll;
+      // apply LODR to hyp score
+      if (lodr_fst_ != nullptr) {
+        lodr_fst_->ComputeScore(lodr_scale, &t.second, context_size);
+      }
     }
   }
 }

--- a/sherpa-onnx/csrc/offline-lm.h
+++ b/sherpa-onnx/csrc/offline-lm.h
@@ -10,12 +10,18 @@
 
 #include "onnxruntime_cxx_api.h"  // NOLINT
 #include "sherpa-onnx/csrc/hypothesis.h"
+#include "sherpa-onnx/csrc/lodr-fst.h"
 #include "sherpa-onnx/csrc/offline-lm-config.h"
 
 namespace sherpa_onnx {
 
 class OfflineLM {
  public:
+  explicit OfflineLM(const OfflineLMConfig &config) : config_(config) {
+    if (config_.lodr_fst != "") {
+      lodr_fst_ = std::make_unique<LODRFST>(LODRFST(config_.lodr_fst));
+    }
+  }
   virtual ~OfflineLM() = default;
 
   static std::unique_ptr<OfflineLM> Create(const OfflineLMConfig &config);
@@ -43,6 +49,11 @@ class OfflineLM {
   // @param hyps It is changed in-place.
   void ComputeLMScore(float scale, int32_t context_size,
                       std::vector<Hypotheses> *hyps);
+
+ private:
+  std::unique_ptr<LODRFST> lodr_fst_;
+  float lodr_scale_ = 0.01;
+  OfflineLMConfig config_;
 };
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/offline-rnn-lm.cc
+++ b/sherpa-onnx/csrc/offline-rnn-lm.cc
@@ -83,11 +83,11 @@ class OfflineRnnLM::Impl {
 };
 
 OfflineRnnLM::OfflineRnnLM(const OfflineLMConfig &config)
-    : impl_(std::make_unique<Impl>(config)) {}
+    : impl_(std::make_unique<Impl>(config)), OfflineLM(config) {}
 
 template <typename Manager>
 OfflineRnnLM::OfflineRnnLM(Manager *mgr, const OfflineLMConfig &config)
-    : impl_(std::make_unique<Impl>(mgr, config)) {}
+    : impl_(std::make_unique<Impl>(mgr, config)), OfflineLM(config) {}
 
 OfflineRnnLM::~OfflineRnnLM() = default;
 

--- a/sherpa-onnx/csrc/online-lm-config.cc
+++ b/sherpa-onnx/csrc/online-lm-config.cc
@@ -22,7 +22,7 @@ void OnlineLMConfig::Register(ParseOptions *po) {
                "Boolean whether to use shallow fusion or rescore.");
   po->Register("lodr-fst", &lodr_fst, "Path to LODR FST model.");
   po->Register("lodr-scale", &lodr_scale, "LODR scale.");
-  po->Register("lodr-backoff-id", &lodr_scale,
+  po->Register("lodr-backoff-id", &lodr_backoff_id,
                "ID of the backoff symbol in the LODR FST.");
 }
 

--- a/sherpa-onnx/csrc/online-lm-config.cc
+++ b/sherpa-onnx/csrc/online-lm-config.cc
@@ -20,6 +20,10 @@ void OnlineLMConfig::Register(ParseOptions *po) {
                "Specify a provider to LM model use: cpu, cuda, coreml");
   po->Register("lm-shallow-fusion", &shallow_fusion,
                "Boolean whether to use shallow fusion or rescore.");
+  po->Register("lodr-fst", &lodr_fst, "Path to LODR FST model.");
+  po->Register("lodr-scale", &lodr_scale, "LODR scale.");
+  po->Register("lodr-backoff-id", &lodr_scale,
+               "ID of the backoff symbol in the LODR FST.");
 }
 
 bool OnlineLMConfig::Validate() const {
@@ -37,6 +41,9 @@ std::string OnlineLMConfig::ToString() const {
   os << "OnlineLMConfig(";
   os << "model=\"" << model << "\", ";
   os << "scale=" << scale << ", ";
+  os << "lodr_scale=" << lodr_scale << ", ";
+  os << "lodr_fst=\"" << lodr_fst << "\", ";
+  os << "lodr_baskoff_id=\"" << lodr_backoff_id << "\", ";
   os << "shallow_fusion=" << (shallow_fusion ? "True" : "False") << ")";
 
   return os.str();

--- a/sherpa-onnx/csrc/online-lm-config.h
+++ b/sherpa-onnx/csrc/online-lm-config.h
@@ -18,18 +18,24 @@ struct OnlineLMConfig {
   float scale = 0.5;
   int32_t lm_num_threads = 1;
   std::string lm_provider = "cpu";
+  std::string lodr_fst = "";
+  float lodr_scale = 0.01;
+  int lodr_backoff_id = 0;
   // enable shallow fusion
   bool shallow_fusion = true;
 
   OnlineLMConfig() = default;
 
   OnlineLMConfig(const std::string &model, float scale, int32_t lm_num_threads,
-                 const std::string &lm_provider, bool shallow_fusion)
+                 const std::string &lm_provider, bool shallow_fusion,
+                 const std::string &lodr_fst, float lodr_scale)
       : model(model),
         scale(scale),
         lm_num_threads(lm_num_threads),
         lm_provider(lm_provider),
-        shallow_fusion(shallow_fusion) {}
+        shallow_fusion(shallow_fusion),
+        lodr_fst(lodr_fst),
+        lodr_scale(lodr_scale) {}
 
   void Register(ParseOptions *po);
   bool Validate() const;

--- a/sherpa-onnx/csrc/online-rnn-lm.cc
+++ b/sherpa-onnx/csrc/online-rnn-lm.cc
@@ -12,6 +12,7 @@
 
 #include "onnxruntime_cxx_api.h"  // NOLINT
 #include "sherpa-onnx/csrc/file-utils.h"
+#include "sherpa-onnx/csrc/lodr-fst.h"
 #include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"
 #include "sherpa-onnx/csrc/session.h"
@@ -35,11 +36,27 @@ class OnlineRnnLM::Impl {
       auto init_states = GetInitStatesSF();
       hyp->nn_lm_scores.value = std::move(init_states.first);
       hyp->nn_lm_states = Convert(std::move(init_states.second));
+      // if LODR enabled, we need to initialize the LODR state
+      if (lodr_fst_ != nullptr) {
+        hyp->lodr_state = std::move(
+                             std::make_shared<LODRStateCost>(lodr_fst_.get()));
+      }
     }
 
     // get lm score for cur token given the hyp->ys[:-1] and save to lm_log_prob
     const float *nn_lm_scores = hyp->nn_lm_scores.value.GetTensorData<float>();
     hyp->lm_log_prob += nn_lm_scores[hyp->ys.back()] * scale;
+
+    // if LODR enabled, we need to update the LODR state
+    if (lodr_fst_ != nullptr) {
+      auto next_lodr_state = std::make_shared<LODRStateCost>(
+                            hyp->lodr_state->forward_one_step(hyp->ys.back()));
+      // calculate the score of the latest token
+      auto score = next_lodr_state->lm_score() - hyp->lodr_state->lm_score();
+      hyp->lodr_state = std::move(next_lodr_state);
+      // apply LODR to hyp score
+      hyp->log_prob += score * config_.lodr_scale;
+    }
 
     // get lm scores for next tokens given the hyp->ys[:] and save to
     // nn_lm_scores
@@ -88,6 +105,12 @@ class OnlineRnnLM::Impl {
           // update NN LM score in hyp
           const float *p_nll = out.first.GetTensorData<float>();
           h.lm_log_prob = -scale * (*p_nll);
+
+          // apply LODR to hyp score
+          if (lodr_fst_ != nullptr) {
+            // We scale LODR scale with LM scale to replicate Icefall code
+            lodr_fst_->ComputeScore(config_.lodr_scale*scale, &h, context_size);
+          }
 
           // update NN LM states in hyp
           h.nn_lm_states = Convert(std::move(out.second));
@@ -154,6 +177,10 @@ class OnlineRnnLM::Impl {
     SHERPA_ONNX_READ_META_DATA(sos_id_, "sos_id");
 
     ComputeInitStates();
+
+    if (config_.lodr_fst != "") {
+      lodr_fst_ = std::make_unique<LODRFST>(LODRFST(config_.lodr_fst));
+    }
   }
 
   void ComputeInitStates() {
@@ -203,6 +230,8 @@ class OnlineRnnLM::Impl {
   int32_t rnn_num_layers_ = 2;
   int32_t rnn_hidden_size_ = 512;
   int32_t sos_id_ = 1;
+
+  std::unique_ptr<LODRFST> lodr_fst_;
 };
 
 OnlineRnnLM::OnlineRnnLM(const OnlineLMConfig &config)


### PR DESCRIPTION
This PR adds LODR support from Icefall to offline and online recognizers for both LM shallow fusion and LM rescore. 
(see https://k2-fsa.github.io/icefall/decoding-with-langugage-models/LODR.html)

Usage example:
```
# offline LM rescore
sherpa-onnx-offline     --tokens=tokens.txt    \
                                     --encoder=encoder.onnx     \
                                     --decoder=decoder.onnx     \
                                     --joiner=joiner.onnx      \
                                     --decoding-method=modified_beam_search  \
                                     --lm=lm.onnx \
                                     --lodr-fst=2gram.fst \
                                     --lodr-scale=-0.5  \
                                     test.wav
# online LM rescore
sherpa-onnx                 --tokens=tokens.txt    \
                                     --encoder=encoder.onnx     \
                                     --decoder=decoder.onnx     \
                                     --joiner=joiner.onnx      \
                                     --decoding-method=modified_beam_search  \
                                     --lm=lm.onnx \
                                     --lodr-fst=2gram.fst \
                                     --lodr-scale=-0.5  \
                                     --lm-shallow-fusion=false \
                                     test.wav
                                     
# online LM shallow fusion
sherpa-onnx                 --tokens=tokens.txt    \
                                     --encoder=encoder.onnx     \
                                     --decoder=decoder.onnx     \
                                     --joiner=joiner.onnx      \
                                     --decoding-method=modified_beam_search  \
                                     --lm=lm.onnx \
                                     --lodr-fst=2gram.fst \
                                     --lodr-scale=-0.5  \
                                     --lodr-backoff-id=500 \
                                     --lm-shallow-fusion=true \
                                     test.wav
```

Where,
- 2gram.fst is the LODR n-gram model in the binary FST format, e.g. created by Icefall using arpa2fst and then compiled to binary (fstcompile)
- "lodr-backoff-id" is the ID of backoff symbol in LODR FST (typically 0 or len(vocabulary))

