### PR TITLE
fix static linking

### DIFF
--- a/sherpa-onnx/csrc/CMakeLists.txt
+++ b/sherpa-onnx/csrc/CMakeLists.txt
@@ -260,7 +260,7 @@ if(SHERPA_ONNX_ENABLE_RKNN)
   endif()
 endif()
 
-if(BUILD_SHARED_LIBS AND NOT DEFINED onnxruntime_lib_files)
+if((BUILD_SHARED_LIBS OR SHERPA_ONNX_USE_PRE_INSTALLED_ONNXRUNTIME_IF_AVAILABLE) AND NOT DEFINED onnxruntime_lib_files)
   target_link_libraries(sherpa-onnx-core onnxruntime)
 else()
   target_link_libraries(sherpa-onnx-core ${onnxruntime_lib_files})


### PR DESCRIPTION
Hi,

This PR is in reference to the issue: https://github.com/k2-fsa/sherpa-onnx/issues/1541

The current cmake logic does not handle the case where ONNX runtime is pre-installed and static linking is used.

The proposed solution modifies the `sherpa-onnx/csrc/CMakeLists.txt` file.
```cmake
if((BUILD_SHARED_LIBS OR SHERPA_ONNX_USE_PRE_INSTALLED_ONNXRUNTIME_IF_AVAILABLE) AND NOT DEFINED onnxruntime_lib_files)
  target_link_libraries(sherpa-onnx-core onnxruntime)
else()
  target_link_libraries(sherpa-onnx-core ${onnxruntime_lib_files})
```
The modified conditioning allows linking to the pre-installed ONNX Runtime when `BUILD_SHARED_LIBS` is True or when `SHERPA_ONNX_USE_PRE_INSTALLED_ONNXRUNTIME_IF_AVAILABLE` is set. This prevents build failures caused by missing onnxruntime_lib_files in static builds.

Thanks