### PR TITLE
cmake build, configurable from env

### DIFF
--- a/cmake/cmake_extension.py
+++ b/cmake/cmake_extension.py
@@ -153,7 +153,9 @@ class BuildExtension(build_ext):
             print(f"Setting PYTHON_EXECUTABLE to {sys.executable}")
             cmake_args += f" -DPYTHON_EXECUTABLE={sys.executable}"
 
-        cmake_args += extra_cmake_args
+        # putting `cmake_args` from env variable ${SHERPA_ONNX_CMAKE_ARGS} last,
+        # so they can onverride the "defaults" stored in `extra_cmake_args`
+        cmake_args = extra_cmake_args + cmake_args
 
         if is_windows():
             build_cmd = f"""
@@ -216,12 +218,18 @@ class BuildExtension(build_ext):
             if not src_file.is_file():
                 src_file = install_dir / ".." / (f + suffix)
 
+            if not src_file.is_file():
+                continue
+
             print(f"Copying {src_file} to {out_bin_dir}/")
             shutil.copy(f"{src_file}", f"{out_bin_dir}/")
 
-        shutil.rmtree(f"{install_dir}/bin")
-        shutil.rmtree(f"{install_dir}/share")
-        shutil.rmtree(f"{install_dir}/lib/pkgconfig")
+        if Path(f"{install_dir}/bin").is_dir():
+            shutil.rmtree(f"{install_dir}/bin")
+        if Path(f"{install_dir}/share").is_dir():
+            shutil.rmtree(f"{install_dir}/share")
+        if Path(f"{install_dir}/lib/pkgconfig").is_dir():
+            shutil.rmtree(f"{install_dir}/lib/pkgconfig")
 
         if is_macos():
             os.remove(f"{install_dir}/lib/libonnxruntime.dylib")

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,10 @@ with open("sherpa-onnx/python/sherpa_onnx/__init__.py", "a") as f:
 
 
 def get_binaries_to_install():
+    cmake_args = os.environ.get("SHERPA_ONNX_CMAKE_ARGS", "")
+    if '-DSHERPA_ONNX_ENABLE_BINARY=OFF' in cmake_args:
+        return None
+
     bin_dir = Path("build") / "sherpa_onnx" / "bin"
     bin_dir.mkdir(parents=True, exist_ok=True)
     suffix = ".exe" if is_windows() else ""
@@ -69,7 +73,7 @@ setuptools.setup(
         "sherpa_onnx": "sherpa-onnx/python/sherpa_onnx",
     },
     packages=["sherpa_onnx"],
-    data_files=[("bin", get_binaries_to_install())],
+    data_files=[("bin", get_binaries_to_install())] if get_binaries_to_install() else None,
     url="https://github.com/k2-fsa/sherpa-onnx",
     long_description=read_long_description(),
     long_description_content_type="text/markdown",

--- a/sherpa-onnx/csrc/parse-options.cc
+++ b/sherpa-onnx/csrc/parse-options.cc
@@ -261,9 +261,6 @@ static bool MustBeQuoted(const std::string &str, ShellType st) {
 // pasted into a shell of ShellType "st" (only bash for now), it
 // will get passed to the program in the same way.
 static std::string QuoteAndEscape(const std::string &str, ShellType /*st*/) {
-  // Only Bash is supported (for the moment).
-  SHERPA_ONNX_CHECK_EQ(st, kBash) << "Invalid shell type.";
-
   // For now we use the following rules:
   // In the normal case, we quote with single-quote "'", and to escape
   // a single-quote we use the string: '\'' (interpreted as closing the


### PR DESCRIPTION
- make sure the defaults in `cmake/cmake_extension.py` variable `extra_cmake_args` can be overriden by `cmake_args` from `${SHERPA_ONNX_CMAKE_ARGS}` env variable
- fix a bug in `sherpa-onnx/csrc/parse-options.cc` which appears when using `-DSHERPA_ONNX_ENABLE_CHECK=ON`