### PR TITLE
Support running sherpa-onnx with RK NPU on Android

### DIFF
--- a/.github/workflows/android-rknn.yaml
+++ b/.github/workflows/android-rknn.yaml
@@ -1,0 +1,283 @@
+name: android-rknn
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/android-rknn.yaml'
+      - 'cmake/**'
+      - 'sherpa-onnx/csrc/*'
+      - 'sherpa-onnx/jni/*'
+      - 'build-android*.sh'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/android-rknn.yaml'
+      - 'cmake/**'
+      - 'sherpa-onnx/csrc/*'
+      - 'sherpa-onnx/jni/*'
+      - 'build-android*.sh'
+
+  workflow_dispatch:
+
+concurrency:
+  group: android-rknn-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-android-rknn-libs:
+    name: Android rknn libs
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ matrix.os }}-android-rknn
+
+      - name: Display NDK HOME
+        shell: bash
+        run: |
+          echo "ANDROID_NDK_LATEST_HOME: ${ANDROID_NDK_LATEST_HOME}"
+          ls -lh ${ANDROID_NDK_LATEST_HOME}
+
+      - name: build android arm64-v8a
+        shell: bash
+        run: |
+          export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+
+          export ANDROID_NDK=$ANDROID_NDK_LATEST_HOME
+          export SHERPA_ONNX_ENABLE_C_API=ON
+          export SHERPA_ONNX_ENABLE_RKNN=ON
+          ./build-android-arm64-v8a.sh
+          mkdir -p jniLibs/arm64-v8a/
+          cp -v ./build-android-arm64-v8a/install/lib/*.so ./jniLibs/arm64-v8a/
+          cp -v ./build-android-arm64-v8a/install/lib/README.md ./jniLibs/arm64-v8a/
+          rm -rf  ./build-android-arm64-v8a/
+
+      - name: build android armv7-eabi
+        shell: bash
+        run: |
+          export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+
+          export ANDROID_NDK=$ANDROID_NDK_LATEST_HOME
+          export SHERPA_ONNX_ENABLE_C_API=ON
+          export SHERPA_ONNX_ENABLE_RKNN=ON
+          ./build-android-armv7-eabi.sh
+          mkdir -p ./jniLibs/armeabi-v7a/
+          cp -v ./build-android-armv7-eabi/install/lib/*.so ./jniLibs/armeabi-v7a/
+          cp -v ./build-android-armv7-eabi/install/lib/README.md ./jniLibs/armeabi-v7a/
+          rm -rf ./build-android-armv7-eabi
+
+      - name: Copy files
+        shell: bash
+        run: |
+          SHERPA_ONNX_VERSION=v$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+          echo "SHERPA_ONNX_VERSION=$SHERPA_ONNX_VERSION" >> "$GITHUB_ENV"
+
+          filename=sherpa-onnx-${SHERPA_ONNX_VERSION}-android-rknn.tar.bz2
+
+          tar cjvf $filename ./jniLibs
+
+          ls -lh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sherpa-onnx-android-libs-rknn
+          path: ./jniLibs
+
+      # https://huggingface.co/docs/hub/spaces-github-actions
+      - name: Publish to huggingface
+        if: (github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 20
+          timeout_seconds: 200
+          shell: bash
+          command: |
+            git config --global user.email "csukuangfj@gmail.com"
+            git config --global user.name "Fangjun Kuang"
+            du -h -d1 .
+            ls -lh
+
+            rm -rf huggingface
+            export GIT_CLONE_PROTECTION_ACTIVE=false
+            GIT_LFS_SKIP_SMUDGE=1 git clone https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/sherpa-onnx-libs huggingface
+
+            cd huggingface
+
+            cp -v ../sherpa-onnx-*-android-rknn.tar.bz2 ./
+
+            git status
+            git lfs track "*.bz2"
+
+            git add .
+
+            git commit -m "upload sherpa-onnx-${SHERPA_ONNX_VERSION}-android.tar.bz2"
+
+            git push https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/sherpa-onnx-libs main
+
+      - name: Release android libs
+        if: (github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa') && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          overwrite: true
+          file: sherpa-onnx-*-android-rknn.tar.bz2
+          # repo_name: k2-fsa/sherpa-onnx
+          # repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
+          # tag: v1.11.3
+
+  build-android-aar-rknn:
+    needs: [build-android-rknn-libs]
+    name: Android rknn AAR
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # https://github.com/actions/setup-java
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin' # See 'Supported distributions' for available options
+          java-version: '21'
+
+      - name: Display NDK HOME
+        shell: bash
+        run: |
+          echo "ANDROID_NDK_LATEST_HOME: ${ANDROID_NDK_LATEST_HOME}"
+          ls -lh ${ANDROID_NDK_LATEST_HOME}
+
+      - name: Retrieve artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sherpa-onnx-android-libs-rknn
+          path: /tmp/jniLibs
+
+      - name: Show jni libs
+        shell: bash
+        run: |
+          ls -lh /tmp/jniLibs
+
+          # drwxr-xr-x 2 runner docker 4.0K Dec 12 06:56 arm64-v8a
+          # drwxr-xr-x 2 runner docker 4.0K Dec 12 06:56 armeabi-v7a
+
+      - name: Copy libs
+        shell: bash
+        run: |
+          for arch in arm64-v8a armeabi-v7a; do
+            cp -v /tmp/jniLibs/$arch/* android/SherpaOnnxAar/sherpa_onnx/src/main/jniLibs/$arch/
+          done
+
+          rm -rf android/SherpaOnnxAar/sherpa_onnx/src/main/jniLibs/x86
+          rm -rf android/SherpaOnnxAar/sherpa_onnx/src/main/jniLibs/x86_64
+
+      - name: Check libs
+        shell: bash
+        run: |
+          ls -lh android/SherpaOnnxAar/sherpa_onnx/src/main/jniLibs/*
+
+      - name: Build aar
+        shell: bash
+        run: |
+          cd android/SherpaOnnxAar
+
+          ./gradlew :sherpa_onnx:assembleRelease
+
+      - name: Display aar
+        shell: bash
+        run: |
+          cd android/SherpaOnnxAar
+
+          ls -lh ./sherpa_onnx/build/outputs/aar/sherpa_onnx-release.aar
+          cp ./sherpa_onnx/build/outputs/aar/sherpa_onnx-release.aar ../../
+
+
+      - name: Rename aar
+        shell: bash
+        run: |
+          SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+          echo "SHERPA_ONNX_VERSION=$SHERPA_ONNX_VERSION" >> "$GITHUB_ENV"
+
+          mv sherpa_onnx-release.aar sherpa-onnx-${SHERPA_ONNX_VERSION}-rknn.aar
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sherpa-onnx-android-aar
+          path: ./*.aar
+
+      # https://huggingface.co/docs/hub/spaces-github-actions
+      - name: Publish to huggingface
+        if: (github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 20
+          timeout_seconds: 200
+          shell: bash
+          command: |
+            git config --global user.email "csukuangfj@gmail.com"
+            git config --global user.name "Fangjun Kuang"
+            du -h -d1 .
+            ls -lh
+
+            rm -rf huggingface
+            export GIT_CLONE_PROTECTION_ACTIVE=false
+            GIT_LFS_SKIP_SMUDGE=1 git clone https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/sherpa-onnx-libs huggingface
+
+            cd huggingface
+            dst=android/aar
+            mkdir -p $dst
+
+            cp -v ../*.aar $dst
+
+            git status
+            git lfs track "*.aar"
+
+            git add .
+
+            git commit -m "upload sherpa-onnx-${SHERPA_ONNX_VERSION}-rknn.aar"
+
+            git push https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/sherpa-onnx-libs main
+
+      - name: Release android aar
+        if: github.repository_owner == 'csukuangfj' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          overwrite: true
+          file: ./*.aar
+          # repo_name: k2-fsa/sherpa-onnx
+          # repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
+          # tag: v1.11.3
+
+      - name: Release android aar
+        if: github.repository_owner == 'k2-fsa' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          overwrite: true
+          file: ./*.aar

--- a/sherpa-onnx/csrc/online-recognizer-impl.cc
+++ b/sherpa-onnx/csrc/online-recognizer-impl.cc
@@ -51,7 +51,9 @@ std::unique_ptr<OnlineRecognizerImpl> OnlineRecognizerImpl::Create(
 #else
     SHERPA_ONNX_LOGE(
         "Please rebuild sherpa-onnx with -DSHERPA_ONNX_ENABLE_RKNN=ON if you "
-        "want to use rknn. Fallback to CPU");
+        "want to use rknn.");
+    SHERPA_ONNX_EXIT(-1);
+    return nullptr
 #endif
   }
 
@@ -108,7 +110,9 @@ std::unique_ptr<OnlineRecognizerImpl> OnlineRecognizerImpl::Create(
 #else
     SHERPA_ONNX_LOGE(
         "Please rebuild sherpa-onnx with -DSHERPA_ONNX_ENABLE_RKNN=ON if you "
-        "want to use rknn. Fallback to CPU");
+        "want to use rknn.");
+    SHERPA_ONNX_EXIT(-1);
+    return nullptr
 #endif
   }
 

--- a/sherpa-onnx/csrc/rknn/online-recognizer-ctc-rknn-impl.h
+++ b/sherpa-onnx/csrc/rknn/online-recognizer-ctc-rknn-impl.h
@@ -55,9 +55,9 @@ class OnlineRecognizerCtcRknnImpl : public OnlineRecognizerImpl {
                                        const OnlineRecognizerConfig &config)
       : OnlineRecognizerImpl(mgr, config),
         config_(config),
-        model_(
-            std::make_unique<OnlineZipformerCtcModelRknn>(config.model_config)),
-        sym_(mgr, config.model_config.tokens),
+        model_(std::make_unique<OnlineZipformerCtcModelRknn>(
+            mgr, config_.model_config)),
+        sym_(mgr, config_.model_config.tokens),
         endpoint_(config_.endpoint_config) {
     InitDecoder();
   }

--- a/sherpa-onnx/csrc/rknn/online-recognizer-transducer-rknn-impl.h
+++ b/sherpa-onnx/csrc/rknn/online-recognizer-transducer-rknn-impl.h
@@ -111,9 +111,33 @@ class OnlineRecognizerTransducerRknnImpl : public OnlineRecognizerImpl {
       : OnlineRecognizerImpl(mgr, config),
         config_(config),
         endpoint_(config_.endpoint_config),
-        model_(
-            std::make_unique<OnlineZipformerTransducerModelRknn>(mgr, config)) {
-    // TODO(fangjun): Support Android
+        model_(std::make_unique<OnlineZipformerTransducerModelRknn>(
+            mgr, config_.model_config)) {
+    if (!config.model_config.tokens_buf.empty()) {
+      sym_ = SymbolTable(config.model_config.tokens_buf, false);
+    } else {
+      /// assuming tokens_buf and tokens are guaranteed not being both empty
+      sym_ = SymbolTable(mgr, config.model_config.tokens);
+    }
+
+    if (sym_.Contains("<unk>")) {
+      unk_id_ = sym_["<unk>"];
+    }
+
+    if (config.decoding_method == "greedy_search") {
+      decoder_ = std::make_unique<OnlineTransducerGreedySearchDecoderRknn>(
+          model_.get(), unk_id_);
+    } else if (config.decoding_method == "modified_beam_search") {
+      decoder_ =
+          std::make_unique<OnlineTransducerModifiedBeamSearchDecoderRknn>(
+              model_.get(), config.max_active_paths, unk_id_);
+    } else {
+      SHERPA_ONNX_LOGE(
+          "Invalid decoding method: '%s'. Support only greedy_search and "
+          "modified_beam_search.",
+          config.decoding_method.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
   }
 
   std::unique_ptr<OnlineStream> CreateStream() const override {

--- a/sherpa-onnx/csrc/rknn/online-zipformer-ctc-model-rknn.cc
+++ b/sherpa-onnx/csrc/rknn/online-zipformer-ctc-model-rknn.cc
@@ -252,7 +252,7 @@ OnlineZipformerCtcModelRknn::OnlineZipformerCtcModelRknn(
 template <typename Manager>
 OnlineZipformerCtcModelRknn::OnlineZipformerCtcModelRknn(
     Manager *mgr, const OnlineModelConfig &config)
-    : impl_(std::make_unique<OnlineZipformerCtcModelRknn>(mgr, config)) {}
+    : impl_(std::make_unique<Impl>(mgr, config)) {}
 
 std::vector<std::vector<uint8_t>> OnlineZipformerCtcModelRknn::GetInitStates()
     const {

--- a/sherpa-onnx/csrc/rknn/online-zipformer-transducer-model-rknn.cc
+++ b/sherpa-onnx/csrc/rknn/online-zipformer-transducer-model-rknn.cc
@@ -435,8 +435,7 @@ OnlineZipformerTransducerModelRknn::OnlineZipformerTransducerModelRknn(
 template <typename Manager>
 OnlineZipformerTransducerModelRknn::OnlineZipformerTransducerModelRknn(
     Manager *mgr, const OnlineModelConfig &config)
-    : impl_(std::make_unique<OnlineZipformerTransducerModelRknn>(mgr, config)) {
-}
+    : impl_(std::make_unique<Impl>(mgr, config)) {}
 
 std::vector<std::vector<uint8_t>>
 OnlineZipformerTransducerModelRknn::GetEncoderInitStates() const {

--- a/sherpa-onnx/csrc/vad-model.cc
+++ b/sherpa-onnx/csrc/vad-model.cc
@@ -22,22 +22,34 @@
 namespace sherpa_onnx {
 
 std::unique_ptr<VadModel> VadModel::Create(const VadModelConfig &config) {
-#if SHERPA_ONNX_ENABLE_RKNN
   if (config.provider == "rknn") {
+#if SHERPA_ONNX_ENABLE_RKNN
     return std::make_unique<SileroVadModelRknn>(config);
-  }
+#else
+    SHERPA_ONNX_LOGE(
+        "Please rebuild sherpa-onnx with -DSHERPA_ONNX_ENABLE_RKNN=ON if you "
+        "want to use rknn.");
+    SHERPA_ONNX_EXIT(-1);
+    return nullptr;
 #endif
+  }
   return std::make_unique<SileroVadModel>(config);
 }
 
 template <typename Manager>
 std::unique_ptr<VadModel> VadModel::Create(Manager *mgr,
                                            const VadModelConfig &config) {
-#if SHERPA_ONNX_ENABLE_RKNN
   if (config.provider == "rknn") {
+#if SHERPA_ONNX_ENABLE_RKNN
     return std::make_unique<SileroVadModelRknn>(mgr, config);
-  }
+#else
+    SHERPA_ONNX_LOGE(
+        "Please rebuild sherpa-onnx with -DSHERPA_ONNX_ENABLE_RKNN=ON if you "
+        "want to use rknn.");
+    SHERPA_ONNX_EXIT(-1);
+    return nullptr;
 #endif
+  }
   return std::make_unique<SileroVadModel>(mgr, config);
 }
 

--- a/sherpa-onnx/kotlin-api/OnlineRecognizer.kt
+++ b/sherpa-onnx/kotlin-api/OnlineRecognizer.kt
@@ -394,6 +394,34 @@ fun getModelConfig(type: Int): OnlineModelConfig? {
                 tokens = "$modelDir/tokens.txt",
             )
         }
+
+        1000 -> {
+            val modelDir = "sherpa-onnx-rk3588-streaming-zipformer-bilingual-zh-en-2023-02-20"
+            return OnlineModelConfig(
+                transducer = OnlineTransducerModelConfig(
+                    encoder = "$modelDir/encoder.rknn",
+                    decoder = "$modelDir/decoder.rknn",
+                    joiner = "$modelDir/joiner.rknn",
+                ),
+                tokens = "$modelDir/tokens.txt",
+                modelType = "zipformer",
+                provider = "rknn",
+            )
+        }
+
+        1001 -> {
+            val modelDir = "sherpa-onnx-rk3588-streaming-zipformer-small-bilingual-zh-en-2023-02-16"
+            return OnlineModelConfig(
+                transducer = OnlineTransducerModelConfig(
+                    encoder = "$modelDir/encoder.rknn",
+                    decoder = "$modelDir/decoder.rknn",
+                    joiner = "$modelDir/joiner.rknn",
+                ),
+                tokens = "$modelDir/tokens.txt",
+                modelType = "zipformer",
+                provider = "rknn",
+            )
+        }
     }
     return null
 }


### PR DESCRIPTION
## Usage

1.  Build sherpa-onnx for RKNN Android
```bash
export SHERPA_ONNX_ENABLE_RKNN=ON
./build-android-arm64-v8a.sh
```

2. Copy the generated libs to your `jniLibs/arm64-v8a` in your Android studio project
3. Select an ASR model. We have listed two models with type 1000 and 1001 for rk3588. You can download more from
https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models

The remaining steps are the same for running sherpa-onnx on Android CPU.


## Screenshots of running sherpa-onnx with RK RNPU on RK3588 Android  (Orangepi 5 max)

| logcat| npu usage|
|---|---|
|<img width="1307" alt="Screenshot 2025-04-15 at 16 31 55" src="https://github.com/user-attachments/assets/b2d5cae3-b6ff-4085-953d-50f4181ce572" />|<img width="1105" alt="Screenshot 2025-04-15 at 16 31 23" src="https://github.com/user-attachments/assets/5e6cb388-6cf7-455e-92ed-48ad77103884" />|


---

Fixes #2025 
CC @onCreate2018 @dlisagod



