### PR TITLE
Fix building rknn wheels

### DIFF
--- a/.github/workflows/build-wheels-aarch64-rknn.yaml
+++ b/.github/workflows/build-wheels-aarch64-rknn.yaml
@@ -25,60 +25,104 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install Python dependencies
-        shell: bash
-        run: |
-          python3 -m pip install --upgrade pip numpy pypinyin sentencepiece setuptools wheel
-
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          key: ${{ matrix.os }}-rknn-linux-aarch64-wheel
-
       - name: Download rknn-toolkit2
         shell: bash
         run: |
           git clone --depth 1 https://github.com/airockchip/rknn-toolkit2
 
       - name: Build sherpa-onnx
-        shell: bash
-        run: |
-          export CMAKE_CXX_COMPILER_LAUNCHER=ccache
-          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-          cmake --version
+        uses: addnab/docker-run-action@v3
+        with:
+            image: quay.io/pypa/manylinux_2_28_aarch64
+            # image: quay.io/pypa/manylinux2014_aarch64 # it does not provide GLIBCXX 3.4.21+
+            options: |
+              --volume ${{ github.workspace }}/:/k2-fsa/sherpa-onnx
+            shell: bash
+            run: |
+              echo "config: ${{ matrix.config }}"
+              uname -a
+              which gcc
 
-          echo "config: ${{ matrix.config }}"
-          uname -a
-          which gcc
+              gcc --version
+              g++ --version
 
-          gcc --version
-          g++ --version
+              find /opt -name "python*"
 
-          echo "pwd"
+              py=${{ matrix.python-version }}
 
-          ls -lh
+              for v in $(seq 0 99); do
+                if [ -f /opt/_internal/cpython-$py.$v/bin/python3 ]; then
+                  py=/opt/_internal/cpython-$py.$v/bin/python3
+                  break
+                fi
+              done
 
-          sudo apt-get update -y
-          sudo apt-get install -y alsa-utils libasound2-dev
+              # there is
+              # py=/opt/_internal/cpython-3.13.3-nogil/bin/python3
+              #
+              echo "py: $py"
 
-          export SHERPA_ONNX_RKNN_TOOLKIT2_PATH=$PWD/rknn-toolkit2
-          export SHERPA_ONNX_RKNN_TOOLKIT2_LIB_DIR=$SHERPA_ONNX_RKNN_TOOLKIT2_PATH/rknpu2/runtime/Linux/librknn_api/aarch64
-          export CPLUS_INCLUDE_PATH=$SHERPA_ONNX_RKNN_TOOLKIT2_PATH/rknpu2/runtime/Linux/librknn_api/include:$CPLUS_INCLUDE_PATH
+              $py --version
 
-          export SHERPA_ONNX_ENABLE_ALSA=1
+              $py -m venv my-py
 
-          export SHERPA_ONNX_CMAKE_ARGS="-DSHERPA_ONNX_ENABLE_RKNN=ON"
-          python3 setup.py bdist_wheel
+              python3 --version
+              which python3
+
+              source ./my-py/bin/activate
+
+              python3 --version
+              which python3
+
+              python3 -m pip install wheel twine setuptools
+
+              echo "pwd"
+
+              cd /k2-fsa/sherpa-onnx/
+
+              ls -lh
+
+              cmake --version
+
+              echo "config: ${{ matrix.config }}"
+              uname -a
+              echo "pwd"
+
+              git clone --depth 1 --branch v1.2.12 https://github.com/alsa-project/alsa-lib
+              pushd alsa-lib
+              ./gitcompile
+              popd
+
+              ls -lh $PWD/alsa-lib/src/.libs
+
+              strings $PWD/alsa-lib/src/.libs/libasound.so.2.0.0 | grep "^GLIBC"
+
+              export CPLUS_INCLUDE_PATH=$PWD/alsa-lib/include:$CPLUS_INCLUDE_PATH
+              export SHERPA_ONNX_ALSA_LIB_DIR=$PWD/alsa-lib/src/.libs
+
+
+              export SHERPA_ONNX_RKNN_TOOLKIT2_PATH=$PWD/rknn-toolkit2
+              export SHERPA_ONNX_RKNN_TOOLKIT2_LIB_DIR=$SHERPA_ONNX_RKNN_TOOLKIT2_PATH/rknpu2/runtime/Linux/librknn_api/aarch64
+              export CPLUS_INCLUDE_PATH=$SHERPA_ONNX_RKNN_TOOLKIT2_PATH/rknpu2/runtime/Linux/librknn_api/include:$CPLUS_INCLUDE_PATH
+
+              export SHERPA_ONNX_ENABLE_ALSA=1
+
+              export SHERPA_ONNX_CMAKE_ARGS="-DSHERPA_ONNX_ENABLE_RKNN=ON"
+              python3 setup.py bdist_wheel
 
       - name: Display results
         shell: bash
         run: |
           ls -lh dist
+
+      - name: Show glibc versions
+        shell: bash
+        run: |
+          mkdir t
+          cp dist/*.whl t
+          cd t
+          unzip ./*.whl
+          strings sherpa_onnx-*.data/data/bin/sherpa-onnx | grep GLIBC
 
       - name: Publish to huggingface
         env:


### PR DESCRIPTION
Many users have reported that the pre-built sherpa-onnx wheels for RK NPU do not work on Ubuntu 20.04 with some errors like below:
![image](https://github.com/user-attachments/assets/0abc5e14-06c3-4047-a974-b49662bd8d56)

After some debugging, we find that
```
cd sherpa_onnx-1.12.0.data/data/bin
strings sherpa-onnx | grep GLIBC

GLIBC_2.17
GLIBC_2.32
GLIBC_2.34
GLIBC_2.27
GLIBC_2.29
GLIBCXX_3.4.20
GLIBCXX_3.4.17
GLIBCXX_3.4.26
GLIBCXX_3.4.19
GLIBCXX_3.4.29
GLIBCXX_3.4.18
GLIBCXX_3.4.11
GLIBCXX_3.4.9
GLIBCXX_3.4.14
GLIBCXX_3.4.30
GLIBCXX_3.4.21
GLIBCXX_3.4.22
GLIBCXX_3.4.15
GLIBCXX_3.4
```
while the `librknnrt.so` we are using depends only on lower versions of glibc and glibcxx
```bash
strings librknnrt.so | grep GLIBC
GLIBC_2.17
GLIBCXX_3.4.20
GLIBCXX_3.4.18
GLIBCXX_3.4.9
GLIBCXX_3.4.11
GLIBCXX_3.4.14
GLIBCXX_3.4.15
GLIBCXX_3.4.22
GLIBCXX_3.4.21
GLIBCXX_3.4
```

After using this PR, the pre-built wheel has the following output:
```
GLIBC_2.17
GLIBC_2.27
GLIBCXX_3.4.20
GLIBCXX_3.4.17
GLIBCXX_3.4.19
GLIBCXX_3.4.18
GLIBCXX_3.4.11
GLIBCXX_3.4.9
GLIBCXX_3.4.14
GLIBCXX_3.4.22
GLIBCXX_3.4.21
GLIBCXX_3.4.15
GLIBCXX_3.4
```

You can see the highest GLIBCXX version is `3.4.22`.

Note that we have to use `quay.io/pypa/manylinux_2_28_aarch64` since `quay.io/pypa/manylinux2014_aarch64` gives the following errors while building `sherpa-onnx` with rknn support:
```
/opt/rh/devtoolset-10/root/usr/libexec/gcc/aarch64-redhat-linux/10/ld: /k2-fsa/sherpa-onnx/rknn-toolkit2/rknpu2/runtime/Linux/librknn_api/aarch64/librknnrt.so: undefined reference to `typeinfo for std::thread::_State@GLIBCXX_3.4.22'
/opt/rh/devtoolset-10/root/usr/libexec/gcc/aarch64-redhat-linux/10/ld: /k2-fsa/sherpa-onnx/rknn-toolkit2/rknpu2/runtime/Linux/librknn_api/aarch64/librknnrt.so: undefined reference to `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::find(char, unsigned long) const@GLIBCXX_3.4.21'
/opt/rh/devtoolset-10/root/usr/libexec/gcc/aarch64-redhat-linux/10/ld: /k2-fsa/sherpa-onnx/rknn-toolkit2/rknpu2/runtime/Linux/librknn_api/aarch64/librknnrt.so: undefined reference to `std::__cxx11::basic_stringstream<char, std::char_traits<char>, std::allocator<char> >::~basic_stringstream()@GLIBCXX_3.4.21'
/opt/rh/devtoolset-10/root/usr/libexec/gcc/aarch64-redhat-linux/10/ld: /k2-fsa/sherpa-onnx/rknn-toolkit2/rknpu2/runtime/Linux/librknn_api/aarch64/librknnrt.so: undefined reference to `std::runtime_error::runtime_error(char const*)@GLIBCXX_3.4.21'
```
