### PR TITLE
JAVA-API: Manual Library Loading Support for Restricted Environments

### DIFF
--- a/sherpa-onnx/java-api/Makefile
+++ b/sherpa-onnx/java-api/Makefile
@@ -6,7 +6,9 @@ out_jar := $(out_dir)/sherpa-onnx.jar
 
 package_dir := com/k2fsa/sherpa/onnx
 
-java_files := WaveReader.java
+java_files := LibraryLoader.java
+
+java_files += WaveReader.java
 java_files += WaveWriter.java
 java_files += EndpointRule.java
 java_files += EndpointConfig.java

--- a/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/AudioTagging.java
+++ b/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/AudioTagging.java
@@ -3,13 +3,10 @@
 package com.k2fsa.sherpa.onnx;
 
 public class AudioTagging {
-    static {
-        System.loadLibrary("sherpa-onnx-jni");
-    }
-
     private long ptr = 0;
 
     public AudioTagging(AudioTaggingConfig config) {
+        LibraryLoader.maybeLoad();
         ptr = newFromFile(config);
     }
 

--- a/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/DenoisedAudio.java
+++ b/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/DenoisedAudio.java
@@ -3,14 +3,11 @@
 package com.k2fsa.sherpa.onnx;
 
 public class DenoisedAudio {
-    static {
-        System.loadLibrary("sherpa-onnx-jni");
-    }
-
     private final float[] samples;
     private final int sampleRate;
 
     public DenoisedAudio(float[] samples, int sampleRate) {
+        LibraryLoader.maybeLoad();
         this.samples = samples;
         this.sampleRate = sampleRate;
     }

--- a/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/GeneratedAudio.java
+++ b/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/GeneratedAudio.java
@@ -3,14 +3,11 @@
 package com.k2fsa.sherpa.onnx;
 
 public class GeneratedAudio {
-    static {
-        System.loadLibrary("sherpa-onnx-jni");
-    }
-
     private final float[] samples;
     private final int sampleRate;
 
     public GeneratedAudio(float[] samples, int sampleRate) {
+        LibraryLoader.maybeLoad();
         this.samples = samples;
         this.sampleRate = sampleRate;
     }

--- a/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/KeywordSpotter.java
+++ b/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/KeywordSpotter.java
@@ -3,13 +3,10 @@
 package com.k2fsa.sherpa.onnx;
 
 public class KeywordSpotter {
-    static {
-        System.loadLibrary("sherpa-onnx-jni");
-    }
-
     private long ptr = 0;
 
     public KeywordSpotter(KeywordSpotterConfig config) {
+        LibraryLoader.maybeLoad();
         ptr = newFromFile(config);
     }
 

--- a/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/LibraryLoader.java
+++ b/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/LibraryLoader.java
@@ -1,0 +1,23 @@
+package com.k2fsa.sherpa.onnx;
+
+public class LibraryLoader {
+    private static volatile boolean autoLoadEnabled = true;
+    private static volatile boolean isLoaded = false;
+
+    static synchronized void loadLibrary() {
+        if (!isLoaded) {
+            System.loadLibrary("sherpa-onnx-jni");
+            isLoaded = true;
+        }
+    }
+
+    public static void setAutoLoadEnabled(boolean enabled) {
+        autoLoadEnabled = enabled;
+    }
+
+    static void maybeLoad() {
+        if (autoLoadEnabled) {
+            loadLibrary();
+        }
+    }
+}

--- a/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/OfflinePunctuation.java
+++ b/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/OfflinePunctuation.java
@@ -3,13 +3,10 @@
 package com.k2fsa.sherpa.onnx;
 
 public class OfflinePunctuation {
-    static {
-        System.loadLibrary("sherpa-onnx-jni");
-    }
-
     private long ptr = 0;
 
     public OfflinePunctuation(OfflinePunctuationConfig config) {
+        LibraryLoader.maybeLoad();
         ptr = newFromFile(config);
     }
 

--- a/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/OfflineRecognizer.java
+++ b/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/OfflineRecognizer.java
@@ -3,13 +3,10 @@
 package com.k2fsa.sherpa.onnx;
 
 public class OfflineRecognizer {
-    static {
-        System.loadLibrary("sherpa-onnx-jni");
-    }
-
     private long ptr = 0;
 
     public OfflineRecognizer(OfflineRecognizerConfig config) {
+        LibraryLoader.maybeLoad();
         ptr = newFromFile(config);
     }
 

--- a/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/OfflineSpeakerDiarization.java
+++ b/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/OfflineSpeakerDiarization.java
@@ -3,13 +3,10 @@
 package com.k2fsa.sherpa.onnx;
 
 public class OfflineSpeakerDiarization {
-    static {
-        System.loadLibrary("sherpa-onnx-jni");
-    }
-
     private long ptr = 0;
 
     public OfflineSpeakerDiarization(OfflineSpeakerDiarizationConfig config) {
+        LibraryLoader.maybeLoad();
         ptr = newFromFile(config);
     }
 

--- a/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/OfflineSpeechDenoiser.java
+++ b/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/OfflineSpeechDenoiser.java
@@ -3,13 +3,10 @@
 package com.k2fsa.sherpa.onnx;
 
 public class OfflineSpeechDenoiser {
-    static {
-        System.loadLibrary("sherpa-onnx-jni");
-    }
-
     private long ptr = 0;
 
     public OfflineSpeechDenoiser(OfflineSpeechDenoiserConfig config) {
+        LibraryLoader.maybeLoad();
         ptr = newFromFile(config);
     }
 

--- a/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/OfflineStream.java
+++ b/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/OfflineStream.java
@@ -3,13 +3,10 @@
 package com.k2fsa.sherpa.onnx;
 
 public class OfflineStream {
-    static {
-        System.loadLibrary("sherpa-onnx-jni");
-    }
-
     private long ptr = 0;
 
     public OfflineStream() {
+        LibraryLoader.maybeLoad();
         this.ptr = 0;
     }
 

--- a/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/OfflineTts.java
+++ b/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/OfflineTts.java
@@ -4,13 +4,10 @@ package com.k2fsa.sherpa.onnx;
 
 
 public class OfflineTts {
-    static {
-        System.loadLibrary("sherpa-onnx-jni");
-    }
-
     private long ptr = 0;
 
     public OfflineTts(OfflineTtsConfig config) {
+        LibraryLoader.maybeLoad();
         ptr = newFromFile(config);
     }
 

--- a/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/OnlinePunctuation.java
+++ b/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/OnlinePunctuation.java
@@ -3,13 +3,10 @@
 package com.k2fsa.sherpa.onnx;
 
 public class OnlinePunctuation {
-    static {
-        System.loadLibrary("sherpa-onnx-jni");
-    }
-
     private long ptr = 0;
 
     public OnlinePunctuation(OnlinePunctuationConfig config) {
+        LibraryLoader.maybeLoad();
         ptr = newFromFile(config);
     }
 

--- a/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/OnlineRecognizer.java
+++ b/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/OnlineRecognizer.java
@@ -4,13 +4,10 @@
 package com.k2fsa.sherpa.onnx;
 
 public class OnlineRecognizer {
-    static {
-        System.loadLibrary("sherpa-onnx-jni");
-    }
-
     private long ptr = 0;
 
     public OnlineRecognizer(OnlineRecognizerConfig config) {
+        LibraryLoader.maybeLoad();
         ptr = newFromFile(config);
     }
 

--- a/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/OnlineStream.java
+++ b/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/OnlineStream.java
@@ -4,13 +4,10 @@
 package com.k2fsa.sherpa.onnx;
 
 public class OnlineStream {
-    static {
-        System.loadLibrary("sherpa-onnx-jni");
-    }
-
     private long ptr = 0;
 
     public OnlineStream() {
+        LibraryLoader.maybeLoad();
         this.ptr = 0;
     }
 

--- a/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/SpeakerEmbeddingExtractor.java
+++ b/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/SpeakerEmbeddingExtractor.java
@@ -3,13 +3,10 @@
 package com.k2fsa.sherpa.onnx;
 
 public class SpeakerEmbeddingExtractor {
-    static {
-        System.loadLibrary("sherpa-onnx-jni");
-    }
-
     private long ptr = 0;
 
     public SpeakerEmbeddingExtractor(SpeakerEmbeddingExtractorConfig config) {
+        LibraryLoader.maybeLoad();
         ptr = newFromFile(config);
     }
 

--- a/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/SpeakerEmbeddingManager.java
+++ b/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/SpeakerEmbeddingManager.java
@@ -3,13 +3,10 @@
 package com.k2fsa.sherpa.onnx;
 
 public class SpeakerEmbeddingManager {
-    static {
-        System.loadLibrary("sherpa-onnx-jni");
-    }
-
     private long ptr = 0;
 
     public SpeakerEmbeddingManager(int dim) {
+        LibraryLoader.maybeLoad();
         ptr = create(dim);
     }
 

--- a/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/SpokenLanguageIdentification.java
+++ b/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/SpokenLanguageIdentification.java
@@ -7,14 +7,11 @@ import java.util.Locale;
 import java.util.Map;
 
 public class SpokenLanguageIdentification {
-    static {
-        System.loadLibrary("sherpa-onnx-jni");
-    }
-
     private final Map<String, String> localeMap;
     private long ptr = 0;
 
     public SpokenLanguageIdentification(SpokenLanguageIdentificationConfig config) {
+        LibraryLoader.maybeLoad();
         ptr = newFromFile(config);
 
         String[] languages = Locale.getISOLanguages();

--- a/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/Vad.java
+++ b/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/Vad.java
@@ -3,13 +3,10 @@
 package com.k2fsa.sherpa.onnx;
 
 public class Vad {
-    static {
-        System.loadLibrary("sherpa-onnx-jni");
-    }
-
     private long ptr = 0;
 
     public Vad(VadModelConfig config) {
+        LibraryLoader.maybeLoad();
         ptr = newFromFile(config);
     }
 

--- a/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/WaveReader.java
+++ b/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/WaveReader.java
@@ -3,16 +3,13 @@
 package com.k2fsa.sherpa.onnx;
 
 public class WaveReader {
-    static {
-        System.loadLibrary("sherpa-onnx-jni");
-    }
-
     private final int sampleRate;
     private final float[] samples;
 
     // It supports only single channel, 16-bit wave file.
     // It will exit the program if the given file has a wrong format
     public WaveReader(String filename) {
+        LibraryLoader.maybeLoad();
         Object[] arr = readWaveFromFile(filename);
         samples = (float[]) arr[0];
         sampleRate = (int) arr[1];


### PR DESCRIPTION
Support for manual loading of the native library, particularly useful in environments where developers cannot control the JVM's `java.library.path`, or any other restriction related to native library loading.

**Problem**:
Some deployment scenarios restrict modification of JVM properties (like `java.library.path`).
This makes it not possible to load the JNI library via the "traditional" `System.loadLibrary()`.

**Solution**:
Allow explicit control over native library loading for such environments, via:
1. Possibility to disable static hard-coded library loading
2. Load from absolute paths manually via standard Java mechanisms

**Changes**:
- Added `LibraryLoader.java` class which is fully backward compatible for existing users, but allows manual control over library auto-loading.
- Modified all JNI classes (e.g., `OfflineTts`) to remove the static initializers and instead use the controlled initialization via `LibraryLoader`.

**Usage examples**:
Default behavior (auto-load), backward compatible:
```java
OfflineTts tts = new OfflineTts(config); // Library loads automatically:
```

Manual control:
```java
// Disable auto-loading
LibraryLoader.setAutoLoadEnabled(false);

// Manually loading lib
System.load(new File(jarFile.getParentFile(), "libsherpa-onnx-jni.so").getAbsolutePath());

// Create instance
OfflineTts tts = new OfflineTts(config);
```