### PR TITLE
修复了C++链接错误，添加-lsherpa-onnx-cxx-api：Update sherpa-onnx-shared.pc.in

### DIFF
--- a/cmake/sherpa-onnx-shared.pc.in
+++ b/cmake/sherpa-onnx-shared.pc.in
@@ -22,4 +22,4 @@ Cflags: -I"${includedir}"
 # Note: -lcargs is required only for the following file
 # https://github.com/k2-fsa/sherpa-onnx/blob/master/c-api-examples/decode-file-c-api.c
 # We add it here so that users don't need to specify -lcargs when compiling decode-file-c-api.c
-Libs: -L"${libdir}" -lsherpa-onnx-c-api -lonnxruntime -Wl,-rpath,${libdir} @SHERPA_ONNX_PKG_WITH_CARGS@ @SHERPA_ONNX_PKG_CONFIG_EXTRA_LIBS@
+Libs: -L"${libdir}" -lsherpa-onnx-cxx-api -lsherpa-onnx-c-api -lonnxruntime -Wl,-rpath,${libdir} @SHERPA_ONNX_PKG_WITH_CARGS@ @SHERPA_ONNX_PKG_CONFIG_EXTRA_LIBS@


### PR DESCRIPTION
修复了C++链接错误，添加-lsherpa-onnx-cxx-api