### PR TITLE
Remove portaudio-go in Go API examples.

### DIFF
--- a/go-api-examples/real-time-speech-recognition-from-microphone/go.mod
+++ b/go-api-examples/real-time-speech-recognition-from-microphone/go.mod
@@ -1,7 +1,3 @@
 module real-time-speech-recognition-from-microphone
 
 go 1.17
-
-require (
-	github.com/csukuangfj/portaudio-go v1.0.3
-)

--- a/go-api-examples/real-time-speech-recognition-from-microphone/main.go
+++ b/go-api-examples/real-time-speech-recognition-from-microphone/main.go
@@ -69,7 +69,7 @@ func main() {
 
 	segment_idx := 0
 
-	onRecvFrames := func(pSample2, pSample []byte, framecount uint32) {
+	onRecvFrames := func(_, pSample []byte, framecount uint32) {
 		samples := samplesInt16ToFloat(pSample)
 		stream.AcceptWaveform(16000, samples)
 

--- a/go-api-examples/real-time-speech-recognition-from-microphone/main.go
+++ b/go-api-examples/real-time-speech-recognition-from-microphone/main.go
@@ -118,14 +118,8 @@ func samplesInt16ToFloat(inSamples []byte) []float32 {
 	outSamples := make([]float32, numSamples)
 
 	for i := 0; i != numSamples; i++ {
-		s := inSamples[i*2 : (i+1)*2]
-
-		var s16 int16
-		buf := bytes.NewReader(s)
-		err := binary.Read(buf, binary.LittleEndian, &s16)
-		if err != nil {
-			log.Fatal("Failed to parse 16-bit sample")
-		}
+		// Decode two bytes into an int16 using bit manipulation
+		s16 := int16(inSamples[2*i]) | int16(inSamples[2*i+1])<<8
 		outSamples[i] = float32(s16) / 32768
 	}
 

--- a/go-api-examples/real-time-speech-recognition-from-microphone/main.go
+++ b/go-api-examples/real-time-speech-recognition-from-microphone/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"bytes"
-	"encoding/binary"
 	"fmt"
 	"github.com/gen2brain/malgo"
 	sherpa "github.com/k2-fsa/sherpa-onnx-go/sherpa_onnx"

--- a/go-api-examples/real-time-speech-recognition-from-microphone/main.go
+++ b/go-api-examples/real-time-speech-recognition-from-microphone/main.go
@@ -1,35 +1,17 @@
 package main
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
-	portaudio "github.com/csukuangfj/portaudio-go"
+	"github.com/gen2brain/malgo"
 	sherpa "github.com/k2-fsa/sherpa-onnx-go/sherpa_onnx"
 	flag "github.com/spf13/pflag"
 	"log"
 	"strings"
 )
 
-func main() {
-	err := portaudio.Initialize()
-	if err != nil {
-		log.Fatalf("Unable to initialize portaudio: %v\n", err)
-	}
-	defer portaudio.Terminate()
-
-	default_device, err := portaudio.DefaultInputDevice()
-	if err != nil {
-		log.Fatal("Failed to get default input device: %v\n", err)
-	}
-	fmt.Printf("Select default input device: %s\n", default_device.Name)
-	param := portaudio.StreamParameters{}
-	param.Input.Device = default_device
-	param.Input.Channels = 1
-	param.Input.Latency = default_device.DefaultLowInputLatency
-
-	param.SampleRate = 16000
-	param.FramesPerBuffer = 0
-	param.Flags = portaudio.ClipOff
-
+func initRecognizer() *sherpa.OnlineRecognizer {
 	config := sherpa.OnlineRecognizerConfig{}
 	config.FeatConfig = sherpa.FeatureConfig{SampleRate: 16000, FeatureDim: 80}
 
@@ -55,37 +37,48 @@ func main() {
 	log.Println("Initializing recognizer (may take several seconds)")
 	recognizer := sherpa.NewOnlineRecognizer(&config)
 	log.Println("Recognizer created!")
+	return recognizer
+}
+
+func main() {
+	ctx, err := malgo.InitContext(nil, malgo.ContextConfig{}, func(message string) {
+		fmt.Printf("LOG <%v>", message)
+	})
+	chk(err)
+
+	defer func() {
+		_ = ctx.Uninit()
+		ctx.Free()
+	}()
+
+	deviceConfig := malgo.DefaultDeviceConfig(malgo.Duplex)
+	deviceConfig.Capture.Format = malgo.FormatS16
+	deviceConfig.Capture.Channels = 1
+	deviceConfig.Playback.Format = malgo.FormatS16
+	deviceConfig.Playback.Channels = 1
+	deviceConfig.SampleRate = 16000
+	deviceConfig.Alsa.NoMMap = 1
+
+	recognizer := initRecognizer()
 	defer sherpa.DeleteOnlineRecognizer(recognizer)
 
 	stream := sherpa.NewOnlineStream(recognizer)
 	defer sherpa.DeleteOnlineStream(stream)
 
-	// you can choose another value for 0.1 if you want
-	samplesPerCall := int32(param.SampleRate * 0.1) // 0.1 second
-
-	samples := make([]float32, samplesPerCall)
-	s, err := portaudio.OpenStream(param, samples)
-	if err != nil {
-		log.Fatalf("Failed to open the stream")
-	}
-	defer s.Close()
-	chk(s.Start())
-
 	var last_text string
 
 	segment_idx := 0
 
-	fmt.Println("Started! Please speak")
+	onRecvFrames := func(pSample2, pSample []byte, framecount uint32) {
+		samples := samplesInt16ToFloat(pSample)
+		stream.AcceptWaveform(16000, samples)
 
-	for {
-		chk(s.Read())
-		stream.AcceptWaveform(int(param.SampleRate), samples)
-
+		// Please use a separate goroutine for decoding in your app
 		for recognizer.IsReady(stream) {
 			recognizer.Decode(stream)
 		}
-
 		text := recognizer.GetResult(stream).Text
+
 		if len(text) != 0 && last_text != text {
 			last_text = strings.ToLower(text)
 			fmt.Printf("\r%d: %s", segment_idx, last_text)
@@ -100,11 +93,41 @@ func main() {
 		}
 	}
 
-	chk(s.Stop())
+	captureCallbacks := malgo.DeviceCallbacks{
+		Data: onRecvFrames,
+	}
+
+	device, err := malgo.InitDevice(ctx.Context, deviceConfig, captureCallbacks)
+	chk(err)
+
+	err = device.Start()
+	chk(err)
+	fmt.Println("Started. Please speak. Press ctrl + C  to exit")
+	fmt.Scanln()
+	device.Uninit()
 }
 
 func chk(err error) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func samplesInt16ToFloat(inSamples []byte) []float32 {
+	numSamples := len(inSamples) / 2
+	outSamples := make([]float32, numSamples)
+
+	for i := 0; i != numSamples; i++ {
+		s := inSamples[i*2 : (i+1)*2]
+
+		var s16 int16
+		buf := bytes.NewReader(s)
+		err := binary.Read(buf, binary.LittleEndian, &s16)
+		if err != nil {
+			log.Fatal("Failed to parse 16-bit sample")
+		}
+		outSamples[i] = float32(s16) / 32768
+	}
+
+	return outSamples
 }

--- a/nodejs-addon-examples/test_asr_non_streaming_whisper.js
+++ b/nodejs-addon-examples/test_asr_non_streaming_whisper.js
@@ -1,6 +1,6 @@
 // Copyright (c)  2024  Xiaomi Corporation
 const sherpa_onnx = require('sherpa-onnx-node');
-console.log(`verison : ${sherpa_onnx.version}`);
+console.log(`version : ${sherpa_onnx.version}`);
 console.log(`git sha1: ${sherpa_onnx.gitSha1}`);
 console.log(`git date: ${sherpa_onnx.gitDate}`);
 

--- a/nodejs-examples/test-offline-whisper.js
+++ b/nodejs-examples/test-offline-whisper.js
@@ -1,7 +1,7 @@
 // Copyright (c)  2023  Xiaomi Corporation (authors: Fangjun Kuang)
 //
 const sherpa_onnx = require('sherpa-onnx');
-console.log(`verison : ${sherpa_onnx.version}`);
+console.log(`version : ${sherpa_onnx.version}`);
 console.log(`git sha1: ${sherpa_onnx.gitSha1}`);
 console.log(`git date: ${sherpa_onnx.gitDate}`);
 


### PR DESCRIPTION
It uses https://github.com/gen2brain/malgo to replace portaudio-go.

malgo uses https://github.com/mackron/miniaudio and works on linux, macos, windows, etc.

Many users have issues with portaudio-go on windows and linux.