### PR TITLE
Support Zipformer transducer ASR with whisper features.

### DIFF
--- a/sherpa-onnx/csrc/features.cc
+++ b/sherpa-onnx/csrc/features.cc
@@ -131,10 +131,13 @@ class FeatureExtractor::Impl {
     std::lock_guard<std::mutex> lock(mutex_);
     if (fbank_) {
       fbank_->InputFinished();
+      return;
     } else if (whisper_fbank_) {
       whisper_fbank_->InputFinished();
+      return;
     } else if (mfcc_) {
       mfcc_->InputFinished();
+      return;
     }
 
     SHERPA_ONNX_LOGE("unreachable code");

--- a/sherpa-onnx/csrc/online-transducer-model.h
+++ b/sherpa-onnx/csrc/online-transducer-model.h
@@ -132,6 +132,8 @@ class OnlineTransducerModel {
 
   virtual int32_t SubsamplingFactor() const { return 4; }
 
+  virtual bool UseWhisperFeature() const { return false; }
+
   virtual OrtAllocator *Allocator() = 0;
 
   Ort::Value BuildDecoderInput(

--- a/sherpa-onnx/csrc/online-zipformer2-transducer-model.cc
+++ b/sherpa-onnx/csrc/online-zipformer2-transducer-model.cc
@@ -120,6 +120,12 @@ void OnlineZipformer2TransducerModel::InitEncoder(void *model_data,
   SHERPA_ONNX_READ_META_DATA(T_, "T");
   SHERPA_ONNX_READ_META_DATA(decode_chunk_len_, "decode_chunk_len");
 
+  std::string feature_type;
+  SHERPA_ONNX_READ_META_DATA_STR_WITH_DEFAULT(feature_type, "feature", "");
+  if (feature_type == "whisper") {
+    use_whisper_feature_ = true;
+  }
+
   if (config_.debug) {
     auto print = [](const std::vector<int32_t> &v, const char *name) {
       std::ostringstream os;

--- a/sherpa-onnx/csrc/online-zipformer2-transducer-model.h
+++ b/sherpa-onnx/csrc/online-zipformer2-transducer-model.h
@@ -52,6 +52,8 @@ class OnlineZipformer2TransducerModel : public OnlineTransducerModel {
   int32_t VocabSize() const override { return vocab_size_; }
   OrtAllocator *Allocator() override { return allocator_; }
 
+  bool UseWhisperFeature() const override { return use_whisper_feature_; }
+
  private:
   void InitEncoder(void *model_data, size_t model_data_length);
   void InitDecoder(void *model_data, size_t model_data_length);
@@ -103,6 +105,10 @@ class OnlineZipformer2TransducerModel : public OnlineTransducerModel {
   int32_t context_size_ = 0;
   int32_t vocab_size_ = 0;
   int32_t feature_dim_ = 80;
+
+  // for models from
+  // https://github.com/k2-fsa/icefall/blob/master/egs/multi_zh-hans/ASR/RESULTS.md#streaming-with-ctc-head
+  bool use_whisper_feature_ = false;
 };
 
 }  // namespace sherpa_onnx


### PR DESCRIPTION
CC @yuekaizhang 

Support models from https://github.com/k2-fsa/icefall/blob/master/egs/multi_zh-hans/ASR/RESULTS.md#multi-chinese-datasets-char-based-training-results-streaming-on-zipformer-large-model

## usage example
Download  onnx model  files from
https://hf-mirror.com/pingzxy/icefall-asr-multi-zh-hans-zipformer-large-onnx/tree/main
```
wget https://hf-mirror.com/pingzxy/icefall-asr-multi-zh-hans-zipformer-large-onnx/resolve/main/encoder-epoch-99-avg-1-chunk-16-left-128.int8.onnx

wget https://hf-mirror.com/pingzxy/icefall-asr-multi-zh-hans-zipformer-large-onnx/resolve/main/decoder-epoch-99-avg-1-chunk-16-left-128.onnx

wget https://hf-mirror.com/pingzxy/icefall-asr-multi-zh-hans-zipformer-large-onnx/resolve/main/joiner-epoch-99-avg-1-chunk-16-left-128.int8.onnx

wget https://hf-mirror.com/pingzxy/icefall-asr-multi-zh-hans-zipformer-large-onnx/resolve/main/tokens.txt
```

```bash
./build/bin/sherpa-onnx \
  --encoder=./encoder-epoch-99-avg-1-chunk-16-left-128.int8.onnx \
  --decoder=./decoder-epoch-99-avg-1-chunk-16-left-128.onnx \
  --joiner=./joiner-epoch-99-avg-1-chunk-16-left-128.int8.onnx \
  --tokens=./tokens.txt \
  /path/to/some.wav
```

