### PR TITLE
fix(canary): use dynamo export, single input_ids and avoid 0/1 specialization

### DIFF
--- a/scripts/nemo/canary/test_180m_flash.py
+++ b/scripts/nemo/canary/test_180m_flash.py
@@ -263,16 +263,15 @@ def main():
     decoder_input_ids.append(token2id["<|notimestamp|>"])
     decoder_input_ids.append(token2id["<|nodiarize|>"])
 
-    decoder_input_ids.append(0)
-
     decoder_mems_list = [np.zeros((1, 0, 1024), dtype=np.float32) for _ in range(6)]
 
-    logits, decoder_mems_list = model.run_decoder(
-        np.array([decoder_input_ids], dtype=np.int32),
-        decoder_mems_list,
-        enc_states,
-        enc_masks,
-    )
+    for pos, decoder_input_id in enumerate(decoder_input_ids):
+        logits, decoder_mems_list = model.run_decoder(
+            np.array([[decoder_input_id,pos]], dtype=np.int32),
+            decoder_mems_list,
+            enc_states,
+            enc_masks,
+        )
     tokens = [logits.argmax()]
     print("decoder_input_ids", decoder_input_ids)
     eos = token2id["<|endoftext|>"]


### PR DESCRIPTION
Using dynamo export fixes issues related to the decoder producing garbage output on long sequences.
In order to use dynamo, the example input needs to match the runtime inputs, therefore requiring fixed size input_ids at runtime and (to avoid 0/1 specialization) a larger decoder_mems_list in the example. opset_version 18 is required for dynamo export. 

Additionally, I enabled int8 exports for the decoder, it seems to work just fine in my testing, while being twice as fast. The fp16 exports seem to be broken, though, this has been the case before as well.

Fixes https://github.com/k2-fsa/sherpa-onnx/issues/2148