### PR TITLE
Fix TTS for UE

### DIFF
--- a/sherpa-onnx/c-api/cxx-api.cc
+++ b/sherpa-onnx/c-api/cxx-api.cc
@@ -419,7 +419,7 @@ GeneratedAudio OfflineTts::Generate(const std::string &text,
   return ans;
 }
 
-const GeneratedAudio *OfflineTts::Generate2(
+std::shared_ptr<GeneratedAudio> OfflineTts::Generate2(
     const std::string &text, int32_t sid /*= 0*/, float speed /*= 1.0*/,
     OfflineTtsCallback callback /*= nullptr*/, void *arg /*= nullptr*/) const {
   auto audio = Generate(text, sid, speed, callback, arg);
@@ -427,10 +427,10 @@ const GeneratedAudio *OfflineTts::Generate2(
   GeneratedAudio *ans = new GeneratedAudio;
   ans->samples = std::move(audio.samples);
   ans->sample_rate = audio.sample_rate;
-  return ans;
-}
 
-void OfflineTts::FreeGeneratedAudio(const GeneratedAudio *p) { delete p; }
+  return std::shared_ptr<GeneratedAudio>(ans,
+                                         [](GeneratedAudio *p) { delete p; });
+}
 
 KeywordSpotter KeywordSpotter::Create(const KeywordSpotterConfig &config) {
   struct SherpaOnnxKeywordSpotterConfig c;

--- a/sherpa-onnx/c-api/cxx-api.h
+++ b/sherpa-onnx/c-api/cxx-api.h
@@ -6,6 +6,7 @@
 #ifndef SHERPA_ONNX_C_API_CXX_API_H_
 #define SHERPA_ONNX_C_API_CXX_API_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -433,16 +434,12 @@ class SHERPA_ONNX_API OfflineTts
                           OfflineTtsCallback callback = nullptr,
                           void *arg = nullptr) const;
 
-  // like Generate, but return a struct pointer. You need to call
-  // FreeGeneratedAudio() to free the returned pointer to avoid memory leak.
+  // Like Generate, but return a smart pointer.
   //
-  // see also https://github.com/k2-fsa/sherpa-onnx/issues/2347
-  const GeneratedAudio *Generate2(const std::string &text, int32_t sid = 0,
-                                  float speed = 1.0,
-                                  OfflineTtsCallback callback = nullptr,
-                                  void *arg = nullptr) const;
-
-  static void FreeGeneratedAudio(const GeneratedAudio *p);
+  // See also https://github.com/k2-fsa/sherpa-onnx/issues/2347
+  std::shared_ptr<GeneratedAudio> Generate2(
+      const std::string &text, int32_t sid = 0, float speed = 1.0,
+      OfflineTtsCallback callback = nullptr, void *arg = nullptr) const;
 
  private:
   explicit OfflineTts(const SherpaOnnxOfflineTts *p);


### PR DESCRIPTION
Fixes #2347 

---

Unreal Engine has its own memory management, so we cannot return a struct containing a std::vector object.