### PR TITLE
Refactor exporting NeMo models

### DIFF
--- a/.github/workflows/export-nemo-fast-conformer-hybrid-transducer-ctc-non-streaming.yaml
+++ b/.github/workflows/export-nemo-fast-conformer-hybrid-transducer-ctc-non-streaming.yaml
@@ -61,6 +61,11 @@ jobs:
               sherpa-onnx-nemo-fast-conformer-ctc-en-de-es-fr-14288
               sherpa-onnx-nemo-fast-conformer-ctc-be-de-en-es-fr-hr-it-pl-ru-uk-20k
               sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000
+              sherpa-onnx-nemo-fast-conformer-ctc-en-24500-int8
+              sherpa-onnx-nemo-fast-conformer-ctc-es-1424-int8
+              sherpa-onnx-nemo-fast-conformer-ctc-en-de-es-fr-14288-int8
+              sherpa-onnx-nemo-fast-conformer-ctc-be-de-en-es-fr-hr-it-pl-ru-uk-20k-int8
+              sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8
             )
 
             for m in ${models[@]}; do
@@ -89,6 +94,11 @@ jobs:
             sherpa-onnx-nemo-fast-conformer-ctc-en-de-es-fr-14288
             sherpa-onnx-nemo-fast-conformer-ctc-be-de-en-es-fr-hr-it-pl-ru-uk-20k
             sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000
+            sherpa-onnx-nemo-fast-conformer-ctc-en-24500-int8
+            sherpa-onnx-nemo-fast-conformer-ctc-es-1424-int8
+            sherpa-onnx-nemo-fast-conformer-ctc-en-de-es-fr-14288-int8
+            sherpa-onnx-nemo-fast-conformer-ctc-be-de-en-es-fr-hr-it-pl-ru-uk-20k-int8
+            sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8
           )
           for d in ${dirs[@]}; do
             tar cjvf ${d}.tar.bz2 ./$d

--- a/.github/workflows/export-nemo-fast-conformer-hybrid-transducer-ctc.yaml
+++ b/.github/workflows/export-nemo-fast-conformer-hybrid-transducer-ctc.yaml
@@ -54,13 +54,18 @@ jobs:
           curl -SL -O https://hf-mirror.com/csukuangfj/sherpa-onnx-nemo-ctc-en-conformer-small/resolve/main/test_wavs/trans.txt
           popd
 
-          cp -av test_wavs ./sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-80ms
-          cp -av test_wavs ./sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-480ms
-          cp -av test_wavs ./sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-1040ms
-
-          tar cjvf sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-80ms.tar.bz2 sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-80ms
-          tar cjvf sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-480ms.tar.bz2 sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-480ms
-          tar cjvf sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-1040ms.tar.bz2 sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-1040ms
+          names=(
+            sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-80ms
+            sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-480ms
+            sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-1040ms
+            sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-80ms-int8
+            sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-480ms-int8
+            sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-1040ms-int8
+          )
+          for d in ${names[@]}; do
+            cp -av test_wavs $d/
+            tar cjvf $d.tar.bz2 $d
+          done
 
       - name: Release
         uses: svenstaro/upload-release-action@v2
@@ -71,3 +76,41 @@ jobs:
           repo_name: k2-fsa/sherpa-onnx
           repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
           tag: asr-models
+
+      - name: Publish to huggingface
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 20
+          timeout_seconds: 200
+          shell: bash
+          command: |
+            git config --global user.email "csukuangfj@gmail.com"
+            git config --global user.name "Fangjun Kuang"
+
+            models=(
+              sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-80ms
+              sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-480ms
+              sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-1040ms
+              sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-80ms-int8
+              sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-480ms-int8
+              sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-1040ms-int8
+            )
+
+            for m in ${models[@]}; do
+              rm -rf huggingface
+              export GIT_LFS_SKIP_SMUDGE=1
+              export GIT_CLONE_PROTECTION_ACTIVE=false
+              git clone https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/$m huggingface
+              cp -av $m/* huggingface
+              cd huggingface
+              git lfs track "*.onnx"
+              git lfs track "*.wav"
+              git status
+              git add .
+              git status
+              git commit -m "first commit"
+              git push https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/$m main
+              cd ..
+            done

--- a/.github/workflows/export-nemo-fast-conformer-hybrid-transducer-transducer-non-streaming.yaml
+++ b/.github/workflows/export-nemo-fast-conformer-hybrid-transducer-transducer-non-streaming.yaml
@@ -61,6 +61,11 @@ jobs:
               sherpa-onnx-nemo-fast-conformer-transducer-en-de-es-fr-14288
               sherpa-onnx-nemo-fast-conformer-transducer-be-de-en-es-fr-hr-it-pl-ru-uk-20k
               sherpa-onnx-nemo-parakeet_tdt_transducer_110m-en-36000
+              sherpa-onnx-nemo-fast-conformer-transducer-en-24500-int8
+              sherpa-onnx-nemo-fast-conformer-transducer-es-1424-int8
+              sherpa-onnx-nemo-fast-conformer-transducer-en-de-es-fr-14288-int8
+              sherpa-onnx-nemo-fast-conformer-transducer-be-de-en-es-fr-hr-it-pl-ru-uk-20k-int8
+              sherpa-onnx-nemo-parakeet_tdt_transducer_110m-en-36000-int8
             )
 
             for m in ${models[@]}; do
@@ -88,6 +93,11 @@ jobs:
             sherpa-onnx-nemo-fast-conformer-transducer-en-de-es-fr-14288
             sherpa-onnx-nemo-fast-conformer-transducer-be-de-en-es-fr-hr-it-pl-ru-uk-20k
             sherpa-onnx-nemo-parakeet_tdt_transducer_110m-en-36000
+            sherpa-onnx-nemo-fast-conformer-transducer-en-24500-int8
+            sherpa-onnx-nemo-fast-conformer-transducer-es-1424-int8
+            sherpa-onnx-nemo-fast-conformer-transducer-en-de-es-fr-14288-int8
+            sherpa-onnx-nemo-fast-conformer-transducer-be-de-en-es-fr-hr-it-pl-ru-uk-20k-int8
+            sherpa-onnx-nemo-parakeet_tdt_transducer_110m-en-36000-int8
           )
           for d in ${dirs[@]}; do
             tar cjvf ${d}.tar.bz2 ./$d

--- a/.github/workflows/export-nemo-fast-conformer-hybrid-transducer-transducer.yaml
+++ b/.github/workflows/export-nemo-fast-conformer-hybrid-transducer-transducer.yaml
@@ -54,13 +54,18 @@ jobs:
           curl -SL -O https://hf-mirror.com/csukuangfj/sherpa-onnx-nemo-ctc-en-conformer-small/resolve/main/test_wavs/trans.txt
           popd
 
-          cp -av test_wavs ./sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-80ms
-          cp -av test_wavs ./sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-480ms
-          cp -av test_wavs ./sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-1040ms
-
-          tar cjvf sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-80ms.tar.bz2 sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-80ms
-          tar cjvf sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-480ms.tar.bz2 sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-480ms
-          tar cjvf sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-1040ms.tar.bz2 sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-1040ms
+          models=(
+            sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-80ms
+            sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-480ms
+            sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-1040ms
+            sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-80ms-int8
+            sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-480ms-int8
+            sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-1040ms-int8
+          )
+          for m in ${models[@]}; do
+            cp -av test_wavs $m
+            tar cjvf $m.tar.bz2 $m
+          done
 
       - name: Release
         uses: svenstaro/upload-release-action@v2
@@ -71,3 +76,41 @@ jobs:
           repo_name: k2-fsa/sherpa-onnx
           repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
           tag: asr-models
+
+      - name: Publish to huggingface
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 20
+          timeout_seconds: 200
+          shell: bash
+          command: |
+            git config --global user.email "csukuangfj@gmail.com"
+            git config --global user.name "Fangjun Kuang"
+
+            models=(
+              sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-80ms
+              sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-480ms
+              sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-1040ms
+              sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-80ms-int8
+              sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-480ms-int8
+              sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-1040ms-int8
+            )
+
+            for m in ${models[@]}; do
+              rm -rf huggingface
+              export GIT_LFS_SKIP_SMUDGE=1
+              export GIT_CLONE_PROTECTION_ACTIVE=false
+              git clone https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/$m huggingface
+              cp -av $m/* huggingface
+              cd huggingface
+              git lfs track "*.onnx"
+              git lfs track "*.wav"
+              git status
+              git add .
+              git status
+              git commit -m "first commit"
+              git push https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/$m main
+              cd ..
+            done

--- a/.github/workflows/export-nemo-parakeet-tdt.yaml
+++ b/.github/workflows/export-nemo-parakeet-tdt.yaml
@@ -1,0 +1,107 @@
+name: export-nemo-parakeet-tdt
+
+on:
+  push:
+    branches:
+      - refactor-export-nemo
+  workflow_dispatch:
+
+concurrency:
+  group: export-nemo-parakeet-tdt-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  export-nemo-parakeet-tdt-0_6b-v2:
+    if: github.repository_owner == 'k2-fsa' || github.repository_owner == 'csukuangfj'
+    name: parakeet tdt
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
+        python-version: ["3.10"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install python dependencies
+        shell: bash
+        run: |
+          pip install \
+            nemo_toolkit['asr'] \
+            "numpy<2" \
+            ipython \
+            kaldi-native-fbank \
+            librosa \
+            onnx==1.17.0 \
+            onnxmltools==1.13.0 \
+            onnxruntime==1.17.1 \
+            soundfile
+
+      - name: Run
+        shell: bash
+        run: |
+          cd scripts/nemo/parakeet-tdt_ctc-0.6b-ja
+          ./run-ctc.sh
+
+      - name: Collect files
+        shell: bash
+        run: |
+          models=(
+            sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8
+            sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-fp16
+          )
+          for m in ${models[@]}; do
+            mv -v scripts/nemo/parakeet-tdt_ctc-0.6b-ja/$m .
+            tar cjfv $m.tar.bz2 $m
+          done
+
+
+      - name: Publish to huggingface
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 20
+          timeout_seconds: 200
+          shell: bash
+          command: |
+            git config --global user.email "csukuangfj@gmail.com"
+            git config --global user.name "Fangjun Kuang"
+
+            models=(
+              sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8
+              sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-fp16
+            )
+
+            for m in ${models[@]}; do
+              rm -rf huggingface
+              export GIT_LFS_SKIP_SMUDGE=1
+              export GIT_CLONE_PROTECTION_ACTIVE=false
+              git clone https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/$m huggingface
+              cp -av $m/* huggingface
+              cd huggingface
+              git lfs track "*.onnx"
+              git lfs track "*.wav"
+              git status
+              git add .
+              git status
+              git commit -m "first commit"
+              git push https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/$m main
+              cd ..
+            done
+
+      - name: Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./*.tar.bz2
+          overwrite: true
+          repo_name: k2-fsa/sherpa-onnx
+          repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
+          tag: asr-models

--- a/.github/workflows/export-nemo-parakeet-tdt.yaml
+++ b/.github/workflows/export-nemo-parakeet-tdt.yaml
@@ -54,7 +54,6 @@ jobs:
         run: |
           models=(
             sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8
-            sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-fp16
           )
           for m in ${models[@]}; do
             mv -v scripts/nemo/parakeet-tdt_ctc-0.6b-ja/$m .
@@ -76,7 +75,6 @@ jobs:
 
             models=(
               sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8
-              sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-fp16
             )
 
             for m in ${models[@]}; do

--- a/scripts/apk/generate-vad-asr-apk-script.py
+++ b/scripts/apk/generate-vad-asr-apk-script.py
@@ -585,7 +585,7 @@ def get_models():
             """,
         ),
         Model(
-            model_name="sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8",
+            model_name="sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8",
             idx=34,
             lang="ja",
             lang2="Japanese",

--- a/scripts/apk/generate-vad-asr-apk-script.py
+++ b/scripts/apk/generate-vad-asr-apk-script.py
@@ -568,6 +568,38 @@ def get_models():
             popd
             """,
         ),
+        Model(
+            model_name="sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8",
+            idx=33,
+            lang="en",
+            lang2="English",
+            short_name="parakeet_tdt_ctc_110m",
+            cmd="""
+            pushd $model_name
+
+            rm -rfv test_wavs
+
+            ls -lh
+
+            popd
+            """,
+        ),
+        Model(
+            model_name="sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8",
+            idx=34,
+            lang="ja",
+            lang2="Japanese",
+            short_name="parakeet-tdt_ctc_0.6b_ja",
+            cmd="""
+            pushd $model_name
+
+            rm -rfv test_wavs
+
+            ls -lh
+
+            popd
+            """,
+        ),
     ]
     return models
 

--- a/scripts/nemo/fast-conformer-hybrid-transducer-ctc/README.md
+++ b/scripts/nemo/fast-conformer-hybrid-transducer-ctc/README.md
@@ -23,5 +23,6 @@ This folder contains scripts for exporting models from
   - https://catalog.ngc.nvidia.com/orgs/nvidia/teams/nemo/models/stt_multilingual_fastconformer_hybrid_large_pc
 
   - https://catalog.ngc.nvidia.com/orgs/nvidia/teams/nemo/models/parakeet-tdt_ctc-110m
+  - https://huggingface.co/nvidia/parakeet-tdt_ctc-0.6b-ja
 
 to `sherpa-onnx`.

--- a/scripts/nemo/fast-conformer-hybrid-transducer-ctc/export-onnx-ctc-non-streaming.py
+++ b/scripts/nemo/fast-conformer-hybrid-transducer-ctc/export-onnx-ctc-non-streaming.py
@@ -6,6 +6,7 @@ from typing import Dict
 import nemo.collections.asr as nemo_asr
 import onnx
 import torch
+from onnxruntime.quantization import QuantType, quantize_dynamic
 
 
 def get_args():
@@ -85,6 +86,12 @@ def main():
         "doc": args.doc,
     }
     add_meta_data(filename, meta_data)
+
+    quantize_dynamic(
+        model_input="./model.onnx",
+        model_output="./model.int8.onnx",
+        weight_type=QuantType.QUInt8,
+    )
 
     print("preprocessor", asr_model.cfg.preprocessor)
     print(meta_data)

--- a/scripts/nemo/fast-conformer-hybrid-transducer-ctc/export-onnx-ctc.py
+++ b/scripts/nemo/fast-conformer-hybrid-transducer-ctc/export-onnx-ctc.py
@@ -6,6 +6,7 @@ from typing import Dict
 import nemo.collections.asr as nemo_asr
 import onnx
 import torch
+from onnxruntime.quantization import QuantType, quantize_dynamic
 
 
 def get_args():
@@ -114,6 +115,11 @@ def main():
         "comment": "Only the CTC branch is exported",
     }
     add_meta_data(filename, meta_data)
+    quantize_dynamic(
+        model_input="./model.onnx",
+        model_output="./model.int8.onnx",
+        weight_type=QuantType.QUInt8,
+    )
 
     print(meta_data)
 

--- a/scripts/nemo/fast-conformer-hybrid-transducer-ctc/export-onnx-transducer-non-streaming.py
+++ b/scripts/nemo/fast-conformer-hybrid-transducer-ctc/export-onnx-transducer-non-streaming.py
@@ -6,6 +6,7 @@ from typing import Dict
 import nemo.collections.asr as nemo_asr
 import onnx
 import torch
+from onnxruntime.quantization import QuantType, quantize_dynamic
 
 
 def get_args():
@@ -89,6 +90,13 @@ def main():
         "doc": args.doc,
     }
     add_meta_data("encoder.onnx", meta_data)
+
+    for m in ["encoder", "decoder", "joiner"]:
+        quantize_dynamic(
+            model_input=f"{m}.onnx",
+            model_output=f"{m}.int8.onnx",
+            weight_type=QuantType.QUInt8,
+        )
 
     print(meta_data)
 

--- a/scripts/nemo/fast-conformer-hybrid-transducer-ctc/export-onnx-transducer.py
+++ b/scripts/nemo/fast-conformer-hybrid-transducer-ctc/export-onnx-transducer.py
@@ -6,6 +6,7 @@ from typing import Dict
 import nemo.collections.asr as nemo_asr
 import onnx
 import torch
+from onnxruntime.quantization import QuantType, quantize_dynamic
 
 
 def get_args():
@@ -121,6 +122,13 @@ def main():
         "comment": "Only the transducer branch is exported",
     }
     add_meta_data("encoder.onnx", meta_data)
+
+    for m in ["encoder", "decoder", "joiner"]:
+        quantize_dynamic(
+            model_input=f"{m}.onnx",
+            model_output=f"{m}.int8.onnx",
+            weight_type=QuantType.QUInt8,
+        )
 
     print(meta_data)
 

--- a/scripts/nemo/fast-conformer-hybrid-transducer-ctc/run-ctc-non-streaming.sh
+++ b/scripts/nemo/fast-conformer-hybrid-transducer-ctc/run-ctc-non-streaming.sh
@@ -19,6 +19,12 @@ log "Process $name at $url"
 d=sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000
 mkdir -p $d
 mv -v model.onnx $d/
+cp -v tokens.txt $d/
+ls -lh $d
+
+d=sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8
+mkdir -p $d
+mv -v model.int8.onnx $d/
 mv -v tokens.txt $d/
 ls -lh $d
 
@@ -33,6 +39,12 @@ log "Process $name at $url"
 d=sherpa-onnx-nemo-fast-conformer-ctc-en-24500
 mkdir -p $d
 mv -v model.onnx $d/
+cp -v tokens.txt $d/
+ls -lh $d
+
+d=sherpa-onnx-nemo-fast-conformer-ctc-en-24500-int8
+mkdir -p $d
+mv -v model.int8.onnx $d/
 mv -v tokens.txt $d/
 ls -lh $d
 
@@ -45,6 +57,12 @@ doc="This collection contains the Spanish FastConformer Hybrid (CTC and Transduc
 d=sherpa-onnx-nemo-fast-conformer-ctc-es-1424
 mkdir -p $d
 mv -v model.onnx $d/
+cp -v tokens.txt $d/
+ls -lh $d
+
+d=sherpa-onnx-nemo-fast-conformer-ctc-es-1424-int8
+mkdir -p $d
+mv -v model.int8.onnx $d/
 mv -v tokens.txt $d/
 ls -lh $d
 
@@ -57,6 +75,12 @@ doc="This collection contains the Multilingual FastConformer Hybrid (Transducer 
 d=sherpa-onnx-nemo-fast-conformer-ctc-en-de-es-fr-14288
 mkdir -p $d
 mv -v model.onnx $d/
+cp -v tokens.txt $d/
+ls -lh $d
+
+d=sherpa-onnx-nemo-fast-conformer-ctc-en-de-es-fr-14288-int8
+mkdir -p $d
+mv -v model.int8.onnx $d/
 mv -v tokens.txt $d/
 ls -lh $d
 
@@ -69,6 +93,12 @@ doc="This collection contains the Multilingual FastConformer Hybrid (Transducer 
 d=sherpa-onnx-nemo-fast-conformer-ctc-be-de-en-es-fr-hr-it-pl-ru-uk-20k
 mkdir -p $d
 mv -v model.onnx $d/
+cp -v tokens.txt $d/
+ls -lh $d
+
+d=sherpa-onnx-nemo-fast-conformer-ctc-be-de-en-es-fr-hr-it-pl-ru-uk-20k-int8
+mkdir -p $d
+mv -v model.int8.onnx $d/
 mv -v tokens.txt $d/
 ls -lh $d
 
@@ -92,6 +122,16 @@ mkdir -p $d/test_wavs
 cp en.wav $d/test_wavs/0.wav
 cp -v $data/en-english.wav $d/test_wavs/1.wav
 
+d=sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8
+python3 ./test-onnx-ctc-non-streaming.py \
+  --model $d/model.int8.onnx \
+  --tokens $d/tokens.txt \
+  --wav $data/en-english.wav
+mkdir -p $d/test_wavs
+
+cp en.wav $d/test_wavs/0.wav
+cp -v $data/en-english.wav $d/test_wavs/1.wav
+
 d=sherpa-onnx-nemo-fast-conformer-ctc-en-24500
 python3 ./test-onnx-ctc-non-streaming.py \
   --model $d/model.onnx \
@@ -101,9 +141,26 @@ mkdir -p $d/test_wavs
 cp en.wav $d/test_wavs/0.wav
 cp -v $data/en-english.wav $d/test_wavs
 
+d=sherpa-onnx-nemo-fast-conformer-ctc-en-24500-int8
+python3 ./test-onnx-ctc-non-streaming.py \
+  --model $d/model.int8.onnx \
+  --tokens $d/tokens.txt \
+  --wav $data/en-english.wav
+mkdir -p $d/test_wavs
+cp en.wav $d/test_wavs/0.wav
+cp -v $data/en-english.wav $d/test_wavs
+
 d=sherpa-onnx-nemo-fast-conformer-ctc-es-1424
 python3 ./test-onnx-ctc-non-streaming.py \
   --model $d/model.onnx \
+  --tokens $d/tokens.txt \
+  --wav $data/es-spanish.wav
+mkdir -p $d/test_wavs
+cp -v $data/es-spanish.wav $d/test_wavs
+
+d=sherpa-onnx-nemo-fast-conformer-ctc-es-1424-int8
+python3 ./test-onnx-ctc-non-streaming.py \
+  --model $d/model.int8.onnx \
   --tokens $d/tokens.txt \
   --wav $data/es-spanish.wav
 mkdir -p $d/test_wavs
@@ -119,11 +176,31 @@ for w in en-english.wav de-german.wav es-spanish.wav fr-french.wav; do
   cp -v $data/$w $d/test_wavs
 done
 
+d=sherpa-onnx-nemo-fast-conformer-ctc-en-de-es-fr-14288-int8
+mkdir -p $d/test_wavs
+for w in en-english.wav de-german.wav es-spanish.wav fr-french.wav; do
+  python3 ./test-onnx-ctc-non-streaming.py \
+    --model $d/model.int8.onnx \
+    --tokens $d/tokens.txt \
+    --wav $data/$w
+  cp -v $data/$w $d/test_wavs
+done
+
 d=sherpa-onnx-nemo-fast-conformer-ctc-be-de-en-es-fr-hr-it-pl-ru-uk-20k
 mkdir -p $d/test_wavs
 for w in en-english.wav de-german.wav es-spanish.wav fr-french.wav hr-croatian.wav it-italian.wav po-polish.wav ru-russian.wav uk-ukrainian.wav; do
   python3 ./test-onnx-ctc-non-streaming.py \
     --model $d/model.onnx \
+    --tokens $d/tokens.txt \
+    --wav $data/$w
+  cp -v $data/$w $d/test_wavs
+done
+
+d=sherpa-onnx-nemo-fast-conformer-ctc-be-de-en-es-fr-hr-it-pl-ru-uk-20k-int8
+mkdir -p $d/test_wavs
+for w in en-english.wav de-german.wav es-spanish.wav fr-french.wav hr-croatian.wav it-italian.wav po-polish.wav ru-russian.wav uk-ukrainian.wav; do
+  python3 ./test-onnx-ctc-non-streaming.py \
+    --model $d/model.int8.onnx \
     --tokens $d/tokens.txt \
     --wav $data/$w
   cp -v $data/$w $d/test_wavs

--- a/scripts/nemo/fast-conformer-hybrid-transducer-ctc/run-ctc.sh
+++ b/scripts/nemo/fast-conformer-hybrid-transducer-ctc/run-ctc.sh
@@ -17,11 +17,22 @@ ms=(
 for m in ${ms[@]}; do
   ./export-onnx-ctc.py --model $m
   d=sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-${m}ms
+
+  d_int8=sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-${m}ms-int8
+
   if [ ! -f $d/model.onnx ]; then
-    mkdir -p $d
+    mkdir -p $d $d_int8
     mv -v model.onnx $d/
-    mv -v tokens.txt $d/
+    cp -v tokens.txt $d/
+
+    mv -v model.int8.onnx $d_int8/
+    mv -v tokens.txt $d_int8/
+
+    echo "---$d---"
     ls -lh $d
+
+    echo "---$d_int8---"
+    ls -lh $d_int8
   fi
 done
 
@@ -29,8 +40,16 @@ done
 
 for m in ${ms[@]}; do
   d=sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-${m}ms
+  echo "---$d---"
   python3 ./test-onnx-ctc.py \
     --model $d/model.onnx \
+    --tokens $d/tokens.txt \
+    --wav ./0.wav
+
+  d=sherpa-onnx-nemo-streaming-fast-conformer-ctc-en-${m}ms-int8
+  echo "---$d---"
+  python3 ./test-onnx-ctc.py \
+    --model $d/model.int8.onnx \
     --tokens $d/tokens.txt \
     --wav ./0.wav
 done

--- a/scripts/nemo/fast-conformer-hybrid-transducer-ctc/run-transducer-non-streaming.sh
+++ b/scripts/nemo/fast-conformer-hybrid-transducer-ctc/run-transducer-non-streaming.sh
@@ -18,7 +18,17 @@ log "Process $name at $url"
 ./export-onnx-transducer-non-streaming.py --model $name --doc "$doc"
 d=sherpa-onnx-nemo-parakeet_tdt_transducer_110m-en-36000
 mkdir -p $d
-mv -v *.onnx $d/
+mv -v encoder.onnx $d/
+mv -v decoder.onnx $d/
+mv -v joiner.onnx $d/
+cp -v tokens.txt $d/
+ls -lh $d
+
+d=sherpa-onnx-nemo-parakeet_tdt_transducer_110m-en-36000-int8
+mkdir -p $d
+mv -v encoder.int8.onnx $d/
+mv -v decoder.int8.onnx $d/
+mv -v joiner.int8.onnx $d/
 mv -v tokens.txt $d/
 ls -lh $d
 
@@ -32,7 +42,17 @@ log "Process $name at $url"
 
 d=sherpa-onnx-nemo-fast-conformer-transducer-en-24500
 mkdir -p $d
-mv -v *.onnx $d/
+mv -v encoder.onnx $d/
+mv -v decoder.onnx $d/
+mv -v joiner.onnx $d/
+cp -v tokens.txt $d/
+ls -lh $d
+
+d=sherpa-onnx-nemo-fast-conformer-transducer-en-24500-int8
+mkdir -p $d
+mv -v encoder.int8.onnx $d/
+mv -v decoder.int8.onnx $d/
+mv -v joiner.int8.onnx $d/
 mv -v tokens.txt $d/
 ls -lh $d
 
@@ -44,7 +64,17 @@ doc="This collection contains the Spanish FastConformer Hybrid (CTC and Transduc
 
 d=sherpa-onnx-nemo-fast-conformer-transducer-es-1424
 mkdir -p $d
-mv -v *.onnx $d/
+mv -v encoder.onnx $d/
+mv -v decoder.onnx $d/
+mv -v joiner.onnx $d/
+cp -v tokens.txt $d/
+ls -lh $d
+
+d=sherpa-onnx-nemo-fast-conformer-transducer-es-1424-int8
+mkdir -p $d
+mv -v encoder.int8.onnx $d/
+mv -v decoder.int8.onnx $d/
+mv -v joiner.int8.onnx $d/
 mv -v tokens.txt $d/
 ls -lh $d
 
@@ -56,7 +86,17 @@ doc="This collection contains the Multilingual FastConformer Hybrid (Transducer 
 
 d=sherpa-onnx-nemo-fast-conformer-transducer-en-de-es-fr-14288
 mkdir -p $d
-mv -v *.onnx $d/
+mv -v encoder.onnx $d/
+mv -v decoder.onnx $d/
+mv -v joiner.onnx $d/
+cp -v tokens.txt $d/
+ls -lh $d
+
+d=sherpa-onnx-nemo-fast-conformer-transducer-en-de-es-fr-14288-int8
+mkdir -p $d
+mv -v encoder.int8.onnx $d/
+mv -v decoder.int8.onnx $d/
+mv -v joiner.int8.onnx $d/
 mv -v tokens.txt $d/
 ls -lh $d
 
@@ -68,7 +108,17 @@ doc="This collection contains the Multilingual FastConformer Hybrid (Transducer 
 
 d=sherpa-onnx-nemo-fast-conformer-transducer-be-de-en-es-fr-hr-it-pl-ru-uk-20k
 mkdir -p $d
-mv -v *.onnx $d/
+mv -v encoder.onnx $d/
+mv -v decoder.onnx $d/
+mv -v joiner.onnx $d/
+cp -v tokens.txt $d/
+ls -lh $d
+
+d=sherpa-onnx-nemo-fast-conformer-transducer-be-de-en-es-fr-hr-it-pl-ru-uk-20k-int8
+mkdir -p $d
+mv -v encoder.int8.onnx $d/
+mv -v decoder.int8.onnx $d/
+mv -v joiner.int8.onnx $d/
 mv -v tokens.txt $d/
 ls -lh $d
 
@@ -101,6 +151,25 @@ mkdir -p $d/test_wavs
 cp en.wav $d/test_wavs/0.wav
 cp -v $data/en-english.wav $d/test_wavs
 
+d=sherpa-onnx-nemo-parakeet_tdt_transducer_110m-en-36000-int8
+python3 ./test-onnx-transducer-non-streaming.py \
+  --encoder $d/encoder.int8.onnx \
+  --decoder $d/decoder.int8.onnx \
+  --joiner $d/joiner.int8.onnx \
+  --tokens $d/tokens.txt \
+  --wav $data/en-english.wav
+
+python3 ./test-onnx-transducer-non-streaming.py \
+  --encoder $d/encoder.int8.onnx \
+  --decoder $d/decoder.int8.onnx \
+  --joiner $d/joiner.int8.onnx \
+  --tokens $d/tokens.txt \
+  --wav ./en.wav
+
+mkdir -p $d/test_wavs
+cp en.wav $d/test_wavs/0.wav
+cp -v $data/en-english.wav $d/test_wavs
+
 d=sherpa-onnx-nemo-fast-conformer-transducer-en-24500
 python3 ./test-onnx-transducer-non-streaming.py \
   --encoder $d/encoder.onnx \
@@ -112,11 +181,32 @@ mkdir -p $d/test_wavs
 cp en.wav $d/test_wavs/0.wav
 cp -v $data/en-english.wav $d/test_wavs
 
+d=sherpa-onnx-nemo-fast-conformer-transducer-en-24500-int8
+python3 ./test-onnx-transducer-non-streaming.py \
+  --encoder $d/encoder.int8.onnx \
+  --decoder $d/decoder.int8.onnx \
+  --joiner $d/joiner.int8.onnx \
+  --tokens $d/tokens.txt \
+  --wav $data/en-english.wav
+mkdir -p $d/test_wavs
+cp en.wav $d/test_wavs/0.wav
+cp -v $data/en-english.wav $d/test_wavs
+
 d=sherpa-onnx-nemo-fast-conformer-transducer-es-1424
 python3 ./test-onnx-transducer-non-streaming.py \
   --encoder $d/encoder.onnx \
   --decoder $d/decoder.onnx \
   --joiner $d/joiner.onnx \
+  --tokens $d/tokens.txt \
+  --wav $data/es-spanish.wav
+mkdir -p $d/test_wavs
+cp -v $data/es-spanish.wav $d/test_wavs
+
+d=sherpa-onnx-nemo-fast-conformer-transducer-es-1424-int8
+python3 ./test-onnx-transducer-non-streaming.py \
+  --encoder $d/encoder.int8.onnx \
+  --decoder $d/decoder.int8.onnx \
+  --joiner $d/joiner.int8.onnx \
   --tokens $d/tokens.txt \
   --wav $data/es-spanish.wav
 mkdir -p $d/test_wavs
@@ -134,6 +224,18 @@ for w in en-english.wav de-german.wav es-spanish.wav fr-french.wav; do
   cp -v $data/$w $d/test_wavs
 done
 
+d=sherpa-onnx-nemo-fast-conformer-transducer-en-de-es-fr-14288-int8
+mkdir -p $d/test_wavs
+for w in en-english.wav de-german.wav es-spanish.wav fr-french.wav; do
+  python3 ./test-onnx-transducer-non-streaming.py \
+    --encoder $d/encoder.int8.onnx \
+    --decoder $d/decoder.int8.onnx \
+    --joiner $d/joiner.int8.onnx \
+    --tokens $d/tokens.txt \
+    --wav $data/$w
+  cp -v $data/$w $d/test_wavs
+done
+
 d=sherpa-onnx-nemo-fast-conformer-transducer-be-de-en-es-fr-hr-it-pl-ru-uk-20k
 mkdir -p $d/test_wavs
 for w in en-english.wav de-german.wav es-spanish.wav fr-french.wav hr-croatian.wav it-italian.wav po-polish.wav ru-russian.wav uk-ukrainian.wav; do
@@ -141,6 +243,18 @@ for w in en-english.wav de-german.wav es-spanish.wav fr-french.wav hr-croatian.w
     --encoder $d/encoder.onnx \
     --decoder $d/decoder.onnx \
     --joiner $d/joiner.onnx \
+    --tokens $d/tokens.txt \
+    --wav $data/$w
+  cp -v $data/$w $d/test_wavs
+done
+
+d=sherpa-onnx-nemo-fast-conformer-transducer-be-de-en-es-fr-hr-it-pl-ru-uk-20k-int8
+mkdir -p $d/test_wavs
+for w in en-english.wav de-german.wav es-spanish.wav fr-french.wav hr-croatian.wav it-italian.wav po-polish.wav ru-russian.wav uk-ukrainian.wav; do
+  python3 ./test-onnx-transducer-non-streaming.py \
+    --encoder $d/encoder.int8.onnx \
+    --decoder $d/decoder.int8.onnx \
+    --joiner $d/joiner.int8.onnx \
     --tokens $d/tokens.txt \
     --wav $data/$w
   cp -v $data/$w $d/test_wavs

--- a/scripts/nemo/fast-conformer-hybrid-transducer-ctc/run-transducer.sh
+++ b/scripts/nemo/fast-conformer-hybrid-transducer-ctc/run-transducer.sh
@@ -17,13 +17,24 @@ ms=(
 for m in ${ms[@]}; do
   ./export-onnx-transducer.py --model $m
   d=sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-${m}ms
+  d_int8=sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-${m}ms-int8
   if [ ! -f $d/encoder.onnx ]; then
-    mkdir -p $d
+    mkdir -p $d $d_int8
     mv -v encoder.onnx $d/
     mv -v decoder.onnx $d/
     mv -v joiner.onnx $d/
-    mv -v tokens.txt $d/
+    cp -v tokens.txt $d/
+
+    mv -v encoder.int8.onnx $d_int8/
+    mv -v decoder.int8.onnx $d_int8/
+    mv -v joiner.int8.onnx $d_int8/
+    mv -v tokens.txt $d_int8/
+
+    echo "---$d---"
     ls -lh $d
+
+    echo "---$d_int8---"
+    ls -lh $d_int8
   fi
 done
 
@@ -35,6 +46,14 @@ for m in ${ms[@]}; do
     --encoder $d/encoder.onnx \
     --decoder $d/decoder.onnx \
     --joiner $d/joiner.onnx \
+    --tokens $d/tokens.txt \
+    --wav ./0.wav
+
+  d=sherpa-onnx-nemo-streaming-fast-conformer-transducer-en-${m}ms-int8
+  python3 ./test-onnx-transducer.py \
+    --encoder $d/encoder.int8.onnx \
+    --decoder $d/decoder.int8.onnx \
+    --joiner $d/joiner.int8.onnx \
     --tokens $d/tokens.txt \
     --wav ./0.wav
 done

--- a/scripts/nemo/parakeet-tdt_ctc-0.6b-ja/export-onnx-ctc.py
+++ b/scripts/nemo/parakeet-tdt_ctc-0.6b-ja/export-onnx-ctc.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright      2025  Xiaomi Corp.        (authors: Fangjun Kuang)
+import argparse
+from typing import Dict
+
+import nemo.collections.asr as nemo_asr
+import onnx
+import onnxmltools
+import torch
+from onnxmltools.utils.float16_converter import convert_float_to_float16_model_path
+from onnxruntime.quantization import QuantType, quantize_dynamic
+
+
+def export_onnx_fp16_large_2gb(onnx_fp32_path, onnx_fp16_path):
+    onnx_fp16_model = convert_float_to_float16_model_path(
+        onnx_fp32_path, keep_io_types=True
+    )
+    onnxmltools.utils.save_model(onnx_fp16_model, onnx_fp16_path)
+
+
+def add_meta_data(filename: str, meta_data: Dict[str, str]):
+    """Add meta data to an ONNX model. It is changed in-place.
+
+    Args:
+      filename:
+        Filename of the ONNX model to be changed.
+      meta_data:
+        Key-value pairs.
+    """
+    model = onnx.load(filename)
+    while len(model.metadata_props):
+        model.metadata_props.pop()
+
+    for key, value in meta_data.items():
+        meta = model.metadata_props.add()
+        meta.key = key
+        meta.value = str(value)
+
+    onnx.save(model, filename)
+
+
+@torch.no_grad()
+def main():
+    args = get_args()
+    asr_model = nemo_asr.models.ASRModel.from_pretrained(
+        model_name="nvidia/parakeet-tdt_ctc-0.6b-ja"
+    )
+
+    print(asr_model.cfg)
+    print(asr_model)
+
+    with open("./tokens.txt", "w", encoding="utf-8") as f:
+        for i, s in enumerate(asr_model.joint.vocabulary):
+            f.write(f"{s} {i}\n")
+        f.write(f"<blk> {i+1}\n")
+        print("Saved to tokens.txt")
+
+    decoder_type = "ctc"
+    asr_model.change_decoding_strategy(decoder_type=decoder_type)
+    asr_model.eval()
+
+    asr_model.set_export_config({"decoder_type": "ctc"})
+
+    filename = "model.onnx"
+
+    asr_model.export(filename)
+
+    normalize_type = asr_model.cfg.preprocessor.normalize
+    if normalize_type == "NA":
+        normalize_type = ""
+
+    meta_data = {
+        "vocab_size": asr_model.decoder.vocab_size,
+        "normalize_type": normalize_type,
+        "subsampling_factor": 8,
+        "model_type": "EncDecHybridRNNTCTCBPEModel",
+        "version": "1",
+        "model_author": "NeMo",
+        "url": "https://huggingface.co/nvidia/parakeet-tdt_ctc-0.6b-ja",
+        "comment": "Only the CTC branch is exported",
+        "doc": "See https://huggingface.co/nvidia/parakeet-tdt_ctc-0.6b-ja",
+    }
+    add_meta_data(filename, meta_data)
+
+    export_onnx_fp16_large_2gb("model.onnx", "model.fp16.onnx")
+
+    quantize_dynamic(
+        model_input="./model.onnx",
+        model_output="./model.int8.onnx",
+        weight_type=QuantType.QUInt8,
+    )
+
+    print("preprocessor", asr_model.cfg.preprocessor)
+    print(meta_data)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nemo/parakeet-tdt_ctc-0.6b-ja/run-ctc.sh
+++ b/scripts/nemo/parakeet-tdt_ctc-0.6b-ja/run-ctc.sh
@@ -22,14 +22,6 @@ cp -av test_wavs $d
 ls -lh $d
 
 
-d=sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-fp16
-
-mkdir -p $d
-mv -v model.fp16.onnx $d/
-mv -v tokens.txt $d/
-cp -av test_wavs $d
-ls -lh $d
-
 d=sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8
 python3 ./test-onnx-ctc-non-streaming.py \
   --model $d/model.int8.onnx \
@@ -38,16 +30,5 @@ python3 ./test-onnx-ctc-non-streaming.py \
 
 python3 ./test-onnx-ctc-non-streaming.py \
   --model $d/model.int8.onnx \
-  --tokens $d/tokens.txt \
-  --wav $d/test_wavs/test_ja_2.wav
-
-d=sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-fp16
-python3 ./test-onnx-ctc-non-streaming.py \
-  --model $d/model.fp16.onnx \
-  --tokens $d/tokens.txt \
-  --wav $d/test_wavs/test_ja_1.wav
-
-python3 ./test-onnx-ctc-non-streaming.py \
-  --model $d/model.fp16.onnx \
   --tokens $d/tokens.txt \
   --wav $d/test_wavs/test_ja_2.wav

--- a/scripts/nemo/parakeet-tdt_ctc-0.6b-ja/run-ctc.sh
+++ b/scripts/nemo/parakeet-tdt_ctc-0.6b-ja/run-ctc.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -ex
+
+python3 ./export-onnx-ctc.py
+
+ls -lh *.onnx
+
+mkdir -p test_wavs
+pushd test_wavs
+curl -SL -O https://huggingface.co/csukuangfj/reazonspeech-k2-v2-ja-en/resolve/main/test_wavs/transcripts.txt
+curl -SL -O https://hf-mirror.com/csukuangfj/reazonspeech-k2-v2-ja-en/resolve/main/test_wavs/test_ja_1.wav
+curl -SL -O https://hf-mirror.com/csukuangfj/reazonspeech-k2-v2-ja-en/resolve/main/test_wavs/test_ja_2.wav
+popd
+
+d=sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8
+
+mkdir -p $d
+mv -v model.int8.onnx $d/
+cp -v tokens.txt $d/
+cp -av test_wavs $d
+ls -lh $d
+
+
+d=sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-fp16
+
+mkdir -p $d
+mv -v model.fp16.onnx $d/
+mv -v tokens.txt $d/
+cp -av test_wavs $d
+ls -lh $d
+
+d=sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8
+python3 ./test-onnx-ctc-non-streaming.py \
+  --model $d/model.int8.onnx \
+  --tokens $d/tokens.txt \
+  --wav $d/test_wavs/test_ja_1.wav
+
+python3 ./test-onnx-ctc-non-streaming.py \
+  --model $d/model.int8.onnx \
+  --tokens $d/tokens.txt \
+  --wav $d/test_wavs/test_ja_2.wav
+
+d=sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-fp16
+python3 ./test-onnx-ctc-non-streaming.py \
+  --model $d/model.fp16.onnx \
+  --tokens $d/tokens.txt \
+  --wav $d/test_wavs/test_ja_1.wav
+
+python3 ./test-onnx-ctc-non-streaming.py \
+  --model $d/model.fp16.onnx \
+  --tokens $d/tokens.txt \
+  --wav $d/test_wavs/test_ja_2.wav

--- a/scripts/nemo/parakeet-tdt_ctc-0.6b-ja/test-onnx-ctc-non-streaming.py
+++ b/scripts/nemo/parakeet-tdt_ctc-0.6b-ja/test-onnx-ctc-non-streaming.py
@@ -1,0 +1,1 @@
+../fast-conformer-hybrid-transducer-ctc/test-onnx-ctc-non-streaming.py

--- a/sherpa-onnx/kotlin-api/OfflineRecognizer.kt
+++ b/sherpa-onnx/kotlin-api/OfflineRecognizer.kt
@@ -601,6 +601,26 @@ fun getOfflineModelConfig(type: Int): OfflineModelConfig? {
                 tokens = "$modelDir/tokens.txt",
             )
         }
+
+        33 -> {
+            val modelDir = "sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8"
+            return OfflineModelConfig(
+                nemo = OfflineNemoEncDecCtcModelConfig(
+                    model = "$modelDir/model.int8.onnx",
+                ),
+                tokens = "$modelDir/tokens.txt",
+            )
+        }
+
+        34 -> {
+            val modelDir = "sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8"
+            return OfflineModelConfig(
+                nemo = OfflineNemoEncDecCtcModelConfig(
+                    model = "$modelDir/model.int8.onnx",
+                ),
+                tokens = "$modelDir/tokens.txt",
+            )
+        }
     }
     return null
 }


### PR DESCRIPTION
See also

| | English | Japanese|
|---|---|---|
|Original huggingface repo|[parakeet-tdt_ctc-110m](https://hf.co/nvidia/parakeet-tdt_ctc-110m)|[parakeet-tdt_ctc-0.6b-ja](https://hf.co/nvidia/parakeet-tdt_ctc-0.6b-ja)|
|Doc in sherpa-onnx|[sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000](https://k2-fsa.github.io/sherpa/onnx/pretrained_models/offline-ctc/nemo/english.html#sherpa-onnx-nemo-parakeet-tdt-ctc-110m-en-36000-english)|[sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8](https://k2-fsa.github.io/sherpa/onnx/pretrained_models/offline-ctc/nemo/japanese.html#sherpa-onnx-nemo-parakeet-tdt-ctc-0-6b-ja-35000-int8-japanese)|
|Real-time ASR Android APK|[Download](https://hf-mirror.com/csukuangfj/sherpa-onnx-apk/blob/main/vad-asr-simulated-streaming/1.12.4/sherpa-onnx-1.12.4-arm64-v8a-simulated_streaming_asr-en-parakeet_tdt_ctc_110m.apk)|[Download](https://hf-mirror.com/csukuangfj/sherpa-onnx-apk/blob/main/vad-asr-simulated-streaming/1.12.4/sherpa-onnx-1.12.4-arm64-v8a-simulated_streaming_asr-ja-parakeet-tdt_ctc_0.6b_ja.apk)|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for exporting, quantizing (int8), testing, and publishing new NeMo Fast Conformer and Parakeet TDT ASR models, including Japanese and English variants.
  * Introduced automation for model export, packaging, and publishing to Hugging Face and GitHub releases.
  * Enhanced Android model selection with new int8 quantized model options for Japanese and English.

* **Documentation**
  * Updated model export documentation to include new Parakeet TDT model links.

* **Chores**
  * Improved workflow automation to handle and publish additional int8 model variants across multiple pipelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->