### PR TITLE
Fix compile errors for Linux

### DIFF
--- a/sherpa-onnx/csrc/ten-vad-model.cc
+++ b/sherpa-onnx/csrc/ten-vad-model.cc
@@ -321,7 +321,7 @@ class TenVadModel::Impl {
   static void LogMel(const float *in, int32_t n, float *out) {
     for (int32_t i = 0; i != n; ++i) {
       // 20.79441541679836 is log(32768*32768)
-      out[i] = std::logf(in[i] + 1e-10) - 20.79441541679836f;
+      out[i] = logf(in[i] + 1e-10) - 20.79441541679836f;
     }
   }
 


### PR DESCRIPTION
```
[ 79%] Building CXX object sherpa-onnx/csrc/CMakeFiles/sherpa-onnx-core.dir/speaker-embedding-extractor-impl.cc.o
/home/runner/work/sherpa-onnx/sherpa-onnx/sherpa-onnx/csrc/ten-vad-model.cc: In static member function ‘static void sherpa_onnx::TenVadModel::Impl::LogMel(const float*, int32_t, float*)’:
/home/runner/work/sherpa-onnx/sherpa-onnx/sherpa-onnx/csrc/ten-vad-model.cc:324:21: error: ‘logf’ is not a member of ‘std’; did you mean ‘logbf’?
  324 |       out[i] = std::logf(in[i] + 1e-10) - 20.79441541679836f;
      |                     ^~~~
      |                     logbf
make[2]: *** [sherpa-onnx/csrc/CMakeFiles/sherpa-onnx-core.dir/build.make:1661: sherpa-onnx/csrc/CMakeFiles/sherpa-onnx-core.dir/ten-vad-model.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:2487: sherpa-onnx/csrc/CMakeFiles/sherpa-onnx-core.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
Error: Process completed with exit code 2.
```

Somehow it fails only on Linux, but works on macos and windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to the way logarithmic calculations are performed, with no impact on user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->