### PR TITLE
fix setgraph in OnlineCtcFstDecoderConfig Java api

### DIFF
--- a/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/OnlineCtcFstDecoderConfig.java
+++ b/sherpa-onnx/java-api/src/com/k2fsa/sherpa/onnx/OnlineCtcFstDecoderConfig.java
@@ -32,7 +32,7 @@ public class OnlineCtcFstDecoderConfig {
         }
 
         public Builder setGraph(String model) {
-            this.graph = graph;
+            this.graph = model;
             return this;
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the decoder configuration was not correctly saving the provided graph setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->