### PR TITLE
Fix punctuations in kokoro tts.

### DIFF
--- a/sherpa-onnx/csrc/kokoro-multi-lang-lexicon.cc
+++ b/sherpa-onnx/csrc/kokoro-multi-lang-lexicon.cc
@@ -69,7 +69,9 @@ class KokoroMultiLangLexicon::Impl {
 
   std::vector<TokenIDs> ConvertTextToTokenIds(const std::string &_text,
                                               const std::string &voice) const {
-    std::string text = ToLowerCase(_text);
+    // we cannot convert text to lowercase here since it will affect
+    // how piper_phonemize handles punctuations inside the text
+    std::string text = _text;
     if (debug_) {
       SHERPA_ONNX_LOGE("After converting to lowercase:\n%s", text.c_str());
     }
@@ -300,7 +302,8 @@ class KokoroMultiLangLexicon::Impl {
 
     this_sentence.push_back(0);
 
-    for (const auto &word : words) {
+    for (const auto &_word : words) {
+      auto word = ToLowerCase(_word);
       if (IsPunctuation(word)) {
         this_sentence.push_back(token2id_.at(word));
 


### PR DESCRIPTION
Previously, there were no pauses at the end of a sentence in the text if the text contains multiple sentences.

This PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text processing to handle lowercase conversion at the word level for non-Chinese words, ensuring better punctuation handling.

* **New Features**
  * Enhanced phoneme tokenization by automatically adding a space token after each period phoneme, improving the output sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->