### PR TITLE
add TtsReader app to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,10 @@ It uses sherpa-onnx for speech-to-text and text-to-speech.
 |---|
 |![](https://github.com/user-attachments/assets/f6eea2d5-1807-42cb-9160-be8da2971e1f)|
 
+### [TtsReader - Desktop application](https://github.com/ys-pro-duction/TtsReader)
+
+A desktop text-to-speech application built using Kotlin Multiplatform.
+
 [sherpa-rs]: https://github.com/thewh1teagle/sherpa-rs
 [silero-vad]: https://github.com/snakers4/silero-vad
 [Raspberry Pi]: https://www.raspberrypi.com/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to include a new TtsReader entry with a link and brief description: “A desktop text-to-speech application built using Kotlin Multiplatform.”
  * Added the TtsReader reference near the top of the README and within the “Projects using sherpa-onnx” section for improved discoverability.
  * No code or API changes; documentation only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->