### PR TITLE
Update APK versions

### DIFF
--- a/android/SherpaOnnx/app/build.gradle
+++ b/android/SherpaOnnx/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.k2fsa.sherpa.onnx"
         minSdk 21
         targetSdk 32
-        versionCode 1
-        versionName "1.0"
+        versionCode 20250817
+        versionName "1.12.9"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/SherpaOnnx2Pass/app/build.gradle
+++ b/android/SherpaOnnx2Pass/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.k2fsa.sherpa.onnx"
         minSdk 21
         targetSdk 32
-        versionCode 1
-        versionName "1.0"
+        versionCode 20250817
+        versionName "1.12.9"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/SherpaOnnxAudioTagging/app/build.gradle.kts
+++ b/android/SherpaOnnxAudioTagging/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.k2fsa.sherpa.onnx.audio.tagging"
         minSdk = 21
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 20250817
+        versionName = "1.12.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/android/SherpaOnnxAudioTaggingWearOs/app/build.gradle.kts
+++ b/android/SherpaOnnxAudioTaggingWearOs/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.k2fsa.sherpa.onnx.audio.tagging.wear.os"
         minSdk = 26
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 20250817
+        versionName = "1.12.9"
         vectorDrawables {
             useSupportLibrary = true
         }

--- a/android/SherpaOnnxJavaDemo/app/build.gradle
+++ b/android/SherpaOnnxJavaDemo/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "com.k2fsa.sherpa.onnx"
         minSdk 28
         targetSdk 34
-        versionCode 1
-        versionName "1.0"
+        versionCode 20250817
+        versionName "1.12.9"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/SherpaOnnxKws/app/build.gradle
+++ b/android/SherpaOnnxKws/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.k2fsa.sherpa.onnx"
         minSdk 21
         targetSdk 32
-        versionCode 1
-        versionName "1.0"
+        versionCode 20250817
+        versionName "1.12.9"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/SherpaOnnxSimulateStreamingAsr/app/build.gradle.kts
+++ b/android/SherpaOnnxSimulateStreamingAsr/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.k2fsa.sherpa.onnx.simulate.streaming.asr"
         minSdk = 21
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 20250817
+        versionName = "1.12.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/android/SherpaOnnxSimulateStreamingAsrWearOs/app/build.gradle.kts
+++ b/android/SherpaOnnxSimulateStreamingAsrWearOs/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.k2fsa.sherpa.onnx.simulate.streaming.asr.wear.os"
         minSdk = 28
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 20250817
+        versionName = "1.12.9"
         vectorDrawables {
             useSupportLibrary = true
         }

--- a/android/SherpaOnnxSpeakerDiarization/app/build.gradle.kts
+++ b/android/SherpaOnnxSpeakerDiarization/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.k2fsa.sherpa.onnx.speaker.diarization"
         minSdk = 21
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 20250817
+        versionName = "1.12.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/android/SherpaOnnxSpeakerIdentification/app/build.gradle.kts
+++ b/android/SherpaOnnxSpeakerIdentification/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.k2fsa.sherpa.onnx.speaker.identification"
         minSdk = 21
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 20250817
+        versionName = "1.12.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/android/SherpaOnnxSpokenLanguageIdentification/app/build.gradle.kts
+++ b/android/SherpaOnnxSpokenLanguageIdentification/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.k2fsa.sherpa.onnx.slid"
         minSdk = 21
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 20250817
+        versionName = "1.12.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/android/SherpaOnnxTts/app/build.gradle
+++ b/android/SherpaOnnxTts/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.k2fsa.sherpa.onnx"
         minSdk 21
         targetSdk 32
-        versionCode 1
-        versionName "1.0"
+        versionCode 20250817
+        versionName "1.12.9"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/SherpaOnnxTtsEngine/app/build.gradle.kts
+++ b/android/SherpaOnnxTtsEngine/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.k2fsa.sherpa.onnx.tts.engine"
         minSdk = 21
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 20250817
+        versionName = "1.12.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/android/SherpaOnnxVad/app/build.gradle
+++ b/android/SherpaOnnxVad/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.k2fsa.sherpa.onnx"
         minSdk 21
         targetSdk 33
-        versionCode 1
-        versionName "1.0"
+        versionCode 20250817
+        versionName "1.12.9"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/SherpaOnnxVadAsr/app/build.gradle
+++ b/android/SherpaOnnxVadAsr/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.k2fsa.sherpa.onnx"
         minSdk 21
         targetSdk 33
-        versionCode 1
-        versionName "1.0"
+        versionCode 20250817
+        versionName "1.12.9"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/SherpaOnnxWebSocket/app/build.gradle
+++ b/android/SherpaOnnxWebSocket/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.k2fsa.sherpa.onnx"
         minSdk 21
         targetSdk 32
-        versionCode 1
-        versionName "1.0"
+        versionCode 20250817
+        versionName "1.12.9"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/new-release.sh
+++ b/new-release.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
 set -ex
+
+old_version_code=20250816
+new_version_code=20250817
+
 old_version="1\.12\.8"
 new_version="1\.12\.9"
 replace_str="s/$old_version/$new_version/g"
@@ -8,6 +12,12 @@ replace_str="s/$old_version/$new_version/g"
 sed -i.bak "$replace_str" ./sherpa-onnx/csrc/version.cc
 sha1=$(git describe --match=NeVeRmAtCh --always --abbrev=8)
 date=$(git log -1 --format=%ad --date=local)
+
+find android -name "build.gradle" -type f -exec sed -i.bak "s/versionName \"$old_version\"/versionName \"$new_version\"/g" {} \;
+find android -name "build.gradle.kts" -type f -exec sed -i.bak "s/versionName = \"$old_version\"/versionName = \"$new_version\"/g" {} \;
+
+find android -name "build.gradle" -type f -exec sed -i.bak "s/versionCode $old_version_code/versionCode $new_version_code/g" {} \;
+find android -name "build.gradle.kts" -type f -exec sed -i.bak "s/versionCode = $old_version_code/versionCode = $new_version_code/g" {} \;
 
 sed -i.bak "s/  static const char \*sha1.*/  static const char \*sha1 = \"$sha1\";/g" ./sherpa-onnx/csrc/version.cc
 sed -i.bak "s/  static const char \*date.*/  static const char \*date = \"$date\";/g" ./sherpa-onnx/csrc/version.cc


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped app version to 1.12.9 with updated build number (20250817) across all Android apps, including Wear OS variants.
  - Updated release tooling to propagate the new version and build number consistently across supported platforms and example projects.
  - No functional, behavior, or dependency changes included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->