### PR TITLE
fix(flutter): fix unicode problem in windows path

### DIFF
--- a/flutter-examples/streaming_asr/lib/utils.dart
+++ b/flutter-examples/streaming_asr/lib/utils.dart
@@ -7,7 +7,7 @@ import "dart:io";
 
 // Copy the asset file from src to dst
 Future<String> copyAssetFile(String src, [String? dst]) async {
-  final Directory directory = await getApplicationDocumentsDirectory();
+  final Directory directory = await getApplicationSupportDirectory();
   if (dst == null) {
     dst = basename(src);
   }

--- a/flutter-examples/tts/lib/isolate_tts.dart
+++ b/flutter-examples/tts/lib/isolate_tts.dart
@@ -104,7 +104,7 @@ class IsolateTts {
       throw Exception('You are supposed to select a model by changing the code before you run the app');
     }
 
-    final Directory directory = await getApplicationDocumentsDirectory();
+    final Directory directory = await getApplicationSupportDirectory();
     modelName = p.join(directory.path, modelDir, modelName);
 
     if (ruleFsts != '') {

--- a/flutter-examples/tts/lib/model.dart
+++ b/flutter-examples/tts/lib/model.dart
@@ -109,7 +109,7 @@ Future<sherpa_onnx.OfflineTts> createOfflineTts() async {
         'You are supposed to select a model by changing the code before you run the app');
   }
 
-  final Directory directory = await getApplicationDocumentsDirectory();
+  final Directory directory = await getApplicationSupportDirectory();
   modelName = p.join(directory.path, modelDir, modelName);
 
   if (ruleFsts != '') {

--- a/flutter-examples/tts/lib/utils.dart
+++ b/flutter-examples/tts/lib/utils.dart
@@ -7,7 +7,7 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
 Future<String> generateWaveFilename([String suffix = '']) async {
-  final Directory directory = await getApplicationDocumentsDirectory();
+  final Directory directory = await getApplicationSupportDirectory();
   DateTime now = DateTime.now();
   final filename =
       '${now.year.toString()}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}-${now.hour.toString().padLeft(2, '0')}-${now.minute.toString().padLeft(2, '0')}-${now.second.toString().padLeft(2, '0')}$suffix.wav';
@@ -38,7 +38,7 @@ Future<void> copyAllAssetFiles() async {
 // Copy the asset file from src to dst.
 // If dst already exists, then just skip the copy
 Future<String> copyAssetFile(String src, [String? dst]) async {
-  final Directory directory = await getApplicationDocumentsDirectory();
+  final Directory directory = await getApplicationSupportDirectory();
   if (dst == null) {
     dst = p.basename(src);
   }


### PR DESCRIPTION
When using `flutter run -d windows`, if the path contains Chinese characters, the error `'tokens.txt not found' `occurs. This PR primarily fixes this issue

```txt
D:\a\sherpa-onnx\sherpa-onnx\sherpa-onnx\csrc\online-model-config.cc:Validate:71 tokens: 'C:\Users\qrnni\OneDrive\文件\sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20/tokens.txt' does not exist, you should provide either a tokens buffer or a tokens file
````


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Asset and model files are now stored in the app’s support directory instead of the documents folder, improving platform alignment and reducing unintended user visibility and backup/sync side effects.
  - Retains smart copying behavior (only writes when missing or size differs) to minimize unnecessary writes.

- Chores
  - No public API changes; behavior unchanged aside from storage location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->