### PR TITLE
feat: add punctuation C++ API

### DIFF
--- a/cxx-api-examples/CMakeLists.txt
+++ b/cxx-api-examples/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(sense-voice-cxx-api sherpa-onnx-cxx-api)
 add_executable(nemo-canary-cxx-api ./nemo-canary-cxx-api.cc)
 target_link_libraries(nemo-canary-cxx-api sherpa-onnx-cxx-api)
 
-add_executable(punctuation-cxx-api.cc ./punctuation-cxx-api.cc)
+add_executable(punctuation-cxx-api ./punctuation-cxx-api.cc)
 target_link_libraries(punctuation-cxx-api sherpa-onnx-cxx-api)
 
 if(SHERPA_ONNX_ENABLE_PORTAUDIO)

--- a/cxx-api-examples/CMakeLists.txt
+++ b/cxx-api-examples/CMakeLists.txt
@@ -30,6 +30,9 @@ target_link_libraries(sense-voice-cxx-api sherpa-onnx-cxx-api)
 add_executable(nemo-canary-cxx-api ./nemo-canary-cxx-api.cc)
 target_link_libraries(nemo-canary-cxx-api sherpa-onnx-cxx-api)
 
+add_executable(punctuation-cxx-api.cc ./punctuation-cxx-api.cc)
+target_link_libraries(punctuation-cxx-api sherpa-onnx-cxx-api)
+
 if(SHERPA_ONNX_ENABLE_PORTAUDIO)
   add_executable(sense-voice-simulate-streaming-microphone-cxx-api
     ./sense-voice-simulate-streaming-microphone-cxx-api.cc

--- a/cxx-api-examples/punctuation-cxx-api.cc
+++ b/cxx-api-examples/punctuation-cxx-api.cc
@@ -1,0 +1,50 @@
+// cxx-api-examples/fire-red-asr-cxx-api.cc
+// Copyright (c)  2025  Xiaomi Corporation
+
+//
+// This file demonstrates how to use FireRedAsr AED with sherpa-onnx's C++ API.
+//
+// clang-format off
+//
+// wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-fire-red-asr-large-zh_en-2025-02-16.tar.bz2
+// tar xvf sherpa-onnx-fire-red-asr-large-zh_en-2025-02-16.tar.bz2
+// rm sherpa-onnx-fire-red-asr-large-zh_en-2025-02-16.tar.bz2
+//
+// clang-format on
+
+#include <chrono>  // NOLINT
+#include <iostream>
+#include <string>
+
+#include "sherpa-onnx/c-api/cxx-api.h"
+
+int32_t main() {
+  const char *kUsageMessage = R"usage(
+Add punctuations to the input text.
+
+The input text can contain both Chinese and English words.
+
+Usage:
+
+wget https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12.tar.bz2
+tar xvf sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12.tar.bz2
+rm sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12.tar.bz2
+
+./bin/sherpa-onnx-offline-punctuation \
+  --ct-transformer=./sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12/model.onnx
+  "你好吗how are you Fantasitic 谢谢我很好你怎么样呢"
+
+The output text should look like below:
+)usage";
+  using namespace sherpa_onnx::cxx;  // NOLINT
+  OfflinePunctuationConfig punctuation_config;
+  punctuation_config.model.ct_transformer = "./models/punctuation.onnx";
+  punctuation_config.model.num_threads = 1;
+  punctuation_config.model.debug = false;
+  punctuation_config.model.provider = "cpu";
+  OfflinePunctuation punct = OfflinePunctuation::Create(punctuation_config);
+  std::string text = "你好吗how are you Fantasitic 谢谢我很好你怎么样呢";
+  std::string text_with_punct = punct.AddPunctuation(text);
+  std::cout << "Original text: " << text << std::endl;
+  std::cout << "With punctuation: " << text_with_punct << std::endl;
+}

--- a/cxx-api-examples/punctuation-cxx-api.cc
+++ b/cxx-api-examples/punctuation-cxx-api.cc
@@ -1,16 +1,5 @@
-// cxx-api-examples/fire-red-asr-cxx-api.cc
+// cxx-api-examples/punctuation-cxx-api.cc
 // Copyright (c)  2025  Xiaomi Corporation
-
-//
-// This file demonstrates how to use FireRedAsr AED with sherpa-onnx's C++ API.
-//
-// clang-format off
-//
-// wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-fire-red-asr-large-zh_en-2025-02-16.tar.bz2
-// tar xvf sherpa-onnx-fire-red-asr-large-zh_en-2025-02-16.tar.bz2
-// rm sherpa-onnx-fire-red-asr-large-zh_en-2025-02-16.tar.bz2
-//
-// clang-format on
 
 #include <chrono>  // NOLINT
 #include <iostream>

--- a/cxx-api-examples/punctuation-cxx-api.cc
+++ b/cxx-api-examples/punctuation-cxx-api.cc
@@ -1,39 +1,35 @@
 // cxx-api-examples/punctuation-cxx-api.cc
 // Copyright (c)  2025  Xiaomi Corporation
 
-#include <chrono>  // NOLINT
+// To use punctuation model:
+// wget https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12.tar.bz2
+// tar xvf sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12.tar.bz2
+// rm sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12.tar.bz2
+
 #include <iostream>
 #include <string>
 
 #include "sherpa-onnx/c-api/cxx-api.h"
 
 int32_t main() {
-  const char *kUsageMessage = R"usage(
-Add punctuations to the input text.
-
-The input text can contain both Chinese and English words.
-
-Usage:
-
-wget https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12.tar.bz2
-tar xvf sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12.tar.bz2
-rm sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12.tar.bz2
-
-./bin/sherpa-onnx-offline-punctuation \
-  --ct-transformer=./sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12/model.onnx
-  "你好吗how are you Fantasitic 谢谢我很好你怎么样呢"
-
-The output text should look like below:
-)usage";
   using namespace sherpa_onnx::cxx;  // NOLINT
+
   OfflinePunctuationConfig punctuation_config;
-  punctuation_config.model.ct_transformer = "./models/punctuation.onnx";
+  punctuation_config.model.ct_transformer = "./sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12/model.onnx";
   punctuation_config.model.num_threads = 1;
   punctuation_config.model.debug = false;
   punctuation_config.model.provider = "cpu";
+
   OfflinePunctuation punct = OfflinePunctuation::Create(punctuation_config);
+  if (!punct.Get()) {
+    std::cerr << "Failed to create punctuation model. Please check your config\n";
+    return -1;
+  }
+
   std::string text = "你好吗how are you Fantasitic 谢谢我很好你怎么样呢";
   std::string text_with_punct = punct.AddPunctuation(text);
   std::cout << "Original text: " << text << std::endl;
   std::cout << "With punctuation: " << text_with_punct << std::endl;
+
+  return 0;
 }

--- a/sherpa-onnx/c-api/cxx-api.cc
+++ b/sherpa-onnx/c-api/cxx-api.cc
@@ -840,7 +840,7 @@ OfflinePunctuation::OfflinePunctuation(const SherpaOnnxOfflinePunctuation *p)
   : MoveOnly<OfflinePunctuation, SherpaOnnxOfflinePunctuation>(p) {}
 
 void OfflinePunctuation::Destroy(const SherpaOnnxOfflinePunctuation *p) const {
-  SherpaOnnxDestroyOfflinePunctuation(p_);
+  SherpaOnnxDestroyOfflinePunctuation(p);
 }
 
 std::string OfflinePunctuation::AddPunctuation(const std::string &text) const {

--- a/sherpa-onnx/c-api/cxx-api.cc
+++ b/sherpa-onnx/c-api/cxx-api.cc
@@ -821,4 +821,33 @@ bool FileExists(const std::string &filename) {
   return SherpaOnnxFileExists(filename.c_str());
 }
 
+// ============================================================
+// For Offline Punctuation
+// ============================================================
+OfflinePunctuation OfflinePunctuation::Create(const OfflinePunctuationConfig &config) {
+  struct SherpaOnnxOfflinePunctuationConfig c;
+  memset(&c, 0, sizeof(c));
+  c.model.ct_transformer = config.model.ct_transformer.c_str();
+  c.model.num_threads = config.model.num_threads;
+  c.model.debug = config.model.debug;
+  c.model.provider = config.model.provider.c_str();
+
+  const SherpaOnnxOfflinePunctuation *punct = SherpaOnnxCreateOfflinePunctuation(&c);
+  return OfflinePunctuation(punct);
+}
+
+OfflinePunctuation::OfflinePunctuation(const SherpaOnnxOfflinePunctuation *p)
+  : MoveOnly<OfflinePunctuation, SherpaOnnxOfflinePunctuation>(p) {}
+
+void OfflinePunctuation::Destroy(const SherpaOnnxOfflinePunctuation *p) const {
+  SherpaOnnxDestroyOfflinePunctuation(p_);
+}
+
+std::string OfflinePunctuation::AddPunctuation(const std::string &text) const {
+  const char *result = SherpaOfflinePunctuationAddPunct(p_, text.c_str());
+  std::string ans(result);
+  SherpaOfflinePunctuationFreeText(result);
+  return ans;
+}
+
 }  // namespace sherpa_onnx::cxx

--- a/sherpa-onnx/c-api/cxx-api.h
+++ b/sherpa-onnx/c-api/cxx-api.h
@@ -673,6 +673,34 @@ SHERPA_ONNX_API std::string GetGitSha1();
 SHERPA_ONNX_API std::string GetGitDate();
 SHERPA_ONNX_API bool FileExists(const std::string &filename);
 
+// ============================================================================
+// Offline Punctuation
+// ============================================================================
+struct OfflinePunctuationModelConfig {
+  std::string ct_transformer;
+  int32_t num_threads = 1;
+  bool debug = false;
+  std::string provider = "cpu";
+};
+
+struct OfflinePunctuationConfig {
+  OfflinePunctuationModelConfig model;
+};
+
+class SHERPA_ONNX_API OfflinePunctuation
+    : public MoveOnly<OfflinePunctuation, SherpaOnnxOfflinePunctuation> {
+ public:
+  static OfflinePunctuation Create(const OfflinePunctuationConfig &config);
+
+  void Destroy(const SherpaOnnxOfflinePunctuation *p) const;
+
+  // Add punctuations to the input text and return it.
+  std::string AddPunctuation(const std::string &text) const;
+
+ private:
+  explicit OfflinePunctuation(const SherpaOnnxOfflinePunctuation *p);
+};
+
 }  // namespace sherpa_onnx::cxx
 
 #endif  // SHERPA_ONNX_C_API_CXX_API_H_


### PR DESCRIPTION
## 描述
添加了punctuation的C++ API接口。

## 修改内容
- 在 `cxx-api.h` 中添加了 `OfflinePunctuation` 类声明
- 在 `cxx-api.cc` 中实现了 `OfflinePunctuation` 类的方法
- 提供了 `Create`、`Destroy` 和 `AddPunctuation` 方法
- 遵循现有的C++ API设计模式

## 修改类型
- [x] 新功能
- [ ] Bug修复
- [ ] 文档更新

## 测试
- [x] 已测试
- [ ] 需要测试

## 检查清单
- [x] 代码符合项目规范
- [ ] 添加了必要的测试
- [ ] 更新了相关文档
- [x] 遵循现有的C++ API设计模式

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an offline punctuation API in the C++ wrapper for automatic punctuation restoration.
  * New methods to create/destroy instances and convert raw text into punctuated output.
  * Configurable model path, thread count, compute provider, and debug options.

* **Examples**
  * Added a C++ example demonstrating configuration and usage of offline punctuation.
  * Example now included as a buildable executable in the examples build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->