### PR TITLE
fix ctrl+c may lead to coredump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ us_silver.json
 kokoro-multi-lang-v1_0
 sherpa-onnx-fire-red-asr-large-zh_en-2025-02-16
 cmake-build-debug
+cmake-build-release
 README-DEV.txt
 *.rknn
 *.jit

--- a/cxx-api-examples/parakeet-tdt-ctc-simulate-streaming-microphone-cxx-api.cc
+++ b/cxx-api-examples/parakeet-tdt-ctc-simulate-streaming-microphone-cxx-api.cc
@@ -165,6 +165,9 @@ int32_t main() {
       while (samples_queue.empty() && !stop) {
         condition_variable.wait(lock);
       }
+      if (stop) {
+        break;
+      }
 
       const auto &s = samples_queue.front();
       if (!resampler.Get()) {

--- a/cxx-api-examples/parakeet-tdt-simulate-streaming-microphone-cxx-api.cc
+++ b/cxx-api-examples/parakeet-tdt-simulate-streaming-microphone-cxx-api.cc
@@ -172,6 +172,9 @@ int32_t main() {
       while (samples_queue.empty() && !stop) {
         condition_variable.wait(lock);
       }
+      if (stop) {
+        break;
+      }
 
       const auto &s = samples_queue.front();
       if (!resampler.Get()) {

--- a/cxx-api-examples/sense-voice-simulate-streaming-alsa-cxx-api.cc
+++ b/cxx-api-examples/sense-voice-simulate-streaming-alsa-cxx-api.cc
@@ -172,6 +172,9 @@ as the device_name.
       while (samples_queue.empty() && !stop) {
         condition_variable.wait(lock);
       }
+      if (stop) {
+        break;
+      }
 
       const auto &s = samples_queue.front();
       buffer.insert(buffer.end(), s.begin(), s.end());

--- a/cxx-api-examples/sense-voice-simulate-streaming-microphone-cxx-api.cc
+++ b/cxx-api-examples/sense-voice-simulate-streaming-microphone-cxx-api.cc
@@ -167,6 +167,10 @@ int32_t main() {
         condition_variable.wait(lock);
       }
 
+      if (stop) {
+        break;
+      }
+
       const auto &s = samples_queue.front();
       if (!resampler.Get()) {
         buffer.insert(buffer.end(), s.begin(), s.end());

--- a/cxx-api-examples/zipformer-ctc-simulate-streaming-alsa-cxx-api.cc
+++ b/cxx-api-examples/zipformer-ctc-simulate-streaming-alsa-cxx-api.cc
@@ -170,6 +170,9 @@ as the device_name.
       while (samples_queue.empty() && !stop) {
         condition_variable.wait(lock);
       }
+      if (stop) {
+        break;
+      }
 
       const auto &s = samples_queue.front();
       buffer.insert(buffer.end(), s.begin(), s.end());

--- a/cxx-api-examples/zipformer-ctc-simulate-streaming-microphone-cxx-api.cc
+++ b/cxx-api-examples/zipformer-ctc-simulate-streaming-microphone-cxx-api.cc
@@ -164,6 +164,9 @@ int32_t main() {
       while (samples_queue.empty() && !stop) {
         condition_variable.wait(lock);
       }
+      if (stop) {
+        break;
+      }
 
       const auto &s = samples_queue.front();
       if (!resampler.Get()) {

--- a/cxx-api-examples/zipformer-transducer-simulate-streaming-microphone-cxx-api.cc
+++ b/cxx-api-examples/zipformer-transducer-simulate-streaming-microphone-cxx-api.cc
@@ -172,6 +172,9 @@ int32_t main() {
       while (samples_queue.empty() && !stop) {
         condition_variable.wait(lock);
       }
+      if (stop) {
+        break;
+      }
 
       const auto &s = samples_queue.front();
       if (!resampler.Get()) {


### PR DESCRIPTION
when ctrl+c pressed, stop -> 1 , and samples_queue maybe empty, no need  post processing in such case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved graceful shutdown across C++ streaming examples (Parakeet TDT CTC, Parakeet TDT, SenseVoice ALSA/Microphone, Zipformer CTC ALSA/Microphone, Zipformer Transducer). Prevents rare crashes or errors on stop/CTRL+C by exiting loops safely before accessing empty queues.

- Chores
  - Updated .gitignore to also ignore cmake-build-release, reducing accidental commits of build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->