### PR TITLE
Support 16KB page size for Android

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -59,6 +59,9 @@ jobs:
           export ANDROID_NDK=$ANDROID_NDK_LATEST_HOME
           export SHERPA_ONNX_ENABLE_C_API=ON
           ./build-android-arm64-v8a.sh
+
+          readelf -l ./build-android-arm64-v8a/install/lib/*.so
+
           mkdir -p jniLibs/arm64-v8a/
           cp -v ./build-android-arm64-v8a/install/lib/*.so ./jniLibs/arm64-v8a/
           cp -v ./build-android-arm64-v8a/install/lib/README.md ./jniLibs/arm64-v8a/
@@ -74,6 +77,9 @@ jobs:
           export SHERPA_ONNX_ENABLE_C_API=ON
           ./build-android-armv7-eabi.sh
           mkdir -p ./jniLibs/armeabi-v7a/
+
+          readelf -l ./build-android-armv7-eabi/install/lib/*.so
+
           cp -v ./build-android-armv7-eabi/install/lib/*.so ./jniLibs/armeabi-v7a/
           cp -v ./build-android-armv7-eabi/install/lib/README.md ./jniLibs/armeabi-v7a/
           rm -rf ./build-android-armv7-eabi
@@ -87,6 +93,9 @@ jobs:
           export ANDROID_NDK=$ANDROID_NDK_LATEST_HOME
           export SHERPA_ONNX_ENABLE_C_API=ON
           ./build-android-x86-64.sh
+
+          readelf -l ./build-android-x86-64/install/lib/*.so
+
           mkdir -p ./jniLibs/x86_64
           cp -v ./build-android-x86-64/install/lib/*.so ./jniLibs/x86_64
           cp -v ./build-android-x86-64/install/lib/README.md ./jniLibs/x86_64
@@ -101,6 +110,9 @@ jobs:
           export ANDROID_NDK=$ANDROID_NDK_LATEST_HOME
           export SHERPA_ONNX_ENABLE_C_API=ON
           ./build-android-x86.sh
+
+          readelf -l ./build-android-x86/install/lib/*.so
+
           mkdir -p ./jniLibs/x86
           cp -v ./build-android-x86/install/lib/*.so ./jniLibs/x86
           cp -v ./build-android-x86/install/lib/README.md ./jniLibs/x86

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,12 @@ if(CMAKE_SYSTEM_NAME STREQUAL OHOS)
   set(CMAKE_C_FLAGS "-Wno-unused-command-line-argument ${CMAKE_C_FLAGS}")
 endif()
 
+if(ANDROID)
+  # see https://github.com/microsoft/onnxruntime/pull/22076
+  # https://github.com/k2-fsa/sherpa-onnx/issues/2413
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,max-page-size=16384")
+endif()
+
 message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 message(STATUS "CMAKE_INSTALL_PREFIX: ${CMAKE_INSTALL_PREFIX}")
 message(STATUS "BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS}")

--- a/scripts/apk/generate-asr-apk-script.py
+++ b/scripts/apk/generate-asr-apk-script.py
@@ -143,7 +143,7 @@ def get_models():
             model_name="sherpa-onnx-streaming-zipformer-zh-14M-2023-02-23",
             idx=9,
             lang="zh",
-            short_name="small_zipformer",
+            short_name="small_zipformer_14M_2023_02_23",
             rule_fsts="itn_zh_number.fst",
             cmd="""
             if [ ! -f itn_zh_number.fst ]; then
@@ -167,7 +167,7 @@ def get_models():
             model_name="sherpa-onnx-streaming-zipformer-en-20M-2023-02-17",
             idx=10,
             lang="en",
-            short_name="small_zipformer",
+            short_name="small_zipformer_20M_2023_02_17",
             cmd="""
             pushd $model_name
             rm -fv encoder-epoch-99-avg-1.onnx
@@ -267,7 +267,7 @@ def get_models():
             model_name="sherpa-onnx-streaming-zipformer-small-ctc-zh-int8-2025-04-01",
             idx=15,
             lang="zh",
-            short_name="int8_small_zipformer",
+            short_name="int8_small_zipformer_2025_04_01",
             rule_fsts="itn_zh_number.fst",
             cmd="""
             if [ ! -f itn_zh_number.fst ]; then
@@ -287,7 +287,7 @@ def get_models():
             model_name="sherpa-onnx-streaming-zipformer-small-ctc-zh-2025-04-01",
             idx=16,
             lang="zh",
-            short_name="small_zipformer",
+            short_name="small_zipformer_2025_04_01",
             rule_fsts="itn_zh_number.fst",
             cmd="""
             if [ ! -f itn_zh_number.fst ]; then
@@ -443,7 +443,7 @@ def get_models():
             model_name="sherpa-onnx-streaming-zipformer-small-ru-vosk-int8-2025-08-16",
             idx=25,
             lang="ru",
-            short_name="small_zipformer_int8",
+            short_name="small_zipformer_int8_2025_08_16",
             cmd="""
             pushd $model_name
             rm -rf test_wavs
@@ -458,7 +458,7 @@ def get_models():
             model_name="sherpa-onnx-streaming-zipformer-small-ru-vosk-2025-08-16",
             idx=26,
             lang="ru",
-            short_name="small_zipformer",
+            short_name="small_zipformer_2025_08_16",
             cmd="""
             pushd $model_name
             rm -rf test_wavs


### PR DESCRIPTION
Fixes #2417 

Fixes #2413

Note that I have tested the 16KB page-aligned `.so` also works on `Android < 15`, so we 
use the default 16KB in sherpa-onnx.

We have built 16KB page-aligned `libonnxruntime.so` for onnxruntime 1.17.1

You only need to use the latest master of sherpa-onnx; everything should work as expected.

CC @A1aM0 @KiSaYuNa @tcoln @Skepller @anita-smith1 @shawshuai

<img width="692" height="484" alt="Screenshot 2025-08-24 at 17 56 12" src="https://github.com/user-attachments/assets/b07cb6ce-f5cb-4d35-a529-91198a6b799f" />

<img width="685" height="489" alt="Screenshot 2025-08-24 at 17 56 23" src="https://github.com/user-attachments/assets/78d430e8-1688-476d-b8cb-41d20ea95856" />






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Updated ASR model options to clearly versioned variants across multiple languages, improving selection clarity in generated APKs.

- Chores
  - Adjusted Android linker settings for shared libraries to improve Android build reliability.
  - Added automated validation of built Android libraries across all architectures in the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->