### PR TITLE
Fix kokoro tts for punctuations

### DIFF
--- a/sherpa-onnx/csrc/kokoro-multi-lang-lexicon.cc
+++ b/sherpa-onnx/csrc/kokoro-multi-lang-lexicon.cc
@@ -274,6 +274,10 @@ class KokoroMultiLangLexicon::Impl {
 
   std::vector<std::vector<int32_t>> ConvertNonChineseToTokenIDs(
       const std::string &text, const std::string &voice) const {
+    if (IsPunctuation(text)) {
+      return {std::vector<int32_t>{0, token2id_.at(text), 0}};
+    }
+
     if (!voice.empty()) {
       return ConvertTextToTokenIDsWithEspeak(text, voice);
     }

--- a/swift-api-examples/compute-speaker-embeddings.swift
+++ b/swift-api-examples/compute-speaker-embeddings.swift
@@ -5,6 +5,8 @@ Please download test files used in this script from
 
 https://github.com/k2-fsa/sherpa-onnx/releases/tag/speaker-recongition-models
 */
+import Foundation
+
 func cosineSimilarity(_ a: [Float], _ b: [Float]) -> Float {
   precondition(a.count == b.count, "Vectors must have the same length")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of standalone punctuation in multi-language text processing, ensuring consistent tokenization regardless of selected voice.

* **Documentation**
  * Updated Swift example to include necessary imports, improving out-of-the-box compilation for the speaker embeddings sample.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->