### PR TITLE
Fix uploading win32 libs to huggingface

### DIFF
--- a/.github/workflows/windows-x86.yaml
+++ b/.github/workflows/windows-x86.yaml
@@ -130,7 +130,7 @@ jobs:
             dst=win32/$SHERPA_ONNX_VERSION
             mkdir -p $dst
 
-            cp -v ../sherpa-onnx-*.tar.bz2 ./win32
+            cp -v ../sherpa-onnx-*.tar.bz2 $dst
 
             git status
             git lfs track "*.bz2"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Build metadata now clearly reports the Windows edition and version used to create the binaries, with a reliable fallback if detailed info isn’t available.
- Chores
  - Windows artifacts published to a versioned directory, improving organization and discoverability across releases.
- Refactor
  - Simplified and hardened Windows OS detection during build, reducing errors and ensuring consistent reporting without affecting non-Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->