### PR TITLE
Update alsa.h

### DIFF
--- a/c-api-examples/asr-microphone-example/alsa.h
+++ b/c-api-examples/asr-microphone-example/alsa.h
@@ -1,1 +1,1 @@
-../../sherpa-onnx/csrc/alsa.h
+#include "../../sherpa-onnx/csrc/alsa.h"


### PR DESCRIPTION
没有使用#include 编译错误

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the ASR microphone example header by converting a plain path line into a proper include directive. This ensures the example compiles reliably across environments and correctly links the intended dependency during builds, with no changes to runtime behavior or public APIs. Improves portability and developer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->