### PR TITLE
Fix using sherpa-onnx as a cmake sub-project.

### DIFF
--- a/.github/workflows/linux-jni.yaml
+++ b/.github/workflows/linux-jni.yaml
@@ -62,7 +62,7 @@ jobs:
           path: ./*.jar
 
       - name: Release jar
-        if: repository_owner == 'csukuangfj' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+        if: github.repository_owner == 'csukuangfj' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         uses: svenstaro/upload-release-action@v2
         with:
           file_glob: true

--- a/cmake/cppinyin.cmake
+++ b/cmake/cppinyin.cmake
@@ -43,7 +43,7 @@ function(download_cppinyin)
 
     file(REMOVE ${cppinyin_SOURCE_DIR}/CMakeLists.txt)
     configure_file(
-        ${CMAKE_CURRENT_LIST_DIR}/cmake/cppinyin.patch
+        ${CMAKE_CURRENT_LIST_DIR}/cppinyin.patch
         ${cppinyin_SOURCE_DIR}/CMakeLists.txt
         COPYONLY
     )

--- a/cmake/cppinyin.cmake
+++ b/cmake/cppinyin.cmake
@@ -43,7 +43,7 @@ function(download_cppinyin)
 
     file(REMOVE ${cppinyin_SOURCE_DIR}/CMakeLists.txt)
     configure_file(
-        ${CMAKE_SOURCE_DIR}/cmake/cppinyin.patch
+        ${CMAKE_CURRENT_LIST_DIR}/cmake/cppinyin.patch
         ${cppinyin_SOURCE_DIR}/CMakeLists.txt
         COPYONLY
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected release workflow gating to ensure tag-push releases are published only from the intended repository owner.

* **Chores**
  * Improved build configuration to reference a local project patch for more reliable, portable builds.
  * No changes to user-facing functionality or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->