### PR TITLE
Bug fix-修复armv8l架构下的Android系统调用java-api时启动异常

### DIFF
--- a/sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/LibraryUtils.java
+++ b/sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/LibraryUtils.java
@@ -189,7 +189,9 @@ public class LibraryUtils {
             detectedArch = "x86";
         } else if (arch.startsWith("aarch64") || arch.startsWith("arm64")) {
             detectedArch = "aarch64";
-        } else {
+        } else if (arch.startsWith("arm")) {
+            detectedArch = "arm"; //armv8l架构
+		} else {
             throw new IllegalStateException("Unsupported arch:" + arch);
         }
 


### PR DESCRIPTION
armv8l架构下的系统，比如Android系统，在使用Java api时，启动时直接抛出异常从而启动失败，主要原因是对架构的判断不支持armv8l，增加了判断支持（对应会加载jniLibs/armeabi-v7a库）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly detect and handle ARM-based architectures (e.g., ARMv8l) during OS/CPU detection to prevent errors on affected devices.
  * Improves reliability of native library loading on ARM systems, reducing startup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->