### PR TITLE
Fix initializing symbol table for OnlineRecognizer.

### DIFF
--- a/sherpa-onnx/csrc/online-recognizer-ctc-impl.h
+++ b/sherpa-onnx/csrc/online-recognizer-ctc-impl.h
@@ -79,6 +79,7 @@ class OnlineRecognizerCtcImpl : public OnlineRecognizerImpl {
       : OnlineRecognizerImpl(config),
         config_(config),
         model_(OnlineCtcModel::Create(config.model_config)),
+        sym_(config.model_config.tokens),
         endpoint_(config_.endpoint_config) {
     PostInit();
   }
@@ -242,10 +243,8 @@ class OnlineRecognizerCtcImpl : public OnlineRecognizerImpl {
  private:
   void PostInit() {
     if (!config_.model_config.tokens_buf.empty()) {
-      sym_ = SymbolTable(config_.model_config.tokens_buf, false);
-    } else {
       /// assuming tokens_buf and tokens are guaranteed not being both empty
-      sym_ = SymbolTable(config_.model_config.tokens, true);
+      sym_ = SymbolTable(config_.model_config.tokens_buf, false);
     }
 
     if (!config_.model_config.wenet_ctc.model.empty()) {


### PR DESCRIPTION
See also https://github.com/k2-fsa/sherpa-onnx/issues/2435#issuecomment-3280606973

@MrBzik Please re-download the APK once 
https://github.com/csukuangfj/sherpa-onnx/actions/runs/17649596976
finishes.  It may take 30 miniutes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected tokenizer configuration precedence: when an in-memory token buffer is provided, it is now reliably used; otherwise the token list from configuration is applied. This ensures consistent symbol table initialization and avoids unexpected overrides.
  * No public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->