### PR TITLE
fix: hot update language for sencevoice

### DIFF
--- a/sherpa-onnx/csrc/offline-recognizer-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-impl.h
@@ -51,7 +51,7 @@ class OfflineRecognizerImpl {
 
   std::string ApplyHomophoneReplacer(std::string text) const;
 
- private:
+ protected:
   OfflineRecognizerConfig config_;
   // for inverse text normalization. Used only if
   // config.rule_fsts is not empty or

--- a/sherpa-onnx/csrc/offline-recognizer-sense-voice-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-sense-voice-impl.h
@@ -63,7 +63,6 @@ class OfflineRecognizerSenseVoiceImpl : public OfflineRecognizerImpl {
   explicit OfflineRecognizerSenseVoiceImpl(
       const OfflineRecognizerConfig &config)
       : OfflineRecognizerImpl(config),
-        config_(config),
         symbol_table_(config_.model_config.tokens),
         model_(std::make_unique<OfflineSenseVoiceModel>(config.model_config)) {
     const auto &meta_data = model_->GetModelMetadata();
@@ -83,7 +82,6 @@ class OfflineRecognizerSenseVoiceImpl : public OfflineRecognizerImpl {
   OfflineRecognizerSenseVoiceImpl(Manager *mgr,
                                   const OfflineRecognizerConfig &config)
       : OfflineRecognizerImpl(mgr, config),
-        config_(config),
         symbol_table_(mgr, config_.model_config.tokens),
         model_(std::make_unique<OfflineSenseVoiceModel>(mgr,
                                                         config.model_config)) {
@@ -356,7 +354,6 @@ class OfflineRecognizerSenseVoiceImpl : public OfflineRecognizerImpl {
     }
   }
 
-  OfflineRecognizerConfig config_;
   SymbolTable symbol_table_;
   std::unique_ptr<OfflineSenseVoiceModel> model_;
   std::unique_ptr<OfflineCtcDecoder> decoder_;


### PR DESCRIPTION
since the parent class OfflineRecognizerImpl already have a config, I think OfflineRecognizerSenseVoiceImpl can resue it, if not so, the recognizer.setConfig will not work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal configuration handling within offline recognition components to improve extensibility and maintainability.
  * Adjusted access levels to better support derived implementations without changing external behavior.
  * No impact on features, performance, or UI.
  * No API changes; existing integrations continue to work as before.
  * No user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->