### PR TITLE
Remove hardcoded dithering value in NeMo transducer recognizer

### DIFF
--- a/sherpa-onnx/csrc/offline-recognizer-transducer-nemo-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-transducer-nemo-impl.h
@@ -145,7 +145,7 @@ class OfflineRecognizerTransducerNeMoImpl : public OfflineRecognizerImpl {
     }
 
     config_.feat_config.nemo_normalize_type =
-        model_->FeatureNormalizationMethod();    
+        model_->FeatureNormalizationMethod();
 
     if (model_->IsGigaAM()) {
       config_.feat_config.low_freq = 0;


### PR DESCRIPTION
Remove hardcoded dithering value, so that it is configurable (e.g via command line).

Related to #2258 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal audio feature handling by relying on the model's normalization setting and removing an internal dither override.
  * Minor code formatting cleanup.
  * No expected user-facing changes or impact on recognition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->