### PR TITLE
Fix ios build script

### DIFF
--- a/build-ios.sh
+++ b/build-ios.sh
@@ -138,7 +138,7 @@ done
 
 # Merge archive first, because the following xcodebuild create xcframework
 # cannot accept multi archive with the same architecture.
-libtool -static -o build/simulator/sherpa-onnx.a \
+libtool -static -o build/simulator/libsherpa-onnx.a \
   build/simulator/lib/libcppinyin_core.a \
   build/simulator/lib/libkaldi-native-fbank-core.a \
   build/simulator/lib/libkissfft-float.a \
@@ -153,7 +153,7 @@ libtool -static -o build/simulator/sherpa-onnx.a \
   build/simulator/lib/libespeak-ng.a \
   build/simulator/lib/libssentencepiece_core.a
 
-libtool -static -o build/os64/sherpa-onnx.a \
+libtool -static -o build/os64/libsherpa-onnx.a \
   build/os64/lib/libcppinyin_core.a \
   build/os64/lib/libkaldi-native-fbank-core.a \
   build/os64/lib/libkissfft-float.a \
@@ -171,17 +171,6 @@ libtool -static -o build/os64/sherpa-onnx.a \
 rm -rf sherpa-onnx.xcframework
 
 xcodebuild -create-xcframework \
-      -library "build/os64/sherpa-onnx.a" \
-      -library "build/simulator/sherpa-onnx.a" \
+      -library "build/os64/libsherpa-onnx.a" -headers install/include \
+      -library "build/simulator/libsherpa-onnx.a" -headers install/include  \
       -output sherpa-onnx.xcframework
-
-# Copy Headers
-mkdir -p sherpa-onnx.xcframework/Headers
-cp -av install/include/* sherpa-onnx.xcframework/Headers
-
-pushd sherpa-onnx.xcframework/ios-arm64_x86_64-simulator
-ln -s sherpa-onnx.a libsherpa-onnx.a
-popd
-
-pushd sherpa-onnx.xcframework/ios-arm64
-ln -s sherpa-onnx.a libsherpa-onnx.a

--- a/ios-swift/SherpaOnnx/SherpaOnnx.xcodeproj/project.pbxproj
+++ b/ios-swift/SherpaOnnx/SherpaOnnx.xcodeproj/project.pbxproj
@@ -464,7 +464,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = "${PROJECT_DIR}/../../build-ios/sherpa-onnx.xcframework/Headers/";
 				INFOPLIST_FILE = SherpaOnnx/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
@@ -494,7 +493,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = "${PROJECT_DIR}/../../build-ios/sherpa-onnx.xcframework/Headers/";
 				INFOPLIST_FILE = SherpaOnnx/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;

--- a/ios-swiftui/SherpaOnnx/SherpaOnnx.xcodeproj/project.pbxproj
+++ b/ios-swiftui/SherpaOnnx/SherpaOnnx.xcodeproj/project.pbxproj
@@ -456,7 +456,6 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = "${PROJECT_DIR}/../../build-ios/sherpa-onnx.xcframework/Headers/";
 				INFOPLIST_FILE = SherpaOnnx/Info.plist;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Use microphone to record voice";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -490,7 +489,6 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = "${PROJECT_DIR}/../../build-ios/sherpa-onnx.xcframework/Headers/";
 				INFOPLIST_FILE = SherpaOnnx/Info.plist;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Use microphone to record voice";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/ios-swiftui/SherpaOnnx2Pass/SherpaOnnx2Pass.xcodeproj/project.pbxproj
+++ b/ios-swiftui/SherpaOnnx2Pass/SherpaOnnx2Pass.xcodeproj/project.pbxproj
@@ -305,7 +305,6 @@
 				DEVELOPMENT_ASSET_PATHS = "\"SherpaOnnx2Pass/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = "${PROJECT_DIR}/../../build-ios/sherpa-onnx.xcframework/Headers/";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -336,7 +335,6 @@
 				DEVELOPMENT_ASSET_PATHS = "\"SherpaOnnx2Pass/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = "${PROJECT_DIR}/../../build-ios/sherpa-onnx.xcframework/Headers/";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/ios-swiftui/SherpaOnnxLangID/SherpaOnnxLangID.xcodeproj/project.pbxproj
+++ b/ios-swiftui/SherpaOnnxLangID/SherpaOnnxLangID.xcodeproj/project.pbxproj
@@ -482,7 +482,6 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = "${PROJECT_DIR}/../../build-ios/sherpa-onnx.xcframework/Headers/";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Use microphone to record voice";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -518,7 +517,6 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = "${PROJECT_DIR}/../../build-ios/sherpa-onnx.xcframework/Headers/";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Use microphone to record voice";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/ios-swiftui/SherpaOnnxSubtitle/SherpaOnnxSubtitle.xcodeproj/project.pbxproj
+++ b/ios-swiftui/SherpaOnnxSubtitle/SherpaOnnxSubtitle.xcodeproj/project.pbxproj
@@ -345,7 +345,6 @@
 				DEVELOPMENT_TEAM = 896WS4KUPV;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = "${PROJECT_DIR}/../../build-ios/sherpa-onnx.xcframework/Headers/";
 				INFOPLIST_FILE = SherpaOnnxSubtitle/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -379,7 +378,6 @@
 				DEVELOPMENT_TEAM = 896WS4KUPV;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = "${PROJECT_DIR}/../../build-ios/sherpa-onnx.xcframework/Headers/";
 				INFOPLIST_FILE = SherpaOnnxSubtitle/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;


### PR DESCRIPTION
# Problem
Swift Packages which use `sherpa-onnx` can't find headers and emit errors about missing prefix `lib` in library names.

# Root cause
iOS build script copies headers into `sherpa-onnx.xcframework/Headers`, but it should copy them for each sdk.

# Solution
* Use parameter `-headers` for `xcodebuild -create-xcframework` command so headers are copied for each arch.
* rename `sherpa-onnx.a` into `libsherpa-onnx.a`
* Remove `HEADER_SEARCH_PATHS` setting from Xcode projects cause it not necessary anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Simplified iOS integration: headers are now bundled with the framework, reducing manual setup.
- Bug Fixes
  - Fewer build/link issues on iOS by standardizing library naming and header handling.
- Chores
  - Streamlined iOS build process and artifact generation.
  - Removed custom header search paths from example projects to rely on framework-provided headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->