### PR TITLE
Fix iOS example apps build

### DIFF
--- a/swift-api-examples/SherpaOnnx.swift
+++ b/swift-api-examples/SherpaOnnx.swift
@@ -920,6 +920,7 @@ func sherpaOnnxOfflineTtsModelConfig(
   vits: SherpaOnnxOfflineTtsVitsModelConfig = sherpaOnnxOfflineTtsVitsModelConfig(),
   matcha: SherpaOnnxOfflineTtsMatchaModelConfig = sherpaOnnxOfflineTtsMatchaModelConfig(),
   kokoro: SherpaOnnxOfflineTtsKokoroModelConfig = sherpaOnnxOfflineTtsKokoroModelConfig(),
+  zipvoice: SherpaOnnxOfflineTtsZipvoiceModelConfig = SherpaOnnxOfflineTtsZipvoiceModelConfig(),
   numThreads: Int = 1,
   debug: Int = 0,
   provider: String = "cpu",
@@ -932,7 +933,8 @@ func sherpaOnnxOfflineTtsModelConfig(
     provider: toCPointer(provider),
     matcha: matcha,
     kokoro: kokoro,
-    kitten: kitten
+    kitten: kitten,
+    zipvoice: zipvoice
   )
 }
 


### PR DESCRIPTION
#2487 has added `zipvoice` parameter to `SherpaOnnxOfflineTtsModelConfig` which breaks iOS example apps building.
Fix the issue by adding default parameter to `sherpaOnnxOfflineTtsModelConfig`.