### PR TITLE
Support https://github.com/ASLP-lab/WenetSpeech-Chuan

### DIFF
--- a/.github/workflows/upload-models.yaml
+++ b/.github/workflows/upload-models.yaml
@@ -177,8 +177,29 @@ jobs:
 
           ls -lh *.tar.bz2
 
-      - name: u2ppconformer
+      - name: wenetspeech chuan paraformer
         if: true
+        shell: bash
+        run: |
+          git lfs install
+          d=sherpa-onnx-paraformer-zh-int8-2025-10-07
+          f=sherpa-onnx-paraformer-zh-2025-10-07
+          git clone https://huggingface.co/csukuangfj/$d
+          git clone https://huggingface.co/csukuangfj/$f
+
+          rm -rf $d/.git
+          rm -rf $f/.gi*
+
+          rm -rf $d/.gitattributes
+          rm -rf $f/.gitattributes
+
+          tar cjfv $d.tar.bz2 $d
+          tar cjfv $f.tar.bz2 $f
+
+          ls -lh *.tar.bz2
+
+      - name: u2ppconformer
+        if: false
         shell: bash
         run: |
           git lfs install

--- a/scripts/apk/generate-vad-asr-apk-script.py
+++ b/scripts/apk/generate-vad-asr-apk-script.py
@@ -730,6 +730,22 @@ def get_models():
             popd
             """,
         ),
+        Model(
+            model_name="sherpa-onnx-paraformer-zh-int8-2025-10-07",
+            idx=43,
+            lang="zh",
+            lang2="四川话",
+            short_name="paraformer_四川话",
+            cmd="""
+            pushd $model_name
+
+            rm -rfv test_wavs
+
+            ls -lh
+
+            popd
+            """,
+        ),
     ]
     return models
 

--- a/sherpa-onnx/kotlin-api/OfflineRecognizer.kt
+++ b/sherpa-onnx/kotlin-api/OfflineRecognizer.kt
@@ -720,6 +720,17 @@ fun getOfflineModelConfig(type: Int): OfflineModelConfig? {
                 tokens = "$modelDir/tokens.txt",
             )
         }
+
+        43 -> {
+            val modelDir = "sherpa-onnx-paraformer-zh-int8-2025-10-07"
+            return OfflineModelConfig(
+                paraformer = OfflineParaformerModelConfig(
+                    model = "$modelDir/model.int8.onnx",
+                ),
+                tokens = "$modelDir/tokens.txt",
+                modelType = "paraformer",
+            )
+        }
     }
     return null
 }


### PR DESCRIPTION
Note only the paraformer model is supported.

# Download

https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models

<img width="1287" height="723" alt="截屏2025-10-07 20 27 59" src="https://github.com/user-attachments/assets/9a6d2a4d-8f5a-4f63-a2cf-888a1a383528" />


# Huggingface space

https://huggingface.co/spaces/k2-fsa/automatic-speech-recognition

<img width="1291" height="826" alt="截屏2025-10-07 20 09 54" src="https://github.com/user-attachments/assets/3ecf7a0b-dd3f-4c14-977c-6f734c7371a7" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for a new Chinese Paraformer (int8) offline ASR model, available in the Kotlin API and APK build script.
- Bug Fixes
  - Corrected a script issue that could cause improper termination in the wenetspeech-yue model section.
- Chores
  - Updated CI to package and publish the new Paraformer model artifacts; previous model packaging step retained but disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->