### PR TITLE
Fix crashing in Android KWS demo

### DIFF
--- a/android/SherpaOnnxKws/app/src/main/java/com/k2fsa/sherpa/onnx/MainActivity.kt
+++ b/android/SherpaOnnxKws/app/src/main/java/com/k2fsa/sherpa/onnx/MainActivity.kt
@@ -121,8 +121,8 @@ class MainActivity : AppCompatActivity() {
                 audioRecord?.let {
                   it.stop()
                   it.release()
-                  audioRecord = null
                 }
+                audioRecord = null
 
                 return
             }
@@ -187,8 +187,9 @@ class MainActivity : AppCompatActivity() {
         audioRecord?.let {
           it.stop()
           it.release()
-          audioRecord = null
         }
+
+        audioRecord = null
     }
 
     private fun initMicrophone(): Boolean {


### PR DESCRIPTION
Only manipulate stream inside the recording thread.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio stream lifecycle and stability for keyword spotting: streams are now created when recording starts, validated before use, and reliably released at the end of the session.
  * Keywords are collected and normalized at recording start; failures to initialize the stream show a user-facing error and abort processing to prevent crashes.
  * UI/status messages clarified to better reflect session and keyword handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->