### PR TITLE
Allow up to 30 seconds ASR for sense-voice on Ascend NPU

### DIFF
--- a/sherpa-onnx/csrc/ascend/offline-sense-voice-model-ascend.cc
+++ b/sherpa-onnx/csrc/ascend/offline-sense-voice-model-ascend.cc
@@ -140,7 +140,8 @@ class OfflineSenseVoiceModelAscend::Impl {
   }
 
   void Preallocate() {
-    max_num_frames_ = (10 * 100 - 7) / 6 + 1;
+    // max 30 seconds
+    max_num_frames_ = (30 * 100 - 7) / 6 + 1;
     x_ptr_ = std::make_unique<AclDevicePtr>(max_num_frames_ * feat_dim_ *
                                             sizeof(float));
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended maximum audio input duration from 10 seconds to 30 seconds for the Ascend offline sense-voice model, allowing longer audio samples to be processed without truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->