### PR TITLE
Export models to Ascend 910B3

### DIFF
--- a/.github/workflows/export-paraformer-to-ascend-npu.yaml
+++ b/.github/workflows/export-paraformer-to-ascend-npu.yaml
@@ -3,7 +3,7 @@ name: export-paraformer-to-ascend-npu
 on:
   push:
     branches:
-      - ascend-npu-acl-api
+      - ascend-910b3
   workflow_dispatch:
 
 concurrency:
@@ -58,6 +58,27 @@ jobs:
             cann: "8.2"
 
           - soc_version: "910B2"
+            image: "gpustack/devel-ascendai-cann:8.2.rc1-910b-ubuntu20.04-v2"
+            framework: "WSChuan-ASR"
+            cann: "8.2"
+
+          # ===== Ascend 910B3 =====
+          - soc_version: "910B3"
+            image: "gpustack/ascendai-cann:8.0.RC3-910b-ubuntu20.04-py3.9"
+            framework: "FunASR"
+            cann: "8.0"
+
+          - soc_version: "910B3"
+            image: "gpustack/ascendai-cann:8.0.RC3-910b-ubuntu20.04-py3.9"
+            framework: "WSChuan-ASR"
+            cann: "8.0"
+
+          - soc_version: "910B3"
+            image: "gpustack/devel-ascendai-cann:8.2.rc1-910b-ubuntu20.04-v2"
+            framework: "FunASR"
+            cann: "8.2"
+
+          - soc_version: "910B3"
             image: "gpustack/devel-ascendai-cann:8.2.rc1-910b-ubuntu20.04-v2"
             framework: "WSChuan-ASR"
             cann: "8.2"
@@ -339,7 +360,7 @@ jobs:
           overwrite: true
           repo_name: k2-fsa/sherpa-onnx
           repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
-          tag: asr-models
+          tag: asr-models-ascend
 
       - name: Release
         if: github.repository_owner == 'k2-fsa'
@@ -348,4 +369,4 @@ jobs:
           file_glob: true
           file: ./*.tar.bz2
           overwrite: true
-          tag: asr-models
+          tag: asr-models-ascend

--- a/.github/workflows/export-sense-voice-to-ascend-npu.yaml
+++ b/.github/workflows/export-sense-voice-to-ascend-npu.yaml
@@ -3,7 +3,7 @@ name: export-sense-voice-to-ascend-npu
 on:
   push:
     branches:
-      - ascend-npu-310
+      - ascend-910b3
   workflow_dispatch:
 
 concurrency:
@@ -58,6 +58,27 @@ jobs:
             cann: "8.2"
 
           - soc_version: "910B2"
+            image: "gpustack/devel-ascendai-cann:8.2.rc1-910b-ubuntu20.04-v2"
+            framework: "WSYue-ASR"
+            cann: "8.2"
+
+          # ===== Ascend 910B3 =====
+          - soc_version: "910B3"
+            image: "gpustack/ascendai-cann:8.0.RC3-910b-ubuntu20.04-py3.9"
+            framework: "FunASR"
+            cann: "8.0"
+
+          - soc_version: "910B3"
+            image: "gpustack/ascendai-cann:8.0.RC3-910b-ubuntu20.04-py3.9"
+            framework: "WSYue-ASR"
+            cann: "8.0"
+
+          - soc_version: "910B3"
+            image: "gpustack/devel-ascendai-cann:8.2.rc1-910b-ubuntu20.04-v2"
+            framework: "FunASR"
+            cann: "8.2"
+
+          - soc_version: "910B3"
             image: "gpustack/devel-ascendai-cann:8.2.rc1-910b-ubuntu20.04-v2"
             framework: "WSYue-ASR"
             cann: "8.2"
@@ -279,7 +300,7 @@ jobs:
           overwrite: true
           repo_name: k2-fsa/sherpa-onnx
           repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
-          tag: asr-models
+          tag: asr-models-ascend
 
       - name: Release
         if: github.repository_owner == 'k2-fsa'
@@ -288,4 +309,4 @@ jobs:
           file_glob: true
           file: ./*.tar.bz2
           overwrite: true
-          tag: asr-models
+          tag: asr-models-ascend


### PR DESCRIPTION
Models for ascend npu can be found at
https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models-ascend

See also https://github.com/modelscope/FunASR/issues/2676#issuecomment-3509291266

@zqWu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for Ascend 910B3 hardware platform with CANN 8.0 and 8.2 configurations
  * Extended export workflows for multiple ASR model frameworks across new platform variants
  * Updated release version tagging for improved release management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->