### PR TITLE
Add C# API for Omnilingual ASR CTC models

### DIFF
--- a/.github/scripts/test-dot-net.sh
+++ b/.github/scripts/test-dot-net.sh
@@ -32,6 +32,9 @@ rm -rf sherpa-onnx-nemo-*
 
 cd ../offline-decode-files
 
+./run-omnilingual-asr-ctc.sh
+rm -rf sherpa-onnx-*
+
 ./run-wenet-ctc.sh
 rm -rf sherpa-onnx-*
 

--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,4 @@ am.mvn
 *bpe.model
 config.yaml
 configuration.json
+sherpa-onnx-omnilingual-asr-1600-languages-300M-ctc-int8-2025-11-12

--- a/dotnet-examples/offline-decode-files/Program.cs
+++ b/dotnet-examples/offline-decode-files/Program.cs
@@ -87,6 +87,9 @@ class OfflineDecodeFiles
     [Option("wenet-ctc", Required = false, HelpText = "Path to model.onnx. Used only for Wenet CTC models")]
     public string WenetCtc { get; set; } = string.Empty;
 
+    [Option("omnilingual-asr-ctc", Required = false, HelpText = "Path to model.onnx. Used only for Omnilingual ASR CTC models")]
+    public string Omnilingual { get; set; } = string.Empty;
+
     [Option("sense-voice-model", Required = false, HelpText = "Path to model.onnx. Used only for SenseVoice CTC models")]
     public string SenseVoiceModel { get; set; } = string.Empty;
 
@@ -257,6 +260,10 @@ to download pre-trained Tdnn models.
     else if (!string.IsNullOrEmpty(options.WenetCtc))
     {
       config.ModelConfig.WenetCtc.Model = options.WenetCtc;
+    }
+    else if (!string.IsNullOrEmpty(options.Omnilingual))
+    {
+      config.ModelConfig.Omnilingual.Model = options.Omnilingual;
     }
     else if (!string.IsNullOrEmpty(options.WhisperEncoder))
     {

--- a/dotnet-examples/offline-decode-files/run-omnilingual-asr-ctc.sh
+++ b/dotnet-examples/offline-decode-files/run-omnilingual-asr-ctc.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if [ ! -f sherpa-onnx-omnilingual-asr-1600-languages-300M-ctc-int8-2025-11-12 ]; then
+  curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-omnilingual-asr-1600-languages-300M-ctc-int8-2025-11-12.tar.bz2
+  tar xvf sherpa-onnx-omnilingual-asr-1600-languages-300M-ctc-int8-2025-11-12.tar.bz2
+  rm sherpa-onnx-omnilingual-asr-1600-languages-300M-ctc-int8-2025-11-12.tar.bz2
+fi
+
+dotnet run \
+  --omnilingual-asr-ctc=./sherpa-onnx-omnilingual-asr-1600-languages-300M-ctc-int8-2025-11-12/model.int8.onnx \
+  --tokens=./sherpa-onnx-omnilingual-asr-1600-languages-300M-ctc-int8-2025-11-12/tokens.txt \
+  --files ./sherpa-onnx-omnilingual-asr-1600-languages-300M-ctc-int8-2025-11-12/test_wavs/en.wav

--- a/scripts/dotnet/OfflineModelConfig.cs
+++ b/scripts/dotnet/OfflineModelConfig.cs
@@ -30,6 +30,7 @@ namespace SherpaOnnx
             ZipformerCtc = new OfflineZipformerCtcModelConfig();
             Canary = new OfflineCanaryModelConfig();
             WenetCtc = new OfflineWenetCtcModelConfig();
+            Omnilingual = new OfflineOmnilingualAsrCtcModelConfig();
         }
         public OfflineTransducerModelConfig Transducer;
         public OfflineParaformerModelConfig Paraformer;
@@ -66,5 +67,6 @@ namespace SherpaOnnx
         public OfflineZipformerCtcModelConfig ZipformerCtc;
         public OfflineCanaryModelConfig Canary;
         public OfflineWenetCtcModelConfig WenetCtc;
+        public OfflineOmnilingualAsrCtcModelConfig Omnilingual;
     }
 }

--- a/scripts/dotnet/OfflineOmnilingualAsrCtcModel.cs
+++ b/scripts/dotnet/OfflineOmnilingualAsrCtcModel.cs
@@ -1,0 +1,18 @@
+/// Copyright (c)  2025  Xiaomi Corporation (authors: Fangjun Kuang)
+
+using System.Runtime.InteropServices;
+
+namespace SherpaOnnx
+{
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct OfflineOmnilingualAsrCtcModelConfig
+    {
+        public OfflineOmnilingualAsrCtcModelConfig()
+        {
+            Model = "";
+        }
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string Model;
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added omnilingual ASR CTC model support to .NET offline decoding examples with a new command-line option for model selection.
  * Introduced new test workflow for omnilingual ASR decoding capabilities.

* **Chores**
  * Updated build configuration to manage omnilingual model artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->