### PR TITLE
Export zipformer ctc models to QNN

### DIFF
--- a/.github/workflows/export-zipformer-ctc-to-qnn-20250703.yaml
+++ b/.github/workflows/export-zipformer-ctc-to-qnn-20250703.yaml
@@ -1,0 +1,303 @@
+name: export-zipformer-ctc-to-qnn-20250703
+
+on:
+  push:
+    branches:
+      - qnn-zipformer-ctc-models
+  workflow_dispatch:
+
+concurrency:
+  group: export-zipformer-ctc-to-qnn-20250703-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  export-zipformer-ctc-to-qnn-20250703:
+    if: github.repository_owner == 'k2-fsa' || github.repository_owner == 'csukuangfj'
+    name: ${{ matrix.input_in_seconds }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04]
+        python-version: ["3.10"]
+        input_in_seconds: ["5", "8", "10", "13", "15", "18", "20", "23", "25", "28", "30"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Display NDK HOME
+        shell: bash
+        run: |
+          echo "ANDROID_NDK_LATEST_HOME: ${ANDROID_NDK_LATEST_HOME}"
+          ls -lh ${ANDROID_NDK_LATEST_HOME}
+
+      - name: Create Python virtual environment
+        shell: bash
+        run: |
+          python3 -m venv py310
+          which python3
+          source py310/bin/activate
+          which python3
+
+      - name: Show ndk-build help
+        shell: bash
+        run: |
+          export PATH=${ANDROID_NDK_LATEST_HOME}:$PATH
+          ndk-build --help
+
+      - name: Download toolkit
+        shell: bash
+        run: |
+          curl -SL -O https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.33.0.250327.zip
+          ls -lh v2.33.0.250327.zip
+
+      - name: Unzip toolkit
+        shell: bash
+        run: |
+          unzip v2.33.0.250327.zip
+
+      - name: Show
+        shell: bash
+        run: |
+          ls -lh
+
+          echo "---ls -lh qairt---"
+
+          ls -lh qairt
+
+          echo "---"
+
+      - name: Install linux dependencies
+        shell: bash
+        run: |
+          ls -lh
+
+          echo "---"
+
+          ls -lh qairt
+
+          cd qairt/2.33.0.250327/bin
+          source envsetup.sh
+
+          yes | sudo ${QNN_SDK_ROOT}/bin/check-linux-dependency.sh || true
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          source py310/bin/activate
+
+          cd qairt/2.33.0.250327/bin
+          source envsetup.sh
+
+          python3 -m pip install \
+            mock \
+            numpy \
+            opencv-python \
+            optuna \
+            packaging \
+            pandas \
+            paramiko \
+            pathlib2 \
+            pillow \
+            plotly \
+            protobuf \
+            psutil \
+            pydantic \
+            pytest \
+            pyyaml \
+            rich \
+            scikit-optimize \
+            scipy \
+            six \
+            tabulate \
+            typing-extensions \
+            xlsxwriter
+
+          python3 "${QNN_SDK_ROOT}/bin/check-python-dependency" || true
+
+          which python3
+
+      - name: Install onnx dependencies
+        shell: bash
+        run: |
+          source py310/bin/activate
+          python3 -m pip install --upgrade \
+            torch==2.0.0+cpu -f https://download.pytorch.org/whl/torch \
+            kaldi_native_fbank \
+            pip \
+            "numpy<2" \
+            onnx==1.17.0 \
+            onnxruntime==1.17.1 \
+            soundfile \
+            librosa \
+            onnxsim \
+            sentencepiece \
+            pyyaml
+
+          which python3
+
+      - name: Show qnn-onnx-converter help
+        shell: bash
+        run: |
+          source py310/bin/activate
+
+          pushd qairt/2.33.0.250327/bin
+          source envsetup.sh
+          popd
+
+          qnn-onnx-converter --help
+
+      - name: Show qnn-model-lib-generator help
+        shell: bash
+        run: |
+          source py310/bin/activate
+
+          pushd qairt/2.33.0.250327/bin
+          source envsetup.sh
+          popd
+
+          qnn-model-lib-generator --help
+
+      - name: Show qnn-net-run help
+        shell: bash
+        run: |
+          source py310/bin/activate
+
+          pushd qairt/2.33.0.250327/bin
+          source envsetup.sh
+          popd
+
+          qnn-net-run --help
+
+      - name: Run ${{ matrix.input_in_seconds }}
+        shell: bash
+        run: |
+          source py310/bin/activate
+
+          pushd qairt/2.33.0.250327/bin
+          source envsetup.sh
+          popd
+
+          export PATH=${ANDROID_NDK_LATEST_HOME}:$PATH
+          export LDFLAGS="-Wl,-z,max-page-size=16384"
+
+          mkdir tmp
+
+          cd tmp
+
+          t=${{ matrix.input_in_seconds }}
+          num_frames=$(($t*100))
+
+          echo "num_frames: $num_frames"
+
+          curl -SL -O https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-ctc-zh-2025-07-03-source-models/resolve/main/generate_test_data.py
+          curl -SL -O https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-ctc-zh-2025-07-03-source-models/resolve/main/test.py
+          chmod +x generate_test_data.py
+
+          curl -SL -O https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-ctc-zh-2025-07-03-source-models/resolve/main/0.wav
+          curl -SL -O https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-ctc-zh-2025-07-03-source-models/resolve/main/1.wav
+          curl -SL -O https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-ctc-zh-2025-07-03-source-models/resolve/main/8k.wav
+          curl -SL -O https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-ctc-zh-2025-07-03-source-models/resolve/main/tokens.txt
+
+          ./generate_test_data.py --num-frames $num_frames --wav 0.wav
+          ./generate_test_data.py --num-frames $num_frames --wav 1.wav
+          ./generate_test_data.py --num-frames $num_frames --wav 8k.wav
+
+          echo -e "0.raw\n1.raw\n8k.raw" > input_list.txt
+
+
+          curl -SL -O https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-ctc-zh-2025-07-03-source-models/resolve/main/model-$t-seconds.onnx
+
+          python3 ../scripts/pyannote/segmentation/show-onnx.py --filename ./model-$t-seconds.onnx
+
+
+          echo "export to qnn"
+          echo "----------$t----------"
+
+          qnn-onnx-converter \
+            --input_network model-$t-seconds.onnx \
+            --output_path ./model-$t-seconds-quantized \
+            --out_node log_probs \
+            --input_list ./input_list.txt \
+            --use_native_input_files  \
+            --input_dtype x float32 \
+            --act_bitwidth 16 \
+            --bias_bitwidth 32 \
+            --input_layout x NTF
+
+          ls -lh
+          mv model-$t-seconds-quantized model-$t-seconds-quantized.cpp
+          echo "----"
+          ls -lh
+
+          python3 "${QNN_SDK_ROOT}/bin/x86_64-linux-clang/qnn-model-lib-generator" \
+            -c "model-$t-seconds-quantized.cpp" \
+            -b "model-$t-seconds-quantized.bin" \
+            -o model_libs > /dev/null 2>&1
+
+          ls -lh model_libs/*/
+
+          readelf -lW model_libs/*/lib*.so
+
+          echo "collect results"
+
+          for p in x86_64-linux-clang aarch64-android; do
+            if [[ $p == x86_64-linux-clang ]]; then
+              d=sherpa-onnx-qnn-$t-seconds-zipformer-ctc-zh-2025-07-03-int8-linux-x64
+            elif [[ $p == aarch64-android ]]; then
+              d=sherpa-onnx-qnn-$t-seconds-zipformer-ctc-zh-2025-07-03-int8-android-aarch64
+            else
+              echo "Unknown $p"
+              exit -1
+            fi
+
+            mkdir -p $d
+            mkdir -p $d/test_wavs
+
+            cp -v model_libs/$p/lib*.so $d/libmodel.so
+            cp -v tokens.txt $d
+            cp -v *.wav $d/test_wavs
+
+            echo "num_frames=$num_frames" > $d/info.txt
+            echo "target=$p" >> $d/info.txt
+
+            ls -lh $d
+            tar cjfv $d.tar.bz2 $d
+            ls -lh *.tar.bz2
+            rm -rf $d
+          done
+
+          echo "----show---"
+          ls -lh *.tar.bz2
+
+          mv *.tar.bz2 ../
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.input_in_seconds }}-seconds
+          path: ./tmp/*.json
+
+      - name: Release
+        if: github.repository_owner == 'csukuangfj'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./*.tar.bz2
+          overwrite: true
+          repo_name: k2-fsa/sherpa-onnx
+          repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
+          tag: asr-models-qnn
+
+      - name: Release
+        if: github.repository_owner == 'k2-fsa'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./*.tar.bz2
+          overwrite: true
+          tag: asr-models-qnn


### PR DESCRIPTION
You can find the exported models at
https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models-qnn

The original onnx model is from
https://k2-fsa.github.io/sherpa/onnx/pretrained_models/offline-ctc/icefall/zipformer.html#sherpa-onnx-zipformer-ctc-zh-int8-2025-07-03-chinese

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CI/CD workflow automation for model export and release pipeline, enabling automated quantized model conversion, building, and artifact distribution to GitHub Releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->