### PR TITLE
Add spaces between English words for Homophone replacer.

### DIFF
--- a/sherpa-onnx/csrc/homophone-replacer.cc
+++ b/sherpa-onnx/csrc/homophone-replacer.cc
@@ -4,6 +4,7 @@
 
 #include "sherpa-onnx/csrc/homophone-replacer.h"
 
+#include <cctype>
 #include <fstream>
 #include <memory>
 #include <sstream>
@@ -176,6 +177,9 @@ class HomophoneReplacer::Impl {
           current_pronunciations.clear();
         }
         ans += w;
+        if (isalpha(w[0])) {
+          ans.push_back(' ');
+        }
         continue;
       }
 
@@ -194,6 +198,10 @@ class HomophoneReplacer::Impl {
 
     if (config_.debug) {
       SHERPA_ONNX_LOGE("Output text: '%s'", ans.c_str());
+    }
+
+    if (!ans.empty() && ans.back() == ' ') {
+      ans.pop_back();
     }
 
     return ans;


### PR DESCRIPTION
To fix the following case
![bcc9cfeff5a4b04bb6b492b73eb0ce9a](https://github.com/user-attachments/assets/5c821511-833c-4733-bea6-0d9e5628f50c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced text replacement output with improved spacing between tokens and removal of unnecessary trailing whitespace for cleaner results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->