### PR TITLE
Fix warnings for initializing tts lexicon.

### DIFF
--- a/sherpa-onnx/csrc/character-lexicon.cc
+++ b/sherpa-onnx/csrc/character-lexicon.cc
@@ -266,7 +266,7 @@ class CharacterLexicon::Impl {
 
     while (std::getline(is, line)) {
       ++line_num;
-      if (line.find_first_not_of(" \t") == std::string::npos) {
+      if (line.find_first_not_of(" \t\n\v\f\r") == std::string::npos) {
         // Line is empty or only spaces/tabs, skip it
         continue;
       }


### PR DESCRIPTION
To fix the following warnings
```
/Users/runner/work/sherpa-onnx/sherpa-onnx/sherpa-onnx/csrc/character-lexicon.cc:InitLexicon:300 Empty token ids for ''
/Users/runner/work/sherpa-onnx/sherpa-onnx/sherpa-onnx/csrc/character-lexicon.cc:InitLexicon:300 Empty token ids for ''
/Users/runner/work/sherpa-onnx/sherpa-onnx/sherpa-onnx/csrc/character-lexicon.cc:InitLexicon:300 Empty token ids for ''
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lexicon initialization now skips empty or whitespace-only lines, preventing spurious entries and improving robustness of lexicon loading and parsing. This reduces errors from malformed input and makes the lexicon processing more tolerant of imperfect source files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->