### PR TITLE
Avoid NaN in NeMo speaker embedding models.

### DIFF
--- a/sherpa-onnx/csrc/speaker-embedding-extractor-nemo-impl.h
+++ b/sherpa-onnx/csrc/speaker-embedding-extractor-nemo-impl.h
@@ -130,7 +130,8 @@ class SpeakerEmbeddingExtractorNeMoImpl : public SpeakerEmbeddingExtractorImpl {
 
     auto EX = m.colwise().mean();
     auto EX2 = m.array().pow(2).colwise().sum() / num_frames;
-    auto variance = EX2 - EX.array().pow(2);
+    auto variance = (EX2 - EX.array().pow(2)).max(1e-5);
+
     auto stddev = variance.array().sqrt();
 
     m = (m.rowwise() - EX).array().rowwise() / (stddev.array() + 1e-5);


### PR DESCRIPTION
Fixes #2818

Closes #2841 

@Asasen1

Due to numerical precision, the `variance` might be negative.
```
auto variance = EX2 - EX.array().pow(2);
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced speaker embedding extraction stability by introducing a minimum variance threshold in feature normalization calculations. This fix prevents potential computational errors during audio feature processing and improves handling of edge cases, ensuring more robust and reliable results across diverse audio inputs and conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->