### PR TITLE
Fix punctuations in matcha zh-en tts

### DIFF
--- a/sherpa-onnx/csrc/matcha-tts-lexicon.cc
+++ b/sherpa-onnx/csrc/matcha-tts-lexicon.cc
@@ -197,7 +197,7 @@ class MatchaTtsLexicon::Impl {
   std::vector<TokenIDs> ConvertTextToTokenIds(const std::string &_text) const {
     std::string text = _text;
     std::vector<std::pair<std::string, std::string>> replace_str_pairs = {
-        {"，", ","}, {"、", ","}, {"；", ";"}, {"：", ":"},
+        {"，", ","}, {"、", ","}, {"；", ";"}, {"：", ","},   {":", ","},
         {"。", "."}, {"？", "?"}, {"！", "!"}, {"\\s+", " "},
     };
     for (const auto &p : replace_str_pairs) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced text normalization by standardizing punctuation handling during text processing. Colon characters are now consistently converted during tokenization to ensure more uniform text processing across all inputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->