### PR TITLE
Add CI for Axera NPU

### DIFF
--- a/.github/workflows/axcl-linux-aarch64.yaml
+++ b/.github/workflows/axcl-linux-aarch64.yaml
@@ -103,15 +103,12 @@ jobs:
               mkdir build
               cd build
 
-              BUILD_SHARED_LIBS=ON
-
               cmake \
                 -DALSA_INCLUDE_DIR=$p/alsa-lib/include \
                 -DALSA_LIBRARY=$p/alsa-lib/src/.libs/libasound.so \
                 -DBUILD_SHARED_LIBS=ON \
                 -DCMAKE_INSTALL_PREFIX=./install \
                 -DSHERPA_ONNX_ENABLE_AXCL=ON \
-                -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS \
                 ..
 
               make -j4 install

--- a/.github/workflows/axera-linux-aarch64.yaml
+++ b/.github/workflows/axera-linux-aarch64.yaml
@@ -114,15 +114,12 @@ jobs:
               mkdir build
               cd build
 
-              BUILD_SHARED_LIBS=ON
-
               cmake \
                 -DALSA_INCLUDE_DIR=$p/alsa-lib/include \
                 -DALSA_LIBRARY=$p/alsa-lib/src/.libs/libasound.so \
                 -DBUILD_SHARED_LIBS=ON \
                 -DCMAKE_INSTALL_PREFIX=./install \
                 -DSHERPA_ONNX_ENABLE_AXERA=ON \
-                -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS \
                 ..
 
               make -j4 install
@@ -234,7 +231,7 @@ jobs:
 
             git push https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/sherpa-onnx-libs main
 
-      - name: Release pre-compiled binaries and libs for inux aarch64
+      - name: Release pre-compiled binaries and libs for linux aarch64
         if: github.repository_owner == 'k2-fsa' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         uses: svenstaro/upload-release-action@v2
         with:


### PR DESCRIPTION
You can download pre-built binaries from the releases page— for example, from version v1.12.19:
https://github.com/k2-fsa/sherpa-onnx/releases/tag/v1.12.19

<img width="2732" height="740" alt="Screenshot 2025-12-08 at 11 41 57" src="https://github.com/user-attachments/assets/b9aa05e3-1f02-444c-beec-4e9e68a7577b" />


<img width="2710" height="744" alt="Screenshot 2025-12-08 at 12 05 33" src="https://github.com/user-attachments/assets/3239e6b5-b280-45ca-866c-89dc71f8d129" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated CI workflows to build, package and upload pre-compiled Sherpa-ONNX binaries for Linux ARM64.
  * Supports AXCL and multiple AXERA SOC variants (ax650, ax630c, ax620q), containerized builds, dependency bundling, binary stripping and tar.bz2 packaging.
  * Artifacts can be uploaded to GitHub Releases and published to Hugging Face with retry and conditional-release logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->