### PR TITLE
Optimize streaming output results when VAD does not detect human voice for a long time

### DIFF
--- a/android/SherpaOnnxSimulateStreamingAsr/app/src/main/java/com/k2fsa/sherpa/onnx/simulate/streaming/asr/screens/Home.kt
+++ b/android/SherpaOnnxSimulateStreamingAsr/app/src/main/java/com/k2fsa/sherpa/onnx/simulate/streaming/asr/screens/Home.kt
@@ -143,6 +143,7 @@ fun HomeScreen() {
                     var startTime = System.currentTimeMillis()
                     var lastText = ""
                     var added = false
+                    var speechStartOffset = 0
 
 
                     while (isStarted) {
@@ -162,6 +163,11 @@ fun HomeScreen() {
                                 offset += windowSize
                                 if (!isSpeechStarted && SimulateStreamingAsr.vad.isSpeechDetected()) {
                                     isSpeechStarted = true
+                                    // offset 0.25s
+                                    speechStartOffset = offset - 6400
+                                    if(speechStartOffset < 0) {
+                                        speechStartOffset = 0
+                                    }
                                     startTime = System.currentTimeMillis()
                                 }
                             }
@@ -172,7 +178,7 @@ fun HomeScreen() {
                                 // You can change it to some other value
                                 val stream = SimulateStreamingAsr.recognizer.createStream()
                                 stream.acceptWaveform(
-                                    buffer.subList(0, offset).toFloatArray(),
+                                    buffer.subList(speechStartOffset, offset).toFloatArray(),
                                     sampleRateInHz
                                 )
                                 SimulateStreamingAsr.recognizer.decode(stream)


### PR DESCRIPTION
Optimize streaming output results when VAD does not detect human voice for a long time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized audio sample processing in streaming speech recognition to exclude pre-speech silence, improving recognition efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->