### PR TITLE
[TTS Engine] Fix engine speed

### DIFF
--- a/android/SherpaOnnxTtsEngine/app/src/main/java/com/k2fsa/sherpa/onnx/tts/engine/MainActivity.kt
+++ b/android/SherpaOnnxTtsEngine/app/src/main/java/com/k2fsa/sherpa/onnx/tts/engine/MainActivity.kt
@@ -101,7 +101,7 @@ class MainActivity : ComponentActivity() {
                                             TtsEngine.speed = it
                                             preferenceHelper.setSpeed(it)
                                         },
-                                        valueRange = 0.2F..5.0F,
+                                        valueRange = MIN_TTS_SPEED..MAX_TTS_SPEED,
                                         modifier = Modifier.fillMaxWidth()
                                     )
                                 }

--- a/android/SherpaOnnxTtsEngine/app/src/main/java/com/k2fsa/sherpa/onnx/tts/engine/TtsEngine.kt
+++ b/android/SherpaOnnxTtsEngine/app/src/main/java/com/k2fsa/sherpa/onnx/tts/engine/TtsEngine.kt
@@ -13,6 +13,9 @@ import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
 
+const val MIN_TTS_SPEED = 0.1f
+const val MAX_TTS_SPEED = 5.0f
+
 object TtsEngine {
     var tts: OfflineTts? = null
 

--- a/android/SherpaOnnxTtsEngine/app/src/main/java/com/k2fsa/sherpa/onnx/tts/engine/TtsService.kt
+++ b/android/SherpaOnnxTtsEngine/app/src/main/java/com/k2fsa/sherpa/onnx/tts/engine/TtsService.kt
@@ -112,21 +112,14 @@ class TtsService : TextToSpeechService() {
         val text = request.charSequenceText.toString()
         // Map Android TTS speech rate (where 100 == normal) to engine speed (1.0 == normal)
         // Allow per-request override from external apps; fallback to engine default if absent.
-        val engineSpeed: Float = run {
-            val rate = try {
-                request.speechRate
-            } catch (e: Throwable) {
-                // Some devices might not expose it; fallback
-                -1
-            }
-            if (rate > 0) {
-                // Map 100 -> 1.0f
-                val mapped = rate / 100.0f
-                mapped.coerceIn(0.1f, 5.0f)
-            } else {
-                // Fallback to current engine/global setting
-                TtsEngine.speed
-            }
+        val rate = runCatching { request.speechRate }.getOrDefault(-1)
+        val engineSpeed = if (rate > 0) {
+            // Map 100 -> 1.0f
+            val mapped = rate / 100.0f
+            mapped.coerceIn(MIN_TTS_SPEED, MAX_TTS_SPEED)
+        } else {
+            // Fallback to current engine/global setting
+            TtsEngine.speed
         }
 
         val ret = onIsLanguageAvailable(language, country, variant)
@@ -134,7 +127,7 @@ class TtsService : TextToSpeechService() {
             callback.error()
             return
         }
-        Log.i(TAG, "text: $text, requestedRate: ${try { request.speechRate } catch (_: Throwable) { null }}, engineSpeed: $engineSpeed")
+        Log.i(TAG, "text: $text, engineSpeed: $engineSpeed")
         val tts = TtsEngine.tts!!
 
         // Note that AudioFormat.ENCODING_PCM_FLOAT requires API level >= 24


### PR DESCRIPTION
Increase the maximum TTS playback speed to 5.0 and add support for using the speech rate provided in each TTS request. This allows external clients to dynamically control the engine’s playback speed instead of relying solely on the global setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended speech playback speed bounds to 0.1x–5.0x for broader audio customization.
  * Per-request speech-rate handling with fallback to the global speed and clamping to the new bounds.
  * Added logging of computed playback speed to improve observability and diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->