### PR TITLE
Add missing IDisposable

### DIFF
--- a/scripts/dotnet/DenoisedAudio.cs
+++ b/scripts/dotnet/DenoisedAudio.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace SherpaOnnx
 {
-    public class DenoisedAudio
+    public class DenoisedAudio : IDisposable
     {
         public DenoisedAudio(IntPtr p)
         {

--- a/scripts/dotnet/OfflineTtsGeneratedAudio.cs
+++ b/scripts/dotnet/OfflineTtsGeneratedAudio.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace SherpaOnnx
 {
-    public class OfflineTtsGeneratedAudio
+    public class OfflineTtsGeneratedAudio : IDisposable
     {
         public OfflineTtsGeneratedAudio(IntPtr p)
         {


### PR DESCRIPTION
The IDisposable interface is needed in order for the garbage collector to work properly, else this can lead to a memory leak.  The other classes in the dotnet scripts folder do have IDisposable.  These 2 classes are missing it.  This makes it consistent with the other classes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced resource management patterns in audio processing components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->