### PR TITLE
Add C# API for Google MedASR model

### DIFF
--- a/.github/scripts/test-dot-net.sh
+++ b/.github/scripts/test-dot-net.sh
@@ -32,6 +32,9 @@ rm -rf sherpa-onnx-nemo-*
 
 cd ../offline-decode-files
 
+./run-medasr-ctc.sh
+rm -rf sherpa-onnx-*
+
 ./run-omnilingual-asr-ctc.sh
 rm -rf sherpa-onnx-*
 

--- a/dotnet-examples/offline-decode-files/Program.cs
+++ b/dotnet-examples/offline-decode-files/Program.cs
@@ -90,6 +90,9 @@ class OfflineDecodeFiles
     [Option("omnilingual-asr-ctc", Required = false, HelpText = "Path to model.onnx. Used only for Omnilingual ASR CTC models")]
     public string Omnilingual { get; set; } = string.Empty;
 
+    [Option("medasr", Required = false, HelpText = "Path to model.onnx. Used only for Google MedASR CTC models")]
+    public string MedAsr { get; set; } = string.Empty;
+
     [Option("sense-voice-model", Required = false, HelpText = "Path to model.onnx. Used only for SenseVoice CTC models")]
     public string SenseVoiceModel { get; set; } = string.Empty;
 
@@ -264,6 +267,10 @@ to download pre-trained Tdnn models.
     else if (!string.IsNullOrEmpty(options.Omnilingual))
     {
       config.ModelConfig.Omnilingual.Model = options.Omnilingual;
+    }
+    else if (!string.IsNullOrEmpty(options.MedAsr))
+    {
+      config.ModelConfig.MedAsr.Model = options.MedAsr;
     }
     else if (!string.IsNullOrEmpty(options.WhisperEncoder))
     {

--- a/dotnet-examples/offline-decode-files/run-medasr-ctc.sh
+++ b/dotnet-examples/offline-decode-files/run-medasr-ctc.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if [ ! -f ./sherpa-onnx-medasr-ctc-en-int8-2025-12-25/tokens.txt ]; then
+  curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-medasr-ctc-en-int8-2025-12-25.tar.bz2
+  tar xvf sherpa-onnx-medasr-ctc-en-int8-2025-12-25.tar.bz2
+  rm sherpa-onnx-medasr-ctc-en-int8-2025-12-25.tar.bz2
+fi
+
+dotnet run \
+  --medasr=./sherpa-onnx-medasr-ctc-en-int8-2025-12-25/model.int8.onnx \
+  --tokens=./sherpa-onnx-medasr-ctc-en-int8-2025-12-25/tokens.txt \
+  --files ./sherpa-onnx-medasr-ctc-en-int8-2025-12-25/test_wavs/0.wav

--- a/scripts/dotnet/OfflineMedAsrCtcModel.cs
+++ b/scripts/dotnet/OfflineMedAsrCtcModel.cs
@@ -1,0 +1,18 @@
+/// Copyright (c)  2025  Xiaomi Corporation (authors: Fangjun Kuang)
+
+using System.Runtime.InteropServices;
+
+namespace SherpaOnnx
+{
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct OfflineMedAsrCtcModelConfig
+    {
+        public OfflineMedAsrCtcModelConfig()
+        {
+            Model = "";
+        }
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string Model;
+    }
+}

--- a/scripts/dotnet/OfflineModelConfig.cs
+++ b/scripts/dotnet/OfflineModelConfig.cs
@@ -31,6 +31,7 @@ namespace SherpaOnnx
             Canary = new OfflineCanaryModelConfig();
             WenetCtc = new OfflineWenetCtcModelConfig();
             Omnilingual = new OfflineOmnilingualAsrCtcModelConfig();
+            MedAsr = new OfflineMedAsrCtcModelConfig();
         }
         public OfflineTransducerModelConfig Transducer;
         public OfflineParaformerModelConfig Paraformer;
@@ -68,5 +69,6 @@ namespace SherpaOnnx
         public OfflineCanaryModelConfig Canary;
         public OfflineWenetCtcModelConfig WenetCtc;
         public OfflineOmnilingualAsrCtcModelConfig Omnilingual;
+        public OfflineMedAsrCtcModelConfig MedAsr;
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Google MedASR CTC models to the .NET offline decoding example. Users can now specify MedASR models via a new `--medasr` command-line option and use them for offline speech recognition alongside existing model types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->