### PR TITLE
Remove filesystem header

### DIFF
--- a/sherpa-onnx/csrc/file-utils.h
+++ b/sherpa-onnx/csrc/file-utils.h
@@ -44,6 +44,8 @@ std::vector<char> ReadFile(NativeResourceManager *mgr,
                            const std::string &filename);
 #endif
 
+std::string ResolveAbsolutePath(const std::string &path);
+
 }  // namespace sherpa_onnx
 
 #endif  // SHERPA_ONNX_CSRC_FILE_UTILS_H_

--- a/sherpa-onnx/csrc/offline-funasr-nano-model.cc
+++ b/sherpa-onnx/csrc/offline-funasr-nano-model.cc
@@ -9,7 +9,6 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
-#include <filesystem>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -1016,10 +1015,7 @@ class OfflineFunASRNanoModel::Impl {
     bool has_external_data = FileExists(data_path);
 
     // Resolve absolute path for model file
-    std::string abs_model_path = model_path;
-    if (!model_path.empty() && !std::filesystem::path(model_path).is_absolute()) {
-      abs_model_path = std::filesystem::absolute(model_path).string();
-    }
+    std::string abs_model_path = ResolveAbsolutePath(model_path);
 
     if (has_external_data) {
       // When external data exists, use absolute file path to create session.


### PR DESCRIPTION
To fix the following errors on macOS

```
[ 69%] Building CXX object sherpa-onnx/csrc/CMakeFiles/sherpa-onnx-core.dir/funasr-nano-tokenizer.cc.o
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/offline-funasr-nano-model.cc:1020:50: error: 'path' is unavailable: introduced in macOS 10.15 unknown
 1020 |     if (!model_path.empty() && !std::filesystem::path(model_path).is_absolute()) {
      |                                                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__filesystem/path.h:382:33: note: 'path' has been explicitly m
arked unavailable here
  382 | class _LIBCPP_EXPORTED_FROM_ABI path {
      |                                 ^
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/offline-funasr-nano-model.cc:1020:33: error: 'path' is unavailable: introduced in macOS 10.15 unknown
 1020 |     if (!model_path.empty() && !std::filesystem::path(model_path).is_absolute()) {
      |                                 ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__filesystem/path.h:413:25: note: 'path' has been explicitly m
arked unavailable here
  413 |   _LIBCPP_HIDE_FROM_ABI path(const _Source& __src, format = format::auto_format) {
      |                         ^
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/offline-funasr-nano-model.cc:1020:33: error: '~path' is unavailable: introduced in macOS 10.15 unknown
 1020 |     if (!model_path.empty() && !std::filesystem::path(model_path).is_absolute()) {
      |                                 ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__filesystem/path.h:434:25: note: '~path' has been explicitly
marked unavailable here
  434 |   _LIBCPP_HIDE_FROM_ABI ~path() = default;
      |                         ^
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/offline-funasr-nano-model.cc:1020:67: error: 'is_absolute' is unavailable: introduced in macOS 10.15 unknown
 1020 |     if (!model_path.empty() && !std::filesystem::path(model_path).is_absolute()) {
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved cross-platform path resolution for model file handling to ensure consistent behavior across Windows and POSIX systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->