### PR TITLE
Fix(csrc/melotts): Map 'v' to 'V' phoneme for English MeloTTS

### DIFF
--- a/scripts/melo-tts/test.py
+++ b/scripts/melo-tts/test.py
@@ -15,6 +15,11 @@ class Lexicon:
             for line in f:
                 s, i = line.split()
                 tokens[s] = int(i)
+        # Map "v" to "V" token ID (same as post_replace_ph in MeloTTS, only for English models)
+        # English models have "V" with token ID 14
+        if tokens.get("V") == 14 and "v" in tokens:
+            tokens["v"] = tokens["V"]
+
 
         lexicon = dict()
         with open(lexion_filename, encoding="utf-8") as f:

--- a/sherpa-onnx/csrc/melo-tts-lexicon.cc
+++ b/sherpa-onnx/csrc/melo-tts-lexicon.cc
@@ -228,6 +228,12 @@ class MeloTtsLexicon::Impl {
     if (!token2id_.count("、") && token2id_.count("，")) {
       token2id_["、"] = token2id_["，"];
     }
+
+    // Map 'v' to 'V' token (same as post_replace_ph in MeloTTS)
+    // Only for English models
+    if (meta_data_.language == "en" && token2id_.count("V")) {
+      token2id_["v"] = token2id_["V"];
+    }
   }
 
   void InitLexicon(std::istream &is) {


### PR DESCRIPTION
# Fix: Map lowercase 'v' to 'V' phoneme for English MeloTTS

Fix pronunciation issue  [https://github.com/k2-fsa/sherpa-onnx/issues/2960](https://github.com/k2-fsa/sherpa-onnx/issues/2960) where words containing 'v' were not pronounced properly in English MeloTTS. This PR maps lowercase 'v' to uppercase 'V' phoneme token ID, following the original MeloTTS implementation.

**Changes:**
- `csrc/melo-tts-lexicon.cc`: Added 'v' to 'V' mapping in `InitTokens()` for English models
- `scripts/melo-tts/test.py`: Added same mapping in Python Lexicon class



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token mapping in lexicon initialization for English language models to ensure lowercase characters are properly aliased to their uppercase equivalents during text-to-speech processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->