### PR TITLE
JS: addon static import logic for bundlers

### DIFF
--- a/scripts/node-addon-api/lib/addon-static-import.js
+++ b/scripts/node-addon-api/lib/addon-static-import.js
@@ -1,0 +1,70 @@
+const os = require('os');
+
+let addon = null;
+
+const platform = os.platform() === 'win32' ? 'win' : os.platform();
+const arch = os.arch();
+
+try {
+  if (arch === 'x64') {
+    if (platform === 'win') {
+      // @ts-expect-error
+      addon = require('../sherpa-onnx-win-x64/sherpa-onnx.node')
+    } else if (platform === 'darwin') {
+      // @ts-expect-error
+      addon = require('../sherpa-onnx-darwin-x64/sherpa-onnx.node')
+    } else if (platform === 'linux') {
+      // @ts-expect-error
+      addon = require('../sherpa-onnx-linux-x64/sherpa-onnx.node')
+    }
+  } else if (arch === 'arm64') {
+    if (platform === 'darwin') {
+      // @ts-expect-error
+      addon = require('../sherpa-onnx-darwin-arm64/sherpa-onnx.node')
+    } else if (platform === 'linux') {
+      // @ts-expect-error
+      addon = require('../sherpa-onnx-linux-arm64/sherpa-onnx.node')
+    }
+  } else if (arch === 'ia32') {
+    if (platform === 'win') {
+      // @ts-expect-error
+      addon = require('../sherpa-onnx-win-ia32/sherpa-onnx.node')
+    }
+  }
+} catch (error) {
+  //
+}
+
+if (!addon) {
+  try {
+    if (arch === 'x64') {
+      if (platform === 'win') {
+        // @ts-expect-error
+        addon = require('./node_modules/sherpa-onnx-win-x64/sherpa-onnx.node')
+      } else if (platform === 'darwin') {
+        // @ts-expect-error
+        addon = require('./node_modules/sherpa-onnx-darwin-x64/sherpa-onnx.node')
+      } else if (platform === 'linux') {
+        // @ts-expect-error
+        addon = require('./node_modules/sherpa-onnx-linux-x64/sherpa-onnx.node')
+      }
+    } else if (arch === 'arm64') {
+      if (platform === 'darwin') {
+        // @ts-expect-error
+        addon = require('./node_modules/sherpa-onnx-darwin-arm64/sherpa-onnx.node')
+      } else if (platform === 'linux') {
+        // @ts-expect-error
+        addon = require('./node_modules/sherpa-onnx-linux-arm64/sherpa-onnx.node')
+      }
+    } else if (arch === 'ia32') {
+      if (platform === 'win') {
+        // @ts-expect-error
+        addon = require('./node_modules/sherpa-onnx-win-ia32/sherpa-onnx.node')
+      }
+    }
+  } catch (error) {
+    //
+  }
+}
+ 
+module.exports = addon;

--- a/scripts/node-addon-api/lib/addon.js
+++ b/scripts/node-addon-api/lib/addon.js
@@ -2,11 +2,13 @@
 
 const os = require('os');
 const path = require('path');
+const addonStaticImport = require('./addon-static-import');
 
 // Package name triggered spam for sherpa-onnx-win32-x64
 // so we have renamed it to sherpa-onnx-win-x64
-const platform_arch =
-    `${os.platform() == 'win32' ? 'win' : os.platform()}-${os.arch()}`;
+const platform = os.platform() === 'win32' ? 'win' : os.platform();
+const arch = os.arch();
+const platform_arch = `${platform}-${arch}`;
 const possible_paths = [
   '../build/Release/sherpa-onnx.node',
   '../build/Debug/sherpa-onnx.node',
@@ -15,19 +17,23 @@ const possible_paths = [
   './sherpa-onnx.node',
 ];
 
-let found = false;
-for (const p of possible_paths) {
-  try {
-    module.exports = require(p);
-    found = true;
-    break;
-  } catch (error) {
-    // do nothing; try the next option
-    ;
+let addon = addonStaticImport;
+
+if (!addon) {
+  for (const p of possible_paths) {
+    try {
+      addon = require(p);
+      break;
+    } catch (error) {
+      // do nothing; try the next option
+      ;
+    }
   }
 }
 
-if (!found) {
+module.exports = addon;
+
+if (!addon) {
   let addon_path =
       `${process.env.PWD}/node_modules/sherpa-onnx-${platform_arch}`;
   const pnpmIndex = __dirname.indexOf(`node_modules${path.sep}.pnpm`);


### PR DESCRIPTION
This pull request updates the way native platform-specific addons are loaded in the Node.js API, helping bundlers find the native addon and bundle it statically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced native addon loading mechanism with improved fallback strategies and better error handling for cross-platform compatibility across different operating systems and architectures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->