### PR TITLE
Update C++ binary for PocketTTS

### DIFF
--- a/sherpa-onnx/csrc/sherpa-onnx-offline-tts-play.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-offline-tts-play.cc
@@ -20,6 +20,7 @@
 #include "sherpa-onnx/csrc/microphone.h"
 #include "sherpa-onnx/csrc/offline-tts.h"
 #include "sherpa-onnx/csrc/parse-options.h"
+#include "sherpa-onnx/csrc/wave-reader.h"
 #include "sherpa-onnx/csrc/wave-writer.h"
 
 static std::condition_variable g_cv;
@@ -220,8 +221,19 @@ or details.
   std::string output_filename = "./generated.wav";
   int32_t sid = 0;
 
+  std::string reference_audio;
+  po.Register(
+      "reference-audio", &reference_audio,
+      "Path to reference audio if you are using a TTS model supporting that");
+
+  sherpa_onnx::GenerationConfig gen_config;
+
   po.Register("output-filename", &output_filename,
               "Path to save the generated audio");
+
+  po.Register(
+      "num-steps", &gen_config.num_steps,
+      "Used by some models, e.g., PocketTTS. Number of flow matching steps");
 
   po.Register("sid", &sid,
               "Speaker ID. Used only for multi-speaker models, e.g., models "
@@ -285,7 +297,31 @@ or details.
 
   fprintf(stderr, "Generating ...\n");
   const auto begin = std::chrono::steady_clock::now();
-  auto audio = tts.Generate(po.GetArg(1), sid, speed, AudioGeneratedCallback);
+
+  sherpa_onnx::GeneratedAudio audio;
+
+  if (!config.model.pocket.lm_flow.empty()) {
+    if (reference_audio.empty()) {
+      fprintf(stderr, "You need to provide --reference-audio for Pocket TTS");
+      exit(EXIT_FAILURE);
+    }
+
+    int32_t sample_rate;
+    bool is_ok = false;
+    auto samples = sherpa_onnx::ReadWave(reference_audio, &sample_rate, &is_ok);
+    if (!is_ok) {
+      fprintf(stderr, "Failed to read '%s'", reference_audio.c_str());
+      exit(EXIT_FAILURE);
+    }
+
+    gen_config.reference_audio = std::move(samples);
+    gen_config.reference_sample_rate = sample_rate;
+
+    audio = tts.Generate(po.GetArg(1), gen_config, AudioGeneratedCallback);
+  } else {
+    audio = tts.Generate(po.GetArg(1), sid, speed, AudioGeneratedCallback);
+  }
+
   const auto end = std::chrono::steady_clock::now();
   g_stopped = true;
   fprintf(stderr, "Generating done!\n");


### PR DESCRIPTION
# Usage example
```bash
build/bin/sherpa-onnx-offline-tts-play \
  --pocket-lm-flow=./sherpa-onnx-pocket-tts-int8-2026-01-26/lm_flow.int8.onnx \
  --pocket-lm-main=./sherpa-onnx-pocket-tts-int8-2026-01-26/lm_main.int8.onnx \
  --pocket-encoder=./sherpa-onnx-pocket-tts-int8-2026-01-26/encoder.onnx \
  --pocket-decoder=./sherpa-onnx-pocket-tts-int8-2026-01-26/decoder.int8.onnx \
  --pocket-text-conditioner=./sherpa-onnx-pocket-tts-int8-2026-01-26/text_conditioner.onnx \
  --pocket-vocab-json=./sherpa-onnx-pocket-tts-int8-2026-01-26/vocab.json \
  --pocket-token-scores-json=./sherpa-onnx-pocket-tts-int8-2026-01-26/token_scores.json \
  --reference-audio=./sherpa-onnx-pocket-tts-int8-2026-01-26/test_wavs/bria.wav \
  --num-threads=2 \
  --num-steps=5 \
  --output-filename="./out-bria.wav" \
  "I am happy to join with you today in what will go down in history as the greatest demonstration for freedom in the history of our nation. Five score years ago, a great American, in whose symbolic shadow we stand today, signed the Emancipation Proclamation. This momentous decree came as a great beacon light of hope to millions of Negro slaves who had been seared in the flames of withering injustice. It came as a joyous daybreak to end the long night of their captivity."
```

## Reference audio

https://github.com/user-attachments/assets/9f034bd0-4369-46bb-9879-13a4e63d8cf4

## Video demo


https://github.com/user-attachments/assets/7aedc38f-121c-4bc7-90ae-f00f050b335d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added reference audio support to text-to-speech generation when using Pocket TTS
- New `--reference-audio` command-line option enables loading reference audio files
- New `--num-steps` command-line option configures flow matching generation steps
- Maintains backward compatibility with existing non-Pocket TTS models

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->