### PR TITLE
feat: Add ys_log_probs to NeMo transducer greedy search decoder

### DIFF
--- a/sherpa-onnx/csrc/offline-transducer-greedy-search-nemo-decoder.cc
+++ b/sherpa-onnx/csrc/offline-transducer-greedy-search-nemo-decoder.cc
@@ -125,6 +125,7 @@ static OfflineTransducerDecoderResult DecodeOneTDT(
   int32_t tokens_this_frame = 0;
 
   int32_t skip = 0;
+  std::vector<float> token_logits_copy(vocab_size);  // Reusable buffer for LogSoftmax
   for (int32_t t = 0; t < num_rows; t += skip) {
     Ort::Value cur_encoder_out = Ort::Value::CreateTensor(
         memory_info, const_cast<float *>(p) + t * num_cols, num_cols,
@@ -152,8 +153,7 @@ static OfflineTransducerDecoderResult DecodeOneTDT(
         std::max_element(token_logits, token_logits + vocab_size)));
 
     // Apply LogSoftmax to token logits and get log probability
-    // Note: Need to make a copy since token_logits is const
-    std::vector<float> token_logits_copy(token_logits, token_logits + vocab_size);
+    std::copy(token_logits, token_logits + vocab_size, token_logits_copy.begin());
     LogSoftmax(token_logits_copy.data(), vocab_size);
     float log_prob = token_logits_copy[y];
 


### PR DESCRIPTION
## Summary

Add `ys_log_probs` population to NeMo transducer greedy search decoder, enabling token-level confidence scores for `nemo_transducer` models like Parakeet TDT.

## Problem

`OfflineRecognizer` with `model_type="nemo_transducer"` returns empty `ys_log_probs` because `offline-transducer-greedy-search-nemo-decoder.cc` doesn't populate it, unlike the standard transducer decoder.

## Solution

- Add `#include "sherpa-onnx/csrc/math.h"` for LogSoftmax
- Apply LogSoftmax to logits and extract log_prob for the selected token
- Push to `ans.ys_log_probs` in both `DecodeOne` and `DecodeOneTDT` paths

## Testing

Tested with Parakeet TDT 0.6B model - `ys_log_probs` now matches token count.

```
Before: tokens=5, ys_log_probs=0
After:  tokens=5, ys_log_probs=5, sample=[-0.030, -0.001, -0.007, -0.012, -0.497]
```

## Related

Similar to PR #2736 which added ysProbs for OnlineRecognizer - this completes the feature for the OfflineRecognizer NeMo path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transducer decoder now records and exposes per-token log-probability scores (confidence) for each selected token, including in duration-based decoding paths, enabling inspection of token-level confidence alongside decoded outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->