### PR TITLE
Do not merge, untested: Wrap SherpaOnnxWriteWaveToBuffer in the GO API

### DIFF
--- a/scripts/go/sherpa_onnx.go
+++ b/scripts/go/sherpa_onnx.go
@@ -1174,6 +1174,17 @@ func (audio *GeneratedAudio) Save(filename string) bool {
 	return ok == 1
 }
 
+func (audio *GeneratedAudio) ToBuffer() []byte {
+	// Similar to Save(): it writes the wave to an allocated buffer; 
+	// Uses the C API: SHERPA_ONNX_API void SherpaOnnxWriteWaveToBuffer(const float *samples, int32_t n, int32_t sample_rate, char *buffer);
+	n := len(audio.Samples)
+	if n == 0 { return nil }
+	fs := C.SherpaOnnxWaveFileSize(C.int(n)) // SHERPA_ONNX_API int64_t SherpaOnnxWaveFileSize(int32_t n_samples);
+	buf := make([]byte, fs)
+	C.SherpaOnnxWriteWaveToBuffer((*C.float)(&audio.Samples[0]), C.int(n), C.int(audio.SampleRate), (*C.char)(unsafe.Pointer(&buf[0])))
+	return buf
+}
+
 // ============================================================
 // For VAD
 // ============================================================


### PR DESCRIPTION
Wrap SherpaOnnxWriteWaveToBuffer into the GO API.

Todo:
- unittest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve generated audio as an in-memory WAV byte buffer instead of writing to disk.
  * Mirrors existing save behavior: returns nil when no samples are present; otherwise returns the complete WAV data ready for immediate use.
  * Simplifies workflows that consume audio directly (playback, upload, or further processing) without filesystem I/O.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->