### PR TITLE
Fix ORT Value default construction for Android build

### DIFF
--- a/sherpa-onnx/csrc/offline-funasr-nano-model.cc
+++ b/sherpa-onnx/csrc/offline-funasr-nano-model.cc
@@ -851,7 +851,7 @@ class OfflineFunASRNanoModel::Impl {
                                llm_output_names_ptr_.size());
     }
 
-    Ort::Value logits;
+    Ort::Value logits{nullptr};
     if (use_cpu_decode_buffers) {
       // For decode step with pre-allocated buffer, create a view to return
       // (outputs will be destroyed but buffer persists)


### PR DESCRIPTION
## Summary
Fixes Android build error with ORT 1.17.x by initializing `Ort::Value` using the null constructor.

## Testing
- Not run (build environment only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential memory initialization issue in the offline speech recognition model for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->