### PR TITLE
fix: Downgrade lifecycle to 2.6.2 to fix build error

### DIFF
--- a/android/SherpaOnnxVadAsr/app/build.gradle
+++ b/android/SherpaOnnxVadAsr/app/build.gradle
@@ -33,13 +33,13 @@ android {
 }
 
 dependencies {
-
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.10.0'
-    
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.2'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10'
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'


### PR DESCRIPTION
The previous PR merged incompatible dependency versions (lifecycle 2.10.0 requires compileSdk 34). I downgraded it to 2.6.2 and added stdlib-jdk8 to fix Duplicate Class errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to improve stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->