### PR TITLE
fix: Downgrade lifecycle to 2.5.1 to fix build error

### DIFF
--- a/android/SherpaOnnxVadAsr/app/build.gradle
+++ b/android/SherpaOnnxVadAsr/app/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.10.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
     
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'


### PR DESCRIPTION
Downgraded `lifecycle-runtime-ktx` to 2.5.1 to be compatible with the current Kotlin 1.7 environment.

This resolves the build error caused by the previous merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal library version to improve compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->