### PR TITLE
Add https://huggingface.co/alphacep/vosk-model-small-streaming-bn

### DIFF
--- a/.github/workflows/apk-asr.yaml
+++ b/.github/workflows/apk-asr.yaml
@@ -23,8 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        total: ["6"]
-        index: ["0", "1", "2", "3", "4", "5"]
+        total: ["15"]
+        index: ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/upload-models.yaml
+++ b/.github/workflows/upload-models.yaml
@@ -3,7 +3,7 @@ name: upload-models
 on:
   push:
     branches:
-      - upload-models
+      - upload-models-2
   workflow_dispatch:
 
 concurrency:

--- a/scripts/apk/generate-asr-apk-script.py
+++ b/scripts/apk/generate-asr-apk-script.py
@@ -499,6 +499,21 @@ def get_models():
             popd
             """,
         ),
+        Model(
+            model_name="sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09",
+            idx=29,
+            lang="bn",
+            short_name="bengali_vosk_2026_02_09",
+            cmd="""
+            pushd $model_name
+
+            rm -rf test_wavs
+
+            ls -lh
+
+            popd
+            """,
+        ),
     ]
 
     return models

--- a/sherpa-onnx/kotlin-api/OnlineRecognizer.kt
+++ b/sherpa-onnx/kotlin-api/OnlineRecognizer.kt
@@ -540,6 +540,19 @@ fun getModelConfig(type: Int): OnlineModelConfig? {
             )
         }
 
+        29 -> {
+            val modelDir = "sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09"
+            return OnlineModelConfig(
+                transducer = OnlineTransducerModelConfig(
+                    encoder = "$modelDir/encoder.onnx",
+                    decoder = "$modelDir/decoder.onnx",
+                    joiner = "$modelDir/joiner.onnx",
+                ),
+                tokens = "$modelDir/tokens.txt",
+                modelType = "zipformer2",
+            )
+        }
+
         1000 -> {
             val modelDir = "sherpa-onnx-rk3588-streaming-zipformer-bilingual-zh-en-2023-02-20"
             return OnlineModelConfig(


### PR DESCRIPTION
It supports streaming ASR for Bengali.

CC @nshmyrev

# Usage
```bash

wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09.tar.bz2

tar xvf sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09.tar.bz2

./build/bin/sherpa-onnx \
  --encoder=./sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09/encoder.onnx \
  --decoder=./sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09/decoder.onnx \
  --joiner=./sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09/joiner.onnx \
  --tokens=./sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09/tokens.txt \
  --model-type=zipformer2 \
  ./sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09/test_wavs/0.wav \
  ./sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09/test_wavs/1.wav
```

The output is given below:
```
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/parse-options.cc:Read:373 ./build/bin/sherpa-onnx --encoder=./sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09/encoder.onnx --decoder=./sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09/decoder.onnx --joiner=./sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09/joiner.onnx --tokens=./sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09/tokens.txt --model-type=zipformer2 ./sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09/test_wavs/0.wav ./sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09/test_wavs/1.wav 

OnlineRecognizerConfig(feat_config=FeatureExtractorConfig(sampling_rate=16000, feature_dim=80, low_freq=20, high_freq=-400, dither=0, normalize_samples=True, snip_edges=False), model_config=OnlineModelConfig(transducer=OnlineTransducerModelConfig(encoder="./sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09/encoder.onnx", decoder="./sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09/decoder.onnx", joiner="./sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09/joiner.onnx"), paraformer=OnlineParaformerModelConfig(encoder="", decoder=""), wenet_ctc=OnlineWenetCtcModelConfig(model="", chunk_size=16, num_left_chunks=4), zipformer2_ctc=OnlineZipformer2CtcModelConfig(model=""), nemo_ctc=OnlineNeMoCtcModelConfig(model=""), t_one_ctc=OnlineToneCtcModelConfig(model=""), provider_config=ProviderConfig(device=0, provider="cpu", cuda_config=CudaConfig(cudnn_conv_algo_search=1), trt_config=TensorrtConfig(trt_max_workspace_size=2147483647, trt_max_partition_iterations=10, trt_min_subgraph_size=5, trt_fp16_enable="True", trt_detailed_build_log="False", trt_engine_cache_enable="True", trt_engine_cache_path=".", trt_timing_cache_enable="True", trt_timing_cache_path=".",trt_dump_subgraphs="False" )), tokens="./sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09/tokens.txt", num_threads=1, warm_up=0, debug=False, model_type="zipformer2", modeling_unit="cjkchar", bpe_vocab=""), lm_config=OnlineLMConfig(model="", scale=0.5, lodr_scale=0.01, lodr_fst="", lodr_backoff_id=-1, shallow_fusion=True), endpoint_config=EndpointConfig(rule1=EndpointRule(must_contain_nonsilence=False, min_trailing_silence=2.4, min_utterance_length=0), rule2=EndpointRule(must_contain_nonsilence=True, min_trailing_silence=1.2, min_utterance_length=0), rule3=EndpointRule(must_contain_nonsilence=False, min_trailing_silence=0, min_utterance_length=20)), ctc_fst_decoder_config=OnlineCtcFstDecoderConfig(graph="", max_active=3000), enable_endpoint=True, max_active_paths=4, hotwords_score=1.5, hotwords_file="", decoding_method="greedy_search", blank_penalty=0, temperature_scale=2, rule_fsts="", rule_fars="", reset_encoder=False, hr=HomophoneReplacerConfig(lexicon="", rule_fsts=""))
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/features.cc:AcceptWaveformImpl:111 Creating a resampler:
   in_sample_rate: 22050
   output_sample_rate: 16000

Start to create recognizer
Recognizer created in 0.29082 s
./sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09/test_wavs/0.wav
Number of threads: 1, Elapsed seconds: 0.28, Audio duration (s): 7, Real time factor (RTF) = 0.28/7 = 0.04
 এদিকে মিঃ তুগলক অরবিন কেজরিওয়াল এবং তার দল আপনায় ঘণ্টায় টুইট করছেন ক্রেডিটের জন্য
{ "text": " এদিকে মিঃ তুগলক অরবিন কেজরিওয়াল এবং তার দল আপনায় ঘণ্টায় টুইট করছেন ক্রেডিটের জন্য", "tokens": [" এ", "দ", "ি", "কে", " মি", "ঃ", " ত", "ু", "গ", "ল", "ক", " অ", "র", "বি", "ন", " ", "কে", "জ", "রি", "ওয়া", "ল", " ", "এবং", " ", "তার", " দ", "ল", " আপ", "ন", "ায়", " ", "ঘ", "ণ", "্", "টা", "য়", " ", "ট", "ু", "ই", "ট", " কর", "ছেন", " ক", "্রে", "ডিট", "ের", " জন", "্য"], "timestamps": [0.00, 0.72, 0.80, 0.84, 1.00, 1.28, 1.44, 1.56, 1.60, 1.68, 1.80, 1.92, 2.00, 2.08, 2.20, 2.28, 2.32, 2.44, 2.56, 2.68, 2.80, 2.92, 2.96, 3.20, 3.28, 3.48, 3.68, 4.08, 4.64, 4.84, 5.12, 5.16, 5.24, 5.32, 5.36, 5.40, 5.48, 5.52, 5.60, 5.64, 5.72, 5.80, 5.96, 6.12, 6.24, 6.28, 6.56, 6.68, 6.88], "ys_probs": [-0.509064, -0.098755, -0.053391, -0.197113, -0.633179, -1.311584, -0.862396, -0.158600, -0.466919, -0.208893, -1.105469, -0.826385, -0.125763, -0.508606, -0.521210, -0.572906, -0.276199, -0.449585, -0.561737, -0.523438, -0.074463, -0.251587, -0.478607, -0.157379, -0.514069, -0.580231, -0.640808, -0.959106, -1.177383, -0.801361, -0.147858, -0.541435, -0.491226, -0.146713, -0.277618, -0.299774, -0.116348, -0.296803, -0.113068, -0.400330, -0.166321, -0.415741, -0.732025, -0.453552, -0.157761, -0.441879, -0.400757, -0.393646, -0.381744], "lm_probs": [], "context_scores": [], "segment": 0, "words": [], "start_time": 0.00, "is_final": false, "is_eof": false}

./sherpa-onnx-streaming-zipformer-bn-vosk-2026-02-09/test_wavs/1.wav
Number of threads: 1, Elapsed seconds: 0.28, Audio duration (s): 7, Real time factor (RTF) = 0.28/7 = 0.04
 তোমার দেশ তোমার জন্য কি করতে পারে তা জিজ্ঞেস করো না বরং তুমি তোমার দেশের জন্য কি করতে পারো তা জিজ্ঞেস করুম
{ "text": " তোমার দেশ তোমার জন্য কি করতে পারে তা জিজ্ঞেস করো না বরং তুমি তোমার দেশের জন্য কি করতে পারো তা জিজ্ঞেস করুম", "tokens": [" তো", "মার", " ", "দেশ", " তো", "মার", " জন", "্য", " কি", " কর", "তে", " পা", "রে", " তা", " জি", "জ্ঞ", "ে", "স", " কর", "ো", " না", " ব", "র", "ং", " ত", "ুমি", " তো", "মার", " ", "দেশ", "ের", " জন", "্য", " কি", " কর", "তে", " পা", "রো", " তা", " জি", "জ্ঞ", "ে", "স", " কর", "ু", "ম"], "timestamps": [0.00, 0.40, 0.64, 0.72, 0.96, 1.12, 1.28, 1.44, 1.60, 1.84, 2.00, 2.12, 2.24, 2.40, 2.64, 2.76, 2.84, 2.92, 3.00, 3.28, 3.32, 3.52, 3.72, 3.84, 3.92, 4.00, 4.16, 4.32, 4.48, 4.52, 4.68, 4.80, 4.96, 5.12, 5.32, 5.48, 5.76, 5.84, 5.96, 6.16, 6.32, 6.40, 6.48, 6.60, 6.88, 6.92], "ys_probs": [-0.183716, -0.165009, -0.293213, -0.358551, -0.107635, -0.080353, -0.354340, -0.788101, -0.899780, -0.562805, -0.179077, -0.253143, -0.494263, -0.168976, -0.141861, -0.156342, -0.389462, -0.324860, -0.695267, -0.767242, -0.626190, -0.717499, -0.046036, -0.063141, -0.096771, -0.226776, -0.110046, -0.222183, -0.145966, -0.162560, -0.094635, -0.419876, -0.255554, -0.740997, -0.158142, -0.674942, -0.227142, -0.429779, -0.339264, -0.165283, -0.022293, -0.608181, -0.685547, -0.630035, -1.476349, -0.438019], "lm_probs": [], "context_scores": [], "segment": 0, "words": [], "start_time": 0.00, "is_final": false, "is_eof": false}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Bengali speech recognition model to supported models.
  * Expanded automated build and deployment system to handle increased model variants.

* **Chores**
  * Updated build configuration matrix and publishing workflow infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->