### PR TITLE
Release v1.12.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.12.25
+
+* Fix building without tts (#3168)
+* Fix publishing npm packages for Linux aarch64 and wheels for macOS (#3169)
+* Export PocketTTS for earlier versions of onnxruntime (#3170)
+* Fix building wheels for Python 3.14 (#3182)
+* Update Eigen from 3.4.0 to 3.4.1 (#3178)
+* fix(flutter): add missing FFI struct fields for OfflineWhisper and FunAsrNano (#3186)
+* Fix building wheels for Windows (#3187)
+
 ## 1.12.24
 
 * Fix UnicodeDecodeError when accessing tokens in FunASR-nano tokenizer (#3058)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ project(sherpa-onnx)
 # Remember to update
 # ./CHANGELOG.md
 # ./new-release.sh
-set(SHERPA_ONNX_VERSION "1.12.24")
+set(SHERPA_ONNX_VERSION "1.12.25")
 
 # Disable warning about
 #

--- a/android/SherpaOnnx/app/build.gradle
+++ b/android/SherpaOnnx/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.k2fsa.sherpa.onnx"
         minSdk 21
         targetSdk 32
-        versionCode 20260210
-        versionName "1.12.24"
+        versionCode 20260214
+        versionName "1.12.25"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/SherpaOnnx2Pass/app/build.gradle
+++ b/android/SherpaOnnx2Pass/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.k2fsa.sherpa.onnx"
         minSdk 21
         targetSdk 32
-        versionCode 20260210
-        versionName "1.12.24"
+        versionCode 20260214
+        versionName "1.12.25"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/SherpaOnnxAar/README.md
+++ b/android/SherpaOnnxAar/README.md
@@ -4,8 +4,8 @@
 git clone https://github.com/k2-fsa/sherpa-onnx
 cd sherpa-onnx
 
-wget https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.24/sherpa-onnx-v1.12.24-android.tar.bz2
-tar xvf sherpa-onnx-v1.12.24-android.tar.bz2
+wget https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.25/sherpa-onnx-v1.12.25-android.tar.bz2
+tar xvf sherpa-onnx-v1.12.25-android.tar.bz2
 
 cp -v jniLibs/arm64-v8a/* android/SherpaOnnxAar/sherpa_onnx/src/main/jniLibs/arm64-v8a/
 cp -v jniLibs/armeabi-v7a/* android/SherpaOnnxAar/sherpa_onnx/src/main/jniLibs/armeabi-v7a/
@@ -16,5 +16,5 @@ cd android/SherpaOnnxAar
 
 ./gradlew :sherpa_onnx:assembleRelease
 ls -lh ./sherpa_onnx/build/outputs/aar/sherpa_onnx-release.aar
-cp ./sherpa_onnx/build/outputs/aar/sherpa_onnx-release.aar ../../sherpa-onnx-1.12.24.aar
+cp ./sherpa_onnx/build/outputs/aar/sherpa_onnx-release.aar ../../sherpa-onnx-1.12.25.aar
 ```

--- a/android/SherpaOnnxAudioTagging/app/build.gradle.kts
+++ b/android/SherpaOnnxAudioTagging/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.k2fsa.sherpa.onnx.audio.tagging"
         minSdk = 21
         targetSdk = 34
-        versionCode = 20260210
-        versionName = "1.12.24"
+        versionCode = 20260214
+        versionName = "1.12.25"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/android/SherpaOnnxAudioTaggingWearOs/app/build.gradle.kts
+++ b/android/SherpaOnnxAudioTaggingWearOs/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.k2fsa.sherpa.onnx.audio.tagging.wear.os"
         minSdk = 26
         targetSdk = 34
-        versionCode = 20260210
-        versionName = "1.12.24"
+        versionCode = 20260214
+        versionName = "1.12.25"
         vectorDrawables {
             useSupportLibrary = true
         }

--- a/android/SherpaOnnxJavaDemo/app/build.gradle
+++ b/android/SherpaOnnxJavaDemo/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "com.k2fsa.sherpa.onnx"
         minSdk 28
         targetSdk 34
-        versionCode 20260210
-        versionName "1.12.24"
+        versionCode 20260214
+        versionName "1.12.25"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -34,5 +34,5 @@ dependencies {
     implementation 'pub.devrel:easypermissions:3.0.0'
     implementation 'androidx.core:core-ktx:1.7.0'
     // implementation files('/Users/fangjun/open-source/sherpa-onnx/android/SherpaOnnxAar/sherpa_onnx/build/outputs/aar/sherpa_onnx-release.aar')
-    implementation 'com.github.k2-fsa:sherpa-onnx:v1.12.24'
+    implementation 'com.github.k2-fsa:sherpa-onnx:v1.12.25'
 }

--- a/android/SherpaOnnxKws/app/build.gradle
+++ b/android/SherpaOnnxKws/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.k2fsa.sherpa.onnx"
         minSdk 21
         targetSdk 32
-        versionCode 20260210
-        versionName "1.12.24"
+        versionCode 20260214
+        versionName "1.12.25"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/SherpaOnnxSimulateStreamingAsr/app/build.gradle.kts
+++ b/android/SherpaOnnxSimulateStreamingAsr/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.k2fsa.sherpa.onnx.simulate.streaming.asr"
         minSdk = 21
         targetSdk = 34
-        versionCode = 20260210
-        versionName = "1.12.24"
+        versionCode = 20260214
+        versionName = "1.12.25"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/android/SherpaOnnxSimulateStreamingAsrWearOs/app/build.gradle.kts
+++ b/android/SherpaOnnxSimulateStreamingAsrWearOs/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.k2fsa.sherpa.onnx.simulate.streaming.asr.wear.os"
         minSdk = 28
         targetSdk = 34
-        versionCode = 20260210
-        versionName = "1.12.24"
+        versionCode = 20260214
+        versionName = "1.12.25"
         vectorDrawables {
             useSupportLibrary = true
         }
@@ -58,7 +58,7 @@ dependencies {
     implementation(libs.compose.foundation)
     implementation(libs.activity.compose)
     implementation(libs.core.splashscreen)
-    implementation("com.github.k2-fsa:sherpa-onnx:v1.12.24")
+    implementation("com.github.k2-fsa:sherpa-onnx:v1.12.25")
     androidTestImplementation(platform(libs.compose.bom))
     androidTestImplementation(libs.ui.test.junit4)
     debugImplementation(libs.ui.tooling)

--- a/android/SherpaOnnxSpeakerDiarization/app/build.gradle.kts
+++ b/android/SherpaOnnxSpeakerDiarization/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.k2fsa.sherpa.onnx.speaker.diarization"
         minSdk = 21
         targetSdk = 34
-        versionCode = 20260210
-        versionName = "1.12.24"
+        versionCode = 20260214
+        versionName = "1.12.25"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/android/SherpaOnnxSpeakerIdentification/app/build.gradle.kts
+++ b/android/SherpaOnnxSpeakerIdentification/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.k2fsa.sherpa.onnx.speaker.identification"
         minSdk = 21
         targetSdk = 34
-        versionCode = 20260210
-        versionName = "1.12.24"
+        versionCode = 20260214
+        versionName = "1.12.25"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/android/SherpaOnnxSpokenLanguageIdentification/app/build.gradle.kts
+++ b/android/SherpaOnnxSpokenLanguageIdentification/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.k2fsa.sherpa.onnx.slid"
         minSdk = 21
         targetSdk = 34
-        versionCode = 20260210
-        versionName = "1.12.24"
+        versionCode = 20260214
+        versionName = "1.12.25"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/android/SherpaOnnxTts/app/build.gradle
+++ b/android/SherpaOnnxTts/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.k2fsa.sherpa.onnx"
         minSdk 21
         targetSdk 32
-        versionCode 20260210
-        versionName "1.12.24"
+        versionCode 20260214
+        versionName "1.12.25"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/SherpaOnnxTtsEngine/app/build.gradle.kts
+++ b/android/SherpaOnnxTtsEngine/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.k2fsa.sherpa.onnx.tts.engine"
         minSdk = 21
         targetSdk = 34
-        versionCode = 20260210
-        versionName = "1.12.24"
+        versionCode = 20260214
+        versionName = "1.12.25"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/android/SherpaOnnxVad/app/build.gradle
+++ b/android/SherpaOnnxVad/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.k2fsa.sherpa.onnx"
         minSdk 21
         targetSdk 33
-        versionCode 20260210
-        versionName "1.12.24"
+        versionCode 20260214
+        versionName "1.12.25"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/SherpaOnnxVadAsr/app/build.gradle
+++ b/android/SherpaOnnxVadAsr/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.k2fsa.sherpa.onnx"
         minSdk 21
         targetSdk 33
-        versionCode 20260210
-        versionName "1.12.24"
+        versionCode 20260214
+        versionName "1.12.25"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/SherpaOnnxWebSocket/app/build.gradle
+++ b/android/SherpaOnnxWebSocket/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.k2fsa.sherpa.onnx"
         minSdk 21
         targetSdk 32
-        versionCode 20260210
-        versionName "1.12.24"
+        versionCode 20260214
+        versionName "1.12.25"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/build-ios-shared.sh
+++ b/build-ios-shared.sh
@@ -242,7 +242,7 @@ for d in ios-arm64_x86_64-simulator ios-arm64; do
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.12.24</string>
+	<string>1.12.25</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
 		<string>iPhoneOS</string>

--- a/dart-api-examples/add-punctuations/pubspec.yaml
+++ b/dart-api-examples/add-punctuations/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.12.24
+  sherpa_onnx: ^1.12.25
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/audio-tagging/pubspec.yaml
+++ b/dart-api-examples/audio-tagging/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.12.24
+  sherpa_onnx: ^1.12.25
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/keyword-spotter/pubspec.yaml
+++ b/dart-api-examples/keyword-spotter/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.12.24
+  sherpa_onnx: ^1.12.25
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   path: ^1.9.0

--- a/dart-api-examples/non-streaming-asr/pubspec.yaml
+++ b/dart-api-examples/non-streaming-asr/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  sherpa_onnx: ^1.12.24
+  sherpa_onnx: ^1.12.25
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/speaker-diarization/pubspec.yaml
+++ b/dart-api-examples/speaker-diarization/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.12.24
+  sherpa_onnx: ^1.12.25
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   path: ^1.9.0

--- a/dart-api-examples/speaker-identification/pubspec.yaml
+++ b/dart-api-examples/speaker-identification/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.12.24
+  sherpa_onnx: ^1.12.25
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/speech-enhancement-gtcrn/pubspec.yaml
+++ b/dart-api-examples/speech-enhancement-gtcrn/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  sherpa_onnx: ^1.12.24
+  sherpa_onnx: ^1.12.25
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   path: ^1.9.0

--- a/dart-api-examples/spoken-language-identification/pubspec.yaml
+++ b/dart-api-examples/spoken-language-identification/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  sherpa_onnx: ^1.12.24
+  sherpa_onnx: ^1.12.25
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   path: ^1.9.0

--- a/dart-api-examples/streaming-asr/pubspec.yaml
+++ b/dart-api-examples/streaming-asr/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  sherpa_onnx: ^1.12.24
+  sherpa_onnx: ^1.12.25
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/tts/pubspec.yaml
+++ b/dart-api-examples/tts/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  sherpa_onnx: ^1.12.24
+  sherpa_onnx: ^1.12.25
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/vad-with-non-streaming-asr/pubspec.yaml
+++ b/dart-api-examples/vad-with-non-streaming-asr/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.12.24
+  sherpa_onnx: ^1.12.25
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/vad/pubspec.yaml
+++ b/dart-api-examples/vad/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.12.24
+  sherpa_onnx: ^1.12.25
   path: ^1.9.0
   args: ^2.5.0
 

--- a/flutter-examples/non_streaming_vad_asr/pubspec.yaml
+++ b/flutter-examples/non_streaming_vad_asr/pubspec.yaml
@@ -5,7 +5,7 @@ description: >
 
 publish_to: 'none'
 
-version: 1.12.24
+version: 1.12.25
 
 topics:
   - speech-recognition
@@ -31,7 +31,7 @@ dependencies:
   record: 6.0.0
   url_launcher: ^6.2.6
 
-  sherpa_onnx: ^1.12.24
+  sherpa_onnx: ^1.12.25
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
 

--- a/flutter-examples/streaming_asr/pubspec.yaml
+++ b/flutter-examples/streaming_asr/pubspec.yaml
@@ -5,7 +5,7 @@ description: >
 
 publish_to: 'none'
 
-version: 1.12.24
+version: 1.12.25
 
 topics:
   - speech-recognition
@@ -30,7 +30,7 @@ dependencies:
   record: ^6.1.2
   url_launcher: ^6.2.6
 
-  sherpa_onnx: ^1.12.24
+  sherpa_onnx: ^1.12.25
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
 

--- a/flutter-examples/tts/pubspec.yaml
+++ b/flutter-examples/tts/pubspec.yaml
@@ -5,7 +5,7 @@ description: >
 
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.12.24
+version: 1.12.25
 
 environment:
   sdk: ">=2.17.0 <4.0.0"
@@ -18,7 +18,7 @@ dependencies:
   cupertino_icons: ^1.0.6
   path_provider: ^2.1.3
   path: ^1.9.0
-  sherpa_onnx: ^1.12.24
+  sherpa_onnx: ^1.12.25
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   url_launcher: 6.2.6

--- a/flutter/sherpa_onnx/pubspec.yaml
+++ b/flutter/sherpa_onnx/pubspec.yaml
@@ -17,7 +17,7 @@ topics:
   - voice-activity-detection
 
 # remember to change the version in ../sherpa_onnx_macos/macos/sherpa_onnx_macos.podspec
-version: 1.12.24
+version: 1.12.25
 
 homepage: https://github.com/k2-fsa/sherpa-onnx
 
@@ -30,23 +30,23 @@ dependencies:
   flutter:
     sdk: flutter
 
-  sherpa_onnx_android: ^1.12.24
+  sherpa_onnx_android: ^1.12.25
   # sherpa_onnx_android:
   #   path: ../sherpa_onnx_android
 
-  sherpa_onnx_macos: ^1.12.24
+  sherpa_onnx_macos: ^1.12.25
   # sherpa_onnx_macos:
   #   path: ../sherpa_onnx_macos
 
-  sherpa_onnx_linux: ^1.12.24
+  sherpa_onnx_linux: ^1.12.25
   # sherpa_onnx_linux:
   #   path: ../sherpa_onnx_linux
 
-  sherpa_onnx_windows: ^1.12.24
+  sherpa_onnx_windows: ^1.12.25
   # sherpa_onnx_windows:
   #   path: ../sherpa_onnx_windows
 
-  sherpa_onnx_ios: ^1.12.24
+  sherpa_onnx_ios: ^1.12.25
   # sherpa_onnx_ios:
   #   path: ../sherpa_onnx_ios
 

--- a/flutter/sherpa_onnx_ios/ios/sherpa_onnx_ios.podspec
+++ b/flutter/sherpa_onnx_ios/ios/sherpa_onnx_ios.podspec
@@ -7,7 +7,7 @@
 # https://groups.google.com/g/dart-ffi/c/nUATMBy7r0c
 Pod::Spec.new do |s|
   s.name             = 'sherpa_onnx_ios'
-  s.version          = '1.12.24'
+  s.version          = '1.12.25'
   s.summary          = 'A new Flutter FFI plugin project.'
   s.description      = <<-DESC
 A new Flutter FFI plugin project.

--- a/flutter/sherpa_onnx_macos/macos/sherpa_onnx_macos.podspec
+++ b/flutter/sherpa_onnx_macos/macos/sherpa_onnx_macos.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'sherpa_onnx_macos'
-  s.version          = '1.12.24'
+  s.version          = '1.12.25'
   s.summary          = 'sherpa-onnx Flutter FFI plugin project.'
   s.description      = <<-DESC
 sherpa-onnx Flutter FFI plugin project.

--- a/harmony-os/SherpaOnnxHar/sherpa_onnx/BuildProfile.ets
+++ b/harmony-os/SherpaOnnxHar/sherpa_onnx/BuildProfile.ets
@@ -1,7 +1,7 @@
 /**
  * Use these variables when you tailor your ArkTS code. They must be of the const type.
  */
-export const HAR_VERSION = '1.12.24';
+export const HAR_VERSION = '1.12.25';
 export const BUILD_MODE_NAME = 'debug';
 export const DEBUG = true;
 export const TARGET_NAME = 'default';

--- a/harmony-os/SherpaOnnxHar/sherpa_onnx/README.md
+++ b/harmony-os/SherpaOnnxHar/sherpa_onnx/README.md
@@ -23,7 +23,7 @@ or update your `oh-package.json5` to include the following:
 
 ```
   "dependencies": {
-    "sherpa_onnx": "1.12.24",
+    "sherpa_onnx": "1.12.25",
   },
 ```
 

--- a/harmony-os/SherpaOnnxHar/sherpa_onnx/oh-package.json5
+++ b/harmony-os/SherpaOnnxHar/sherpa_onnx/oh-package.json5
@@ -1,6 +1,6 @@
 {
   "name": "sherpa_onnx",
-  "version": "1.12.24",
+  "version": "1.12.25",
   "description": "On-device speech-to-text, text-to-speech, and speaker diarization using Next-gen Kaldi without Internet connection",
   "main": "Index.ets",
   "author": "The next-gen Kaldi team",

--- a/harmony-os/SherpaOnnxSpeakerDiarization/entry/oh-package.json5
+++ b/harmony-os/SherpaOnnxSpeakerDiarization/entry/oh-package.json5
@@ -6,7 +6,7 @@
   "author": "",
   "license": "",
   "dependencies": {
-    "sherpa_onnx": "1.12.24"
+    "sherpa_onnx": "1.12.25"
   }
 }
 

--- a/harmony-os/SherpaOnnxSpeakerIdentification/entry/oh-package.json5
+++ b/harmony-os/SherpaOnnxSpeakerIdentification/entry/oh-package.json5
@@ -6,7 +6,7 @@
   "author": "",
   "license": "",
   "dependencies": {
-    "sherpa_onnx": "1.12.24",
+    "sherpa_onnx": "1.12.25",
   }
 }
 

--- a/harmony-os/SherpaOnnxStreamingAsr/entry/oh-package.json5
+++ b/harmony-os/SherpaOnnxStreamingAsr/entry/oh-package.json5
@@ -6,7 +6,7 @@
   "author": "",
   "license": "",
   "dependencies": {
-    "sherpa_onnx": "1.12.24",
+    "sherpa_onnx": "1.12.25",
   }
 }
 

--- a/harmony-os/SherpaOnnxTts/entry/oh-package.json5
+++ b/harmony-os/SherpaOnnxTts/entry/oh-package.json5
@@ -6,7 +6,7 @@
   "author": "",
   "license": "",
   "dependencies": {
-    "sherpa_onnx": "1.12.24",
+    "sherpa_onnx": "1.12.25",
   }
 }
 

--- a/harmony-os/SherpaOnnxVadAsr/entry/README.md
+++ b/harmony-os/SherpaOnnxVadAsr/entry/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Please download ./sherpa_onnx-v1.12.24.har
+Please download ./sherpa_onnx-v1.12.25.har
 from <https://huggingface.co/csukuangfj/sherpa-onnx-harmony-os/tree/main/har>
 
 Hint: For users who have no access to huggingface, please use

--- a/harmony-os/SherpaOnnxVadAsr/entry/oh-package.json5
+++ b/harmony-os/SherpaOnnxVadAsr/entry/oh-package.json5
@@ -7,7 +7,7 @@
   "license": "",
   "dependencies": {
     // please see https://ohpm.openharmony.cn/#/cn/detail/sherpa_onnx
-    "sherpa_onnx": "1.12.24",
+    "sherpa_onnx": "1.12.25",
   }
 }
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -2,8 +2,8 @@ jdk:
   - openjdk17
 
 before_install:
-  - wget https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.24/sherpa-onnx-1.12.24.aar
+  - wget https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.25/sherpa-onnx-1.12.25.aar
 
 install:
-  - FILE="-Dfile=sherpa-onnx-1.12.24.aar"
-  - mvn install:install-file $FILE -DgroupId=com.k2fsa.sherpa.onnx -DartifactId=sherpa-onnx -Dversion=1.12.24 -Dpackaging=aar -DgeneratePom=true
+  - FILE="-Dfile=sherpa-onnx-1.12.25.aar"
+  - mvn install:install-file $FILE -DgroupId=com.k2fsa.sherpa.onnx -DartifactId=sherpa-onnx -Dversion=1.12.25 -Dpackaging=aar -DgeneratePom=true

--- a/mfc-examples/README.md
+++ b/mfc-examples/README.md
@@ -5,9 +5,9 @@ for speech recognition.
 
 |Directory| Pre-built exe (x64)|Pre-built exe (x86)| Description|
 |---------|--------------------|-------------------|------------|
-|[./NonStreamingSpeechRecognition](./NonStreamingSpeechRecognition)|[URL](https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.24/sherpa-onnx-non-streaming-asr-x64-v1.12.24.exe)|[URL](https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.24/sherpa-onnx-non-streaming-asr-x86-v1.12.24.exe)| Non-streaming speech recognition|
-|[./StreamingSpeechRecognition](./StreamingSpeechRecognition)|[URL](https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.24/sherpa-onnx-streaming-asr-x64-v1.12.24.exe)|[URL](https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.24/sherpa-onnx-streaming-asr-x86-v1.12.24.exe)| Streaming speech recognition|
-|[./NonStreamingTextToSpeech](./NonStreamingTextToSpeech)|[URL](https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.24/sherpa-onnx-non-streaming-tts-x64-v1.12.24.exe)|[URL](https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.24/sherpa-onnx-non-streaming-tts-x86-v1.12.24.exe)| Non-streaming text to speech|
+|[./NonStreamingSpeechRecognition](./NonStreamingSpeechRecognition)|[URL](https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.25/sherpa-onnx-non-streaming-asr-x64-v1.12.25.exe)|[URL](https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.25/sherpa-onnx-non-streaming-asr-x86-v1.12.25.exe)| Non-streaming speech recognition|
+|[./StreamingSpeechRecognition](./StreamingSpeechRecognition)|[URL](https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.25/sherpa-onnx-streaming-asr-x64-v1.12.25.exe)|[URL](https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.25/sherpa-onnx-streaming-asr-x86-v1.12.25.exe)| Streaming speech recognition|
+|[./NonStreamingTextToSpeech](./NonStreamingTextToSpeech)|[URL](https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.25/sherpa-onnx-non-streaming-tts-x64-v1.12.25.exe)|[URL](https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.25/sherpa-onnx-non-streaming-tts-x86-v1.12.25.exe)| Non-streaming text to speech|
 
 Caution: You need to use Windows and install Visual Studio 2022 in order to
 compile it.

--- a/new-release.sh
+++ b/new-release.sh
@@ -2,11 +2,11 @@
 
 set -ex
 
-old_version_code=20260115
-new_version_code=20260210
+old_version_code=20260210
+new_version_code=20260214
 
-old_version="1\.12\.23"
-new_version="1\.12\.24"
+old_version="1\.12\.24"
+new_version="1\.12\.25"
 
 replace_str="s/$old_version/$new_version/g"
 

--- a/nodejs-addon-examples/package.json
+++ b/nodejs-addon-examples/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "sherpa-onnx-node": "^1.12.24"
+    "sherpa-onnx-node": "^1.12.25"
   }
 }

--- a/nodejs-examples/package.json
+++ b/nodejs-examples/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "mic": "^2.1.2",
     "naudiodon2": "^2.4.0",
-    "sherpa-onnx": "^1.12.24",
+    "sherpa-onnx": "^1.12.25",
     "wav": "^1.0.2"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.k2fsa.sherpa.onnx</groupId>
     <artifactId>sherpa-onnx-android</artifactId>
-    <version>1.12.24</version>
+    <version>1.12.25</version>
     <url>https://github.com/k2-fsa/sherpa-onnx</url>
     <packaging>pom</packaging>
     <description>First Android Library</description>

--- a/scripts/wheel/sherpa-onnx-bin/setup.py
+++ b/scripts/wheel/sherpa-onnx-bin/setup.py
@@ -13,7 +13,7 @@ print("bin_files", bin_files)
 
 setup(
     name="sherpa-onnx-bin",
-    version="1.12.24",
+    version="1.12.25",
     description="Binary executables for sherpa-onnx",
     author="The sherpa-onnx development team",
     url="https://github.com/k2-fsa/sherpa-onnx",
@@ -23,7 +23,7 @@ setup(
     packages=[],
     data_files=[("Scripts", bin_files) if is_windows() else ("bin", bin_files)],
     install_requires=[
-        "sherpa-onnx-core==1.12.24",
+        "sherpa-onnx-core==1.12.25",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/scripts/wheel/sherpa-onnx-core/setup.py
+++ b/scripts/wheel/sherpa-onnx-core/setup.py
@@ -23,7 +23,7 @@ def get_binaries():
 
 setup(
     name="sherpa-onnx-core",
-    version="1.12.24",
+    version="1.12.25",
     description="Core shared libraries for sherpa-onnx",
     packages=["sherpa_onnx"],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ setuptools.setup(
         ],
     },
     license="Apache licensed, as found in the LICENSE file",
-    install_requires=["sherpa-onnx-core==1.12.24"] if need_split_package() else None,
+    install_requires=["sherpa-onnx-core==1.12.25"] if need_split_package() else None,
 )
 
 with open("sherpa-onnx/python/sherpa_onnx/__init__.py", "r") as f:

--- a/sherpa-onnx/csrc/version.cc
+++ b/sherpa-onnx/csrc/version.cc
@@ -7,17 +7,17 @@
 namespace sherpa_onnx {
 
 const char *GetGitDate() {
-  static const char *date = "Tue Feb 10 11:36:14 2026";
+  static const char *date = "Sat Feb 14 22:31:54 2026";
   return date;
 }
 
 const char *GetGitSha1() {
-  static const char *sha1 = "2ea8c9a0";
+  static const char *sha1 = "20429103";
   return sha1;
 }
 
 const char *GetVersionStr() {
-  static const char *version = "1.12.24";
+  static const char *version = "1.12.25";
   return version;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed building without TTS support
  * Fixed npm package publishing for Linux aarch64 and macOS wheels
  * Fixed Python 3.14 wheel building
  * Fixed Windows wheel building
  * Added missing Flutter FFI struct fields

* **Chores**
  * Updated Eigen dependency to 3.4.1
  * Enhanced PocketTTS export compatibility with earlier onnxruntime versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->