### PR TITLE
Fix heap-buffer-overflow in ReadWaveImpl when data chunk size is odd

### DIFF
--- a/sherpa-onnx/csrc/wave-reader.cc
+++ b/sherpa-onnx/csrc/wave-reader.cc
@@ -223,7 +223,8 @@ std::vector<std::vector<float>> ReadWaveImpl(std::istream &is,
     // As we assume each sample contains two bytes, so it is divided by 2 here
     std::vector<int16_t> samples(header.subchunk2_size / 2);
 
-    is.read(reinterpret_cast<char *>(samples.data()), header.subchunk2_size);
+    is.read(reinterpret_cast<char *>(samples.data()),
+            samples.size() * sizeof(int16_t));
     if (!is) {
       SHERPA_ONNX_LOGE("Failed to read %d bytes", header.subchunk2_size);
       *is_ok = false;


### PR DESCRIPTION
  When parsing 16-bit PCM WAV files, the buffer is allocated as
  subchunk2_size/2 int16_t samples (integer division rounds down), but
  is.read() uses the raw subchunk2_size as the byte count. If
  subchunk2_size is odd, this reads one byte beyond the allocated buffer.

  Use samples.size() * sizeof(int16_t) as the read length instead, so
  the read is always bounded by the actual buffer capacity.

  Fixes #3052

_This patch is generated by ASKRepair, an agentic automated vulnerability repair framework._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio file reading to correctly handle 16-bit PCM data by aligning read operations with allocated memory capacity, improving reliability when processing wave files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->