### PR TITLE
Update C#/Swift/Pascal API for PocketTTS' VoiceEmbeddingCacheCapacity.

### DIFF
--- a/scripts/dotnet/OfflineTtsPocketModelConfig.cs
+++ b/scripts/dotnet/OfflineTtsPocketModelConfig.cs
@@ -17,6 +17,7 @@ namespace SherpaOnnx
             TextConditioner = "";
             VocabJson = "";
             TokenScoresJson = "";
+            VoiceEmbeddingCacheCapacity = 50;
         }
 
         [MarshalAs(UnmanagedType.LPStr)]
@@ -39,6 +40,8 @@ namespace SherpaOnnx
 
         [MarshalAs(UnmanagedType.LPStr)]
         public string TokenScoresJson;
+
+        public int VoiceEmbeddingCacheCapacity;
     }
 }
 

--- a/sherpa-onnx/pascal-api/sherpa_onnx.pas
+++ b/sherpa-onnx/pascal-api/sherpa_onnx.pas
@@ -144,8 +144,10 @@ type
     TextConditioner: AnsiString;
     VocabJson: AnsiString;
     TokenScoresJson: AnsiString;
+    VoiceEmbeddingCacheCapacity: Integer;
 
     function ToString: AnsiString;
+    class operator Initialize({$IFDEF FPC}var{$ELSE}out{$ENDIF} Dest: TSherpaOnnxOfflineTtsPocketModelConfig);
   end;
 
   TSherpaOnnxOfflineTtsModelConfig = record
@@ -1103,6 +1105,7 @@ type
     TextConditioner: PAnsiChar;
     VocabJson: PAnsiChar;
     TokenScoresJson: PAnsiChar;
+    VoiceEmbeddingCacheCapacity: cint32;
   end;
 
   SherpaOnnxOfflineTtsModelConfig = record
@@ -2638,6 +2641,11 @@ begin
   Dest.GuidanceScale := 1.0;
 end;
 
+class operator TSherpaOnnxOfflineTtsPocketModelConfig.Initialize({$IFDEF FPC}var{$ELSE}out{$ENDIF} Dest: TSherpaOnnxOfflineTtsPocketModelConfig);
+begin
+  Dest.VoiceEmbeddingCacheCapacity := 50;
+end;
+
 function TSherpaOnnxOfflineTtsPocketModelConfig.ToString: AnsiString;
 begin
   Result := Format('TSherpaOnnxOfflineTtsPocketModelConfig(' +
@@ -2647,10 +2655,11 @@ begin
     'Decoder := %s, ' +
     'TextConditioner := %s, ' +
     'VocabJson := %s, ' +
-    'TokenScoresJson := %s' +
+    'TokenScoresJson := %s, ' +
+    'VoiceEmbeddingCacheCapacity := %d' +
     ')',
     [Self.LmFlow, Self.LmMain, Self.Encoder, Self.Decoder, Self.TextConditioner,
-     Self.VocabJson, Self.TokenScoresJson]);
+     Self.VocabJson, Self.TokenScoresJson, Self.VoiceEmbeddingCacheCapacity]);
 end;
 
 function TSherpaOnnxOfflineTtsModelConfig.ToString: AnsiString;
@@ -2753,6 +2762,7 @@ begin
   C.Model.Pocket.TextConditioner := PAnsiChar(Config.Model.Pocket.TextConditioner);
   C.Model.Pocket.VocabJson := PAnsiChar(Config.Model.Pocket.VocabJson);
   C.Model.Pocket.TokenScoresJson := PAnsiChar(Config.Model.Pocket.TokenScoresJson);
+  C.Model.Pocket.VoiceEmbeddingCacheCapacity := Config.Model.Pocket.VoiceEmbeddingCacheCapacity;
 
   C.Model.NumThreads := Config.Model.NumThreads;
   C.Model.Provider := PAnsiChar(Config.Model.Provider);

--- a/swift-api-examples/SherpaOnnx.swift
+++ b/swift-api-examples/SherpaOnnx.swift
@@ -1035,6 +1035,7 @@ func sherpaOnnxOfflineTtsPocketModelConfig(
   textConditioner: String = "",
   vocabJson: String = "",
   tokenScoresJson: String = "",
+  voiceEmbeddingCacheCapacity: Int = 50
 ) -> SherpaOnnxOfflineTtsPocketModelConfig {
   return SherpaOnnxOfflineTtsPocketModelConfig(
     lm_flow: toCPointer(lmFlow),
@@ -1043,7 +1044,8 @@ func sherpaOnnxOfflineTtsPocketModelConfig(
     decoder: toCPointer(decoder),
     text_conditioner: toCPointer(textConditioner),
     vocab_json: toCPointer(vocabJson),
-    token_scores_json: toCPointer(tokenScoresJson)
+    token_scores_json: toCPointer(tokenScoresJson),
+    voice_embedding_cache_capacity: Int32(voiceEmbeddingCacheCapacity)
   )
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added voice embedding cache capacity configuration parameter to the offline TTS pocket model with a default capacity of 50, now supported across all language bindings (.NET, Pascal, Swift).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->