### PR TITLE
Replace deprecated std::istrstream with std::istringstream

### DIFF
--- a/sherpa-onnx/c-api/c-api.cc
+++ b/sherpa-onnx/c-api/c-api.cc
@@ -8,7 +8,7 @@
 #include <cstring>
 #include <memory>
 #include <string>
-#include <strstream>
+#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -1821,10 +1821,14 @@ const SherpaOnnxWave *SherpaOnnxReadWave(const char *filename) {
 
 const SherpaOnnxWave *SherpaOnnxReadWaveFromBinaryData(const char *data,
                                                        int32_t n) {
+  if (!data || n <= 0) {
+    return nullptr;
+  }
+
   int32_t sample_rate = -1;
   bool is_ok = false;
 
-  std::istrstream is(data, n);
+  std::istringstream is(std::string(data, n));
 
   std::vector<float> samples = sherpa_onnx::ReadWave(is, &sample_rate, &is_ok);
   if (!is_ok) {

--- a/sherpa-onnx/csrc/audio-tagging-label-file.cc
+++ b/sherpa-onnx/csrc/audio-tagging-label-file.cc
@@ -9,8 +9,6 @@
 #include <string>
 
 #if __ANDROID_API__ >= 9
-#include <strstream>
-
 #include "android/asset_manager.h"
 #include "android/asset_manager_jni.h"
 #endif
@@ -30,7 +28,7 @@ AudioTaggingLabels::AudioTaggingLabels(const std::string &filename) {
 AudioTaggingLabels::AudioTaggingLabels(AAssetManager *mgr,
                                        const std::string &filename) {
   auto buf = ReadFile(mgr, filename);
-  std::istrstream is(buf.data(), buf.size());
+  std::istringstream is(std::string(buf.data(), buf.size()));
   Init(is);
 }
 #endif

--- a/sherpa-onnx/csrc/character-lexicon.cc
+++ b/sherpa-onnx/csrc/character-lexicon.cc
@@ -10,7 +10,6 @@
 #include <regex>  // NOLINT
 #include <sstream>
 #include <string>
-#include <strstream>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -65,14 +64,14 @@ class CharacterLexicon::Impl {
 
     {
       auto buf = ReadFile(mgr, tokens);
-      std::istrstream is(buf.data(), buf.size());
+      std::istringstream is(std::string(buf.data(), buf.size()));
 
       InitTokens(is);
     }
 
     {
       auto buf = ReadFile(mgr, lexicon);
-      std::istrstream is(buf.data(), buf.size());
+      std::istringstream is(std::string(buf.data(), buf.size()));
       InitLexicon(is);
     }
   }

--- a/sherpa-onnx/csrc/homophone-replacer.cc
+++ b/sherpa-onnx/csrc/homophone-replacer.cc
@@ -9,7 +9,6 @@
 #include <memory>
 #include <sstream>
 #include <string>
-#include <strstream>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -112,7 +111,7 @@ class HomophoneReplacer::Impl {
     {
       auto buf = ReadFile(mgr, config.lexicon);
 
-      std::istrstream is(buf.data(), buf.size());
+      std::istringstream is(std::string(buf.data(), buf.size()));
       InitLexicon(is);
     }
 
@@ -125,7 +124,7 @@ class HomophoneReplacer::Impl {
           SHERPA_ONNX_LOGE("hr rule fst: %s", f.c_str());
         }
         auto buf = ReadFile(mgr, f);
-        std::istrstream is(buf.data(), buf.size());
+        std::istringstream is(std::string(buf.data(), buf.size()));
         replacer_list_.push_back(
             std::make_unique<kaldifst::TextNormalizer>(is));
       }

--- a/sherpa-onnx/csrc/keyword-spotter-transducer-impl.h
+++ b/sherpa-onnx/csrc/keyword-spotter-transducer-impl.h
@@ -9,7 +9,7 @@
 #include <memory>
 #include <regex>  // NOLINT
 #include <string>
-#include <strstream>
+#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -321,7 +321,7 @@ class KeywordSpotterTransducerImpl : public KeywordSpotterImpl {
 
     auto buf = ReadFile(mgr, config_.keywords_file);
 
-    std::istrstream is(buf.data(), buf.size());
+    std::istringstream is(std::string(buf.data(), buf.size()));
 
     if (!is) {
 #if __OHOS__

--- a/sherpa-onnx/csrc/kokoro-multi-lang-lexicon.cc
+++ b/sherpa-onnx/csrc/kokoro-multi-lang-lexicon.cc
@@ -9,7 +9,6 @@
 #include <regex>
 #include <sstream>
 #include <string>
-#include <strstream>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -438,7 +437,7 @@ class KokoroMultiLangLexicon::Impl {
   void InitTokens(Manager *mgr, const std::string &tokens) {
     auto buf = ReadFile(mgr, tokens);
 
-    std::istrstream is(buf.data(), buf.size());
+    std::istringstream is(std::string(buf.data(), buf.size()));
     InitTokens(is);
   }
 
@@ -491,7 +490,7 @@ class KokoroMultiLangLexicon::Impl {
     for (const auto &f : files) {
       auto buf = ReadFile(mgr, f);
 
-      std::istrstream is(buf.data(), buf.size());
+      std::istringstream is(std::string(buf.data(), buf.size()));
       InitLexicon(is);
     }
   }

--- a/sherpa-onnx/csrc/lexicon.cc
+++ b/sherpa-onnx/csrc/lexicon.cc
@@ -11,7 +11,6 @@
 #include <memory>
 #include <sstream>
 #include <string>
-#include <strstream>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -131,13 +130,13 @@ Lexicon::Lexicon(Manager *mgr, const std::string &lexicon,
 
   {
     auto buf = ReadFile(mgr, tokens);
-    std::istrstream is(buf.data(), buf.size());
+    std::istringstream is(std::string(buf.data(), buf.size()));
     InitTokens(is);
   }
 
   {
     auto buf = ReadFile(mgr, lexicon);
-    std::istrstream is(buf.data(), buf.size());
+    std::istringstream is(std::string(buf.data(), buf.size()));
     InitLexicon(is);
   }
 

--- a/sherpa-onnx/csrc/matcha-tts-lexicon.cc
+++ b/sherpa-onnx/csrc/matcha-tts-lexicon.cc
@@ -12,7 +12,6 @@
 #include <regex>  // NOLINT
 #include <sstream>
 #include <string>
-#include <strstream>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -174,7 +173,7 @@ class MatchaTtsLexicon::Impl {
 
     {
       auto buf = ReadFile(mgr, tokens);
-      std::istrstream is(buf.data(), buf.size());
+      std::istringstream is(std::string(buf.data(), buf.size()));
 
       InitTokens(is);
     }
@@ -184,7 +183,7 @@ class MatchaTtsLexicon::Impl {
     for (const auto &f : files) {
       auto buf = ReadFile(mgr, f);
 
-      std::istrstream is(buf.data(), buf.size());
+      std::istringstream is(std::string(buf.data(), buf.size()));
       InitLexicon(is);
     }
 

--- a/sherpa-onnx/csrc/melo-tts-lexicon.cc
+++ b/sherpa-onnx/csrc/melo-tts-lexicon.cc
@@ -8,7 +8,6 @@
 #include <regex>  // NOLINT
 #include <sstream>
 #include <string>
-#include <strstream>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -53,14 +52,14 @@ class MeloTtsLexicon::Impl {
     {
       auto buf = ReadFile(mgr, tokens);
 
-      std::istrstream is(buf.data(), buf.size());
+      std::istringstream is(std::string(buf.data(), buf.size()));
       InitTokens(is);
     }
 
     {
       auto buf = ReadFile(mgr, lexicon);
 
-      std::istrstream is(buf.data(), buf.size());
+      std::istringstream is(std::string(buf.data(), buf.size()));
       InitLexicon(is);
     }
   }

--- a/sherpa-onnx/csrc/offline-recognizer-impl.cc
+++ b/sherpa-onnx/csrc/offline-recognizer-impl.cc
@@ -6,7 +6,7 @@
 
 #include <memory>
 #include <string>
-#include <strstream>
+#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -806,7 +806,7 @@ OfflineRecognizerImpl::OfflineRecognizerImpl(
         SHERPA_ONNX_LOGE("rule fst: %s", f.c_str());
       }
       auto buf = ReadFile(mgr, f);
-      std::istrstream is(buf.data(), buf.size());
+      std::istringstream is(std::string(buf.data(), buf.size()));
       itn_list_.push_back(std::make_unique<kaldifst::TextNormalizer>(is));
     }
   }
@@ -824,7 +824,7 @@ OfflineRecognizerImpl::OfflineRecognizerImpl(
       auto buf = ReadFile(mgr, f);
 
       std::unique_ptr<std::istream> s(
-          new std::istrstream(buf.data(), buf.size()));
+          new std::istringstream(std::string(buf.data(), buf.size())));
 
       std::unique_ptr<fst::FarReader<fst::StdArc>> reader(
           fst::FarReader<fst::StdArc>::Open(std::move(s)));

--- a/sherpa-onnx/csrc/offline-tts-character-frontend.cc
+++ b/sherpa-onnx/csrc/offline-tts-character-frontend.cc
@@ -10,7 +10,6 @@
 #include <memory>
 #include <sstream>
 #include <string>
-#include <strstream>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -96,7 +95,7 @@ OfflineTtsCharacterFrontend::OfflineTtsCharacterFrontend(
     const OfflineTtsVitsModelMetaData &meta_data)
     : meta_data_(meta_data) {
   auto buf = ReadFile(mgr, tokens);
-  std::istrstream is(buf.data(), buf.size());
+  std::istringstream is(std::string(buf.data(), buf.size()));
   token2id_ = ReadTokens(is);
 }
 

--- a/sherpa-onnx/csrc/offline-tts-kitten-impl.h
+++ b/sherpa-onnx/csrc/offline-tts-kitten-impl.h
@@ -8,7 +8,7 @@
 #include <ios>
 #include <memory>
 #include <string>
-#include <strstream>
+#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -102,7 +102,7 @@ class OfflineTtsKittenImpl : public OfflineTtsImpl {
 #endif
         }
         auto buf = ReadFile(mgr, f);
-        std::istrstream is(buf.data(), buf.size());
+        std::istringstream is(std::string(buf.data(), buf.size()));
         tn_list_.push_back(std::make_unique<kaldifst::TextNormalizer>(is));
       }
     }
@@ -124,7 +124,7 @@ class OfflineTtsKittenImpl : public OfflineTtsImpl {
         auto buf = ReadFile(mgr, f);
 
         std::unique_ptr<std::istream> s(
-            new std::istrstream(buf.data(), buf.size()));
+            new std::istringstream(std::string(buf.data(), buf.size())));
 
         std::unique_ptr<fst::FarReader<fst::StdArc>> reader(
             fst::FarReader<fst::StdArc>::Open(std::move(s)));

--- a/sherpa-onnx/csrc/offline-tts-kokoro-impl.h
+++ b/sherpa-onnx/csrc/offline-tts-kokoro-impl.h
@@ -8,7 +8,7 @@
 #include <ios>
 #include <memory>
 #include <string>
-#include <strstream>
+#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -103,7 +103,7 @@ class OfflineTtsKokoroImpl : public OfflineTtsImpl {
 #endif
         }
         auto buf = ReadFile(mgr, f);
-        std::istrstream is(buf.data(), buf.size());
+        std::istringstream is(std::string(buf.data(), buf.size()));
         tn_list_.push_back(std::make_unique<kaldifst::TextNormalizer>(is));
       }
     }
@@ -125,7 +125,7 @@ class OfflineTtsKokoroImpl : public OfflineTtsImpl {
         auto buf = ReadFile(mgr, f);
 
         std::unique_ptr<std::istream> s(
-            new std::istrstream(buf.data(), buf.size()));
+            new std::istringstream(std::string(buf.data(), buf.size())));
 
         std::unique_ptr<fst::FarReader<fst::StdArc>> reader(
             fst::FarReader<fst::StdArc>::Open(std::move(s)));

--- a/sherpa-onnx/csrc/offline-tts-matcha-impl.h
+++ b/sherpa-onnx/csrc/offline-tts-matcha-impl.h
@@ -7,7 +7,7 @@
 #include <algorithm>
 #include <memory>
 #include <string>
-#include <strstream>
+#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -151,7 +151,7 @@ class OfflineTtsMatchaImpl : public OfflineTtsImpl {
 #endif
         }
         auto buf = ReadFile(mgr, f);
-        std::istrstream is(buf.data(), buf.size());
+        std::istringstream is(std::string(buf.data(), buf.size()));
         tn_list_.push_back(std::make_unique<kaldifst::TextNormalizer>(is));
       }
     }
@@ -173,7 +173,7 @@ class OfflineTtsMatchaImpl : public OfflineTtsImpl {
         auto buf = ReadFile(mgr, f);
 
         std::unique_ptr<std::istream> s(
-            new std::istrstream(buf.data(), buf.size()));
+            new std::istringstream(std::string(buf.data(), buf.size())));
 
         std::unique_ptr<fst::FarReader<fst::StdArc>> reader(
             fst::FarReader<fst::StdArc>::Open(std::move(s)));

--- a/sherpa-onnx/csrc/offline-tts-pocket-impl.h
+++ b/sherpa-onnx/csrc/offline-tts-pocket-impl.h
@@ -16,6 +16,7 @@
 #include <list>
 #include <memory>
 #include <mutex>
+#include <sstream>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -115,7 +116,7 @@ class OfflineTtsPocketImpl : public OfflineTtsImpl {
 #endif
         }
         auto buf = ReadFile(mgr, f);
-        std::istrstream is(buf.data(), buf.size());
+        std::istringstream is(std::string(buf.data(), buf.size()));
         tn_list_.push_back(std::make_unique<kaldifst::TextNormalizer>(is));
       }
     }
@@ -137,7 +138,7 @@ class OfflineTtsPocketImpl : public OfflineTtsImpl {
         auto buf = ReadFile(mgr, f);
 
         std::unique_ptr<std::istream> s(
-            new std::istrstream(buf.data(), buf.size()));
+            new std::istringstream(std::string(buf.data(), buf.size())));
 
         std::unique_ptr<fst::FarReader<fst::StdArc>> reader(
             fst::FarReader<fst::StdArc>::Open(std::move(s)));

--- a/sherpa-onnx/csrc/offline-tts-vits-impl.h
+++ b/sherpa-onnx/csrc/offline-tts-vits-impl.h
@@ -6,7 +6,7 @@
 
 #include <memory>
 #include <string>
-#include <strstream>
+#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -103,7 +103,7 @@ class OfflineTtsVitsImpl : public OfflineTtsImpl {
 #endif
         }
         auto buf = ReadFile(mgr, f);
-        std::istrstream is(buf.data(), buf.size());
+        std::istringstream is(std::string(buf.data(), buf.size()));
         tn_list_.push_back(std::make_unique<kaldifst::TextNormalizer>(is));
       }
     }
@@ -125,7 +125,7 @@ class OfflineTtsVitsImpl : public OfflineTtsImpl {
         auto buf = ReadFile(mgr, f);
 
         std::unique_ptr<std::istream> s(
-            new std::istrstream(buf.data(), buf.size()));
+            new std::istringstream(std::string(buf.data(), buf.size())));
 
         std::unique_ptr<fst::FarReader<fst::StdArc>> reader(
             fst::FarReader<fst::StdArc>::Open(std::move(s)));

--- a/sherpa-onnx/csrc/offline-tts-zipvoice-impl.h
+++ b/sherpa-onnx/csrc/offline-tts-zipvoice-impl.h
@@ -8,7 +8,7 @@
 #include <cmath>
 #include <memory>
 #include <string>
-#include <strstream>
+#include <sstream>
 #include <utility>
 #include <vector>
 

--- a/sherpa-onnx/csrc/online-recognizer-impl.cc
+++ b/sherpa-onnx/csrc/online-recognizer-impl.cc
@@ -6,7 +6,7 @@
 
 #include <memory>
 #include <string>
-#include <strstream>
+#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -217,7 +217,7 @@ OnlineRecognizerImpl::OnlineRecognizerImpl(Manager *mgr,
         SHERPA_ONNX_LOGE("rule fst: %s", f.c_str());
       }
       auto buf = ReadFile(mgr, f);
-      std::istrstream is(buf.data(), buf.size());
+      std::istringstream is(std::string(buf.data(), buf.size()));
       itn_list_.push_back(std::make_unique<kaldifst::TextNormalizer>(is));
     }
   }
@@ -235,7 +235,7 @@ OnlineRecognizerImpl::OnlineRecognizerImpl(Manager *mgr,
       auto buf = ReadFile(mgr, f);
 
       std::unique_ptr<std::istream> s(
-          new std::istrstream(buf.data(), buf.size()));
+          new std::istringstream(std::string(buf.data(), buf.size())));
 
       std::unique_ptr<fst::FarReader<fst::StdArc>> reader(
           fst::FarReader<fst::StdArc>::Open(std::move(s)));

--- a/sherpa-onnx/csrc/piper-phonemize-lexicon.cc
+++ b/sherpa-onnx/csrc/piper-phonemize-lexicon.cc
@@ -11,7 +11,6 @@
 #include <mutex>
 #include <sstream>
 #include <string>
-#include <strstream>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -347,7 +346,7 @@ PiperPhonemizeLexicon::PiperPhonemizeLexicon(
     : vits_meta_data_(vits_meta_data) {
   {
     auto buf = ReadFile(mgr, tokens);
-    std::istrstream is(buf.data(), buf.size());
+    std::istringstream is(std::string(buf.data(), buf.size()));
     token2id_ = ReadTokens(is);
   }
 
@@ -400,7 +399,7 @@ PiperPhonemizeLexicon::PiperPhonemizeLexicon(
     : matcha_meta_data_(matcha_meta_data), is_matcha_(true) {
   {
     auto buf = ReadFile(mgr, tokens);
-    std::istrstream is(buf.data(), buf.size());
+    std::istringstream is(std::string(buf.data(), buf.size()));
     token2id_ = ReadTokens(is);
   }
 
@@ -417,7 +416,7 @@ PiperPhonemizeLexicon::PiperPhonemizeLexicon(
     : kokoro_meta_data_(kokoro_meta_data), is_kokoro_(true) {
   {
     auto buf = ReadFile(mgr, tokens);
-    std::istrstream is(buf.data(), buf.size());
+    std::istringstream is(std::string(buf.data(), buf.size()));
     token2id_ = ReadTokens(is);
   }
 
@@ -434,7 +433,7 @@ PiperPhonemizeLexicon::PiperPhonemizeLexicon(
     : kitten_meta_data_(kitten_meta_data), is_kitten_(true) {
   {
     auto buf = ReadFile(mgr, tokens);
-    std::istrstream is(buf.data(), buf.size());
+    std::istringstream is(std::string(buf.data(), buf.size()));
     token2id_ = ReadTokens(is);
   }
 

--- a/sherpa-onnx/csrc/rknn/keyword-spotter-transducer-rknn-impl.h
+++ b/sherpa-onnx/csrc/rknn/keyword-spotter-transducer-rknn-impl.h
@@ -9,7 +9,7 @@
 #include <memory>
 #include <regex>  // NOLINT
 #include <string>
-#include <strstream>
+#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -260,7 +260,7 @@ class KeywordSpotterTransducerRknnImpl : public KeywordSpotterImpl {
 
     auto buf = ReadFile(mgr, config_.keywords_file);
 
-    std::istrstream is(buf.data(), buf.size());
+    std::istringstream is(std::string(buf.data(), buf.size()));
 
     if (!is) {
 #if __OHOS__

--- a/sherpa-onnx/csrc/symbol-table.cc
+++ b/sherpa-onnx/csrc/symbol-table.cc
@@ -10,7 +10,6 @@
 #include <fstream>
 #include <sstream>
 #include <string>
-#include <strstream>
 #include <unordered_map>
 #include <utility>
 
@@ -164,7 +163,7 @@ template <typename Manager>
 SymbolTable::SymbolTable(Manager *mgr, const std::string &filename) {
   auto buf = ReadFile(mgr, filename);
 
-  std::istrstream is(buf.data(), buf.size());
+  std::istringstream is(std::string(buf.data(), buf.size()));
   Init(is);
 }
 

--- a/sherpa-onnx/jni/common.h
+++ b/sherpa-onnx/jni/common.h
@@ -8,7 +8,7 @@
 #include <string>
 
 #if __ANDROID_API__ >= 9
-#include <strstream>
+#include <sstream>
 
 #include "android/asset_manager.h"
 #include "android/asset_manager_jni.h"

--- a/sherpa-onnx/jni/wave-reader.cc
+++ b/sherpa-onnx/jni/wave-reader.cc
@@ -101,7 +101,7 @@ Java_com_k2fsa_sherpa_onnx_WaveReader_00024Companion_readWaveFromAsset(
   }
   std::vector<char> buffer = sherpa_onnx::ReadFile(mgr, p_filename);
 
-  std::istrstream is(buffer.data(), buffer.size());
+  std::istringstream is(std::string(buffer.data(), buffer.size()));
 #else
   std::ifstream is(p_filename, std::ios::binary);
 #endif


### PR DESCRIPTION
## Summary

`std::istrstream` (from `<strstream>`) has been deprecated since C++98 and produces `-Wdeprecated-declarations` warnings on GCC 14+ and Clang 18+. This PR replaces all 37 usages across 23 files with `std::istringstream` (from `<sstream>`).

## Changes

- **Pattern A** (30 sites): `std::istrstream is(buf.data(), buf.size())` → `std::istringstream is(std::string(buf.data(), buf.size()))`
- **Pattern B** (7 sites): `new std::istrstream(buf.data(), buf.size())` → `new std::istringstream(std::string(buf.data(), buf.size()))`
- For files that already include `<sstream>`, the redundant `<strstream>` include is simply removed
- For `offline-tts-pocket-impl.h` which used `istrstream` without including `<strstream>` (transitive include), `<sstream>` was added directly
- For `offline-tts-zipvoice-impl.h` which includes `<strstream>` but never uses `istrstream`, replaced with `<sstream>`

## Safety

The zero-copy property of `istrstream` is not needed at any of these call sites:
- All source buffers (`buf` from `ReadFile`, `data` from C API) outlive the stream usage
- Data sizes are small (symbol tables, lexicons, WAV chunks, FST rules)
- For heap-allocated Pattern B cases, `istringstream` is actually safer — the stream owns its data, eliminating any dangling-pointer risk

## Files changed (23)

| Category | Files |
|----------|-------|
| C API | `c-api/c-api.cc` |
| Core | `symbol-table.cc`, `lexicon.cc`, `offline-recognizer-impl.cc`, `online-recognizer-impl.cc`, `audio-tagging-label-file.cc`, `keyword-spotter-transducer-impl.h`, `piper-phonemize-lexicon.cc` |
| TTS | `offline-tts-matcha-impl.h`, `offline-tts-vits-impl.h`, `offline-tts-character-frontend.cc`, `offline-tts-kokoro-impl.h`, `offline-tts-kitten-impl.h`, `offline-tts-pocket-impl.h`, `offline-tts-zipvoice-impl.h`, `matcha-tts-lexicon.cc`, `melo-tts-lexicon.cc`, `character-lexicon.cc`, `kokoro-multi-lang-lexicon.cc`, `homophone-replacer.cc` |
| RKNN | `rknn/keyword-spotter-transducer-rknn-impl.h` |
| JNI | `jni/common.h`, `jni/wave-reader.cc` |

No functional or behavioral changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust handling of invalid/empty audio input to avoid failures when loading wave data.

* **Chores**
  * Replaced deprecated C++ stream usage across multiple internal modules for improved compatibility and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->