### PR TITLE
Export Moonshine v2 models to sherpa-onnx

### DIFF
--- a/.github/workflows/export-moonshine-to-onnx.yaml
+++ b/.github/workflows/export-moonshine-to-onnx.yaml
@@ -3,7 +3,7 @@ name: export-moonshine-to-onnx
 on:
   push:
     branches:
-      - export-moonshine-v2
+      - export-moonshine-v2-2
   workflow_dispatch:
 
 concurrency:
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [macos-latest]
         python-version: ["3.10"]
-        version: [v1, v2]
+        version: [v2]
 
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
         run: |
           pip install -q onnx onnxruntime librosa tokenizers soundfile moonshine-voice
 
-      - name: Run ${{ matrix.version }}
+      - name: Run v1
         if: matrix.version == 'v1'
         shell: bash
         run: |
@@ -46,7 +46,7 @@ jobs:
           mv -v scripts/moonshine/*.tar.bz2 .
           mv -v scripts/moonshine/sherpa-onnx-* ./
 
-      - name: Run ${{ matrix.version }}
+      - name: Run v2
         if: matrix.version == 'v2'
         shell: bash
         run: |
@@ -79,6 +79,13 @@ jobs:
             models=(
               sherpa-onnx-moonshine-tiny-en-int8
               sherpa-onnx-moonshine-base-en-int8
+              sherpa-onnx-moonshine-base-ar-quantized-2026-02-27
+              sherpa-onnx-moonshine-base-en-quantized-2026-02-27
+              sherpa-onnx-moonshine-base-es-quantized-2026-02-27
+              sherpa-onnx-moonshine-base-ja-quantized-2026-02-27
+              sherpa-onnx-moonshine-base-zh-quantized-2026-02-27
+              sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27
+              sherpa-onnx-moonshine-tiny-ja-quantized-2026-02-27
             )
             for d in ${models[@]}; do
               if [ ! -d $d ]; then

--- a/scripts/moonshine/v2/run.sh
+++ b/scripts/moonshine/v2/run.sh
@@ -21,6 +21,12 @@ python3 -m moonshine_voice.download --language ko --model-arch 0
 python3 -m moonshine_voice.download --language vi --model-arch 1
 python3 -m moonshine_voice.download --language uk --model-arch 1
 
+sleep 2
+
+ls -lh models/download.moonshine.ai/model/*/*/*
+
+sleep 2
+
 names=(
   base-ar
   base-en
@@ -35,7 +41,7 @@ for name in ${names[@]}; do
   mv -v models/download.moonshine.ai/model/$name/quantized/$name/* .
   python3 ./generate_tokens.py
   rm tokenizer.bin
-  d=sherpa-onnx-moonshine-$name-2026-02-27
+  d=sherpa-onnx-moonshine-$name-quantized-2026-02-27
   mkdir -p $d
   mv *ort $d/
   cp LICENSE $d
@@ -54,7 +60,6 @@ for name in ${names[@]}; do
   mv -v $d.tar.bz2 ../../../
 done
 
-# ls -lh models/download.moonshine.ai/model/*/*/*
 #
 # models/download.moonshine.ai/model/base-ar/quantized/base-ar:
 # total 135M

--- a/sherpa-onnx/python/csrc/offline-moonshine-model-config.cc
+++ b/sherpa-onnx/python/csrc/offline-moonshine-model-config.cc
@@ -17,9 +17,9 @@ void PybindOfflineMoonshineModelConfig(py::module *m) {
       .def(py::init<const std::string &, const std::string &,
                     const std::string &, const std::string &,
                     const std::string &>(),
-           py::arg("preprocessor"), py::arg("encoder"),
-           py::arg("uncached_decoder"), py::arg("cached_decoder"),
-           py::arg("merged_decoder"))
+           py::arg("preprocessor") = {}, py::arg("encoder") = {},
+           py::arg("uncached_decoder") = {}, py::arg("cached_decoder") = {},
+           py::arg("merged_decoder") = {})
       .def_readwrite("preprocessor", &PyClass::preprocessor)
       .def_readwrite("encoder", &PyClass::encoder)
       .def_readwrite("uncached_decoder", &PyClass::uncached_decoder)

--- a/sherpa-onnx/python/sherpa_onnx/offline_recognizer.py
+++ b/sherpa-onnx/python/sherpa_onnx/offline_recognizer.py
@@ -1335,6 +1335,87 @@ class OfflineRecognizer(object):
         return self
 
     @classmethod
+    def from_moonshine_v2(
+        cls,
+        encoder: str,
+        decoder: str,
+        tokens: str,
+        num_threads: int = 1,
+        decoding_method: str = "greedy_search",
+        debug: bool = False,
+        provider: str = "cpu",
+        rule_fsts: str = "",
+        rule_fars: str = "",
+        hr_dict_dir: str = "",
+        hr_rule_fsts: str = "",
+        hr_lexicon: str = "",
+    ):
+        """
+        Please refer to
+        `<https://k2-fsa.github.io/sherpa/onnx/moonshine/index.html>`_
+        to download pre-trained models for different kinds of moonshine v2 models,
+        e.g., tiny-en, base-zh, etc.
+
+        Args:
+          encoder:
+            Path to the encoder model, e.g., encoder_model.ort
+          decoder:
+            Path to the merged decoder model, e.g., decoder_model_merged.ort,
+          tokens:
+            Path to ``tokens.txt``. Each line in ``tokens.txt`` contains two
+            columns::
+
+                symbol integer_id
+
+          num_threads:
+            Number of threads for neural network computation.
+          decoding_method:
+            Valid values: greedy_search.
+          debug:
+            True to show debug messages.
+          provider:
+            onnxruntime execution providers. Valid values are: cpu, cuda, coreml.
+          rule_fsts:
+            If not empty, it specifies fsts for inverse text normalization.
+            If there are multiple fsts, they are separated by a comma.
+          rule_fars:
+            If not empty, it specifies fst archives for inverse text normalization.
+            If there are multiple archives, they are separated by a comma.
+        """
+        self = cls.__new__(cls)
+        model_config = OfflineModelConfig(
+            moonshine=OfflineMoonshineModelConfig(
+                encoder=encoder,
+                merged_decoder=decoder,
+            ),
+            tokens=tokens,
+            num_threads=num_threads,
+            debug=debug,
+            provider=provider,
+        )
+
+        unused_feat_config = FeatureExtractorConfig(
+            sampling_rate=16000,
+            feature_dim=80,
+        )
+
+        recognizer_config = OfflineRecognizerConfig(
+            model_config=model_config,
+            feat_config=unused_feat_config,
+            decoding_method=decoding_method,
+            rule_fsts=rule_fsts,
+            rule_fars=rule_fars,
+            hr=HomophoneReplacerConfig(
+                dict_dir=hr_dict_dir,
+                lexicon=hr_lexicon,
+                rule_fsts=hr_rule_fsts,
+            ),
+        )
+        self.recognizer = _Recognizer(recognizer_config)
+        self.config = recognizer_config
+        return self
+
+    @classmethod
     def from_tdnn_ctc(
         cls,
         model: str,


### PR DESCRIPTION
You can download the models from
https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models

See also
- [sherpa-onnx-moonshine-tiny-ko-quantized-2026-02-27.tar.bz2](https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-tiny-ko-quantized-2026-02-27.tar.bz2)
- [sherpa-onnx-moonshine-tiny-ja-quantized-2026-02-27.tar.bz2](https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-tiny-ja-quantized-2026-02-27.tar.bz2)
- [sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27.tar.bz2](https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27.tar.bz2)
- [sherpa-onnx-moonshine-base-zh-quantized-2026-02-27.tar.bz2](https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-base-zh-quantized-2026-02-27.tar.bz2)
- [sherpa-onnx-moonshine-base-vi-quantized-2026-02-27.tar.bz2](https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-base-vi-quantized-2026-02-27.tar.bz2)
- [sherpa-onnx-moonshine-base-uk-quantized-2026-02-27.tar.bz2](https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-base-uk-quantized-2026-02-27.tar.bz2)
- [sherpa-onnx-moonshine-base-ja-quantized-2026-02-27.tar.bz2](https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-base-ja-quantized-2026-02-27.tar.bz2)
- [sherpa-onnx-moonshine-base-es-quantized-2026-02-27.tar.bz2](https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-base-es-quantized-2026-02-27.tar.bz2)
- [sherpa-onnx-moonshine-base-en-quantized-2026-02-27.tar.bz2](https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-base-en-quantized-2026-02-27.tar.bz2)
- [sherpa-onnx-moonshine-base-ar-quantized-2026-02-27.tar.bz2](https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-base-ar-quantized-2026-02-27.tar.bz2)

Usage:

```bash
./build/bin/sherpa-onnx-offline \
  --moonshine-encoder=./sherpa-onnx-moonshine-base-zh-quantized-2026-02-27/encoder_model.ort \
  --moonshine-merged-decoder=./sherpa-onnx-moonshine-base-zh-quantized-2026-02-27/decoder_model_merged.ort \
  --tokens=./sherpa-onnx-moonshine-base-zh-quantized-2026-02-27/tokens.txt \
  --debug=0 \
  ./sherpa-onnx-moonshine-base-zh-quantized-2026-02-27/test_wavs/0.wav
```

Output logs are:

```
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/parse-options.cc:Read:373 ./build/bin/sherpa-onnx-offline --moonshine-encoder=./sherpa-onnx-moonshine-base-zh-quantized-2026-02-27/encoder_model.ort --moonshine-merged-decoder=./sherpa-onnx-moonshine-base-zh-quantized-2026-02-27/decoder_model_merged.ort --tokens=./sherpa-onnx-moonshine-base-zh-quantized-2026-02-27/tokens.txt --debug=0 ./sherpa-onnx-moonshine-base-zh-quantized-2026-02-27/test_wavs/0.wav 

OfflineRecognizerConfig(feat_config=FeatureExtractorConfig(sampling_rate=16000, feature_dim=80, low_freq=20, high_freq=-400, dither=0, normalize_samples=True, snip_edges=False), model_config=OfflineModelConfig(transducer=OfflineTransducerModelConfig(encoder_filename="", decoder_filename="", joiner_filename=""), paraformer=OfflineParaformerModelConfig(model=""), nemo_ctc=OfflineNemoEncDecCtcModelConfig(model=""), whisper=OfflineWhisperModelConfig(encoder="", decoder="", language="", task="transcribe", tail_paddings=-1, enable_token_timestamps=False, enable_segment_timestamps=False), fire_red_asr=OfflineFireRedAsrModelConfig(encoder="", decoder=""), tdnn=OfflineTdnnModelConfig(model=""), zipformer_ctc=OfflineZipformerCtcModelConfig(model=""), wenet_ctc=OfflineWenetCtcModelConfig(model=""), sense_voice=OfflineSenseVoiceModelConfig(model="", language="auto", use_itn=False), moonshine=OfflineMoonshineModelConfig(preprocessor="", encoder="./sherpa-onnx-moonshine-base-zh-quantized-2026-02-27/encoder_model.ort", uncached_decoder="", cached_decoder="", merged_decoder="./sherpa-onnx-moonshine-base-zh-quantized-2026-02-27/decoder_model_merged.ort"), dolphin=OfflineDolphinModelConfig(model=""), canary=OfflineCanaryModelConfig(encoder="", decoder="", src_lang="", tgt_lang="", use_pnc=True), omnilingual=OfflineOmnilingualAsrCtcModelConfig(model=""), funasr_nano=OfflineFunASRNanoModelConfig(encoder_adaptor="", llm="", embedding="", tokenizer="", system_prompt="You are a helpful assistant.", user_prompt="语音转写：", max_new_tokens=512, temperature=1e-06, top_p=0.8, seed=42, language="", itn=True, hotwords=""), medasr=OfflineMedAsrCtcModelConfig(model=""), fire_red_asr_ctc=OfflineFireRedAsrCtcModelConfig(model=""), telespeech_ctc="", tokens="./sherpa-onnx-moonshine-base-zh-quantized-2026-02-27/tokens.txt", num_threads=2, debug=False, provider="cpu", model_type="", modeling_unit="cjkchar", bpe_vocab=""), lm_config=OfflineLMConfig(model="", scale=0.5, lodr_scale=0.01, lodr_fst="", lodr_backoff_id=-1), ctc_fst_decoder_config=OfflineCtcFstDecoderConfig(graph="", max_active=3000), decoding_method="greedy_search", max_active_paths=4, hotwords_file="", hotwords_score=1.5, blank_penalty=0, rule_fsts="", rule_fars="", hr=HomophoneReplacerConfig(lexicon="", rule_fsts=""))
Creating recognizer ...
recognizer created in 0.351 s
Started
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/offline-stream.cc:AcceptWaveformImpl:133 Creating a resampler:
   in_sample_rate: 24000
   output_sample_rate: 16000

Done!

./sherpa-onnx-moonshine-base-zh-quantized-2026-02-27/test_wavs/0.wav
{"lang": "", "emotion": "", "event": "", "text": " 不要问你的国家能为你做什么，而要问你能为你的国家做什么。", "timestamps": [], "durations": [], "tokens":[" ", "不", "要", "问", "你", "的", "国", "家", "能", "为", "你", "<0xE5>", "<0x81>", "<0x9A>", "<0xE4>", "<0xBB>", "<0x80>", "么", "，", "而", "要", "问", "你", "能", "为", "你", "的", "国", "家", "<0xE5>", "<0x81>", "<0x9A>", "<0xE4>", "<0xBB>", "<0x80>", "么", "。"], "ys_log_probs": [], "words": []}
----
num threads: 2
decoding method: greedy_search
Elapsed seconds: 0.079 s
Real time factor (RTF): 0.079 / 4.759 = 0.017
```
 
cc @nshmyrev @nabil6391 @zhitao-zeng @jiangzhuo

---

CI logs
```
models/download.moonshine.ai/model/base-en/quantized/base-en:
total 292776
-rw-r--r--  1 runner  staff   104M Feb 27 09:27 decoder_model_merged.ort
-rw-r--r--  1 runner  staff    30M Feb 27 09:26 encoder_model.ort
-rw-r--r--  1 runner  staff   244K Feb 27 09:27 tokenizer.bin
models/download.moonshine.ai/model/base-es/quantized/base-es:
total 126608
-rw-r--r--  1 runner  staff    42M Feb 27 09:26 decoder_model_merged.ort
-rw-r--r--  1 runner  staff    20M Feb 27 09:26 encoder_model.ort
-rw-r--r--  1 runner  staff   236K Feb 27 09:26 tokenizer.bin
models/download.moonshine.ai/model/base-ja/quantized/base-ja:
total 275408
-rw-r--r--  1 runner  staff   104M Feb 27 09:27 decoder_model_merged.ort
-rw-r--r--  1 runner  staff    30M Feb 27 09:27 encoder_model.ort
-rw-r--r--  1 runner  staff   244K Feb 27 09:27 tokenizer.bin
models/download.moonshine.ai/model/base-uk/quantized/base-uk:
total 275408
-rw-r--r--  1 runner  staff   104M Feb 27 09:27 decoder_model_merged.ort
-rw-r--r--  1 runner  staff    30M Feb 27 09:27 encoder_model.ort
-rw-r--r--  1 runner  staff   244K Feb 27 09:27 tokenizer.bin
models/download.moonshine.ai/model/base-vi/quantized/base-vi:
total 275408
-rw-r--r--  1 runner  staff   104M Feb 27 09:27 decoder_model_merged.ort
-rw-r--r--  1 runner  staff    30M Feb 27 09:27 encoder_model.ort
-rw-r--r--  1 runner  staff   244K Feb 27 09:27 tokenizer.bin
models/download.moonshine.ai/model/base-zh/quantized/base-zh:
total 291336
-rw-r--r--  1 runner  staff   104M Feb 27 09:26 decoder_model_merged.ort
-rw-r--r--  1 runner  staff    30M Feb 27 09:26 encoder_model.ort
-rw-r--r--  1 runner  staff   244K Feb 27 09:26 tokenizer.bin
models/download.moonshine.ai/model/tiny-en/quantized/tiny-en:
total 85840
-rw-r--r--  1 runner  staff    29M Feb 27 09:26 decoder_model_merged.ort
-rw-r--r--  1 runner  staff    13M Feb 27 09:26 encoder_model.ort
-rw-r--r--  1 runner  staff   244K Feb 27 09:26 tokenizer.bin
models/download.moonshine.ai/model/tiny-ja/quantized/tiny-ja:
total 140280
-rw-r--r--  1 runner  staff    56M Feb 27 09:27 decoder_model_merged.ort
-rw-r--r--  1 runner  staff    13M Feb 27 09:27 encoder_model.ort
-rw-r--r--  1 runner  staff   244K Feb 27 09:27 tokenizer.bin
models/download.moonshine.ai/model/tiny-ko/quantized/tiny-ko:
total 141024
-rw-r--r--  1 runner  staff    56M Feb 27 09:27 decoder_model_merged.ort
-rw-r--r--  1 runner  staff    13M Feb 27 09:27 encoder_model.ort
-rw-r--r--  1 runner  staff   244K Feb 27 09:27 tokenizer.bin
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Moonshine v2 model support with multiple quantized variants
  * Expanded model distribution to additional platforms

* **Chores**
  * Updated model export and publishing workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->