### PR TITLE
Update Python APIs for Moonshine v2 models

### DIFF
--- a/.github/scripts/test-python.sh
+++ b/.github/scripts/test-python.sh
@@ -8,6 +8,18 @@ log() {
   echo -e "$(date '+%Y-%m-%d %H:%M:%S') (${fname}:${BASH_LINENO[0]}:${FUNCNAME[1]}) $*"
 }
 
+log "test Moonshine v2"
+
+curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27.tar.bz2
+tar xvf sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27.tar.bz2
+rm sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27.tar.bz2
+
+ls -lh sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27
+
+python3 ./python-api-examples/offline-moonshine-decode-files-v2.py
+
+rm -rf  sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27
+
 log "test FireRedASR CTC"
 
 curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-fire-red-asr2-ctc-zh_en-int8-2026-02-25.tar.bz2

--- a/python-api-examples/offline-moonshine-decode-files-v2.py
+++ b/python-api-examples/offline-moonshine-decode-files-v2.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+"""
+This file shows how to use a non-streaming Moonshine model from
+https://github.com/usefulsensors/moonshine
+to decode files.
+
+Please download model files from
+https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models
+
+For instance,
+
+wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27.tar.bz2
+tar xvf sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27.tar.bz2
+rm sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27.tar.bz2
+"""
+
+import datetime as dt
+from pathlib import Path
+
+import sherpa_onnx
+import soundfile as sf
+
+
+def create_recognizer():
+    encoder = "./sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27/encoder_model.ort"
+    decoder = (
+        "./sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27/decoder_model_merged.ort"
+    )
+    tokens = "./sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27/tokens.txt"
+    test_wav = "./sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27/test_wavs/0.wav"
+
+    if not Path(encoder).is_file() or not Path(test_wav).is_file():
+        raise ValueError(
+            """Please download model files from
+            https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models
+            """
+        )
+    return (
+        sherpa_onnx.OfflineRecognizer.from_moonshine_v2(
+            encoder=encoder,
+            decoder=decoder,
+            tokens=tokens,
+            debug=False,  # Set to True to see more logs
+        ),
+        test_wav,
+    )
+
+
+def main():
+    recognizer, wave_filename = create_recognizer()
+
+    audio, sample_rate = sf.read(wave_filename, dtype="float32", always_2d=True)
+    audio = audio[:, 0]  # only use the first channel
+
+    # audio is a 1-D float32 numpy array normalized to the range [-1, 1]
+    # sample_rate does not need to be 16000 Hz
+
+    start_t = dt.datetime.now()
+
+    stream = recognizer.create_stream()
+    stream.accept_waveform(sample_rate, audio)
+    recognizer.decode_stream(stream)
+
+    end_t = dt.datetime.now()
+    elapsed_seconds = (end_t - start_t).total_seconds()
+    duration = audio.shape[-1] / sample_rate
+    rtf = elapsed_seconds / duration
+
+    print(stream.result)
+    print(wave_filename)
+    print("Text:", stream.result.text)
+    print(f"Audio duration:\t{duration:.3f} s")
+    print(f"Elapsed:\t{elapsed_seconds:.3f} s")
+    print(f"RTF = {elapsed_seconds:.3f}/{duration:.3f} = {rtf:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sherpa-onnx/python/csrc/offline-moonshine-model-config.cc
+++ b/sherpa-onnx/python/csrc/offline-moonshine-model-config.cc
@@ -17,9 +17,9 @@ void PybindOfflineMoonshineModelConfig(py::module *m) {
       .def(py::init<const std::string &, const std::string &,
                     const std::string &, const std::string &,
                     const std::string &>(),
-           py::arg("preprocessor") = {}, py::arg("encoder") = {},
-           py::arg("uncached_decoder") = {}, py::arg("cached_decoder") = {},
-           py::arg("merged_decoder") = {})
+           py::arg("preprocessor") = "", py::arg("encoder") = "",
+           py::arg("uncached_decoder") = "", py::arg("cached_decoder") = "",
+           py::arg("merged_decoder") = "")
       .def_readwrite("preprocessor", &PyClass::preprocessor)
       .def_readwrite("encoder", &PyClass::encoder)
       .def_readwrite("uncached_decoder", &PyClass::uncached_decoder)


### PR DESCRIPTION
# Usage
```bash
(py312) fangjuns-MacBook-Pro:sherpa-onnx fangjun$ python3 ./python-api-examples/offline-moonshine-decode-files-v2.py
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/offline-stream.cc:AcceptWaveformImpl:133 Creating a resampler:
   in_sample_rate: 24000
   output_sample_rate: 16000

{"lang": "", "emotion": "", "event": "", "text": " Ask not what your country can do for you. Ask what you can do for your country.", "timestamps": [], "durations": [], "tokens":[" Ask", " not", " what", " your", " country", " can", " do", " for", " you", ".", " Ask", " what", " you", " can", " do", " for", " your", " country", "."], "ys_log_probs": [], "words": []}
./sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27/test_wavs/0.wav
Text:  Ask not what your country can do for you. Ask what you can do for your country.
Audio duration: 3.845 s
Elapsed:        0.056 s
RTF = 0.056/3.845 = 0.015
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Python example demonstrating offline audio decoding with Moonshine v2 model, including timing metrics and real-time factor calculations.
  * Expanded testing infrastructure for Moonshine v2 and FireRedASR CTC models.

* **Bug Fixes**
  * Fixed default parameter values in Moonshine model configuration for improved API usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->