### PR TITLE
Add Pascal API for Moonshine v2

### DIFF
--- a/.github/workflows/pascal.yaml
+++ b/.github/workflows/pascal.yaml
@@ -215,6 +215,8 @@ jobs:
           rm -rf sherpa-onnx-*
           echo "---"
 
+          ./run-moonshine-v2.sh
+
           ./run-moonshine.sh
           rm -rf sherpa-onnx-*
           echo "---"

--- a/pascal-api-examples/non-streaming-asr/.gitignore
+++ b/pascal-api-examples/non-streaming-asr/.gitignore
@@ -8,6 +8,7 @@ paraformer_itn
 sense_voice
 telespeech_ctc
 moonshine
+moonshine_v2
 dolphin_ctc
 zipformer_ctc
 wenet_ctc

--- a/pascal-api-examples/non-streaming-asr/moonshine_v2.pas
+++ b/pascal-api-examples/non-streaming-asr/moonshine_v2.pas
@@ -1,0 +1,78 @@
+{ Copyright (c)  2024-2026  Xiaomi Corporation }
+
+{
+This file shows how to use a non-streaming Moonshine v2 model
+to decode files.
+
+You can download the model files from
+https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models
+}
+
+program moonshine_v2;
+
+{$mode objfpc}
+
+uses
+  sherpa_onnx,
+  DateUtils,
+  SysUtils;
+
+var
+  Wave: TSherpaOnnxWave;
+  WaveFilename: AnsiString;
+
+  Config: TSherpaOnnxOfflineRecognizerConfig;
+  Recognizer: TSherpaOnnxOfflineRecognizer;
+  Stream: TSherpaOnnxOfflineStream;
+  RecognitionResult: TSherpaOnnxOfflineRecognizerResult;
+
+  Start: TDateTime;
+  Stop: TDateTime;
+
+  Elapsed: Single;
+  Duration: Single;
+  RealTimeFactor: Single;
+begin
+  Initialize(Config);
+
+  Config.ModelConfig.Moonshine.Encoder := './sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27/encoder_model.ort';
+  Config.ModelConfig.Moonshine.MergedDecoder := './sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27/decoder_model_merged.ort';
+
+  Config.ModelConfig.Tokens := './sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27/tokens.txt';
+  Config.ModelConfig.Provider := 'cpu';
+  Config.ModelConfig.NumThreads := 1;
+  Config.ModelConfig.Debug := False;
+
+  WaveFilename := './sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27/test_wavs/0.wav';
+
+  Wave := SherpaOnnxReadWave(WaveFilename);
+
+  Recognizer := TSherpaOnnxOfflineRecognizer.Create(Config);
+  Stream := Recognizer.CreateStream();
+  Start := Now;
+
+  Stream.AcceptWaveform(Wave.Samples, Wave.SampleRate);
+  Recognizer.Decode(Stream);
+
+  RecognitionResult := Recognizer.GetResult(Stream);
+
+  Stop := Now;
+
+  Elapsed := MilliSecondsBetween(Stop, Start) / 1000;
+  Duration := Length(Wave.Samples) / Wave.SampleRate;
+  RealTimeFactor := Elapsed / Duration;
+
+  WriteLn(RecognitionResult.ToString);
+  WriteLn(Format('NumThreads %d', [Config.ModelConfig.NumThreads]));
+  WriteLn(Format('Elapsed %.3f s', [Elapsed]));
+  WriteLn(Format('Wave duration %.3f s', [Duration]));
+  WriteLn(Format('RTF = %.3f/%.3f = %.3f', [Elapsed, Duration, RealTimeFactor]));
+
+  {Free resources to avoid memory leak.
+
+  Note: You don't need to invoke them for this simple script.
+  However, you have to invoke them in your own large/complex project.
+  }
+  FreeAndNil(Stream);
+  FreeAndNil(Recognizer);
+end.

--- a/pascal-api-examples/non-streaming-asr/run-moonshine-v2.sh
+++ b/pascal-api-examples/non-streaming-asr/run-moonshine-v2.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -ex
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SHERPA_ONNX_DIR=$(cd $SCRIPT_DIR/../.. && pwd)
+
+echo "SHERPA_ONNX_DIR: $SHERPA_ONNX_DIR"
+
+if [[ ! -f ../../build/install/lib/libsherpa-onnx-c-api.dylib  && ! -f ../../build/install/lib/libsherpa-onnx-c-api.so && ! -f ../../build/install/lib/sherpa-onnx-c-api.dll ]]; then
+  mkdir -p ../../build
+  pushd ../../build
+  cmake \
+    -DCMAKE_INSTALL_PREFIX=./install \
+    -DSHERPA_ONNX_ENABLE_PYTHON=OFF \
+    -DSHERPA_ONNX_ENABLE_TESTS=OFF \
+    -DSHERPA_ONNX_ENABLE_CHECK=OFF \
+    -DBUILD_SHARED_LIBS=ON \
+    -DSHERPA_ONNX_ENABLE_PORTAUDIO=OFF \
+    ..
+
+  cmake --build . --target install --config Release
+  ls -lh lib
+  popd
+fi
+
+if [ ! -f ./sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27/encoder_model.ort ]; then
+  curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27.tar.bz2
+  tar xvf sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27.tar.bz2
+  rm sherpa-onnx-moonshine-tiny-en-quantized-2026-02-27.tar.bz2
+fi
+
+fpc \
+  -dSHERPA_ONNX_USE_SHARED_LIBS \
+  -Fu$SHERPA_ONNX_DIR/sherpa-onnx/pascal-api \
+  -Fl$SHERPA_ONNX_DIR/build/install/lib \
+  ./moonshine_v2.pas
+
+export LD_LIBRARY_PATH=$SHERPA_ONNX_DIR/build/install/lib:$LD_LIBRARY_PATH
+export DYLD_LIBRARY_PATH=$SHERPA_ONNX_DIR/build/install/lib:$DYLD_LIBRARY_PATH
+
+./moonshine_v2

--- a/sherpa-onnx/pascal-api/sherpa_onnx.pas
+++ b/sherpa-onnx/pascal-api/sherpa_onnx.pas
@@ -435,6 +435,7 @@ type
     Encoder: AnsiString;
     UncachedDecoder: AnsiString;
     CachedDecoder: AnsiString;
+    MergedDecoder: AnsiString;
     function ToString: AnsiString;
   end;
 
@@ -947,6 +948,7 @@ type
     Encoder: PAnsiChar;
     UncachedDecoder: PAnsiChar;
     CachedDecoder: PAnsiChar;
+    MergedDecoder: PAnsiChar;
   end;
   SherpaOnnxOfflineTdnnModelConfig = record
     Model: PAnsiChar;
@@ -1921,8 +1923,10 @@ begin
     'Preprocessor := %s, ' +
     'Encoder := %s, ' +
     'UncachedDecoder := %s, ' +
-    'CachedDecoder := %s)',
-    [Self.Preprocessor, Self.Encoder, Self.UncachedDecoder, Self.CachedDecoder]);
+    'CachedDecoder := %s, ' +
+    'MergedDecoder := %s)',
+    [Self.Preprocessor, Self.Encoder, Self.UncachedDecoder, Self.CachedDecoder,
+     Self.MergedDecoder]);
 end;
 
 function TSherpaOnnxOfflineTdnnModelConfig.ToString: AnsiString;
@@ -2054,6 +2058,7 @@ begin
   C.ModelConfig.Moonshine.Encoder := PAnsiChar(Config.ModelConfig.Moonshine.Encoder);
   C.ModelConfig.Moonshine.UncachedDecoder := PAnsiChar(Config.ModelConfig.Moonshine.UncachedDecoder);
   C.ModelConfig.Moonshine.CachedDecoder := PAnsiChar(Config.ModelConfig.Moonshine.CachedDecoder);
+  C.ModelConfig.Moonshine.MergedDecoder := PAnsiChar(Config.ModelConfig.Moonshine.MergedDecoder);
 
   C.ModelConfig.FireRedAsr.Encoder := PAnsiChar(Config.ModelConfig.FireRedAsr.Encoder);
   C.ModelConfig.FireRedAsr.Decoder := PAnsiChar(Config.ModelConfig.FireRedAsr.Decoder);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Moonshine v2 offline speech recognition example with automated dependency management and compilation.
  * Added merged decoder variant support to Moonshine model configuration.

* **Tests**
  * Enhanced CI/CD pipeline to validate the new Moonshine v2 example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->