### PR TITLE
Fix #3171 : 去掉生成绝对路径函数中的窄字符WindowsAPI调用，改用宽字符API和C++17 std::filesystem来避免win平台中文路径问题

### DIFF
--- a/sherpa-onnx/csrc/file-utils.cc
+++ b/sherpa-onnx/csrc/file-utils.cc
@@ -92,9 +92,12 @@ std::vector<char> ReadFile(const std::string &filename) {
     }
 
     std::streamsize size = file.tellg();
+    if (size < 0) {
+      return {};
+    }
     file.seekg(0, std::ios::beg);
 
-    std::vector<char> buffer(size);
+    std::vector<char> buffer(static_cast<size_t>(size));
     if (!file.read(buffer.data(), size)) {
       return {};
     }

--- a/sherpa-onnx/csrc/file-utils.cc
+++ b/sherpa-onnx/csrc/file-utils.cc
@@ -5,27 +5,35 @@
 #include "sherpa-onnx/csrc/file-utils.h"
 
 #include <fstream>
-#include <filesystem>
 #include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
 
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <sys/stat.h>
+#include <unistd.h>
+#include <limits.h>
+#endif
+
 #include "sherpa-onnx/csrc/macros.h"
 
 namespace sherpa_onnx {
 std::wstring ToWideString(const std::string &s);
+std::string ToString(const std::wstring &s);
 
 bool FileExists(const std::string &filename) {
   try {
 #ifdef _WIN32
-    std::wstring wide_path = ToWideString(filename);
-    std::filesystem::path file_path(wide_path);
+    DWORD attributes = GetFileAttributesW(ToWideString(filename).c_str());
+    
+    return attributes != INVALID_FILE_ATTRIBUTES && !(attributes & FILE_ATTRIBUTE_DIRECTORY);
 #else
-    std::filesystem::path file_path(filename);
+    struct stat file_stat;
+    return stat(filename.c_str(), &file_stat) == 0 && S_ISREG(file_stat.st_mode);
 #endif
-    return std::filesystem::exists(file_path) && 
-           std::filesystem::is_regular_file(file_path);
   } catch (const std::exception&) {
     return false;
   }
@@ -39,14 +47,44 @@ void AssertFileExists(const std::string &filename) {
 }
 
 std::vector<char> ReadFile(const std::string &filename) {
+  if (filename.empty()) {
+    return {};
+  }
   try {
-#ifdef _WIN32
-    std::wstring wide_path = ToWideString(filename);
-    std::filesystem::path file_path(wide_path);
+#ifdef _WIN32     
+    HANDLE hFile = CreateFileW(
+        ToWideString(filename).c_str(),
+        GENERIC_READ,
+        FILE_SHARE_READ,
+        nullptr,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL,
+        nullptr
+    );
+
+    if (hFile == INVALID_HANDLE_VALUE) {
+      return {};
+    }
+
+    std::unique_ptr<void, decltype(&CloseHandle)> file_guard(
+      hFile, CloseHandle);
+
+    LARGE_INTEGER file_size;
+    if (!GetFileSizeEx(hFile, &file_size) || file_size.QuadPart > SIZE_MAX) {
+      return {};
+    }
+
+    std::vector<char> buffer(static_cast<size_t>(file_size.QuadPart));
+
+    DWORD bytes_read = 0;
+    if (!::ReadFile(hFile, buffer.data(), static_cast<DWORD>(buffer.size()), &bytes_read, nullptr) ||
+        bytes_read != buffer.size()) {
+      return {};
+    }
+    
+    return buffer;
 #else
-    std::filesystem::path file_path(filename);
-#endif
-    std::ifstream file(file_path, std::ios::binary | std::ios::ate);
+    std::ifstream file(filename, std::ios::binary | std::ios::ate);
     if (!file.is_open()) {
       return {};
     }
@@ -60,6 +98,7 @@ std::vector<char> ReadFile(const std::string &filename) {
     }
 
     return buffer;
+#endif
   } catch (const std::exception&) {
     return {};
   }
@@ -138,23 +177,33 @@ std::string ResolveAbsolutePath(const std::string &path) {
   try {
 #ifdef _WIN32
     std::wstring wide_path = ToWideString(path);
-    std::filesystem::path fs_path(wide_path);
-#else
-    std::filesystem::path fs_path(path);
-#endif
-    
-    // If already absolute, return normalized path
-    if (fs_path.is_absolute()) {
-      return fs_path.lexically_normal().u8string();
+    DWORD required_size = GetFullPathNameW(wide_path.c_str(), 0, nullptr, nullptr);
+    if (required_size == 0) {
+      return path;
     }
     
-    // Convert to absolute path and normalize
-    std::filesystem::path abs_path = std::filesystem::absolute(fs_path);
-    abs_path = abs_path.lexically_normal();
+    std::vector<wchar_t> buffer(required_size);
+    DWORD actual_size = GetFullPathNameW(
+        wide_path.c_str(),
+        required_size,
+        buffer.data(),
+        nullptr
+    );
     
-    return abs_path.u8string();
+    if (actual_size == 0 || actual_size >= required_size) {
+      return path;
+    }
+    
+    std::wstring resolved_wide(buffer.data(), actual_size);
+    return ToString(resolved_wide);
+#else
+    char resolved_path[PATH_MAX];
+    if (realpath(path.c_str(), resolved_path) == nullptr) {
+      return path;
+    }
+    return std::string(resolved_path);
+#endif
   } catch (const std::exception&) {
-    // If conversion fails, return original path
     return path;
   }
 }

--- a/sherpa-onnx/csrc/file-utils.cc
+++ b/sherpa-onnx/csrc/file-utils.cc
@@ -20,13 +20,18 @@ namespace sherpa_onnx {
 namespace sherpa_onnx {
 
 bool FileExists(const std::string &filename) {
+  try {
 #ifdef _WIN32
-  std::wstring wide_path = ToWideString(filename);
-  std::ifstream file(wide_path);
-  return file.good();
+    std::wstring wide_path = ToWideString(filename);
+    std::filesystem::path file_path(wide_path);
 #else
-  return std::ifstream(filename).good();
+    std::filesystem::path file_path(filename);
 #endif
+    return std::filesystem::exists(file_path) && 
+           std::filesystem::is_regular_file(file_path);
+  } catch (const std::filesystem::filesystem_error&) {
+    return false;
+  }
 }
 
 void AssertFileExists(const std::string &filename) {
@@ -37,25 +42,30 @@ void AssertFileExists(const std::string &filename) {
 }
 
 std::vector<char> ReadFile(const std::string &filename) {
+  try {
 #ifdef _WIN32
-  std::wstring wide_path = ToWideString(filename);
-  std::ifstream file(wide_path, std::ios::binary | std::ios::ate);
+    std::wstring wide_path = ToWideString(filename);
+    std::filesystem::path file_path(wide_path);
 #else
-  std::ifstream file(filename, std::ios::binary | std::ios::ate);
+    std::filesystem::path file_path(filename);
 #endif
-  if (!file.is_open()) {
+    std::ifstream file(file_path, std::ios::binary | std::ios::ate);
+    if (!file.is_open()) {
+      return {};
+    }
+
+    std::streamsize size = file.tellg();
+    file.seekg(0, std::ios::beg);
+
+    std::vector<char> buffer(size);
+    if (!file.read(buffer.data(), size)) {
+      return {};
+    }
+
+    return buffer;
+  } catch (const std::filesystem::filesystem_error&) {
     return {};
   }
-
-  std::streamsize size = file.tellg();
-  file.seekg(0, std::ios::beg);
-
-  std::vector<char> buffer(size);
-  if (!file.read(buffer.data(), size)) {
-    return {};
-  }
-
-  return buffer;
 }
 
 #if __ANDROID_API__ >= 9
@@ -129,7 +139,12 @@ std::string ResolveAbsolutePath(const std::string &path) {
   }
 
   try {
+#ifdef _WIN32
+    std::wstring wide_path = ToWideString(path);
+    std::filesystem::path fs_path(wide_path);
+#else
     std::filesystem::path fs_path(path);
+#endif
     
     // If already absolute, return normalized path
     if (fs_path.is_absolute()) {

--- a/sherpa-onnx/csrc/file-utils.cc
+++ b/sherpa-onnx/csrc/file-utils.cc
@@ -14,10 +14,7 @@
 #include "sherpa-onnx/csrc/macros.h"
 
 namespace sherpa_onnx {
-  std::wstring ToWideString(const std::string &s);
-}  // namespace sherpa_onnx
-
-namespace sherpa_onnx {
+std::wstring ToWideString(const std::string &s);
 
 bool FileExists(const std::string &filename) {
   try {
@@ -29,7 +26,7 @@ bool FileExists(const std::string &filename) {
 #endif
     return std::filesystem::exists(file_path) && 
            std::filesystem::is_regular_file(file_path);
-  } catch (const std::filesystem::filesystem_error&) {
+  } catch (const std::exception&) {
     return false;
   }
 }
@@ -63,7 +60,7 @@ std::vector<char> ReadFile(const std::string &filename) {
     }
 
     return buffer;
-  } catch (const std::filesystem::filesystem_error&) {
+  } catch (const std::exception&) {
     return {};
   }
 }
@@ -156,7 +153,7 @@ std::string ResolveAbsolutePath(const std::string &path) {
     abs_path = abs_path.lexically_normal();
     
     return abs_path.u8string();
-  } catch (const std::filesystem::filesystem_error&) {
+  } catch (const std::exception&) {
     // If conversion fails, return original path
     return path;
   }

--- a/sherpa-onnx/csrc/file-utils.cc
+++ b/sherpa-onnx/csrc/file-utils.cc
@@ -16,6 +16,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <limits.h>
+#include <stdlib.h>
 #endif
 
 #include "sherpa-onnx/csrc/macros.h"

--- a/sherpa-onnx/csrc/file-utils.cc
+++ b/sherpa-onnx/csrc/file-utils.cc
@@ -5,24 +5,28 @@
 #include "sherpa-onnx/csrc/file-utils.h"
 
 #include <fstream>
+#include <filesystem>
 #include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
 
-#ifdef _WIN32
-#include <windows.h>
-#else
-#include <limits.h>
-#include <stdlib.h>
-#endif
-
 #include "sherpa-onnx/csrc/macros.h"
+
+namespace sherpa_onnx {
+  std::wstring ToWideString(const std::string &s);
+}  // namespace sherpa_onnx
 
 namespace sherpa_onnx {
 
 bool FileExists(const std::string &filename) {
+#ifdef _WIN32
+  std::wstring wide_path = ToWideString(filename);
+  std::ifstream file(wide_path);
+  return file.good();
+#else
   return std::ifstream(filename).good();
+#endif
 }
 
 void AssertFileExists(const std::string &filename) {
@@ -33,7 +37,12 @@ void AssertFileExists(const std::string &filename) {
 }
 
 std::vector<char> ReadFile(const std::string &filename) {
+#ifdef _WIN32
+  std::wstring wide_path = ToWideString(filename);
+  std::ifstream file(wide_path, std::ios::binary | std::ios::ate);
+#else
   std::ifstream file(filename, std::ios::binary | std::ios::ate);
+#endif
   if (!file.is_open()) {
     return {};
   }
@@ -119,33 +128,23 @@ std::string ResolveAbsolutePath(const std::string &path) {
     return path;
   }
 
-#ifdef _WIN32
-  // Check if path is already absolute (drive letter or UNC path)
-  if ((path.size() > 1 && path[1] == ':') ||
-      (path.size() > 1 && path[0] == '\\' && path[1] == '\\')) {
+  try {
+    std::filesystem::path fs_path(path);
+    
+    // If already absolute, return normalized path
+    if (fs_path.is_absolute()) {
+      return fs_path.lexically_normal().u8string();
+    }
+    
+    // Convert to absolute path and normalize
+    std::filesystem::path abs_path = std::filesystem::absolute(fs_path);
+    abs_path = abs_path.lexically_normal();
+    
+    return abs_path.u8string();
+  } catch (const std::filesystem::filesystem_error&) {
+    // If conversion fails, return original path
     return path;
   }
-
-  char buffer[MAX_PATH];
-  if (GetFullPathNameA(path.c_str(), MAX_PATH, buffer, nullptr)) {
-    return std::string(buffer);
-  }
-
-  return path;  // fallback on failure
-
-#else
-  // POSIX: absolute paths start with '/'
-  if (path[0] == '/') {
-    return path;
-  }
-
-  char buffer[PATH_MAX];
-  if (realpath(path.c_str(), buffer)) {
-    return std::string(buffer);
-  }
-
-  return path;  // fallback on failure
-#endif
 }
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/file-utils.cc
+++ b/sherpa-onnx/csrc/file-utils.cc
@@ -25,7 +25,6 @@ std::wstring ToWideString(const std::string &s);
 std::string ToString(const std::wstring &s);
 
 bool FileExists(const std::string &filename) {
-  try {
 #ifdef _WIN32
     DWORD attributes = GetFileAttributesW(ToWideString(filename).c_str());
     
@@ -34,9 +33,6 @@ bool FileExists(const std::string &filename) {
     struct stat file_stat;
     return stat(filename.c_str(), &file_stat) == 0 && S_ISREG(file_stat.st_mode);
 #endif
-  } catch (const std::exception&) {
-    return false;
-  }
 }
 
 void AssertFileExists(const std::string &filename) {
@@ -77,8 +73,14 @@ std::vector<char> ReadFile(const std::string &filename) {
     std::vector<char> buffer(static_cast<size_t>(file_size.QuadPart));
 
     DWORD bytes_read = 0;
-    if (!::ReadFile(hFile, buffer.data(), static_cast<DWORD>(buffer.size()), &bytes_read, nullptr) ||
-        bytes_read != buffer.size()) {
+    bool read_success = ::ReadFile(
+      hFile, 
+      buffer.data(), 
+      static_cast<DWORD>(buffer.size()), 
+      &bytes_read, 
+      nullptr
+    );
+    if (!read_success || bytes_read != buffer.size()) {
       return {};
     }
     


### PR DESCRIPTION
## 修复 #3171 

此 PR 解决了 issue #3171  中提到的win平台中文路径解析问题。

### 修改内容：
- 重构 `ResolveAbsolutePath` 函数，使用 `std::filesystem` API
- 正确处理绝对路径和相对路径的转换
- 使用 `lexically_normal()` 规范化路径格式
- 添加异常处理，避免路径转换失败时程序崩溃

### 测试：
- ✅ Windows MSVC 编译通过

Fixes #3171 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked low-level file handling with explicit Windows and POSIX branches for clearer cross-platform behavior.
  * Improved file-existence checks, robust file reading, and absolute-path resolution with safer fallbacks on failure.
  * Introduced cross-platform string/path conversion utilities to support OS-specific operations.
  * Centralized error handling and removed single-platform dependencies for more reliable path normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->