### PR TITLE
Support dynamic decoder layers in canary model runtime

### DIFF
--- a/sherpa-onnx/csrc/offline-canary-model-meta-data.h
+++ b/sherpa-onnx/csrc/offline-canary-model-meta-data.h
@@ -15,7 +15,7 @@ struct OfflineCanaryModelMetaData {
   int32_t subsampling_factor = 8;
   int32_t feat_dim = 120;
   int32_t num_decoder_layers = 6;
-  int64_t decoder_hidden_size = 1024;
+  int32_t decoder_hidden_size = 1024;
   std::string normalize_type;
   std::unordered_map<std::string, int32_t> lang2id;
 };

--- a/sherpa-onnx/csrc/offline-canary-model.cc
+++ b/sherpa-onnx/csrc/offline-canary-model.cc
@@ -181,34 +181,10 @@ class OfflineCanaryModel::Impl {
     SHERPA_ONNX_READ_META_DATA(meta_.subsampling_factor, "subsampling_factor");
     SHERPA_ONNX_READ_META_DATA(meta_.feat_dim, "feat_dim");
 
-    // Read decoder architecture metadata (with defaults for backward compat)
-    {
-      Ort::AllocatorWithDefaultOptions alloc;
-      try {
-        auto num_layers_str = meta_data.LookupCustomMetadataMapAllocated(
-            "num_decoder_layers", alloc);
-        if (num_layers_str) {
-          int32_t num_layers = std::stoi(num_layers_str.get());
-          if (num_layers > 0) {
-            meta_.num_decoder_layers = num_layers;
-          }
-        }
-      } catch (const std::exception &) {
-        // Use default (6) if not present or on parsing error
-      }
-      try {
-        auto hidden_size_str = meta_data.LookupCustomMetadataMapAllocated(
-            "decoder_hidden_size", alloc);
-        if (hidden_size_str) {
-          int64_t hidden_size = std::stoll(hidden_size_str.get());
-          if (hidden_size > 0) {
-            meta_.decoder_hidden_size = hidden_size;
-          }
-        }
-      } catch (const std::exception &) {
-        // Use default (1024) if not present or on parsing error
-      }
-    }
+    SHERPA_ONNX_READ_META_DATA_WITH_DEFAULT(meta_.num_decoder_layers,
+                                            "num_decoder_layers", 6);
+    SHERPA_ONNX_READ_META_DATA_WITH_DEFAULT(meta_.decoder_hidden_size,
+                                            "decoder_hidden_size", 1024);
   }
 
   void InitDecoder(void *model_data, size_t model_data_length) {


### PR DESCRIPTION
Enables canary-1b-v2 which uses 10 decoder memory states (8 transformer layers + initial + final layer norm).

Related to #3190 and #3193.

Problem: `GetInitialDecoderStates()` in the canary model runtime hardcodes 6 decoder layers and 1024 hidden size. This works for canary-180m-flash (6 layers) but fails for larger canary models e.g. canary-1b-v2 which has 10 decoder memory states (8 transformer layers + initial + final layer norm).

This PR makes it read `num_decoder_layers` and `decoder_hidden_size` from the ONNX encoder metadata instead of hardcoding. Defaults to 6/1024 for backward compatibility with existing 180m models that don't have these metadata fields.

The PR introduces changes to the following files:
 - `sherpa-onnx/csrc/offline-canary-model-meta-data.h`: add `num_decoder_layers`, `decoder_hidden_size` fields with defaults
 - `sherpa-onnx/csrc/offline-canary-model.cc`: read from metadata in `InitEncoder()`, use in `GetInitialDecoderStates()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Model initialization now reads decoder architecture (layer count and hidden size) from model metadata instead of fixed values.
  * Metadata extended to include decoder layer count and hidden size, enabling support for more model variants.
  * Backward compatibility preserved via automatic default fallbacks when metadata is missing or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->