### PR TITLE
Results goes to stdout

### DIFF
--- a/sherpa-onnx/csrc/sherpa-onnx-keyword-spotter.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-keyword-spotter.cc
@@ -103,8 +103,9 @@ for a list of pre-trained models to download.
       if (!r.keyword.empty()) {
         keyword_spotter.Reset(s.get());
 
-        fprintf(stderr, "%s\n%s\n\n", wav_filename.c_str(),
-                r.AsJsonString().c_str());
+        fprintf(stderr, "%s\n", wav_filename.c_str());
+        fprintf(stdout, "%s\n", r.AsJsonString().c_str());
+        fprintf(stderr, "\n");
       }
     }
 
@@ -163,8 +164,9 @@ for a list of pre-trained models to download.
         const auto r = keyword_spotter.GetResult(p_ss);
         if (!r.keyword.empty()) {
           os << s.filename << "\n";
-          os << r.AsJsonString() << "\n\n";
           fprintf(stderr, "%s", os.str().c_str());
+          fprintf(stdout, "%s\n", r.AsJsonString().c_str());
+          fprintf(stderr, "\n");
         }
       }
 

--- a/sherpa-onnx/csrc/sherpa-onnx-offline-audio-tagging.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-offline-audio-tagging.cc
@@ -81,7 +81,8 @@ for more models.
   int32_t i = 0;
 
   for (const auto &event : results) {
-    fprintf(stderr, "%d: %s\n", i, event.ToString().c_str());
+    fprintf(stderr, "%d: ", i);
+    fprintf(stdout, "%s\n", event.ToString().c_str());
     i += 1;
   }
 

--- a/sherpa-onnx/csrc/sherpa-onnx-offline-language-identification.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-offline-language-identification.cc
@@ -88,8 +88,9 @@ for a list of pre-trained models to download.
   const auto end = std::chrono::steady_clock::now();
 
   fprintf(stderr, "Done!\n\n");
-  fprintf(stderr, "%s\nDetected language: %s\n", wav_filename.c_str(),
-          language.c_str());
+  fprintf(stderr, "%s\n", wav_filename.c_str());
+  fprintf(stderr, "Detected language: ");
+  fprintf(stdout, "%s\n", language.c_str());
 
   float elapsed_seconds =
       std::chrono::duration_cast<std::chrono::milliseconds>(end - begin)

--- a/sherpa-onnx/csrc/sherpa-onnx-offline-parallel.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-offline-parallel.cc
@@ -116,8 +116,9 @@ void AsrInference(const std::vector<std::vector<std::string>> &chunk_wav_paths,
     elapsed_seconds_batch += elapsed_seconds;
     int i = 0;
     for (const auto &wav_filename : wav_paths) {
-      fprintf(stderr, "%s\n%s\n----\n", wav_filename.c_str(),
-              ss[i]->GetResult().AsJsonString().c_str());
+      fprintf(stderr, "%s\n", wav_filename.c_str());
+      fprintf(stdout, "%s\n", ss[i]->GetResult().AsJsonString().c_str());
+      fprintf(stderr, "----\n");
       i = i + 1;
     }
     ss_pointers.clear();

--- a/sherpa-onnx/csrc/sherpa-onnx-offline-punctuation.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-offline-punctuation.cc
@@ -65,5 +65,6 @@ The output text should look like below:
   fprintf(stderr, "Num threads: %d\n", config.model.num_threads);
   fprintf(stderr, "Elapsed seconds: %.3f s\n", elapsed_seconds);
   fprintf(stderr, "Input text: %s\n", text.c_str());
-  fprintf(stderr, "Output text: %s\n", text_with_punct.c_str());
+  fprintf(stderr, "Output text: ");
+  fprintf(stdout, "%s\n", text_with_punct.c_str());
 }

--- a/sherpa-onnx/csrc/sherpa-onnx-offline.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-offline.cc
@@ -177,8 +177,9 @@ for a list of pre-trained models to download.
 
   fprintf(stderr, "Done!\n\n");
   for (int32_t i = 1; i <= po.NumArgs(); ++i) {
-    fprintf(stderr, "%s\n%s\n----\n", po.GetArg(i).c_str(),
-            ss[i - 1]->GetResult().AsJsonString().c_str());
+    fprintf(stderr, "%s\n", po.GetArg(i).c_str());
+    fprintf(stdout, "%s\n", ss[i - 1]->GetResult().AsJsonString().c_str());
+    fprintf(stderr, "----\n");
   }
 
   float elapsed_seconds =

--- a/sherpa-onnx/csrc/sherpa-onnx-online-punctuation.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-online-punctuation.cc
@@ -70,5 +70,6 @@ The output text should look like below:
   fprintf(stderr, "Num threads: %d\n", config.model.num_threads);
   fprintf(stderr, "Elapsed seconds: %.3f s\n", elapsed_seconds);
   fprintf(stderr, "Input text: %s\n", text.c_str());
-  fprintf(stderr, "Output text: %s\n", text_with_punct_case.c_str());
+  fprintf(stderr, "Output text: ");
+  fprintf(stdout, "%s\n", text_with_punct_case.c_str());
 }

--- a/sherpa-onnx/csrc/sherpa-onnx-vad-with-offline-asr.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-vad-with-offline-asr.cc
@@ -230,8 +230,8 @@ for a list of pre-trained models to download.
       recognizer.DecodeStream(s.get());
       const auto &result = s->GetResult();
       if (!result.text.empty()) {
-        fprintf(stderr, "%.3f -- %.3f: %s\n", start_time, end_time,
-                result.text.c_str());
+        fprintf(stderr, "%.3f -- %.3f: ", start_time, end_time);
+        fprintf(stdout, "%s\n", result.text.c_str());
       }
       vad->Pop();
     }


### PR DESCRIPTION
I'm doubting this commit makes it in as-is, but wanted to suggest or start a conversation.

I noticed that the result of some of these commands goes to stderr with everything else.

More specifically in my case, sherpa-onnx-offline outputs json intermingled with other debugging information. This makes it difficult to pipe it straight to another command.

This change makes it so it goes to stdout, and I changed a few others while I was at it. I tried to keep newlines and everything the same to make it so that you could just redirect stdout to stderr and get the same result as before.

This is still not perfect. In the sherpa-onnx-offline example, we are in a loop. I assume this is to give result of each file input. This change will make it print JSON, but not one big valid JSON (in an array). I wanted to keep my change backwards compatible (assuming stdout redirect), but there could be a bigger change somewhere to standardize the output reporting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Output stream handling updated across multiple command-line tools: keyword spotting, audio tagging, language identification, punctuation, and speech recognition. Results now appear on standard output instead of standard error, while labels and metadata remain on standard error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->