### PR TITLE
feat: add generic SetOption/GetOption to OnlineStream/OfflineStream (C++ core)

### DIFF
--- a/sherpa-onnx/csrc/offline-stream.cc
+++ b/sherpa-onnx/csrc/offline-stream.cc
@@ -11,6 +11,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -20,6 +21,7 @@
 #include "sherpa-onnx/csrc/math.h"
 #include "sherpa-onnx/csrc/offline-recognizer.h"
 #include "sherpa-onnx/csrc/resample.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 
 namespace sherpa_onnx {
 
@@ -222,6 +224,39 @@ class OfflineStream::Impl {
 
   const ContextGraphPtr &GetContextGraph() const { return context_graph_; }
 
+  void SetOption(const std::string &key, const std::string &value) {
+    options_[key] = value;
+  }
+
+  bool HasOption(const std::string &key) const {
+    return options_.count(key) != 0;
+  }
+
+  const std::string &GetOption(const std::string &key) const {
+    auto it = options_.find(key);
+    if (it != options_.end()) {
+      return it->second;
+    }
+    static const std::string kEmpty;
+    return kEmpty;
+  }
+
+  int32_t GetOptionInt(const std::string &key, int32_t default_value) const {
+    auto it = options_.find(key);
+    if (it != options_.end()) {
+      return ToIntOrDefault(it->second, default_value);
+    }
+    return default_value;
+  }
+
+  float GetOptionFloat(const std::string &key, float default_value) const {
+    auto it = options_.find(key);
+    if (it != options_.end()) {
+      return ToFloatOrDefault(it->second, default_value);
+    }
+    return default_value;
+  }
+
  private:
   // see
   // https://github.com/pytorch/audio/blob/main/src/torchaudio/functional/functional.py#L359
@@ -298,6 +333,8 @@ class OfflineStream::Impl {
 
   // used only when (is_moonshine_ || is_omnilingual_asr_) == true
   std::vector<float> samples_;
+
+  std::unordered_map<std::string, std::string> options_;
 };
 
 OfflineStream::OfflineStream(const FeatureExtractorConfig &config /*= {}*/,
@@ -339,6 +376,30 @@ const ContextGraphPtr &OfflineStream::GetContextGraph() const {
 const OfflineRecognitionResult &OfflineStream::GetResult() const {
   return impl_->GetResult();
 }
+
+void OfflineStream::SetOption(const std::string &key,
+                              const std::string &value) {
+  impl_->SetOption(key, value);
+}
+
+bool OfflineStream::HasOption(const std::string &key) const {
+  return impl_->HasOption(key);
+}
+
+const std::string &OfflineStream::GetOption(const std::string &key) const {
+  return impl_->GetOption(key);
+}
+
+int32_t OfflineStream::GetOptionInt(const std::string &key,
+                                    int32_t default_value) const {
+  return impl_->GetOptionInt(key, default_value);
+}
+
+float OfflineStream::GetOptionFloat(const std::string &key,
+                                    float default_value) const {
+  return impl_->GetOptionFloat(key, default_value);
+}
+
 std::string OfflineRecognitionResult::AsJsonString() const {
   std::ostringstream os;
   os << "{";

--- a/sherpa-onnx/csrc/offline-stream.h
+++ b/sherpa-onnx/csrc/offline-stream.h
@@ -115,6 +115,18 @@ class OfflineStream {
   /** Get the ContextGraph of this stream */
   const ContextGraphPtr &GetContextGraph() const;
 
+  // Generic per-stream option mechanism (key-value string pairs).
+  void SetOption(const std::string &key, const std::string &value);
+  bool HasOption(const std::string &key) const;
+
+  // Returns the value for the given key, or an empty string if the key
+  // does not exist. No exception is thrown for missing keys.
+  const std::string &GetOption(const std::string &key) const;
+  int32_t GetOptionInt(const std::string &key,
+                       int32_t default_value = 0) const;
+  float GetOptionFloat(const std::string &key,
+                       float default_value = 0.0f) const;
+
  private:
   class Impl;
   std::unique_ptr<Impl> impl_;

--- a/sherpa-onnx/csrc/online-stream.cc
+++ b/sherpa-onnx/csrc/online-stream.cc
@@ -4,10 +4,13 @@
 #include "sherpa-onnx/csrc/online-stream.h"
 
 #include <memory>
+#include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include "sherpa-onnx/csrc/features.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 #include "sherpa-onnx/csrc/transducer-keyword-decoder.h"
 
 namespace sherpa_onnx {
@@ -128,6 +131,39 @@ class OnlineStream::Impl {
     return paraformer_alpha_cache_;
   }
 
+  void SetOption(const std::string &key, const std::string &value) {
+    options_[key] = value;
+  }
+
+  bool HasOption(const std::string &key) const {
+    return options_.count(key) != 0;
+  }
+
+  const std::string &GetOption(const std::string &key) const {
+    auto it = options_.find(key);
+    if (it != options_.end()) {
+      return it->second;
+    }
+    static const std::string kEmpty;
+    return kEmpty;
+  }
+
+  int32_t GetOptionInt(const std::string &key, int32_t default_value) const {
+    auto it = options_.find(key);
+    if (it != options_.end()) {
+      return ToIntOrDefault(it->second, default_value);
+    }
+    return default_value;
+  }
+
+  float GetOptionFloat(const std::string &key, float default_value) const {
+    auto it = options_.find(key);
+    if (it != options_.end()) {
+      return ToFloatOrDefault(it->second, default_value);
+    }
+    return default_value;
+  }
+
   void SetFasterDecoder(std::unique_ptr<kaldi_decoder::FasterDecoder> decoder) {
     faster_decoder_ = std::move(decoder);
   }
@@ -159,6 +195,7 @@ class OnlineStream::Impl {
   std::vector<float> paraformer_encoder_out_cache_;
   std::vector<float> paraformer_alpha_cache_;
   OnlineParaformerDecoderResult paraformer_result_;
+  std::unordered_map<std::string, std::string> options_;
   std::unique_ptr<kaldi_decoder::FasterDecoder> faster_decoder_;
   int32_t faster_decoder_processed_frames_ = 0;
 };
@@ -280,6 +317,29 @@ std::vector<float> &OnlineStream::GetParaformerEncoderOutCache() {
 
 std::vector<float> &OnlineStream::GetParaformerAlphaCache() {
   return impl_->GetParaformerAlphaCache();
+}
+
+void OnlineStream::SetOption(const std::string &key,
+                             const std::string &value) {
+  impl_->SetOption(key, value);
+}
+
+bool OnlineStream::HasOption(const std::string &key) const {
+  return impl_->HasOption(key);
+}
+
+const std::string &OnlineStream::GetOption(const std::string &key) const {
+  return impl_->GetOption(key);
+}
+
+int32_t OnlineStream::GetOptionInt(const std::string &key,
+                                   int32_t default_value) const {
+  return impl_->GetOptionInt(key, default_value);
+}
+
+float OnlineStream::GetOptionFloat(const std::string &key,
+                                   float default_value) const {
+  return impl_->GetOptionFloat(key, default_value);
 }
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/online-stream.h
+++ b/sherpa-onnx/csrc/online-stream.h
@@ -6,6 +6,7 @@
 #define SHERPA_ONNX_CSRC_ONLINE_STREAM_H_
 
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "kaldi-decoder/csrc/faster-decoder.h"
@@ -110,6 +111,18 @@ class OnlineStream {
   std::vector<float> &GetParaformerFeatCache();
   std::vector<float> &GetParaformerEncoderOutCache();
   std::vector<float> &GetParaformerAlphaCache();
+
+  // Generic per-stream option mechanism (key-value string pairs).
+  void SetOption(const std::string &key, const std::string &value);
+  bool HasOption(const std::string &key) const;
+
+  // Returns the value for the given key, or an empty string if the key
+  // does not exist. No exception is thrown for missing keys.
+  const std::string &GetOption(const std::string &key) const;
+  int32_t GetOptionInt(const std::string &key,
+                       int32_t default_value = 0) const;
+  float GetOptionFloat(const std::string &key,
+                       float default_value = 0.0f) const;
 
  private:
   class Impl;


### PR DESCRIPTION
## Summary

Ref #3101 (Part 1a)

Add a generic key-value option mechanism to both `OnlineStream` and `OfflineStream` C++ core classes. This is the foundation for the SetOption API — follow-up PRs add C API, CXX wrapper, language bindings, and Paraformer migration.

## New C++ Methods

```cpp
// OnlineStream & OfflineStream
void SetOption(const std::string &key, const std::string &value);
bool HasOption(const std::string &key) const;
const std::string &GetOption(const std::string &key) const;
int32_t GetOptionInt(const std::string &key, int32_t default_value = 0) const;
float GetOptionFloat(const std::string &key, float default_value = 0.0f) const;
```

## Design

- Options stored as `std::unordered_map<std::string, std::string>` in Pimpl `Impl`
- `GetOption` returns empty string for missing keys (no exceptions)
- Existing APIs are untouched — no breaking changes

## Files Changed (4 files, +138 lines)

| File | Change |
|------|--------|
| `online-stream.h` | Add method declarations, `#include <string>` |
| `online-stream.cc` | Add `options_` map and implementations |
| `offline-stream.h` | Add method declarations |
| `offline-stream.cc` | Add `options_` map and implementations |

## Test Plan

- [ ] Build on macOS/Linux — verify compilation passes
- [ ] Existing tests still pass (no breaking changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable per-stream options with a new public API for both offline and online streams. Users can set and retrieve string-based key-value options with typed accessors (string, integer, float) and default fallback values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->