### PR TITLE
feat: add SetOption/GetOption CXX wrapper

### DIFF
--- a/sherpa-onnx/c-api/cxx-api.cc
+++ b/sherpa-onnx/c-api/cxx-api.cc
@@ -62,6 +62,18 @@ void OnlineStream::InputFinished() const {
   SherpaOnnxOnlineStreamInputFinished(p_);
 }
 
+void OnlineStream::SetOption(const char *key, const char *value) const {
+  SherpaOnnxOnlineStreamSetOption(p_, key, value);
+}
+
+const char *OnlineStream::GetOption(const char *key) const {
+  return SherpaOnnxOnlineStreamGetOption(p_, key);
+}
+
+int32_t OnlineStream::HasOption(const char *key) const {
+  return SherpaOnnxOnlineStreamHasOption(p_, key);
+}
+
 OnlineRecognizer OnlineRecognizer::Create(
     const OnlineRecognizerConfig &config) {
   struct SherpaOnnxOnlineRecognizerConfig c;
@@ -209,6 +221,18 @@ void OfflineStream::Destroy(const SherpaOnnxOfflineStream *p) const {
 void OfflineStream::AcceptWaveform(int32_t sample_rate, const float *samples,
                                    int32_t n) const {
   SherpaOnnxAcceptWaveformOffline(p_, sample_rate, samples, n);
+}
+
+void OfflineStream::SetOption(const char *key, const char *value) const {
+  SherpaOnnxOfflineStreamSetOption(p_, key, value);
+}
+
+const char *OfflineStream::GetOption(const char *key) const {
+  return SherpaOnnxOfflineStreamGetOption(p_, key);
+}
+
+int32_t OfflineStream::HasOption(const char *key) const {
+  return SherpaOnnxOfflineStreamHasOption(p_, key);
 }
 
 static SherpaOnnxOfflineRecognizerConfig Convert(

--- a/sherpa-onnx/c-api/cxx-api.h
+++ b/sherpa-onnx/c-api/cxx-api.h
@@ -179,6 +179,10 @@ class SHERPA_ONNX_API OnlineStream
 
   void InputFinished() const;
 
+  void SetOption(const char *key, const char *value) const;
+  const char *GetOption(const char *key) const;
+  int32_t HasOption(const char *key) const;
+
   void Destroy(const SherpaOnnxOnlineStream *p) const;
 };
 
@@ -377,6 +381,10 @@ class SHERPA_ONNX_API OfflineStream
 
   void AcceptWaveform(int32_t sample_rate, const float *samples,
                       int32_t n) const;
+
+  void SetOption(const char *key, const char *value) const;
+  const char *GetOption(const char *key) const;
+  int32_t HasOption(const char *key) const;
 
   void Destroy(const SherpaOnnxOfflineStream *p) const;
 };


### PR DESCRIPTION
## Summary

Ref #3101 (Part 1c) — depends on #3308

Add `SetOption`/`GetOption` methods to the C++ wrapper (`cxx-api`) for both `OnlineStream` and `OfflineStream`.

## Files Changed (2 files, +22 lines)

| File | Change |
|------|--------|
| `cxx-api.h` | Add method declarations |
| `cxx-api.cc` | Implementations calling C API |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-stream configuration options: set and retrieve custom options for both online and offline streams.
  * Added final chunk signaling for online streams: enables explicit notification when processing the final audio chunk in streaming scenarios.
  * Extended API support across C, C++, and Python interfaces for unified stream control and option management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->