### PR TITLE
feat: migrate Paraformer is_final to use SetOption mechanism

### DIFF
--- a/sherpa-onnx/csrc/online-recognizer-paraformer-impl.h
+++ b/sherpa-onnx/csrc/online-recognizer-paraformer-impl.h
@@ -160,7 +160,16 @@ class OnlineRecognizerParaformerImpl : public OnlineRecognizerImpl {
   }
 
   bool IsReady(OnlineStream *s) const override {
-    return s->GetNumProcessedFrames() + chunk_size_ < s->NumFramesReady();
+    if (s->GetNumProcessedFrames() + chunk_size_ < s->NumFramesReady()) {
+      return true;
+    }
+    // is_final: accept short chunks (less than chunk_size_ frames)
+    // Users should call SetOption("is_final", "1") before the last decode.
+    if (s->GetOptionInt("is_final", 0) &&
+        s->GetNumProcessedFrames() < s->NumFramesReady()) {
+      return true;
+    }
+    return false;
   }
 
   void DecodeStreams(OnlineStream **ss, int32_t n) const override {
@@ -222,8 +231,26 @@ class OnlineRecognizerParaformerImpl : public OnlineRecognizerImpl {
  private:
   void DecodeStream(OnlineStream *s) const {
     const auto num_processed_frames = s->GetNumProcessedFrames();
-    std::vector<float> frames = s->GetFrames(num_processed_frames, chunk_size_);
-    s->GetNumProcessedFrames() += chunk_size_ - 1;
+    int32_t available_frames = s->NumFramesReady() - num_processed_frames;
+    bool is_final = s->GetOptionInt("is_final", 0);
+
+    // For the final short chunk (fewer frames than chunk_size_):
+    // read the remaining frames and pad with zeros to chunk_size_.
+    bool is_short_final = is_final && available_frames < chunk_size_;
+
+    std::vector<float> frames =
+        s->GetFrames(num_processed_frames,
+                     is_short_final ? available_frames : chunk_size_);
+
+    if (is_short_final) {
+      int32_t feat_dim_raw = config_.feat_config.feature_dim;
+      frames.resize(chunk_size_ * feat_dim_raw, 0.0f);
+      // Consume all remaining frames (no overlap needed).
+      s->GetNumProcessedFrames() += available_frames;
+    } else {
+      // Normal: advance by chunk_size_ - 1 to keep 1-frame overlap.
+      s->GetNumProcessedFrames() += chunk_size_ - 1;
+    }
 
     frames = ApplyLFR(frames);
     ApplyCMVN(&frames);


### PR DESCRIPTION
## Summary

Ref #3101 — depends on #3309

Migrate the Paraformer `is_final` support from model-specific `SetParaformerFinalChunk`/`IsParaformerFinalChunk` to the generic `SetOption("is_final", "1")` / `GetOptionInt("is_final", 0)` mechanism.

## Changes
- `sherpa-onnx/csrc/online-recognizer-paraformer-impl.h`: Use `GetOptionInt("is_final", 0)` to detect the final chunk and handle short final chunks with zero-padding.

## Usage
Users call `SetOption("is_final", "1")` on the `OnlineStream` before the last decode to process remaining audio frames.