### PR TITLE
feat: add SetOption/GetOption/HasOption Python bindings

### DIFF
--- a/sherpa-onnx/python/csrc/offline-stream.cc
+++ b/sherpa-onnx/python/csrc/offline-stream.cc
@@ -69,6 +69,12 @@ void PybindOfflineStream(py::module *m) {
           },
           py::arg("sample_rate"), py::arg("waveform"), kAcceptWaveformUsage,
           py::call_guard<py::gil_scoped_release>())
+      .def("set_option", &PyClass::SetOption, py::arg("key"),
+           py::arg("value"), py::call_guard<py::gil_scoped_release>())
+      .def("has_option", &PyClass::HasOption, py::arg("key"),
+           py::call_guard<py::gil_scoped_release>())
+      .def("get_option", &PyClass::GetOption, py::arg("key"),
+           py::call_guard<py::gil_scoped_release>())
       .def_property_readonly("result", &PyClass::GetResult);
 }
 

--- a/sherpa-onnx/python/csrc/online-stream.cc
+++ b/sherpa-onnx/python/csrc/online-stream.cc
@@ -52,6 +52,12 @@ void PybindOnlineStream(py::module *m) {
           py::call_guard<py::gil_scoped_release>())
       .def("input_finished", &PyClass::InputFinished,
            py::call_guard<py::gil_scoped_release>())
+      .def("set_option", &PyClass::SetOption, py::arg("key"),
+           py::arg("value"), py::call_guard<py::gil_scoped_release>())
+      .def("has_option", &PyClass::HasOption, py::arg("key"),
+           py::call_guard<py::gil_scoped_release>())
+      .def("get_option", &PyClass::GetOption, py::arg("key"),
+           py::call_guard<py::gil_scoped_release>())
       .def("get_frames", &PyClass::GetFrames,
            py::arg("frame_index"), py::arg("n"), kGetFramesUsage,
            py::call_guard<py::gil_scoped_release>());


### PR DESCRIPTION
## Summary

Ref #3101 — depends on #3309

Add `set_option`, `get_option`, and `has_option` Python bindings for both `OnlineStream` and `OfflineStream` via pybind11.

## Files Changed
- `sherpa-onnx/python/csrc/online-stream.cc`
- `sherpa-onnx/python/csrc/offline-stream.cc`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration management methods for offline and online streams: users can now set, check for existence of, and retrieve stream options programmatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->