### PR TITLE
feat: add SetOption/GetOption/HasOption Java and JNI bindings

### DIFF
--- a/sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/OfflineStream.java
+++ b/sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/OfflineStream.java
@@ -26,6 +26,18 @@ public class OfflineStream {
         acceptWaveform(this.ptr, samples, sampleRate);
     }
 
+    public void setOption(String key, String value) {
+        setOption(this.ptr, key, value);
+    }
+
+    public String getOption(String key) {
+        return getOption(this.ptr, key);
+    }
+
+    public boolean hasOption(String key) {
+        return hasOption(this.ptr, key);
+    }
+
     public void release() {
         // stream object must be release after used
         if (this.ptr == 0) {
@@ -42,6 +54,12 @@ public class OfflineStream {
     }
 
     private native void acceptWaveform(long ptr, float[] samples, int sampleRate);
+
+    private native void setOption(long ptr, String key, String value);
+
+    private native String getOption(long ptr, String key);
+
+    private native boolean hasOption(long ptr, String key);
 
     private native void delete(long ptr);
 }

--- a/sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/OnlineStream.java
+++ b/sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/OnlineStream.java
@@ -31,6 +31,18 @@ public class OnlineStream {
         inputFinished(this.ptr);
     }
 
+    public void setOption(String key, String value) {
+        setOption(this.ptr, key, value);
+    }
+
+    public String getOption(String key) {
+        return getOption(this.ptr, key);
+    }
+
+    public boolean hasOption(String key) {
+        return hasOption(this.ptr, key);
+    }
+
     public void release() {
         close();
     }
@@ -53,6 +65,12 @@ public class OnlineStream {
     private native void acceptWaveform(long ptr, float[] samples, int sampleRate);
 
     private native void inputFinished(long ptr);
+
+    private native void setOption(long ptr, String key, String value);
+
+    private native String getOption(long ptr, String key);
+
+    private native boolean hasOption(long ptr, String key);
 
     private native void delete(long ptr);
 }

--- a/sherpa-onnx/jni/offline-stream.cc
+++ b/sherpa-onnx/jni/offline-stream.cc
@@ -23,3 +23,34 @@ JNIEXPORT void JNICALL Java_com_k2fsa_sherpa_onnx_OfflineStream_acceptWaveform(
   stream->AcceptWaveform(sample_rate, p, n);
   env->ReleaseFloatArrayElements(samples, p, JNI_ABORT);
 }
+
+SHERPA_ONNX_EXTERN_C
+JNIEXPORT void JNICALL Java_com_k2fsa_sherpa_onnx_OfflineStream_setOption(
+    JNIEnv *env, jobject /*obj*/, jlong ptr, jstring key, jstring value) {
+  auto stream = reinterpret_cast<sherpa_onnx::OfflineStream *>(ptr);
+  const char *p_key = env->GetStringUTFChars(key, nullptr);
+  const char *p_value = env->GetStringUTFChars(value, nullptr);
+  stream->SetOption(p_key, p_value);
+  env->ReleaseStringUTFChars(key, p_key);
+  env->ReleaseStringUTFChars(value, p_value);
+}
+
+SHERPA_ONNX_EXTERN_C
+JNIEXPORT jstring JNICALL Java_com_k2fsa_sherpa_onnx_OfflineStream_getOption(
+    JNIEnv *env, jobject /*obj*/, jlong ptr, jstring key) {
+  auto stream = reinterpret_cast<sherpa_onnx::OfflineStream *>(ptr);
+  const char *p_key = env->GetStringUTFChars(key, nullptr);
+  const std::string &value = stream->GetOption(p_key);
+  env->ReleaseStringUTFChars(key, p_key);
+  return env->NewStringUTF(value.c_str());
+}
+
+SHERPA_ONNX_EXTERN_C
+JNIEXPORT jboolean JNICALL Java_com_k2fsa_sherpa_onnx_OfflineStream_hasOption(
+    JNIEnv *env, jobject /*obj*/, jlong ptr, jstring key) {
+  auto stream = reinterpret_cast<sherpa_onnx::OfflineStream *>(ptr);
+  const char *p_key = env->GetStringUTFChars(key, nullptr);
+  jboolean result = stream->HasOption(p_key);
+  env->ReleaseStringUTFChars(key, p_key);
+  return result;
+}

--- a/sherpa-onnx/jni/online-stream.cc
+++ b/sherpa-onnx/jni/online-stream.cc
@@ -30,3 +30,34 @@ JNIEXPORT void JNICALL Java_com_k2fsa_sherpa_onnx_OnlineStream_inputFinished(
   auto stream = reinterpret_cast<sherpa_onnx::OnlineStream *>(ptr);
   stream->InputFinished();
 }
+
+SHERPA_ONNX_EXTERN_C
+JNIEXPORT void JNICALL Java_com_k2fsa_sherpa_onnx_OnlineStream_setOption(
+    JNIEnv *env, jobject /*obj*/, jlong ptr, jstring key, jstring value) {
+  auto stream = reinterpret_cast<sherpa_onnx::OnlineStream *>(ptr);
+  const char *p_key = env->GetStringUTFChars(key, nullptr);
+  const char *p_value = env->GetStringUTFChars(value, nullptr);
+  stream->SetOption(p_key, p_value);
+  env->ReleaseStringUTFChars(key, p_key);
+  env->ReleaseStringUTFChars(value, p_value);
+}
+
+SHERPA_ONNX_EXTERN_C
+JNIEXPORT jstring JNICALL Java_com_k2fsa_sherpa_onnx_OnlineStream_getOption(
+    JNIEnv *env, jobject /*obj*/, jlong ptr, jstring key) {
+  auto stream = reinterpret_cast<sherpa_onnx::OnlineStream *>(ptr);
+  const char *p_key = env->GetStringUTFChars(key, nullptr);
+  const std::string &value = stream->GetOption(p_key);
+  env->ReleaseStringUTFChars(key, p_key);
+  return env->NewStringUTF(value.c_str());
+}
+
+SHERPA_ONNX_EXTERN_C
+JNIEXPORT jboolean JNICALL Java_com_k2fsa_sherpa_onnx_OnlineStream_hasOption(
+    JNIEnv *env, jobject /*obj*/, jlong ptr, jstring key) {
+  auto stream = reinterpret_cast<sherpa_onnx::OnlineStream *>(ptr);
+  const char *p_key = env->GetStringUTFChars(key, nullptr);
+  jboolean result = stream->HasOption(p_key);
+  env->ReleaseStringUTFChars(key, p_key);
+  return result;
+}


### PR DESCRIPTION
## Summary

Ref #3101 — depends on #3309

Add `setOption`, `getOption`, and `hasOption` for `OnlineStream`/`OfflineStream` in Java and JNI.

Kotlin bindings are in a separate PR: #3354.

## Files Changed
- `sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/OnlineStream.java`
- `sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/OfflineStream.java`
- `sherpa-onnx/jni/online-stream.cc`
- `sherpa-onnx/jni/offline-stream.cc`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added option management capabilities to both offline and online streams, allowing users to set configuration options, retrieve values, and verify option existence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->