### PR TITLE
feat: add SetOption/GetOption/HasOption C# bindings

### DIFF
--- a/scripts/dotnet/OfflineStream.cs
+++ b/scripts/dotnet/OfflineStream.cs
@@ -18,6 +18,22 @@ namespace SherpaOnnx
             AcceptWaveform(Handle, sampleRate, samples, samples.Length);
         }
 
+        public void SetOption(string key, string value)
+        {
+            SherpaOnnxOfflineStreamSetOption(Handle, key, value);
+        }
+
+        public string GetOption(string key)
+        {
+            IntPtr p = SherpaOnnxOfflineStreamGetOption(Handle, key);
+            return Marshal.PtrToStringAnsi(p) ?? "";
+        }
+
+        public bool HasOption(string key)
+        {
+            return SherpaOnnxOfflineStreamHasOption(Handle, key) == 1;
+        }
+
         public OfflineRecognizerResult Result
         {
             get
@@ -58,6 +74,15 @@ namespace SherpaOnnx
 
         [DllImport(Dll.Filename, EntryPoint = "SherpaOnnxAcceptWaveformOffline")]
         private static extern void AcceptWaveform(IntPtr handle, int sampleRate, float[] samples, int n);
+
+        [DllImport(Dll.Filename)]
+        private static extern void SherpaOnnxOfflineStreamSetOption(IntPtr handle, [MarshalAs(UnmanagedType.LPStr)] string key, [MarshalAs(UnmanagedType.LPStr)] string value);
+
+        [DllImport(Dll.Filename)]
+        private static extern IntPtr SherpaOnnxOfflineStreamGetOption(IntPtr handle, [MarshalAs(UnmanagedType.LPStr)] string key);
+
+        [DllImport(Dll.Filename)]
+        private static extern int SherpaOnnxOfflineStreamHasOption(IntPtr handle, [MarshalAs(UnmanagedType.LPStr)] string key);
 
         [DllImport(Dll.Filename, EntryPoint = "SherpaOnnxGetOfflineStreamResult")]
         private static extern IntPtr GetResult(IntPtr handle);

--- a/scripts/dotnet/OnlineStream.cs
+++ b/scripts/dotnet/OnlineStream.cs
@@ -24,6 +24,22 @@ namespace SherpaOnnx
             SherpaOnnxOnlineStreamInputFinished(Handle);
         }
 
+        public void SetOption(string key, string value)
+        {
+            SherpaOnnxOnlineStreamSetOption(Handle, key, value);
+        }
+
+        public string GetOption(string key)
+        {
+            IntPtr p = SherpaOnnxOnlineStreamGetOption(Handle, key);
+            return Marshal.PtrToStringAnsi(p) ?? "";
+        }
+
+        public bool HasOption(string key)
+        {
+            return SherpaOnnxOnlineStreamHasOption(Handle, key) == 1;
+        }
+
         ~OnlineStream()
         {
             Cleanup();
@@ -56,6 +72,15 @@ namespace SherpaOnnx
 
         [DllImport(Dll.Filename)]
         private static extern void SherpaOnnxOnlineStreamInputFinished(IntPtr handle);
+
+        [DllImport(Dll.Filename)]
+        private static extern void SherpaOnnxOnlineStreamSetOption(IntPtr handle, [MarshalAs(UnmanagedType.LPStr)] string key, [MarshalAs(UnmanagedType.LPStr)] string value);
+
+        [DllImport(Dll.Filename)]
+        private static extern IntPtr SherpaOnnxOnlineStreamGetOption(IntPtr handle, [MarshalAs(UnmanagedType.LPStr)] string key);
+
+        [DllImport(Dll.Filename)]
+        private static extern int SherpaOnnxOnlineStreamHasOption(IntPtr handle, [MarshalAs(UnmanagedType.LPStr)] string key);
     }
 
 }


### PR DESCRIPTION
## Summary

Ref #3101 — depends on #3309

Add `SetOption`, `GetOption`, and `HasOption` to `OnlineStream`/`OfflineStream` in C# via DllImport.

## Files Changed
- `scripts/dotnet/OnlineStream.cs`
- `scripts/dotnet/OfflineStream.cs`