### PR TITLE
feat: add SetOption/GetOption WASM/JavaScript bindings

### DIFF
--- a/wasm/asr/CMakeLists.txt
+++ b/wasm/asr/CMakeLists.txt
@@ -21,9 +21,13 @@ set(exported_functions
   SherpaOnnxGetOnlineStreamResultAsJson
   SherpaOnnxIsOnlineStreamReady
   SherpaOnnxOnlineStreamAcceptWaveform
+  SherpaOnnxOnlineStreamGetOption
   SherpaOnnxOnlineStreamInputFinished
   SherpaOnnxOnlineStreamIsEndpoint
   SherpaOnnxOnlineStreamReset
+  SherpaOnnxOnlineStreamSetOption
+  SherpaOnnxOfflineStreamGetOption
+  SherpaOnnxOfflineStreamSetOption
   #
 )
 set(mangled_exported_functions)

--- a/wasm/asr/sherpa-onnx-asr.js
+++ b/wasm/asr/sherpa-onnx-asr.js
@@ -1656,6 +1656,36 @@ class OfflineStream {
         this.handle, sampleRate, pointer, samples.length);
     this.Module._free(pointer);
   }
+
+  /**
+   * @param key {String} The option name
+   * @param value {String} The option value
+   */
+  setOption(key, value) {
+    const keyLen = this.Module.lengthBytesUTF8(key) + 1;
+    const valueLen = this.Module.lengthBytesUTF8(value) + 1;
+    const pKey = this.Module._malloc(keyLen);
+    const pValue = this.Module._malloc(valueLen);
+    this.Module.stringToUTF8(key, pKey, keyLen);
+    this.Module.stringToUTF8(value, pValue, valueLen);
+    this.Module._SherpaOnnxOfflineStreamSetOption(this.handle, pKey, pValue);
+    this.Module._free(pKey);
+    this.Module._free(pValue);
+  }
+
+  /**
+   * @param key {String} The option name
+   * @returns {String} The option value, or empty string if not set
+   */
+  getOption(key) {
+    const keyLen = this.Module.lengthBytesUTF8(key) + 1;
+    const pKey = this.Module._malloc(keyLen);
+    this.Module.stringToUTF8(key, pKey, keyLen);
+    const pValue = this.Module._SherpaOnnxOfflineStreamGetOption(this.handle, pKey);
+    const value = this.Module.UTF8ToString(pValue);
+    this.Module._free(pKey);
+    return value;
+  }
 };
 
 class OfflineRecognizer {
@@ -1738,6 +1768,36 @@ class OnlineStream {
 
   inputFinished() {
     this.Module._SherpaOnnxOnlineStreamInputFinished(this.handle);
+  }
+
+  /**
+   * @param key {String} The option name
+   * @param value {String} The option value
+   */
+  setOption(key, value) {
+    const keyLen = this.Module.lengthBytesUTF8(key) + 1;
+    const valueLen = this.Module.lengthBytesUTF8(value) + 1;
+    const pKey = this.Module._malloc(keyLen);
+    const pValue = this.Module._malloc(valueLen);
+    this.Module.stringToUTF8(key, pKey, keyLen);
+    this.Module.stringToUTF8(value, pValue, valueLen);
+    this.Module._SherpaOnnxOnlineStreamSetOption(this.handle, pKey, pValue);
+    this.Module._free(pKey);
+    this.Module._free(pValue);
+  }
+
+  /**
+   * @param key {String} The option name
+   * @returns {String} The option value, or empty string if not set
+   */
+  getOption(key) {
+    const keyLen = this.Module.lengthBytesUTF8(key) + 1;
+    const pKey = this.Module._malloc(keyLen);
+    this.Module.stringToUTF8(key, pKey, keyLen);
+    const pValue = this.Module._SherpaOnnxOnlineStreamGetOption(this.handle, pKey);
+    const value = this.Module.UTF8ToString(pValue);
+    this.Module._free(pKey);
+    return value;
   }
 };
 

--- a/wasm/kws/CMakeLists.txt
+++ b/wasm/kws/CMakeLists.txt
@@ -16,7 +16,9 @@ set(exported_functions
   SherpaOnnxGetKeywordResult
   SherpaOnnxIsKeywordStreamReady
   SherpaOnnxOnlineStreamAcceptWaveform
+  SherpaOnnxOnlineStreamGetOption
   SherpaOnnxOnlineStreamInputFinished
+  SherpaOnnxOnlineStreamSetOption
   SherpaOnnxResetKeywordStream
 )
 set(mangled_exported_functions)

--- a/wasm/nodejs/CMakeLists.txt
+++ b/wasm/nodejs/CMakeLists.txt
@@ -26,9 +26,11 @@ set(exported_functions
   SherpaOnnxGetOnlineStreamResultAsJson
   SherpaOnnxIsOnlineStreamReady
   SherpaOnnxOnlineStreamAcceptWaveform
+  SherpaOnnxOnlineStreamGetOption
   SherpaOnnxOnlineStreamInputFinished
   SherpaOnnxOnlineStreamIsEndpoint
   SherpaOnnxOnlineStreamReset
+  SherpaOnnxOnlineStreamSetOption
   # non-streaming ASR
   PrintOfflineRecognizerConfig
   SherpaOnnxAcceptWaveformOffline
@@ -42,6 +44,8 @@ set(exported_functions
   SherpaOnnxDestroyOfflineStreamResultJson
   SherpaOnnxGetOfflineStreamResult
   SherpaOnnxGetOfflineStreamResultAsJson
+  SherpaOnnxOfflineStreamGetOption
+  SherpaOnnxOfflineStreamSetOption
   SherpaOnnxOfflineRecognizerSetConfig
   # online kws
   SherpaOnnxCreateKeywordSpotter


### PR DESCRIPTION
## Summary
Ref #3101 (Part 7) — depends on #3308

Add `setOption`/`getOption` to `OnlineStream`/`OfflineStream` in WASM JS, and export new symbols in CMakeLists.

## Changes (4 files, +70 lines)
| File | Change |
|------|--------|
| `wasm/asr/sherpa-onnx-asr.js` | JS methods |
| `wasm/asr/CMakeLists.txt` | Export symbols |
| `wasm/kws/CMakeLists.txt` | Export symbols |
| `wasm/nodejs/CMakeLists.txt` | Export symbols |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added getOption() and setOption() methods to stream classes, enabling dynamic retrieval and modification of stream configuration options at runtime.
  * Both online and offline stream variants are now fully supported with option management capabilities.
  * Stream parameters are accessible and modifiable through simple string-based key-value configuration pairs for greater runtime control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->