### PR TITLE
Fix padding bug in test-onnx-streaming.py for long audio

### DIFF
--- a/scripts/wenet/test-onnx-streaming.py
+++ b/scripts/wenet/test-onnx-streaming.py
@@ -136,7 +136,7 @@ def main():
     filename = "./0.wav"
     x = get_features(filename)
 
-    padding = torch.zeros(int(16000 * 0.5), 80)
+    padding = torch.zeros(50, 80)
     x = torch.cat([x, padding], dim=0)
 
     chunk_length = (


### PR DESCRIPTION
## Problem

`test-onnx-streaming.py` crashes with `Gather index out of bounds`
when processing audio longer than ~118 seconds.

## Root Cause

Line 139 creates padding in the fbank feature domain but uses
sample-domain calculation:

    padding = torch.zeros(int(16000 * 0.5), 80)  # 8000 frames ≈ 80s

The intent is 0.5s of padding, which should be 50 fbank frames (at 10ms
frame shift), not 8000.

The extra 8000 frames cause the streaming offset to exceed the positional
encoding table size (max_len=5000) for long audio.

## Fix

    padding = torch.zeros(50, 80)  # 50 frames = 0.5s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated streaming model test parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->