### PR TITLE
Use onnxruntime 1.23.2 for Android

### DIFF
--- a/build-android-arm64-v8a.sh
+++ b/build-android-arm64-v8a.sh
@@ -68,7 +68,7 @@ fi
 
 echo "ANDROID_NDK: $ANDROID_NDK"
 sleep 1
-onnxruntime_version=1.17.1
+onnxruntime_version=1.23.2
 
 if [ $BUILD_SHARED_LIBS == ON ]; then
   if [ ! -f $onnxruntime_version/jni/arm64-v8a/libonnxruntime.so ]; then

--- a/build-android-armv7-eabi.sh
+++ b/build-android-armv7-eabi.sh
@@ -69,7 +69,7 @@ fi
 echo "ANDROID_NDK: $ANDROID_NDK"
 sleep 1
 
-onnxruntime_version=1.17.1
+onnxruntime_version=1.23.2
 
 if [ $BUILD_SHARED_LIBS == ON ]; then
   if [ ! -f $onnxruntime_version/jni/armeabi-v7a/libonnxruntime.so ]; then

--- a/build-android-x86-64.sh
+++ b/build-android-x86-64.sh
@@ -69,7 +69,7 @@ fi
 echo "ANDROID_NDK: $ANDROID_NDK"
 sleep 1
 
-onnxruntime_version=1.17.1
+onnxruntime_version=1.23.2
 
 if [ $BUILD_SHARED_LIBS == ON ]; then
   if [ ! -f $onnxruntime_version/jni/x86_64/libonnxruntime.so ]; then

--- a/build-android-x86.sh
+++ b/build-android-x86.sh
@@ -49,7 +49,7 @@ fi
 echo "ANDROID_NDK: $ANDROID_NDK"
 sleep 1
 
-onnxruntime_version=1.17.1
+onnxruntime_version=1.23.2
 
 if [ ! -f $onnxruntime_version/jni/x86/libonnxruntime.so ]; then
   mkdir -p $onnxruntime_version


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ONNX Runtime library to version 1.23.2 for Android builds across all supported architectures (ARM64, ARMv7, x86_64, and x86).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->