### PR TITLE
WebAssembly: Update download progress text to show MB instead of raw byte counts

### DIFF
--- a/wasm/asr/app-asr.js
+++ b/wasm/asr/app-asr.js
@@ -58,8 +58,10 @@ Module.setStatus = function(status) {
     const total = BigInt(downloadMatch[2]);
     const percent =
         total === 0 ? 0.00 : Number((downloaded * 10000n) / total) / 100;
-    status = `Downloading data... ${percent.toFixed(2)}% (${downloadMatch[1]}/${
-        downloadMatch[2]})`;
+    const downloadedMB = Number(downloaded) / (1024 * 1024);
+    const totalMB = Number(total) / (1024 * 1024);
+    status = `Downloading data... ${percent.toFixed(2)}% (${downloadedMB.toFixed(2)} MB/${
+        totalMB.toFixed(2)} MB)`;
     console.log(`here ${status}`)
   }
 

--- a/wasm/vad-asr/app-vad-asr.js
+++ b/wasm/vad-asr/app-vad-asr.js
@@ -154,8 +154,10 @@ Module.setStatus = function(status) {
     const total = BigInt(downloadMatch[2]);
     const percent =
         total === 0 ? 0.00 : Number((downloaded * 10000n) / total) / 100;
-    status = `Downloading data... ${percent.toFixed(2)}% (${downloadMatch[1]}/${
-        downloadMatch[2]})`;
+    const downloadedMB = Number(downloaded) / (1024 * 1024);
+    const totalMB = Number(total) / (1024 * 1024);
+    status = `Downloading data... ${percent.toFixed(2)}% (${downloadedMB.toFixed(2)} MB/${
+        totalMB.toFixed(2)} MB)`;
     console.log(`here ${status}`)
   }
 

--- a/wasm/vad/app-vad.js
+++ b/wasm/vad/app-vad.js
@@ -63,8 +63,10 @@ Module.setStatus = function(status) {
     const total = BigInt(downloadMatch[2]);
     const percent =
         total === 0 ? 0.00 : Number((downloaded * 10000n) / total) / 100;
-    status = `Downloading data... ${percent.toFixed(2)}% (${downloadMatch[1]}/${
-        downloadMatch[2]})`;
+    const downloadedMB = Number(downloaded) / (1024 * 1024);
+    const totalMB = Number(total) / (1024 * 1024);
+    status = `Downloading data... ${percent.toFixed(2)}% (${downloadedMB.toFixed(2)} MB/${
+        totalMB.toFixed(2)} MB)`;
     console.log(`here ${status}`)
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced download progress display across audio processing modules to show file sizes in megabytes (MB) for improved readability. Progress messages now display formatted sizes (e.g., "XX.XX MB/YYY.YY MB") instead of raw byte counts, making download tracking clearer for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->