### PR TITLE
docs: add fcitx5-vinput to projects using sherpa-onnx

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,14 @@ Example [a chat box agent](https://github.com/SamYuan1990/i18n-agent-action)
 
 a multimodal chatbot based on go with sherpa-onnx's speech lib api.
 
+### [fcitx5-vinput](https://github.com/xifan2333/fcitx5-vinput)
+
+Local offline voice input plugin for [Fcitx5](https://github.com/fcitx/fcitx5) (Linux input method framework).
+It uses C++ with offline ASR for speech recognition, supporting push-to-talk,
+command mode, and optional LLM post-processing.
+
+Video demo in Chinese: [fcitx5-vinput](https://www.bilibili.com/video/BV1a6cUzVE6F)
+
 [silero-vad]: https://github.com/snakers4/silero-vad
 [Raspberry Pi]: https://www.raspberrypi.com/
 [RV1126]: https://www.rock-chips.com/uploads/pdf/2022.8.26/191/RV1126%20Brief%20Datasheet.pdf


### PR DESCRIPTION
Add [fcitx5-vinput](https://github.com/xifan2333/fcitx5-vinput) to the projects section in README.

fcitx5-vinput is a local offline voice input plugin for Fcitx5 (Linux input method framework) powered by sherpa-onnx.

Closes #3349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new README section for fcitx5-vinput describing the local offline voice input plugin, its features (offline ASR, push-to-talk, command mode, optional LLM post-processing) and included a Chinese video demo link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->