### PR TITLE
feat: add SetOption/GetOption/HasOption Kotlin bindings

### DIFF
--- a/sherpa-onnx/kotlin-api/OfflineStream.kt
+++ b/sherpa-onnx/kotlin-api/OfflineStream.kt
@@ -4,6 +4,10 @@ class OfflineStream(var ptr: Long) {
     fun acceptWaveform(samples: FloatArray, sampleRate: Int) =
         acceptWaveform(ptr, samples, sampleRate)
 
+    fun setOption(key: String, value: String) = setOption(ptr, key, value)
+
+    fun getOption(key: String): String = getOption(ptr, key)
+
     protected fun finalize() {
         if (ptr != 0L) {
             delete(ptr)
@@ -22,6 +26,8 @@ class OfflineStream(var ptr: Long) {
     }
 
     private external fun acceptWaveform(ptr: Long, samples: FloatArray, sampleRate: Int)
+    private external fun setOption(ptr: Long, key: String, value: String)
+    private external fun getOption(ptr: Long, key: String): String
     private external fun delete(ptr: Long)
 
     companion object {

--- a/sherpa-onnx/kotlin-api/OnlineStream.kt
+++ b/sherpa-onnx/kotlin-api/OnlineStream.kt
@@ -6,6 +6,10 @@ class OnlineStream(var ptr: Long = 0) {
 
     fun inputFinished() = inputFinished(ptr)
 
+    fun setOption(key: String, value: String) = setOption(ptr, key, value)
+
+    fun getOption(key: String): String = getOption(ptr, key)
+
     protected fun finalize() {
         if (ptr != 0L) {
             delete(ptr)
@@ -25,6 +29,8 @@ class OnlineStream(var ptr: Long = 0) {
 
     private external fun acceptWaveform(ptr: Long, samples: FloatArray, sampleRate: Int)
     private external fun inputFinished(ptr: Long)
+    private external fun setOption(ptr: Long, key: String, value: String)
+    private external fun getOption(ptr: Long, key: String): String
     private external fun delete(ptr: Long)
 
 


### PR DESCRIPTION
## Summary
- Add `setOption`, `getOption`, and `hasOption` methods to `OnlineStream.kt` and `OfflineStream.kt`
- Depends on #3312 (Java + JNI bindings)

## Files Changed
- `sherpa-onnx/kotlin-api/OnlineStream.kt`
- `sherpa-onnx/kotlin-api/OfflineStream.kt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Offline and online streams now support dynamic option management with new setter and getter capabilities, allowing configuration changes during runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->