### PR TITLE
Add link to C API doc

### DIFF
--- a/sherpa-onnx/c-api/README.md
+++ b/sherpa-onnx/c-api/README.md
@@ -1,13 +1,18 @@
 # Introduction
 
 
+## View doc
+
+You can find documentation for C API and CXX API at the following address:
+<https://k2-fsa.github.io/sherpa/onnx/c-api/html/index.html>
+
 ## Generate doc
 
-```
+```bash
 sudo apt install doxygen graphviz      # Ubuntu/Debian
 brew install doxygen graphviz          # macOS
 ```
 
-```
+```bash
 doxygen ./Doxyfile
 ```


### PR DESCRIPTION
See also
https://k2-fsa.github.io/sherpa/onnx/c-api/html/index.html

<img width="2848" height="1810" alt="Screenshot 2026-03-20 at 17 55 06" src="https://github.com/user-attachments/assets/f39ca960-4c22-48a9-978d-ba026389d88b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added direct links to the C API and CXX API documentation for improved accessibility.
  * Enhanced code example formatting in the README with explicit bash code blocks for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->