### PR TITLE
Fix building Rust doc

### DIFF
--- a/sherpa-onnx/rust/sherpa-onnx-sys/Cargo.toml
+++ b/sherpa-onnx/rust/sherpa-onnx-sys/Cargo.toml
@@ -28,3 +28,7 @@ shared = []
 bzip2 = "0.4"
 tar = "0.4"
 ureq = "2.12"
+
+[package.metadata.docs.rs]
+default-features = false
+features = []

--- a/sherpa-onnx/rust/sherpa-onnx-sys/build.rs
+++ b/sherpa-onnx/rust/sherpa-onnx-sys/build.rs
@@ -44,6 +44,13 @@ fn main() {
 fn try_main() -> Result<(), DynError> {
     println!("cargo:rerun-if-env-changed=SHERPA_ONNX_LIB_DIR");
     println!("cargo:rerun-if-env-changed=SHERPA_ONNX_ARCHIVE_DIR");
+    println!("cargo:rerun-if-env-changed=DOCS_RS");
+
+    if env::var_os("DOCS_RS").is_some() {
+        // docs.rs sets DOCS_RS=1; skip downloading/linking native libraries
+        // so that `cargo doc` can succeed without the real C artifacts.
+        return Ok(());
+    }
 
     let target_os = env::var("CARGO_CFG_TARGET_OS")?;
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH")?;

--- a/sherpa-onnx/rust/sherpa-onnx/Cargo.toml
+++ b/sherpa-onnx/rust/sherpa-onnx/Cargo.toml
@@ -28,3 +28,7 @@ shared = ["sherpa-onnx-sys/shared"]
 sherpa-onnx-sys = { path = "../sherpa-onnx-sys", version = "1.12.33", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[package.metadata.docs.rs]
+default-features = false
+features = []


### PR DESCRIPTION
Fix the error in https://docs.rs/crate/sherpa-onnx/latest/builds/3056327

```
# error kind
ExecutionFailed


# pre-build errors
command failed: exit status: 101




# rustc version
rustc 1.96.0-nightly (f66622c7e 2026-03-23)


# docs.rs version
docsrs 0.0.0 (da7690ee 2026-03-15 )


# build log
[INFO] running `Command { std: "docker" "create" "-v" "/home/cratesfyi/workspace/builds/sherpa-onnx-1.12.33/target:/opt/rustwide/target:rw,Z" "-v" "/home/cratesfyi/workspace/builds/sherpa-onnx-1.12.33/source:/opt/rustwide/workdir:ro,Z" "-v" "/home/cratesfyi/workspace/cargo-home:/opt/rustwide/cargo-home:ro,Z" "-v" "/home/cratesfyi/workspace/rustup-home:/opt/rustwide/rustup-home:ro,Z" "-e" "SOURCE_DIR=/opt/rustwide/workdir" "-e" "CARGO_TARGET_DIR=/opt/rustwide/target" "-e" "DOCS_RS=1" "-e" "CARGO_HOME=/opt/rustwide/cargo-home" "-e" "RUSTUP_HOME=/opt/rustwide/rustup-home" "-w" "/opt/rustwide/workdir" "-m" "6442450944" "--cpus" "6" "--user" "1001:1001" "--network" "none" "ghcr.io/rust-lang/crates-build-env/linux@sha256:d429b63d4308055ea97f60fb1d3dfca48854a00942f1bd2ad806beaf015945ec" "/opt/rustwide/cargo-home/bin/cargo" "+nightly" "rustdoc" "--lib" "-Zrustdoc-map" "--config" "build.rustdocflags=[\"--cfg\", \"docsrs\", \"-Z\", \"unstable-options\", \"--emit=invocation-specific\", \"--resource-suffix\", \"-20260323-1.96.0-nightly-f66622c7e\", \"--static-root-path\", \"/-/rustdoc.static/\", \"--cap-lints\", \"warn\", \"--extern-html-root-takes-precedence\"]" "--offline" "-Zunstable-options" "--config=doc.extern-map.registries.crates-io=\"https://docs.rs/{pkg_name}/{version}/x86_64-unknown-linux-gnu\"" "-Zrustdoc-scrape-examples" "-j6" "--target" "x86_64-unknown-linux-gnu", kill_on_drop: false }`
[INFO] [stderr] WARNING: Your kernel does not support swap limit capabilities or the cgroup is not mounted. Memory limited without swap.
[INFO] [stdout] ed8f50b3ffc0d350c40233006e3faa0dd3bdd243b7864e5f08eb6fb5c7c179e4
[INFO] running `Command { std: "docker" "start" "-a" "ed8f50b3ffc0d350c40233006e3faa0dd3bdd243b7864e5f08eb6fb5c7c179e4", kill_on_drop: false }`
[INFO] [stderr] warning: target filter specified, but no targets matched; this is a no-op
[INFO] [stderr]    Compiling sherpa-onnx-sys v1.12.33
[INFO] [stderr] error: failed to run custom build command for `sherpa-onnx-sys v1.12.33`
[INFO] [stderr] 
[INFO] [stderr] Caused by:
[INFO] [stderr]   process didn't exit successfully: `/opt/rustwide/target/debug/build/sherpa-onnx-sys-0d6f1593e9f1efea/build-script-build` (exit status: 101)
[INFO] [stderr]   --- stdout
[INFO] [stderr]   cargo:rerun-if-env-changed=SHERPA_ONNX_LIB_DIR
[INFO] [stderr]   cargo:rerun-if-env-changed=SHERPA_ONNX_ARCHIVE_DIR
[INFO] [stderr] 
[INFO] [stderr]   --- stderr
[INFO] [stderr]   Downloading sherpa-onnx libs from https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.33/sherpa-onnx-v1.12.33-linux-x64-static-lib.tar.bz2
[INFO] [stderr] 
[INFO] [stderr]   thread 'main' (16) panicked at /opt/rustwide/cargo-home/registry/src/index.crates.io-1949cf8c6b5b557f/sherpa-onnx-sys-1.12.33/build.rs:40:9:
[INFO] [stderr]   Failed to download sherpa-onnx archive from https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.33/sherpa-onnx-v1.12.33-linux-x64-static-lib.tar.bz2: https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.12.33/sherpa-onnx-v1.12.33-linux-x64-static-lib.tar.bz2: Dns Failed: resolve dns name 'github.com:443': failed to lookup address information: Temporary failure in name resolution
[INFO] [stderr]   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[INFO] running `Command { std: "docker" "inspect" "ed8f50b3ffc0d350c40233006e3faa0dd3bdd243b7864e5f08eb6fb5c7c179e4", kill_on_drop: false }`
[INFO] running `Command { std: "docker" "rm" "-f" "ed8f50b3ffc0d350c40233006e3faa0dd3bdd243b7864e5f08eb6fb5c7c179e4", kill_on_drop: false }`
[INFO] [stdout] ed8f50b3ffc0d350c40233006e3faa0dd3bdd243b7864e5f08eb6fb5c7c179e4
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced docs.rs configuration for improved documentation generation
  * Optimized build process during documentation generation by streamlining platform-specific setup steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->