### PR TITLE
Update tests for Qwen3 ASR

### DIFF
--- a/.github/scripts/test-python.sh
+++ b/.github/scripts/test-python.sh
@@ -8,6 +8,23 @@ log() {
   echo -e "$(date '+%Y-%m-%d %H:%M:%S') (${fname}:${BASH_LINENO[0]}:${FUNCNAME[1]}) $*"
 }
 
+log "test Qwen3 ASR"
+
+wget -q https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25.tar.bz2
+tar xvf sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25.tar.bz2
+rm sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25.tar.bz2
+
+python3 ./python-api-examples/offline-qwen3-asr-decode-files.py \
+  --conv-frontend=./sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/conv_frontend.onnx \
+  --encoder=./sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/encoder.int8.onnx \
+  --decoder=./sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/decoder.int8.onnx \
+  --tokenizer=./sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/tokenizer \
+  --max-new-tokens=128 \
+  --num-threads=2 \
+  ./sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/test_wavs/raokouling.wav
+
+rm -rf sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25
+
 log "test Supertonic TTS"
 
 curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/sherpa-onnx-supertonic-tts-int8-2026-03-06.tar.bz2

--- a/.github/workflows/c-api.yaml
+++ b/.github/workflows/c-api.yaml
@@ -76,6 +76,36 @@ jobs:
             otool -L ./install/lib/libsherpa-onnx-c-api.dylib
           fi
 
+      - name: Test Qwen3 ASR
+        shell: bash
+        run: |
+          name=qwen3-asr-c-api
+          gcc -o $name ./c-api-examples/$name.c \
+            -I ./build/install/include \
+            -L ./build/install/lib/ \
+            -l sherpa-onnx-c-api \
+            -l onnxruntime
+
+          ls -lh $name
+
+          if [[ ${{ matrix.os }} == ubuntu-latest || ${{ matrix.os }} == ubuntu-22.04-arm ]]; then
+            ldd ./$name
+            echo "----"
+            readelf -d ./$name
+          fi
+
+          curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25.tar.bz2
+          tar xvf sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25.tar.bz2
+          rm sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25.tar.bz2
+
+          export LD_LIBRARY_PATH=$PWD/build/install/lib:$LD_LIBRARY_PATH
+          export DYLD_LIBRARY_PATH=$PWD/build/install/lib:$DYLD_LIBRARY_PATH
+
+          ./$name
+
+          rm -rf sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25
+          rm $name
+
       - name: Test source separation (Spleeter)
         shell: bash
         run: |

--- a/.github/workflows/cxx-api.yaml
+++ b/.github/workflows/cxx-api.yaml
@@ -78,6 +78,37 @@ jobs:
             otool -L ./install/lib/libsherpa-onnx-cxx-api.dylib
           fi
 
+      - name: Test Qwen3 ASR
+        shell: bash
+        run: |
+          name=qwen3-asr-cxx-api
+          g++ -std=c++17 -o $name ./cxx-api-examples/$name.cc \
+            -I ./build/install/include \
+            -L ./build/install/lib/ \
+            -l sherpa-onnx-cxx-api \
+            -l sherpa-onnx-c-api \
+            -l onnxruntime
+
+          ls -lh $name
+
+          if [[ ${{ matrix.os }} == ubuntu-latest || ${{ matrix.os }} == ubuntu-22.04-arm ]]; then
+            ldd ./$name
+            echo "----"
+            readelf -d ./$name
+          fi
+
+          curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25.tar.bz2
+          tar xvf sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25.tar.bz2
+          rm sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25.tar.bz2
+
+          export LD_LIBRARY_PATH=$PWD/build/install/lib:$LD_LIBRARY_PATH
+          export DYLD_LIBRARY_PATH=$PWD/build/install/lib:$DYLD_LIBRARY_PATH
+
+          ./$name
+
+          rm -rf sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25
+          rm $name
+
       - name: Test Source Separation (Spleeter)
         shell: bash
         run: |

--- a/.github/workflows/run-python-test-macos.yaml
+++ b/.github/workflows/run-python-test-macos.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - python
     paths:
       - '.github/workflows/run-python-test-macos.yaml'
       - '.github/scripts/test-python.sh'

--- a/.github/workflows/run-python-test.yaml
+++ b/.github/workflows/run-python-test.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - python
     paths:
       - '.github/workflows/run-python-test.yaml'
       - '.github/scripts/test-python.sh'

--- a/c-api-examples/qwen3-asr-c-api.c
+++ b/c-api-examples/qwen3-asr-c-api.c
@@ -7,10 +7,18 @@
 //
 // clang-format off
 //
-// Prepare a local model directory with:
-//   conv_frontend.onnx, encoder.onnx, decoder.onnx, tokenizer/ (vocab.json, ...)
-// and a 16-bit PCM mono WAV, then adjust paths below.
+// Build:
+//   cmake --build build --target qwen3-asr-c-api
 //
+// Model:
+//   wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25.tar.bz2
+//   tar xvf sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25.tar.bz2
+//
+// Run:
+//   ./build/bin/qwen3-asr-c-api
+//
+// Note: If the input audio is too long, you can set option on the stream:
+//   SherpaOnnxOfflineStreamSetOption(stream, "max_new_tokens", "256");
 // clang-format on
 
 #include <stdio.h>
@@ -21,11 +29,11 @@
 
 int32_t main() {
   // clang-format off
-  const char *wav_filename = "./test.wav";
-  const char *conv_frontend = "./model/conv_frontend.onnx";
-  const char *encoder = "./model/encoder.onnx";
-  const char *decoder = "./model/decoder.onnx";
-  const char *tokenizer = "./model/tokenizer";
+  const char *wav_filename = "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/test_wavs/raokouling.wav";
+  const char *conv_frontend = "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/conv_frontend.onnx";
+  const char *encoder = "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/encoder.int8.onnx";
+  const char *decoder = "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/decoder.int8.onnx";
+  const char *tokenizer = "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/tokenizer";
   // clang-format on
 
   const SherpaOnnxWave *wave = SherpaOnnxReadWave(wav_filename);
@@ -41,7 +49,7 @@ int32_t main() {
   qwen3.decoder = decoder;
   qwen3.tokenizer = tokenizer;
   qwen3.max_total_len = 512;
-  qwen3.max_new_tokens = 64;
+  qwen3.max_new_tokens = 128;
   qwen3.temperature = 1e-6f;
   qwen3.top_p = 0.8f;
   qwen3.seed = 42;

--- a/cxx-api-examples/qwen3-asr-cxx-api.cc
+++ b/cxx-api-examples/qwen3-asr-cxx-api.cc
@@ -6,10 +6,18 @@
 //
 // clang-format off
 //
-// Usage:
-//   Adjust paths to conv_frontend.onnx, encoder.onnx, decoder.onnx, tokenizer/
-//   and input WAV, then build and run this example.
+// Build:
+//   cmake --build build --target qwen3-asr-cxx-api
 //
+// Model:
+//   wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25.tar.bz2
+//   tar xvf sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25.tar.bz2
+//
+// Run:
+//   ./build/bin/qwen3-asr-cxx-api
+//
+// Note: If the input audio is too long, you can change max_new_tokens via
+//   stream.SetOption("max_new_tokens", "256");
 // clang-format on
 
 #include <chrono>
@@ -28,18 +36,18 @@ int32_t main(int32_t argc, char *argv[]) {
   config.model_config.provider = "cpu";
 
   // clang-format off
-  config.model_config.qwen3_asr.conv_frontend = "./model/conv_frontend.onnx";
-  config.model_config.qwen3_asr.encoder = "./model/encoder.onnx";
-  config.model_config.qwen3_asr.decoder = "./model/decoder.onnx";
-  config.model_config.qwen3_asr.tokenizer = "./model/tokenizer";
+  config.model_config.qwen3_asr.conv_frontend = "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/conv_frontend.onnx";
+  config.model_config.qwen3_asr.encoder = "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/encoder.int8.onnx";
+  config.model_config.qwen3_asr.decoder = "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/decoder.int8.onnx";
+  config.model_config.qwen3_asr.tokenizer = "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/tokenizer";
   config.model_config.qwen3_asr.max_total_len = 512;
-  config.model_config.qwen3_asr.max_new_tokens = 64;
+  config.model_config.qwen3_asr.max_new_tokens = 128;
   config.model_config.qwen3_asr.temperature = 1e-6f;
   config.model_config.qwen3_asr.top_p = 0.8f;
   config.model_config.qwen3_asr.seed = 42;
   // clang-format on
 
-  std::string wave_filename = "./test.wav";
+  std::string wave_filename = "sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/test_wavs/raokouling.wav";
   if (argc >= 2) {
     wave_filename = argv[1];
   }

--- a/python-api-examples/offline-qwen3-asr-decode-files.py
+++ b/python-api-examples/offline-qwen3-asr-decode-files.py
@@ -7,13 +7,18 @@ Decode audio files using Qwen3-ASR with sherpa-onnx Python API.
 
 Usage:
     python offline-qwen3-asr-decode-files.py \\
-        --conv-frontend=/path/to/conv_frontend.onnx \\
-        --encoder=/path/to/encoder.onnx \\
-        --decoder=/path/to/decoder.onnx \\
-        --tokenizer=/path/to/tokenizer_dir \\
-        [--num-threads=4] \\
-        [--provider=cpu] \\
-        audio1.wav audio2.wav ...
+        --conv-frontend=./sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/conv_frontend.onnx \\
+        --encoder=./sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/encoder.int8.onnx \\
+        --decoder=./sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/decoder.int8.onnx \\
+        --tokenizer=./sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/tokenizer \\
+        --max-new-tokens=128 \\
+        --num-threads=2 \\
+        ./sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/test_wavs/raokouling.wav
+
+Note: If the input audio is too long, you can increase --max-new-tokens (e.g., 256).
+You can also change it per-stream after creating the recognizer:
+    stream = recognizer.create_stream()
+    stream.set_option("max_new_tokens", "256")
 """
 
 import argparse
@@ -73,7 +78,7 @@ def get_args():
     parser.add_argument(
         "--max-new-tokens",
         type=int,
-        default=64,
+        default=128,
         help="Maximum number of new tokens to generate",
     )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Qwen3 ASR testing support to C, C++, and Python API workflows
  * Enabled Python workflow triggers on the `python` branch

* **Documentation**
  * Updated Qwen3 ASR examples with new model configurations
  * Increased default token generation limit from 64 to 128 in examples
  * Updated examples to use optimized int8 model variants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->