### PR TITLE
Update Swift API example for Qwen3 ASR

### DIFF
--- a/.github/scripts/test-swift.sh
+++ b/.github/scripts/test-swift.sh
@@ -7,6 +7,9 @@ echo "pwd: $PWD"
 cd swift-api-examples
 ls -lh
 
+./run-qwen3-asr.sh
+rm -rf sherpa-onnx-qwen3-*
+
 ./run-test-version.sh
 
 ./run-moonshine-v2-asr.sh

--- a/.github/workflows/swift.yaml
+++ b/.github/workflows/swift.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - swift
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
     paths:

--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,4 @@ sherpa-onnx-zipvoice-distill-int8-zh-en-emilia
 sherpa-onnx-kws-zipformer-wenetspeech-3.3M-2024-01-01-mobile
 sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8
 doxygen-docs
+sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25

--- a/swift-api-examples/SherpaOnnx.swift
+++ b/swift-api-examples/SherpaOnnx.swift
@@ -479,7 +479,7 @@ func sherpaOnnxOfflineQwen3ASRModelConfig(
   decoder: String = "",
   tokenizer: String = "",
   maxTotalLen: Int = 512,
-  maxNewTokens: Int = 64,
+  maxNewTokens: Int = 128,
   temperature: Float = 1e-6,
   topP: Float = 0.8,
   seed: Int = 42
@@ -1232,6 +1232,15 @@ typealias TtsCallbackWithArg = (
   ) -> Int32
 )?
 
+class SherpaOnnxCallbackPair {
+  var cb: TtsCallbackWithArg
+  var arg: UnsafeMutableRawPointer?
+  init(cb: TtsCallbackWithArg, arg: UnsafeMutableRawPointer?) {
+    self.cb = cb
+    self.arg = arg
+  }
+}
+
 typealias TtsProgressCallbackWithArg =
   @convention(c) (
     UnsafePointer<Float>?, Int32, Float, UnsafeMutableRawPointer?
@@ -1328,7 +1337,7 @@ class SherpaOnnxOfflineTtsWrapper {
   }
 
   func generate(text: String, sid: Int = 0, speed: Float = 1.0) -> SherpaOnnxGeneratedAudioWrapper {
-    var config = SherpaOnnxGenerationConfigSwift(speed: speed, sid: sid)
+    let config = SherpaOnnxGenerationConfigSwift(speed: speed, sid: sid)
     return generateWithConfig(text: text, config: config, callback: nil, arg: nil)
   }
 
@@ -1336,13 +1345,17 @@ class SherpaOnnxOfflineTtsWrapper {
     text: String, callback: TtsCallbackWithArg, arg: UnsafeMutableRawPointer, sid: Int = 0,
     speed: Float = 1.0
   ) -> SherpaOnnxGeneratedAudioWrapper {
-    var config = SherpaOnnxGenerationConfigSwift(speed: speed, sid: sid)
+    let config = SherpaOnnxGenerationConfigSwift(speed: speed, sid: sid)
 
-    let wrapper: TtsProgressCallbackWithArg = { samples, n, progress, arg in
-      return callback(samples, n, arg)
+    let pair = SherpaOnnxCallbackPair(cb: callback, arg: arg)
+    let unmanaged = Unmanaged.passRetained(pair)
+    let wrapper: TtsProgressCallbackWithArg = { samples, n, progress, rawArg in
+      let p = Unmanaged<SherpaOnnxCallbackPair>.fromOpaque(rawArg!).takeUnretainedValue()
+      return p.cb!(samples, n, p.arg)
     }
-
-    return generateWithConfig(text: text, config: config, callback: wrapper, arg: arg)
+    let result = generateWithConfig(text: text, config: config, callback: wrapper, arg: unmanaged.toOpaque())
+    unmanaged.release()
+    return result
   }
 
   func generateWithConfig(

--- a/swift-api-examples/qwen3-asr.swift
+++ b/swift-api-examples/qwen3-asr.swift
@@ -1,0 +1,54 @@
+func run() {
+  let convFrontend =
+    "./sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/conv_frontend.onnx"
+  let encoder =
+    "./sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/encoder.int8.onnx"
+  let decoder =
+    "./sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/decoder.int8.onnx"
+  let tokenizer =
+    "./sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/tokenizer"
+
+  let qwen3Asr = sherpaOnnxOfflineQwen3ASRModelConfig(
+    convFrontend: convFrontend,
+    encoder: encoder,
+    decoder: decoder,
+    tokenizer: tokenizer,
+    maxTotalLen: 512,
+    maxNewTokens: 128,
+    temperature: 1e-6,
+    topP: 0.8,
+    seed: 42
+  )
+
+  let modelConfig = sherpaOnnxOfflineModelConfig(
+    tokens: "",
+    numThreads: 2,
+    provider: "cpu",
+    debug: 0,
+    qwen3Asr: qwen3Asr
+  )
+
+  let featConfig = sherpaOnnxFeatureConfig()
+  var config = sherpaOnnxOfflineRecognizerConfig(
+    featConfig: featConfig,
+    modelConfig: modelConfig
+  )
+
+  let recognizer = SherpaOnnxOfflineRecognizer(config: &config)
+
+  let filePath =
+    "./sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/test_wavs/raokouling.wav"
+  let audio = SherpaOnnxWaveWrapper.readWave(filename: filePath)
+
+  let result = recognizer.decode(samples: audio.samples, sampleRate: audio.sampleRate)
+  print("decode done")
+
+  print("\nresult is:\n\(result.text)")
+}
+
+@main
+struct App {
+  static func main() {
+    run()
+  }
+}

--- a/swift-api-examples/run-qwen3-asr.sh
+++ b/swift-api-examples/run-qwen3-asr.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if [ ! -d ../build-swift-macos ]; then
+  echo "Please run ../build-swift-macos.sh first!"
+  exit 1
+fi
+
+if [ ! -f ./sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25/encoder.int8.onnx ]; then
+  echo "Please download the pre-trained model for testing."
+  echo "You can refer to"
+  echo ""
+  echo "https://k2-fsa.github.io/sherpa/onnx/pretrained_models/index.html"
+  echo ""
+  echo "for help"
+
+  wget -q https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25.tar.bz2
+  tar xvf sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25.tar.bz2
+  rm sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25.tar.bz2
+
+  ls -lh sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25
+fi
+
+if [ ! -e ./qwen3-asr ]; then
+  # Note: We use -lc++ to link against libc++ instead of libstdc++
+  swiftc \
+    -lc++ \
+    -I ../build-swift-macos/install/include \
+    -import-objc-header ./SherpaOnnx-Bridging-Header.h \
+    ./qwen3-asr.swift ./SherpaOnnx.swift \
+    -L ../build-swift-macos/install/lib/ \
+    -l sherpa-onnx \
+    -l onnxruntime \
+    -o qwen3-asr
+
+  strip qwen3-asr
+else
+  echo "./qwen3-asr exists - skip building"
+fi
+
+export DYLD_LIBRARY_PATH=$PWD/../build-swift-macos/install/lib:$DYLD_LIBRARY_PATH
+./qwen3-asr


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Qwen3 ASR example for Swift with an automated setup script that downloads required model artifacts and builds the executable.

* **Chores**
  * Extended Swift CI pipeline to build on the `swift` branch in addition to `master`.
  * Updated default max tokens parameter to 128 for improved text generation quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->