### PR TITLE
spacemit provider: add provider with config file, then update to 2.0.2

### DIFF
--- a/sherpa-onnx/csrc/session.cc
+++ b/sherpa-onnx/csrc/session.cc
@@ -92,16 +92,6 @@ static void ParseConfigFile(
 
     config[std::move(key)] = std::move(value);
   }
-
-  if (config.find("DEBUG") != config.end()) {
-    auto config_debug = ToIntOrDefault(config["DEBUG"], 0) == 1;
-    if (config_debug) {
-      for (const auto &kv : config) {
-        SHERPA_ONNX_LOGE("Provider config: %s=%s", kv.first.c_str(),
-                         kv.second.c_str());
-      }
-    }
-  }
 }
 
 static void SplitProviderAndConfig(
@@ -121,15 +111,24 @@ static void SplitProviderAndConfig(
   std::string config_path = Trim(provider_str.substr(pos + 1));
   provider_str = Trim(provider_str.substr(0, pos));
 
-  SHERPA_ONNX_LOGE("Provider string: %s. Config path: %s", provider_str.c_str(),
-                   config_path.c_str());
-
   if (config_path.empty()) {
     SHERPA_ONNX_LOGE("Provider config path is empty: %s", s.c_str());
     SHERPA_ONNX_EXIT(-1);
   }
 
   ParseConfigFile(config_path, config);
+
+  if (config.find("DEBUG") != config.end()) {
+    auto config_debug = ToIntOrDefault(config["DEBUG"], 0) == 1;
+    if (config_debug) {
+      SHERPA_ONNX_LOGE("Provider string: %s. Config path: %s",
+                       provider_str.c_str(), config_path.c_str());
+      for (const auto &kv : config) {
+        SHERPA_ONNX_LOGE("Provider config: %s=%s", kv.first.c_str(),
+                         kv.second.c_str());
+      }
+    }
+  }
 }
 
 Ort::SessionOptions GetSessionOptionsImpl(


### PR DESCRIPTION
command like this
~~~
SHERPA_ONNX_INSTALL_DIR=${1}
export LD_LIBRARY_PATH=${SHERPA_ONNX_INSTALL_DIR}/lib

${SHERPA_ONNX_INSTALL_DIR}/bin/sherpa-onnx-offline-tts \
  --provider=spacemit:matcha.config \
  --num-threads=4 \
  --matcha-vocoder=./vocos-22khz-univ.dynq.onnx \
  --matcha-acoustic-model=./model-steps-3.dynq.onnx \
  --matcha-dict-dir=./dict \
  --matcha-tokens=./tokens.txt \
  --matcha-lexicon=./lexicon.txt \
  --output-filename=./generated.wav \
  "这是一个测试"
~~~

and config file
~~~
SPACEMIT_EP_PERFER_CORE_ARCH:0x5064
SPACEMIT_EP_INTRA_THREAD_NUM:4
SPACEMIT_EP_USE_GLOBAL_INTRA_THREAD:1
~~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support specifying provider:<config_path> to load key/value options from a file; numeric options validated and profiling can be enabled via config.

* **Refactor**
  * Session options are now driven by config entries and remaining values are passed through to the selected provider.

* **Bug Fixes**
  * Improved handling and logging of malformed or missing config entries; provider options merged sensibly with sensible defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->