### PR TITLE
Add Speed of Sound to projects using sherpa-onnx

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,10 +300,10 @@ for 新一代 Kaldi **微信交流群** and **QQ 交流群**.
 
 ### [Speed of Sound](https://github.com/zugaldia/speedofsound)
 
-A voice-typing application for the Linux desktop (GTK4/Adwaita).
-It captures microphone audio, transcribes it offline using Sherpa ONNX ASR models,
-optionally polishes the text with an LLM, and types the result into the active window
-via XDG Remote Desktop Portal keyboard simulation.
+> A voice-typing application for the Linux desktop (GTK4/Adwaita).
+> It captures microphone audio, transcribes it offline using Sherpa ONNX ASR models,
+> optionally polishes the text with an LLM, and types the result into the active window
+> via XDG Remote Desktop Portal keyboard simulation.
 
 ### [VoxSherpa TTS](https://github.com/CodeBySonu95/VoxSherpa-TTS)
 


### PR DESCRIPTION
[Speed of Sound](https://github.com/zugaldia/speedofsound) is a voice-typing application for the Linux desktop available on Flathub and Snapcraft. It captures microphone audio, transcribes it offline using Sherpa ONNX ASR models, optionally polishes the text with an LLM, and types the result into the active window via XDG Remote Desktop Portal keyboard simulation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Speed of Sound" entry to projects using sherpa-onnx — documents a Linux desktop voice-typing workflow that captures microphone audio, performs offline transcription with Sherpa ONNX ASR models, optionally polishes text with an LLM, and simulates keyboard input into the active window via the desktop portal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->