### PR TITLE
Remove num_threads assertion from OnlineRecognizer model configs

### DIFF
--- a/sherpa-onnx/python/sherpa_onnx/online_recognizer.py
+++ b/sherpa-onnx/python/sherpa_onnx/online_recognizer.py
@@ -230,8 +230,6 @@ class OnlineRecognizer(object):
         _assert_file_exists(decoder)
         _assert_file_exists(joiner)
 
-        assert num_threads > 0, num_threads
-
         transducer_config = OnlineTransducerModelConfig(
             encoder=encoder,
             decoder=decoder,
@@ -415,8 +413,6 @@ class OnlineRecognizer(object):
         _assert_file_exists(encoder)
         _assert_file_exists(decoder)
 
-        assert num_threads > 0, num_threads
-
         paraformer_config = OnlineParaformerModelConfig(
             encoder=encoder,
             decoder=decoder,
@@ -550,8 +546,6 @@ class OnlineRecognizer(object):
         _assert_file_exists(tokens)
         _assert_file_exists(model)
 
-        assert num_threads > 0, num_threads
-
         zipformer2_ctc_config = OnlineZipformer2CtcModelConfig(model=model)
 
         provider_config = ProviderConfig(
@@ -680,8 +674,6 @@ class OnlineRecognizer(object):
         _assert_file_exists(tokens)
         _assert_file_exists(model)
 
-        assert num_threads > 0, num_threads
-
         t_one_ctc_config = OnlineToneCtcModelConfig(
             model=model,
         )
@@ -805,8 +797,6 @@ class OnlineRecognizer(object):
         self = cls.__new__(cls)
         _assert_file_exists(tokens)
         _assert_file_exists(model)
-
-        assert num_threads > 0, num_threads
 
         nemo_ctc_config = OnlineNeMoCtcModelConfig(
             model=model,
@@ -936,8 +926,6 @@ class OnlineRecognizer(object):
         self = cls.__new__(cls)
         _assert_file_exists(tokens)
         _assert_file_exists(model)
-
-        assert num_threads > 0, num_threads
 
         wenet_ctc_config = OnlineWenetCtcModelConfig(
             model=model,


### PR DESCRIPTION
Removed assertions for num_threads in multiple model configurations since it prevented negative values which are valid for rk npu 

Valid num_threads for rk npu is 1 (auto), 0 (core 0), -1 (core 1), -2 (core 2), -3 (core 0_1), -4 (core 0_1_2)

Related to #3446 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined factory constructors by removing intermediate validation checks. Parameter validation now occurs downstream in the configuration layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->