### PR TITLE
Fix URL in Wake Word project entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,8 +469,8 @@ keyword spotting (KWS) to detect custom wake phrases and trigger VS Code command
 Audio capture is handled by [decibri](https://github.com/analyticsinmotion/decibri), a
 cross-platform Node.js microphone streaming library with prebuilt native binaries.
 
-- [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=AnalyticsInMotion.wake-word)
-- [Open VSX](https://open-vsx.org/extension/AnalyticsInMotion/wake-word)
+- [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=analytics-in-motion.wake-word)
+- [Open VSX](https://open-vsx.org/extension/analytics-in-motion/wake-word)
 - [decibri integration guides for sherpa-onnx](https://decibri.dev/docs/node/integrations/sherpa-onnx-stt.html)
 
 [silero-vad]: https://github.com/snakers4/silero-vad


### PR DESCRIPTION
Fixes a broken link in the Wake Word entry added in #3447.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed external links for the "Wake Word" VS Code extension to ensure proper routing to the VS Code Marketplace and Open VSX pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->