### PR TITLE
Add hotwords argument to OfflineQwen3ASRModelConfig

### DIFF
--- a/sherpa-onnx/python/csrc/offline-qwen3-asr-model-config.cc
+++ b/sherpa-onnx/python/csrc/offline-qwen3-asr-model-config.cc
@@ -15,12 +15,13 @@ void PybindOfflineQwen3ASRModelConfig(py::module *m) {
   py::class_<PyClass>(*m, "OfflineQwen3ASRModelConfig")
       .def(py::init<const std::string &, const std::string &,
                     const std::string &, const std::string &, int32_t, int32_t,
-                    float, float, int32_t>(),
+                    float, float, int32_t, const std::string &>(),
            py::arg("conv_frontend") = "", py::arg("encoder") = "",
            py::arg("decoder") = "", py::arg("tokenizer") = "",
            py::arg("max_total_len") = 512, py::arg("max_new_tokens") = 128,
            py::arg("temperature") = 1e-6f, py::arg("top_p") = 0.8f,
-           py::arg("seed") = 42)
+           py::arg("seed") = 42, 
+           py::arg("hotwords") = "")
       .def_readwrite("conv_frontend", &PyClass::conv_frontend)
       .def_readwrite("encoder", &PyClass::encoder)
       .def_readwrite("decoder", &PyClass::decoder)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `hotwords` parameter to the offline Qwen3 ASR model configuration, allowing users to specify custom hotwords for improved speech recognition performance in specialized domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->