### PR TITLE
Fix Qwen3-ASR hotwords handling

### DIFF
--- a/dotnet-examples/non-streaming-qwen3-asr-decode-files/Program.cs
+++ b/dotnet-examples/non-streaming-qwen3-asr-decode-files/Program.cs
@@ -1,9 +1,9 @@
-// Copyright (c)  2026  Xiaomi Corporation
+﻿// Copyright (c)  2026  Xiaomi Corporation
 //
 // This file shows how to use a Qwen3 ASR model for speech recognition.
 //
 // You can find the model doc at
-// https://k2-fsa.github.io/sherpa/onnx/qwen3-asr.html
+// https://k2-fsa.github.io/sherpa/onnx/qwen3-asr
 using SherpaOnnx;
 
 class NonStreamingQwen3Asr

--- a/sherpa-onnx/csrc/offline-recognizer-qwen3-asr-impl.cc
+++ b/sherpa-onnx/csrc/offline-recognizer-qwen3-asr-impl.cc
@@ -709,7 +709,8 @@ OfflineRecognitionResult OfflineRecognizerQwen3ASRImpl::GenerateText(
   // Optional per-stream hotwords via SetOption("hotwords", comma-separated
   // CSV).
   const std::string hotwords = Qwen3FormatHotwordsForPrompt(
-      stream->HasOption("hotwords") ? stream->GetOption("hotwords") : "");
+      stream->HasOption("hotwords") ? stream->GetOption("hotwords")
+                                    : qwen3_config.hotwords);
 
   std::string language;
   if (stream->HasOption("language")) {
@@ -981,9 +982,9 @@ OfflineRecognitionResult OfflineRecognizerQwen3ASRImpl::GenerateText(
   std::vector<int64_t> cleaned_ids = generated_ids;
   if (!generated_ids.empty()) {
     const size_t prefix_window = std::min<size_t>(16, generated_ids.size());
-    auto asr_text_it = std::find(generated_ids.begin(),
-                                 generated_ids.begin() + prefix_window,
-                                 asr_text_token_id_);
+    auto asr_text_it =
+        std::find(generated_ids.begin(), generated_ids.begin() + prefix_window,
+                  asr_text_token_id_);
 
     // Only strip a leading scaffold prefix recognized by token ID.
     if (asr_text_it != generated_ids.begin() + prefix_window &&
@@ -991,10 +992,8 @@ OfflineRecognitionResult OfflineRecognizerQwen3ASRImpl::GenerateText(
       std::vector<int64_t> prefix_ids(generated_ids.begin(),
                                       std::next(asr_text_it));
       std::string prefix_text = tokenizer_->Decode(prefix_ids);
-      if (prefix_text.rfind("language ", 0) == 0 &&
-          prefix_text.size() >= 10 &&
-          prefix_text.compare(prefix_text.size() - 10, 10, "<asr_text>") ==
-              0) {
+      if (prefix_text.rfind("language ", 0) == 0 && prefix_text.size() >= 10 &&
+          prefix_text.compare(prefix_text.size() - 10, 10, "<asr_text>") == 0) {
         cleaned_ids.assign(std::next(asr_text_it), generated_ids.end());
       }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hotwords handling in speech recognition to properly use model-level configuration defaults when stream-specific options are not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->