### PR TITLE
Use model file paths to initialize ONNX Runtime sessions

### DIFF
--- a/sherpa-onnx/csrc/alsa-play.cc
+++ b/sherpa-onnx/csrc/alsa-play.cc
@@ -5,6 +5,7 @@
 #ifdef SHERPA_ONNX_ENABLE_ALSA
 
 #include "sherpa-onnx/csrc/alsa-play.h"
+#include "sherpa-onnx/csrc/macros.h"
 
 #include <algorithm>
 #include <cstdio>
@@ -18,7 +19,7 @@ AlsaPlay::AlsaPlay(const char *device_name, int32_t sample_rate) {
 
   if (err) {
     fprintf(stderr, "Unable to open: %s. %s\n", device_name, snd_strerror(err));
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   SetParameters(sample_rate);
@@ -47,14 +48,14 @@ void AlsaPlay::SetParameters(int32_t sample_rate) {
   if (err < 0) {
     printf("SND_PCM_ACCESS_RW_INTERLEAVED is not supported: %s\n",
            snd_strerror(err));
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   err = snd_pcm_hw_params_set_format(handle_, params, SND_PCM_FORMAT_S16_LE);
 
   if (err < 0) {
     printf("Can't set format to 16-bit: %s\n", snd_strerror(err));
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   err = snd_pcm_hw_params_set_channels(handle_, params, 1);
@@ -72,7 +73,7 @@ void AlsaPlay::SetParameters(int32_t sample_rate) {
   err = snd_pcm_hw_params(handle_, params);
   if (err < 0) {
     printf("Can't set hardware parameters. %s\n", snd_strerror(err));
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   uint32_t tmp;
@@ -121,7 +122,7 @@ void AlsaPlay::Play(const std::vector<float> &samples) {
       snd_pcm_prepare(handle_);
     } else if (err < 0) {
       printf("Can't write to PCM device: %s\n", snd_strerror(err));
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
   }
 
@@ -136,7 +137,7 @@ void AlsaPlay::Play(const std::vector<float> &samples) {
       snd_pcm_prepare(handle_);
     } else if (err < 0) {
       printf("Can't write to PCM device: %s\n", snd_strerror(err));
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
   }
 }

--- a/sherpa-onnx/csrc/alsa.cc
+++ b/sherpa-onnx/csrc/alsa.cc
@@ -5,6 +5,7 @@
 #ifdef SHERPA_ONNX_ENABLE_ALSA
 
 #include "sherpa-onnx/csrc/alsa.h"
+#include "sherpa-onnx/csrc/macros.h"
 
 #include <algorithm>
 #include <cstdio>
@@ -49,7 +50,7 @@ and if you want to select card 3 and device 0 on that card, please use:
   if (err) {
     fprintf(stderr, "Unable to open: %s. %s\n", device_name, snd_strerror(err));
     fprintf(stderr, "%s\n", kDeviceHelp);
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   snd_pcm_hw_params_t *hw_params;
@@ -58,21 +59,21 @@ and if you want to select card 3 and device 0 on that card, please use:
   err = snd_pcm_hw_params_any(capture_handle_, hw_params);
   if (err) {
     fprintf(stderr, "Failed to initialize hw_params: %s\n", snd_strerror(err));
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   err = snd_pcm_hw_params_set_access(capture_handle_, hw_params,
                                      SND_PCM_ACCESS_RW_INTERLEAVED);
   if (err) {
     fprintf(stderr, "Failed to set access type: %s\n", snd_strerror(err));
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   err = snd_pcm_hw_params_set_format(capture_handle_, hw_params,
                                      SND_PCM_FORMAT_S16_LE);
   if (err) {
     fprintf(stderr, "Failed to set format: %s\n", snd_strerror(err));
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   // mono
@@ -86,7 +87,7 @@ and if you want to select card 3 and device 0 on that card, please use:
       fprintf(stderr, "Failed to set number of channels to 2. %s\n",
               snd_strerror(err));
 
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
     actual_channel_count_ = 2;
     fprintf(stderr,
@@ -101,7 +102,7 @@ and if you want to select card 3 and device 0 on that card, please use:
   if (err) {
     fprintf(stderr, "Failed to set sample rate to, %d: %s\n",
             expected_sample_rate_, snd_strerror(err));
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
   actual_sample_rate_ = actual_sample_rate;
 
@@ -128,13 +129,13 @@ and if you want to select card 3 and device 0 on that card, please use:
   err = snd_pcm_hw_params(capture_handle_, hw_params);
   if (err) {
     fprintf(stderr, "Failed to set hw params: %s\n", snd_strerror(err));
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   err = snd_pcm_prepare(capture_handle_);
   if (err) {
     fprintf(stderr, "Failed to prepare for recording: %s\n", snd_strerror(err));
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   fprintf(stderr, "Recording started!\n");
@@ -154,7 +155,7 @@ const std::vector<float> &Alsa::Read(int32_t num_samples) {
           stderr,
           "Too many overruns. It is very likely that the RTF on your board is "
           "larger than 1. Please use ./bin/sherpa-onnx to compute the RTF.\n");
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
     fprintf(stderr, "XRUN.\n");
     snd_pcm_prepare(capture_handle_);
@@ -163,7 +164,7 @@ const std::vector<float> &Alsa::Read(int32_t num_samples) {
     return tmp;
   } else if (count < 0) {
     fprintf(stderr, "Can't read PCM device: %s\n", snd_strerror(count));
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   samples_.resize(count * actual_channel_count_);

--- a/sherpa-onnx/csrc/audio-tagging-ced-impl.h
+++ b/sherpa-onnx/csrc/audio-tagging-ced-impl.h
@@ -31,7 +31,7 @@ class AudioTaggingCEDImpl : public AudioTaggingImpl {
     if (model_.NumEventClasses() != labels_.NumEventClasses()) {
       SHERPA_ONNX_LOGE("number of classes: %d (model) != %d (label file)",
                        model_.NumEventClasses(), labels_.NumEventClasses());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
   }
 
@@ -44,7 +44,7 @@ class AudioTaggingCEDImpl : public AudioTaggingImpl {
     if (model_.NumEventClasses() != labels_.NumEventClasses()) {
       SHERPA_ONNX_LOGE("number of classes: %d (model) != %d (label file)",
                        model_.NumEventClasses(), labels_.NumEventClasses());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
   }
 #endif

--- a/sherpa-onnx/csrc/audio-tagging-label-file.cc
+++ b/sherpa-onnx/csrc/audio-tagging-label-file.cc
@@ -60,7 +60,7 @@ void AudioTaggingLabels::Init(std::istream &is) {
     int32_t i = std::stoi(index, &pos);
     if (index.empty() || pos != index.size()) {
       SHERPA_ONNX_LOGE("Invalid line: %s", line.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (i != static_cast<int32_t>(names_.size())) {
@@ -71,7 +71,7 @@ void AudioTaggingLabels::Init(std::istream &is) {
     }
     if (name.empty() || name.front() != '"' || name.back() != '"') {
       SHERPA_ONNX_LOGE("Invalid line: %s", line.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     names_.emplace_back(name.begin() + 1, name.end() - 1);

--- a/sherpa-onnx/csrc/audio-tagging-zipformer-impl.h
+++ b/sherpa-onnx/csrc/audio-tagging-zipformer-impl.h
@@ -31,7 +31,7 @@ class AudioTaggingZipformerImpl : public AudioTaggingImpl {
     if (model_.NumEventClasses() != labels_.NumEventClasses()) {
       SHERPA_ONNX_LOGE("number of classes: %d (model) != %d (label file)",
                        model_.NumEventClasses(), labels_.NumEventClasses());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
   }
 
@@ -44,7 +44,7 @@ class AudioTaggingZipformerImpl : public AudioTaggingImpl {
     if (model_.NumEventClasses() != labels_.NumEventClasses()) {
       SHERPA_ONNX_LOGE("number of classes: %d (model) != %d (label file)",
                        model_.NumEventClasses(), labels_.NumEventClasses());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
   }
 #endif

--- a/sherpa-onnx/csrc/base64-decode.cc
+++ b/sherpa-onnx/csrc/base64-decode.cc
@@ -25,7 +25,7 @@ static int32_t Ord(char c) {
 
   SHERPA_ONNX_LOGE("Unknown character %d, %c\n", c, c);
 
-  exit(-1);
+  SHERPA_ONNX_EXIT(-1);
 }
 
 // see
@@ -33,7 +33,7 @@ static int32_t Ord(char c) {
 std::string Base64Decode(const std::string &s) {
   if (s.empty()) {
     SHERPA_ONNX_LOGE("Empty string!");
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   int32_t n = static_cast<int32_t>(s.size()) / 4 * 3;

--- a/sherpa-onnx/csrc/circular-buffer.cc
+++ b/sherpa-onnx/csrc/circular-buffer.cc
@@ -15,7 +15,7 @@ CircularBuffer::CircularBuffer(int32_t capacity) {
   if (capacity <= 0) {
     SHERPA_ONNX_LOGE("Please specify a positive capacity. Given: %d\n",
                      capacity);
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
   buffer_.resize(capacity);
 }

--- a/sherpa-onnx/csrc/context-graph.cc
+++ b/sherpa-onnx/csrc/context-graph.cc
@@ -88,7 +88,7 @@ ContextGraph::ForwardOneStep(const ContextState *state, int32_t token,
 
   if (!node) {
     SHERPA_ONNX_LOGE("Some bad things happened.");
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   const ContextState *matched_node =

--- a/sherpa-onnx/csrc/features.cc
+++ b/sherpa-onnx/csrc/features.cc
@@ -92,7 +92,7 @@ class FeatureExtractor::Impl {
             "You changed the input sampling rate!! Expected: %d, given: "
             "%d",
             resampler_->GetInputSamplingRate(), sampling_rate);
-        exit(-1);
+        SHERPA_ONNX_EXIT(-1);
       }
 
       std::vector<float> samples;

--- a/sherpa-onnx/csrc/file-utils.cc
+++ b/sherpa-onnx/csrc/file-utils.cc
@@ -69,7 +69,7 @@ std::vector<char> ReadFile(AAssetManager *mgr, const std::string &filename) {
   if (!asset) {
     __android_log_print(ANDROID_LOG_FATAL, "sherpa-onnx",
                         "Read binary file: Load '%s' failed", filename.c_str());
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   auto p = reinterpret_cast<const char *>(AAsset_getBuffer(asset));

--- a/sherpa-onnx/csrc/hifigan-vocoder.cc
+++ b/sherpa-onnx/csrc/hifigan-vocoder.cc
@@ -22,6 +22,7 @@
 #include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"
 #include "sherpa-onnx/csrc/session.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 
 namespace sherpa_onnx {
 
@@ -32,8 +33,9 @@ class HifiganVocoder::Impl {
       : env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(num_threads, provider)),
         allocator_{} {
-    auto buf = ReadFile(model);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -65,8 +67,15 @@ class HifiganVocoder::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
+                                             sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of this "
+          "function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/keyword-spotter-impl.cc
+++ b/sherpa-onnx/csrc/keyword-spotter-impl.cc
@@ -70,7 +70,7 @@ std::unique_ptr<KeywordSpotterImpl> KeywordSpotterImpl::Create(
   }
 
   SHERPA_ONNX_LOGE("Please specify a model");
-  exit(-1);
+  SHERPA_ONNX_EXIT(-1);
 }
 
 #if __ANDROID_API__ >= 9

--- a/sherpa-onnx/csrc/keyword-spotter-transducer-impl.h
+++ b/sherpa-onnx/csrc/keyword-spotter-transducer-impl.h
@@ -284,7 +284,7 @@ class KeywordSpotterTransducerImpl : public KeywordSpotterImpl {
     if (!EncodeKeywords(is, sym_, &keywords_id_, &keywords_, &boost_scores_,
                         &thresholds_)) {
       SHERPA_ONNX_LOGE("Encode keywords failed.");
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
     keywords_graph_ = std::make_shared<ContextGraph>(
         keywords_id_, config_.keywords_score, config_.keywords_threshold,
@@ -309,7 +309,7 @@ class KeywordSpotterTransducerImpl : public KeywordSpotterImpl {
       SHERPA_ONNX_LOGE("Open keywords file failed: '%s'",
                        config_.keywords_file.c_str());
 #endif
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
     InitKeywords(is);
 #endif
@@ -331,7 +331,7 @@ class KeywordSpotterTransducerImpl : public KeywordSpotterImpl {
       SHERPA_ONNX_LOGE("Open keywords file failed: '%s'",
                        config_.keywords_file.c_str());
 #endif
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
     InitKeywords(is);
   }

--- a/sherpa-onnx/csrc/kokoro-multi-lang-lexicon.cc
+++ b/sherpa-onnx/csrc/kokoro-multi-lang-lexicon.cc
@@ -3,6 +3,7 @@
 // Copyright (c)  2025  Xiaomi Corporation
 
 #include "sherpa-onnx/csrc/kokoro-multi-lang-lexicon.h"
+#include "sherpa-onnx/csrc/macros.h"
 
 #include <fstream>
 #include <regex>

--- a/sherpa-onnx/csrc/macros.h
+++ b/sherpa-onnx/csrc/macros.h
@@ -51,7 +51,12 @@
   } while (0)
 #endif
 
-#define SHERPA_ONNX_EXIT(code) exit(code)
+#define SHERPA_ONNX_EXIT(code) \
+  do {                         \
+    fflush(stdout);            \
+    fflush(stderr);            \
+    _Exit(code);               \
+  } while (0)
 
 // Read an integer
 #define SHERPA_ONNX_READ_META_DATA(dst, src_key)                           \

--- a/sherpa-onnx/csrc/melo-tts-lexicon.cc
+++ b/sherpa-onnx/csrc/melo-tts-lexicon.cc
@@ -270,7 +270,7 @@ class MeloTtsLexicon::Impl {
 
       if ((token_list.size() & 1) != 0) {
         SHERPA_ONNX_LOGE("Invalid line %d: '%s'", line_num, line.c_str());
-        exit(-1);
+        SHERPA_ONNX_EXIT(-1);
       }
 
       int32_t num_phones = token_list.size() / 2;
@@ -282,7 +282,7 @@ class MeloTtsLexicon::Impl {
         tone_list.push_back(std::stoi(token_list[i + num_phones], nullptr));
         if (tone_list.back() < 0 || tone_list.back() > 50) {
           SHERPA_ONNX_LOGE("Invalid line %d: '%s'", line_num, line.c_str());
-          exit(-1);
+          SHERPA_ONNX_EXIT(-1);
         }
       }
 
@@ -293,7 +293,7 @@ class MeloTtsLexicon::Impl {
 
       if (ids.size() != num_phones) {
         SHERPA_ONNX_LOGE("Invalid line %d: '%s'", line_num, line.c_str());
-        exit(-1);
+        SHERPA_ONNX_EXIT(-1);
       }
 
       std::vector<int64_t> ids64{ids.begin(), ids.end()};

--- a/sherpa-onnx/csrc/microphone.cc
+++ b/sherpa-onnx/csrc/microphone.cc
@@ -3,6 +3,7 @@
 // Copyright (c)  2022-2023  Xiaomi Corporation
 
 #include "sherpa-onnx/csrc/microphone.h"
+#include "sherpa-onnx/csrc/macros.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -13,7 +14,7 @@ Microphone::Microphone() {
   PaError err = Pa_Initialize();
   if (err != paNoError) {
     fprintf(stderr, "portaudio error: %s\n", Pa_GetErrorText(err));
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 }
 

--- a/sherpa-onnx/csrc/offline-canary-model.cc
+++ b/sherpa-onnx/csrc/offline-canary-model.cc
@@ -39,15 +39,13 @@ class OfflineCanaryModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    {
-      auto buf = ReadFile(config.canary.encoder);
-      InitEncoder(buf.data(), buf.size());
-    }
+    encoder_sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.canary.encoder), sess_opts_);
+    InitEncoder(nullptr, 0);
 
-    {
-      auto buf = ReadFile(config.canary.decoder);
-      InitDecoder(buf.data(), buf.size());
-    }
+    decoder_sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.canary.decoder), sess_opts_);
+    InitDecoder(nullptr, 0);
   }
 
   template <typename Manager>
@@ -141,8 +139,15 @@ class OfflineCanaryModel::Impl {
 
  private:
   void InitEncoder(void *model_data, size_t model_data_length) {
-    encoder_sess_ = std::make_unique<Ort::Session>(
-        env_, model_data, model_data_length, sess_opts_);
+    if (model_data) {
+      encoder_sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!encoder_sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the encoder session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(encoder_sess_.get(), &encoder_input_names_,
                   &encoder_input_names_ptr_);
@@ -188,8 +193,15 @@ class OfflineCanaryModel::Impl {
   }
 
   void InitDecoder(void *model_data, size_t model_data_length) {
-    decoder_sess_ = std::make_unique<Ort::Session>(
-        env_, model_data, model_data_length, sess_opts_);
+    if (model_data) {
+      decoder_sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!decoder_sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the decoder session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(decoder_sess_.get(), &decoder_input_names_,
                   &decoder_input_names_ptr_);

--- a/sherpa-onnx/csrc/offline-ced-model.cc
+++ b/sherpa-onnx/csrc/offline-ced-model.cc
@@ -3,6 +3,7 @@
 // Copyright (c)  2024  Xiaomi Corporation
 
 #include "sherpa-onnx/csrc/offline-ced-model.h"
+#include "sherpa-onnx/csrc/macros.h"
 
 #include <memory>
 #include <string>
@@ -24,8 +25,9 @@ class OfflineCEDModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config_.ced);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config_.ced), sess_opts_);
+    Init(nullptr, 0);
   }
 
 #if __ANDROID_API__ >= 9
@@ -53,8 +55,15 @@ class OfflineCEDModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/offline-ct-transformer-model.cc
+++ b/sherpa-onnx/csrc/offline-ct-transformer-model.cc
@@ -3,6 +3,7 @@
 // Copyright (c)  2024  Xiaomi Corporation
 
 #include "sherpa-onnx/csrc/offline-ct-transformer-model.h"
+#include "sherpa-onnx/csrc/macros.h"
 
 #include <memory>
 #include <string>
@@ -32,8 +33,9 @@ class OfflineCtTransformerModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config_.ct_transformer);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config_.ct_transformer), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -63,8 +65,15 @@ class OfflineCtTransformerModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 
@@ -83,7 +92,7 @@ class OfflineCtTransformerModel::Impl {
     if (static_cast<int32_t>(tokens.size()) != vocab_size) {
       SHERPA_ONNX_LOGE("tokens.size() %d != vocab_size %d",
                        static_cast<int32_t>(tokens.size()), vocab_size);
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     SHERPA_ONNX_READ_META_DATA_VEC_STRING_SEP(meta_data_.id2punct,

--- a/sherpa-onnx/csrc/offline-ctc-model.cc
+++ b/sherpa-onnx/csrc/offline-ctc-model.cc
@@ -30,6 +30,8 @@
 #include "sherpa-onnx/csrc/offline-wenet-ctc-model.h"
 #include "sherpa-onnx/csrc/offline-zipformer-ctc-model.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"
+#include "sherpa-onnx/csrc/session.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 
 namespace {
 
@@ -47,6 +49,69 @@ enum class ModelType : std::uint8_t {
 }  // namespace
 
 namespace sherpa_onnx {
+
+static ModelType GetModelType(const std::string &model_path, bool debug) {
+  Ort::Env env(ORT_LOGGING_LEVEL_ERROR);
+  Ort::SessionOptions sess_opts;
+  sess_opts.SetIntraOpNumThreads(1);
+  sess_opts.SetInterOpNumThreads(1);
+
+  auto sess = std::make_unique<Ort::Session>(
+      env, SHERPA_ONNX_TO_ORT_PATH(model_path), sess_opts);
+
+  Ort::ModelMetadata meta_data = sess->GetModelMetadata();
+  if (debug) {
+    std::ostringstream os;
+    PrintModelMetadata(os, meta_data);
+#if __OHOS__
+    SHERPA_ONNX_LOGE("%{public}s\n", os.str().c_str());
+#else
+    SHERPA_ONNX_LOGE("%s\n", os.str().c_str());
+#endif
+  }
+
+  Ort::AllocatorWithDefaultOptions allocator;
+  auto model_type =
+      LookupCustomModelMetaData(meta_data, "model_type", allocator);
+  if (model_type.empty()) {
+    SHERPA_ONNX_LOGE(
+        "No model_type in the metadata!\n"
+        "If you are using models from NeMo, please refer to\n"
+        "https://huggingface.co/csukuangfj/"
+        "sherpa-onnx-nemo-ctc-en-citrinet-512/blob/main/add-model-metadata.py\n"
+        "or "
+        "https://github.com/k2-fsa/sherpa-onnx/tree/master/scripts/nemo/"
+        "fast-conformer-hybrid-transducer-ctc\n"
+        "If you are using models from WeNet, please refer to\n"
+        "https://github.com/k2-fsa/sherpa-onnx/blob/master/scripts/wenet/"
+        "run.sh\n"
+        "If you are using models from TeleSpeech, please refer to\n"
+        "https://github.com/k2-fsa/sherpa-onnx/blob/master/scripts/tele-speech/"
+        "add-metadata.py"
+        "\n"
+        "for how to add metadata to model.onnx\n");
+    return ModelType::kUnknown;
+  }
+
+  if (model_type == "EncDecCTCModelBPE") {
+    return ModelType::kEncDecCTCModelBPE;
+  } else if (model_type == "EncDecCTCModel") {
+    return ModelType::kEncDecCTCModel;
+  } else if (model_type == "EncDecHybridRNNTCTCBPEModel") {
+    return ModelType::kEncDecHybridRNNTCTCBPEModel;
+  } else if (model_type == "tdnn") {
+    return ModelType::kTdnn;
+  } else if (model_type == "zipformer2_ctc") {
+    return ModelType::kZipformerCtc;
+  } else if (model_type == "wenet_ctc") {
+    return ModelType::kWenetCtc;
+  } else if (model_type == "telespeech_ctc") {
+    return ModelType::kTeleSpeechCtc;
+  } else {
+    SHERPA_ONNX_LOGE("Unsupported model_type: %s", model_type.c_str());
+    return ModelType::kUnknown;
+  }
+}
 
 static ModelType GetModelType(char *model_data, size_t model_data_length,
                               bool debug) {
@@ -150,14 +215,10 @@ std::unique_ptr<OfflineCtcModel> OfflineCtcModel::Create(
     filename = config.telespeech_ctc;
   } else {
     SHERPA_ONNX_LOGE("Please specify a CTC model");
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
-  {
-    auto buffer = ReadFile(filename);
-
-    model_type = GetModelType(buffer.data(), buffer.size(), config.debug);
-  }
+  model_type = GetModelType(filename, config.debug);
 
   switch (model_type) {
     case ModelType::kEncDecCTCModelBPE:
@@ -220,7 +281,7 @@ std::unique_ptr<OfflineCtcModel> OfflineCtcModel::Create(
     filename = config.telespeech_ctc;
   } else {
     SHERPA_ONNX_LOGE("Please specify a CTC model");
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   {

--- a/sherpa-onnx/csrc/offline-dolphin-model.cc
+++ b/sherpa-onnx/csrc/offline-dolphin-model.cc
@@ -35,8 +35,9 @@ class OfflineDolphinModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config_.dolphin.model);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config_.dolphin.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -81,8 +82,15 @@ class OfflineDolphinModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/offline-fire-red-asr-model.cc
+++ b/sherpa-onnx/csrc/offline-fire-red-asr-model.cc
@@ -48,15 +48,15 @@ class OfflineFireRedAsrModel::Impl {
         cpu_mem_info_(
             Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeDefault)),
         is_cpu_provider_(config.provider == "cpu" || config.provider.empty()) {
-    {
-      auto buf = ReadFile(config.fire_red_asr.encoder);
-      InitEncoder(buf.data(), buf.size());
-    }
+    encoder_sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.fire_red_asr.encoder),
+        sess_opts_);
+    InitEncoder(nullptr, 0);
 
-    {
-      auto buf = ReadFile(config.fire_red_asr.decoder);
-      InitDecoder(buf.data(), buf.size());
-    }
+    decoder_sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.fire_red_asr.decoder),
+        sess_opts_);
+    InitDecoder(nullptr, 0);
 
     InitCudaIOBinding();
   }
@@ -188,8 +188,15 @@ class OfflineFireRedAsrModel::Impl {
 
  private:
   void InitEncoder(void *model_data, size_t model_data_length) {
-    encoder_sess_ = std::make_unique<Ort::Session>(
-        env_, model_data, model_data_length, sess_opts_);
+    if (model_data) {
+      encoder_sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!encoder_sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the encoder session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(encoder_sess_.get(), &encoder_input_names_,
                   &encoder_input_names_ptr_);
@@ -225,8 +232,15 @@ class OfflineFireRedAsrModel::Impl {
   }
 
   void InitDecoder(void *model_data, size_t model_data_length) {
-    decoder_sess_ = std::make_unique<Ort::Session>(
-        env_, model_data, model_data_length, sess_opts_);
+    if (model_data) {
+      decoder_sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!decoder_sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the decoder session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(decoder_sess_.get(), &decoder_input_names_,
                   &decoder_input_names_ptr_);

--- a/sherpa-onnx/csrc/offline-medasr-ctc-model.cc
+++ b/sherpa-onnx/csrc/offline-medasr-ctc-model.cc
@@ -65,8 +65,9 @@ class OfflineMedAsrCtcModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config_.medasr.model);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config_.medasr.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -108,8 +109,15 @@ class OfflineMedAsrCtcModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/offline-moonshine-model.cc
+++ b/sherpa-onnx/csrc/offline-moonshine-model.cc
@@ -33,25 +33,24 @@ class OfflineMoonshineModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    {
-      auto buf = ReadFile(config.moonshine.preprocessor);
-      InitPreprocessor(buf.data(), buf.size());
-    }
+    preprocessor_sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.moonshine.preprocessor),
+        sess_opts_);
+    InitPreprocessor(nullptr, 0);
 
-    {
-      auto buf = ReadFile(config.moonshine.encoder);
-      InitEncoder(buf.data(), buf.size());
-    }
+    encoder_sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.moonshine.encoder), sess_opts_);
+    InitEncoder(nullptr, 0);
 
-    {
-      auto buf = ReadFile(config.moonshine.uncached_decoder);
-      InitUnCachedDecoder(buf.data(), buf.size());
-    }
+    uncached_decoder_sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.moonshine.uncached_decoder),
+        sess_opts_);
+    InitUnCachedDecoder(nullptr, 0);
 
-    {
-      auto buf = ReadFile(config.moonshine.cached_decoder);
-      InitCachedDecoder(buf.data(), buf.size());
-    }
+    cached_decoder_sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.moonshine.cached_decoder),
+        sess_opts_);
+    InitCachedDecoder(nullptr, 0);
   }
 
   template <typename Manager>
@@ -169,8 +168,15 @@ class OfflineMoonshineModel::Impl {
 
  private:
   void InitPreprocessor(void *model_data, size_t model_data_length) {
-    preprocessor_sess_ = std::make_unique<Ort::Session>(
-        env_, model_data, model_data_length, sess_opts_);
+    if (model_data) {
+      preprocessor_sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!preprocessor_sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the preprocessor session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(preprocessor_sess_.get(), &preprocessor_input_names_,
                   &preprocessor_input_names_ptr_);
@@ -180,8 +186,15 @@ class OfflineMoonshineModel::Impl {
   }
 
   void InitEncoder(void *model_data, size_t model_data_length) {
-    encoder_sess_ = std::make_unique<Ort::Session>(
-        env_, model_data, model_data_length, sess_opts_);
+    if (model_data) {
+      encoder_sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!encoder_sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the encoder session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(encoder_sess_.get(), &encoder_input_names_,
                   &encoder_input_names_ptr_);
@@ -191,8 +204,15 @@ class OfflineMoonshineModel::Impl {
   }
 
   void InitUnCachedDecoder(void *model_data, size_t model_data_length) {
-    uncached_decoder_sess_ = std::make_unique<Ort::Session>(
-        env_, model_data, model_data_length, sess_opts_);
+    if (model_data) {
+      uncached_decoder_sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!uncached_decoder_sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the uncached decoder session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(uncached_decoder_sess_.get(), &uncached_decoder_input_names_,
                   &uncached_decoder_input_names_ptr_);
@@ -203,8 +223,15 @@ class OfflineMoonshineModel::Impl {
   }
 
   void InitCachedDecoder(void *model_data, size_t model_data_length) {
-    cached_decoder_sess_ = std::make_unique<Ort::Session>(
-        env_, model_data, model_data_length, sess_opts_);
+    if (model_data) {
+      cached_decoder_sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!cached_decoder_sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the cached decoder session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(cached_decoder_sess_.get(), &cached_decoder_input_names_,
                   &cached_decoder_input_names_ptr_);

--- a/sherpa-onnx/csrc/offline-nemo-enc-dec-ctc-model.cc
+++ b/sherpa-onnx/csrc/offline-nemo-enc-dec-ctc-model.cc
@@ -34,8 +34,9 @@ class OfflineNemoEncDecCtcModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config_.nemo_ctc.model);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config_.nemo_ctc.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -90,8 +91,15 @@ class OfflineNemoEncDecCtcModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/offline-paraformer-model.cc
+++ b/sherpa-onnx/csrc/offline-paraformer-model.cc
@@ -34,8 +34,9 @@ class OfflineParaformerModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config_.paraformer.model);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config_.paraformer.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -71,8 +72,15 @@ class OfflineParaformerModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/offline-recognizer-cohere-transcribe-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-cohere-transcribe-impl.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/math.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/offline-cohere-transcribe-decoder.h"
 #include "sherpa-onnx/csrc/offline-cohere-transcribe-greedy-search-decoder.h"
 #include "sherpa-onnx/csrc/offline-cohere-transcribe-model.h"

--- a/sherpa-onnx/csrc/offline-recognizer-fire-red-asr-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-fire-red-asr-impl.h
@@ -14,6 +14,7 @@
 
 #include "Eigen/Dense"
 #include "sherpa-onnx/csrc/offline-fire-red-asr-decoder.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/offline-fire-red-asr-greedy-search-decoder.h"
 #include "sherpa-onnx/csrc/offline-fire-red-asr-model.h"
 #include "sherpa-onnx/csrc/offline-model-config.h"

--- a/sherpa-onnx/csrc/offline-recognizer-impl.cc
+++ b/sherpa-onnx/csrc/offline-recognizer-impl.cc
@@ -320,10 +320,8 @@ std::unique_ptr<OfflineRecognizerImpl> OfflineRecognizerImpl::Create(
     SHERPA_ONNX_EXIT(-1);
   }
 
-  auto buf = ReadFile(model_filename);
-
-  auto encoder_sess =
-      std::make_unique<Ort::Session>(env, buf.data(), buf.size(), sess_opts);
+  auto encoder_sess = std::make_unique<Ort::Session>(
+      env, SHERPA_ONNX_TO_ORT_PATH(model_filename), sess_opts);
 
   Ort::ModelMetadata meta_data = encoder_sess->GetModelMetadata();
 

--- a/sherpa-onnx/csrc/offline-recognizer-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-impl.h
@@ -36,7 +36,7 @@ class OfflineRecognizerImpl {
   virtual std::unique_ptr<OfflineStream> CreateStream(
       const std::string &hotwords) const {
     SHERPA_ONNX_LOGE("Only transducer models support contextual biasing.");
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   virtual std::unique_ptr<OfflineStream> CreateStream() const = 0;

--- a/sherpa-onnx/csrc/offline-recognizer-paraformer-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-paraformer-impl.h
@@ -13,6 +13,7 @@
 
 #include "Eigen/Dense"
 #include "sherpa-onnx/csrc/offline-model-config.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/offline-paraformer-decoder.h"
 #include "sherpa-onnx/csrc/offline-paraformer-greedy-search-decoder.h"
 #include "sherpa-onnx/csrc/offline-paraformer-model.h"

--- a/sherpa-onnx/csrc/offline-recognizer-transducer-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-transducer-impl.h
@@ -113,7 +113,7 @@ class OfflineRecognizerTransducerImpl : public OfflineRecognizerImpl {
     } else {
       SHERPA_ONNX_LOGE("Unsupported decoding method: %s",
                        config_.decoding_method.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
   }
 
@@ -153,7 +153,7 @@ class OfflineRecognizerTransducerImpl : public OfflineRecognizerImpl {
     } else {
       SHERPA_ONNX_LOGE("Unsupported decoding method: %s",
                        config_.decoding_method.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
   }
 
@@ -263,7 +263,7 @@ class OfflineRecognizerTransducerImpl : public OfflineRecognizerImpl {
     if (!is) {
       SHERPA_ONNX_LOGE("Open hotwords file failed: '%s'",
                        config_.hotwords_file.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (!EncodeHotwords(is, config_.model_config.modeling_unit, symbol_table_,
@@ -287,7 +287,7 @@ class OfflineRecognizerTransducerImpl : public OfflineRecognizerImpl {
     if (!is) {
       SHERPA_ONNX_LOGE("Open hotwords file failed: '%s'",
                        config_.hotwords_file.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (!EncodeHotwords(is, config_.model_config.modeling_unit, symbol_table_,

--- a/sherpa-onnx/csrc/offline-recognizer-whisper-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-whisper-impl.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/offline-model-config.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/offline-recognizer-impl.h"
 #include "sherpa-onnx/csrc/offline-recognizer.h"
 #include "sherpa-onnx/csrc/offline-whisper-decoder.h"
@@ -56,7 +57,7 @@ class OfflineRecognizerWhisperImpl : public OfflineRecognizerImpl {
       SHERPA_ONNX_LOGE(
           "Only greedy_search is supported at present for whisper. Given %s",
           config_.decoding_method.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
   }
 

--- a/sherpa-onnx/csrc/offline-rnn-lm.cc
+++ b/sherpa-onnx/csrc/offline-rnn-lm.cc
@@ -34,8 +34,9 @@ class OfflineRnnLM::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_{GetSessionOptions(config)},
         allocator_{} {
-    auto buf = ReadFile(config_.model);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config_.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -60,8 +61,15 @@ class OfflineRnnLM::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/offline-sense-voice-model.cc
+++ b/sherpa-onnx/csrc/offline-sense-voice-model.cc
@@ -34,8 +34,9 @@ class OfflineSenseVoiceModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config_.sense_voice.model);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config_.sense_voice.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -77,8 +78,15 @@ class OfflineSenseVoiceModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/offline-source-separation-impl.cc
+++ b/sherpa-onnx/csrc/offline-source-separation-impl.cc
@@ -3,6 +3,7 @@
 // Copyright (c)  2025  Xiaomi Corporation
 
 #include "sherpa-onnx/csrc/offline-source-separation-impl.h"
+#include "sherpa-onnx/csrc/macros.h"
 
 #include <algorithm>
 #include <memory>

--- a/sherpa-onnx/csrc/offline-source-separation-spleeter-model.cc
+++ b/sherpa-onnx/csrc/offline-source-separation-spleeter-model.cc
@@ -3,6 +3,7 @@
 // Copyright (c)  2025  Xiaomi Corporation
 
 #include "sherpa-onnx/csrc/offline-source-separation-spleeter-model.h"
+#include "sherpa-onnx/csrc/macros.h"
 
 #include <memory>
 #include <string>
@@ -32,15 +33,14 @@ class OfflineSourceSeparationSpleeterModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    {
-      auto buf = ReadFile(config.spleeter.vocals);
-      InitVocals(buf.data(), buf.size());
-    }
+    vocals_sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.spleeter.vocals), sess_opts_);
+    InitVocals(nullptr, 0);
 
-    {
-      auto buf = ReadFile(config.spleeter.accompaniment);
-      InitAccompaniment(buf.data(), buf.size());
-    }
+    accompaniment_sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.spleeter.accompaniment),
+        sess_opts_);
+    InitAccompaniment(nullptr, 0);
   }
 
   template <typename Manager>
@@ -81,8 +81,15 @@ class OfflineSourceSeparationSpleeterModel::Impl {
 
  private:
   void InitVocals(void *model_data, size_t model_data_length) {
-    vocals_sess_ = std::make_unique<Ort::Session>(
-        env_, model_data, model_data_length, sess_opts_);
+    if (model_data) {
+      vocals_sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!vocals_sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the vocals session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(vocals_sess_.get(), &vocals_input_names_,
                   &vocals_input_names_ptr_);
@@ -135,8 +142,15 @@ class OfflineSourceSeparationSpleeterModel::Impl {
   }
 
   void InitAccompaniment(void *model_data, size_t model_data_length) {
-    accompaniment_sess_ = std::make_unique<Ort::Session>(
-        env_, model_data, model_data_length, sess_opts_);
+    if (model_data) {
+      accompaniment_sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!accompaniment_sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the accompaniment session "
+          "outside of this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(accompaniment_sess_.get(), &accompaniment_input_names_,
                   &accompaniment_input_names_ptr_);

--- a/sherpa-onnx/csrc/offline-source-separation-uvr-model.cc
+++ b/sherpa-onnx/csrc/offline-source-separation-uvr-model.cc
@@ -3,6 +3,7 @@
 // Copyright (c)  2025  Xiaomi Corporation
 
 #include "sherpa-onnx/csrc/offline-source-separation-uvr-model.h"
+#include "sherpa-onnx/csrc/macros.h"
 
 #include <memory>
 #include <string>
@@ -32,8 +33,9 @@ class OfflineSourceSeparationUvrModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config.uvr.model);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.uvr.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -58,8 +60,15 @@ class OfflineSourceSeparationUvrModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
+++ b/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
@@ -13,6 +13,7 @@
 
 #include "Eigen/Dense"
 #include "sherpa-onnx/csrc/fast-clustering.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/math.h"
 #include "sherpa-onnx/csrc/offline-speaker-diarization-impl.h"
 #include "sherpa-onnx/csrc/offline-speaker-segmentation-pyannote-model.h"

--- a/sherpa-onnx/csrc/offline-speaker-segmentation-pyannote-model.cc
+++ b/sherpa-onnx/csrc/offline-speaker-segmentation-pyannote-model.cc
@@ -3,6 +3,7 @@
 // Copyright (c)  2024  Xiaomi Corporation
 
 #include "sherpa-onnx/csrc/offline-speaker-segmentation-pyannote-model.h"
+#include "sherpa-onnx/csrc/macros.h"
 
 #include <memory>
 #include <string>
@@ -21,6 +22,7 @@
 #include "sherpa-onnx/csrc/file-utils.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"
 #include "sherpa-onnx/csrc/session.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 
 namespace sherpa_onnx {
 
@@ -31,8 +33,9 @@ class OfflineSpeakerSegmentationPyannoteModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config_.pyannote.model);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config_.pyannote.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -59,8 +62,15 @@ class OfflineSpeakerSegmentationPyannoteModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/offline-speech-denoiser-dpdfnet-model.cc
+++ b/sherpa-onnx/csrc/offline-speech-denoiser-dpdfnet-model.cc
@@ -48,8 +48,9 @@ class OfflineSpeechDenoiserDpdfNetModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config.dpdfnet.model);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.dpdfnet.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -91,8 +92,15 @@ class OfflineSpeechDenoiserDpdfNetModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
     GetOutputNames(sess_.get(), &output_names_, &output_names_ptr_);

--- a/sherpa-onnx/csrc/offline-speech-denoiser-gtcrn-model.cc
+++ b/sherpa-onnx/csrc/offline-speech-denoiser-gtcrn-model.cc
@@ -3,6 +3,7 @@
 // Copyright (c)  2025  Xiaomi Corporation
 
 #include "sherpa-onnx/csrc/offline-speech-denoiser-gtcrn-model.h"
+#include "sherpa-onnx/csrc/macros.h"
 
 #include <memory>
 #include <string>
@@ -32,10 +33,9 @@ class OfflineSpeechDenoiserGtcrnModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    {
-      auto buf = ReadFile(config.gtcrn.model);
-      Init(buf.data(), buf.size());
-    }
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.gtcrn.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -103,8 +103,15 @@ class OfflineSpeechDenoiserGtcrnModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/offline-stream.cc
+++ b/sherpa-onnx/csrc/offline-stream.cc
@@ -294,7 +294,7 @@ class OfflineStream::Impl {
       SHERPA_ONNX_LOGE(
           "Only normalize_type=per_feature is implemented. Given: %s",
           config_.nemo_normalize_type.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     NemoNormalizePerFeature(p, num_frames, feature_dim);

--- a/sherpa-onnx/csrc/offline-tdnn-ctc-model.cc
+++ b/sherpa-onnx/csrc/offline-tdnn-ctc-model.cc
@@ -34,8 +34,9 @@ class OfflineTdnnCtcModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config_.tdnn.model);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config_.tdnn.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -79,8 +80,15 @@ class OfflineTdnnCtcModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/offline-telespeech-ctc-model.cc
+++ b/sherpa-onnx/csrc/offline-telespeech-ctc-model.cc
@@ -34,8 +34,9 @@ class OfflineTeleSpeechCtcModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config_.telespeech_ctc);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config_.telespeech_ctc), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -87,8 +88,15 @@ class OfflineTeleSpeechCtcModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/offline-transducer-model.cc
+++ b/sherpa-onnx/csrc/offline-transducer-model.cc
@@ -24,6 +24,7 @@
 #include "sherpa-onnx/csrc/offline-transducer-decoder.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"
 #include "sherpa-onnx/csrc/session.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 
 namespace sherpa_onnx {
 
@@ -34,20 +35,20 @@ class OfflineTransducerModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    {
-      auto buf = ReadFile(config.transducer.encoder_filename);
-      InitEncoder(buf.data(), buf.size());
-    }
+    encoder_sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.encoder_filename),
+        sess_opts_);
+    InitEncoder(nullptr, 0);
 
-    {
-      auto buf = ReadFile(config.transducer.decoder_filename);
-      InitDecoder(buf.data(), buf.size());
-    }
+    decoder_sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.decoder_filename),
+        sess_opts_);
+    InitDecoder(nullptr, 0);
 
-    {
-      auto buf = ReadFile(config.transducer.joiner_filename);
-      InitJoiner(buf.data(), buf.size());
-    }
+    joiner_sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.joiner_filename),
+        sess_opts_);
+    InitJoiner(nullptr, 0);
   }
 
   template <typename Manager>
@@ -157,8 +158,15 @@ class OfflineTransducerModel::Impl {
 
  private:
   void InitEncoder(void *model_data, size_t model_data_length) {
-    encoder_sess_ = std::make_unique<Ort::Session>(
-        env_, model_data, model_data_length, sess_opts_);
+    if (model_data) {
+      encoder_sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!encoder_sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the encoder session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(encoder_sess_.get(), &encoder_input_names_,
                   &encoder_input_names_ptr_);
@@ -181,8 +189,15 @@ class OfflineTransducerModel::Impl {
   }
 
   void InitDecoder(void *model_data, size_t model_data_length) {
-    decoder_sess_ = std::make_unique<Ort::Session>(
-        env_, model_data, model_data_length, sess_opts_);
+    if (model_data) {
+      decoder_sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!decoder_sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the decoder session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(decoder_sess_.get(), &decoder_input_names_,
                   &decoder_input_names_ptr_);
@@ -205,8 +220,15 @@ class OfflineTransducerModel::Impl {
   }
 
   void InitJoiner(void *model_data, size_t model_data_length) {
-    joiner_sess_ = std::make_unique<Ort::Session>(
-        env_, model_data, model_data_length, sess_opts_);
+    if (model_data) {
+      joiner_sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!joiner_sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the joiner session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(joiner_sess_.get(), &joiner_input_names_,
                   &joiner_input_names_ptr_);

--- a/sherpa-onnx/csrc/offline-transducer-nemo-model.cc
+++ b/sherpa-onnx/csrc/offline-transducer-nemo-model.cc
@@ -24,6 +24,7 @@
 #include "sherpa-onnx/csrc/offline-transducer-decoder.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"
 #include "sherpa-onnx/csrc/session.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 #include "sherpa-onnx/csrc/transpose.h"
 
 namespace sherpa_onnx {
@@ -35,20 +36,20 @@ class OfflineTransducerNeMoModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    {
-      auto buf = ReadFile(config.transducer.encoder_filename);
-      InitEncoder(buf.data(), buf.size());
-    }
+    encoder_sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.encoder_filename),
+        sess_opts_);
+    InitEncoder(nullptr, 0);
 
-    {
-      auto buf = ReadFile(config.transducer.decoder_filename);
-      InitDecoder(buf.data(), buf.size());
-    }
+    decoder_sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.decoder_filename),
+        sess_opts_);
+    InitDecoder(nullptr, 0);
 
-    {
-      auto buf = ReadFile(config.transducer.joiner_filename);
-      InitJoiner(buf.data(), buf.size());
-    }
+    joiner_sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.joiner_filename),
+        sess_opts_);
+    InitJoiner(nullptr, 0);
   }
 
   template <typename Manager>
@@ -170,8 +171,15 @@ class OfflineTransducerNeMoModel::Impl {
 
  private:
   void InitEncoder(void *model_data, size_t model_data_length) {
-    encoder_sess_ = std::make_unique<Ort::Session>(
-        env_, model_data, model_data_length, sess_opts_);
+    if (model_data) {
+      encoder_sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!encoder_sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the encoder session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(encoder_sess_.get(), &encoder_input_names_,
                   &encoder_input_names_ptr_);
@@ -219,8 +227,15 @@ class OfflineTransducerNeMoModel::Impl {
   }
 
   void InitDecoder(void *model_data, size_t model_data_length) {
-    decoder_sess_ = std::make_unique<Ort::Session>(
-        env_, model_data, model_data_length, sess_opts_);
+    if (model_data) {
+      decoder_sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!decoder_sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the decoder session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(decoder_sess_.get(), &decoder_input_names_,
                   &decoder_input_names_ptr_);
@@ -230,8 +245,15 @@ class OfflineTransducerNeMoModel::Impl {
   }
 
   void InitJoiner(void *model_data, size_t model_data_length) {
-    joiner_sess_ = std::make_unique<Ort::Session>(
-        env_, model_data, model_data_length, sess_opts_);
+    if (model_data) {
+      joiner_sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!joiner_sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the joiner session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(joiner_sess_.get(), &joiner_input_names_,
                   &joiner_input_names_ptr_);

--- a/sherpa-onnx/csrc/offline-tts-character-frontend.cc
+++ b/sherpa-onnx/csrc/offline-tts-character-frontend.cc
@@ -51,7 +51,7 @@ static std::unordered_map<char32_t, int32_t> ReadTokens(std::istream &is) {
     iss >> std::ws;
     if (!iss.eof()) {
       SHERPA_ONNX_LOGE("Error when reading tokens: %s", line.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     // Form models from coqui-ai/TTS, we have saved the IDs of the following
@@ -64,7 +64,7 @@ static std::unordered_map<char32_t, int32_t> ReadTokens(std::istream &is) {
     if (s.size() != 1) {
       SHERPA_ONNX_LOGE("Error when reading tokens at Line %s. size: %d",
                        line.c_str(), static_cast<int32_t>(s.size()));
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     char32_t c = s[0];
@@ -72,7 +72,7 @@ static std::unordered_map<char32_t, int32_t> ReadTokens(std::istream &is) {
     if (token2id.count(c)) {
       SHERPA_ONNX_LOGE("Duplicated token %s. Line %s. Existing ID: %d",
                        sym.c_str(), line.c_str(), token2id.at(c));
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     token2id.insert({c, id});

--- a/sherpa-onnx/csrc/offline-tts-kitten-model.cc
+++ b/sherpa-onnx/csrc/offline-tts-kitten-model.cc
@@ -34,10 +34,10 @@ class OfflineTtsKittenModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto model_buf = ReadFile(config.kitten.model);
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.kitten.model), sess_opts_);
     auto voices_buf = ReadFile(config.kitten.voices);
-    Init(model_buf.data(), model_buf.size(), voices_buf.data(),
-         voices_buf.size());
+    Init(nullptr, 0, voices_buf.data(), voices_buf.size());
   }
 
   template <typename Manager>
@@ -98,8 +98,15 @@ class OfflineTtsKittenModel::Impl {
  private:
   void Init(void *model_data, size_t model_data_length, const char *voices_data,
             size_t voices_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
+                                             sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of this "
+          "function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/offline-tts-kokoro-model.cc
+++ b/sherpa-onnx/csrc/offline-tts-kokoro-model.cc
@@ -34,10 +34,10 @@ class OfflineTtsKokoroModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto model_buf = ReadFile(config.kokoro.model);
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.kokoro.model), sess_opts_);
     auto voices_buf = ReadFile(config.kokoro.voices);
-    Init(model_buf.data(), model_buf.size(), voices_buf.data(),
-         voices_buf.size());
+    Init(nullptr, 0, voices_buf.data(), voices_buf.size());
   }
 
   template <typename Manager>
@@ -64,7 +64,7 @@ class OfflineTtsKokoroModel::Impl {
     if (x_shape[0] != 1) {
       SHERPA_ONNX_LOGE("Support only batch_size == 1. Given: %d",
                        static_cast<int32_t>(x_shape[0]));
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     // there is a 0 at the front and end of x
@@ -105,8 +105,15 @@ class OfflineTtsKokoroModel::Impl {
  private:
   void Init(void *model_data, size_t model_data_length, const char *voices_data,
             size_t voices_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
+                                             sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of this "
+          "function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/offline-tts-matcha-model.cc
+++ b/sherpa-onnx/csrc/offline-tts-matcha-model.cc
@@ -23,6 +23,7 @@
 #include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"
 #include "sherpa-onnx/csrc/session.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 
 namespace sherpa_onnx {
 
@@ -33,8 +34,9 @@ class OfflineTtsMatchaModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config.matcha.acoustic_model);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.matcha.acoustic_model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -59,7 +61,7 @@ class OfflineTtsMatchaModel::Impl {
     if (x_shape[0] != 1) {
       SHERPA_ONNX_LOGE("Support only batch_size == 1. Given: %d",
                        static_cast<int32_t>(x_shape[0]));
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     int64_t len = x_shape[1];
@@ -122,8 +124,15 @@ class OfflineTtsMatchaModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/offline-tts-vits-model.cc
+++ b/sherpa-onnx/csrc/offline-tts-vits-model.cc
@@ -23,6 +23,7 @@
 #include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"
 #include "sherpa-onnx/csrc/session.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 
 namespace sherpa_onnx {
 
@@ -33,8 +34,9 @@ class OfflineTtsVitsModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config.vits.model);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.vits.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -68,7 +70,7 @@ class OfflineTtsVitsModel::Impl {
     if (x_shape[0] != 1) {
       SHERPA_ONNX_LOGE("Support only batch_size == 1. Given: %d",
                        static_cast<int32_t>(x_shape[0]));
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     int64_t len = x_shape[1];
@@ -119,8 +121,15 @@ class OfflineTtsVitsModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 
@@ -202,7 +211,7 @@ class OfflineTtsVitsModel::Impl {
             "Please download the latest MeloTTS model and retry. Current "
             "version: %d. Expected version: %d",
             meta_data_.version, expected_version);
-        exit(-1);
+        SHERPA_ONNX_EXIT(-1);
       }
 
       // NOTE(fangjun):
@@ -219,7 +228,7 @@ class OfflineTtsVitsModel::Impl {
     if (x_shape[0] != 1) {
       SHERPA_ONNX_LOGE("Support only batch_size == 1. Given: %d",
                        static_cast<int32_t>(x_shape[0]));
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     int64_t len = x_shape[1];
@@ -280,7 +289,7 @@ class OfflineTtsVitsModel::Impl {
     if (x_shape[0] != 1) {
       SHERPA_ONNX_LOGE("Support only batch_size == 1. Given: %d",
                        static_cast<int32_t>(x_shape[0]));
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     int64_t len = x_shape[1];

--- a/sherpa-onnx/csrc/offline-tts-zipvoice-model.cc
+++ b/sherpa-onnx/csrc/offline-tts-zipvoice-model.cc
@@ -38,11 +38,13 @@ class OfflineTtsZipvoiceModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config.zipvoice.encoder);
-    InitEncoder(buf.data(), buf.size());
+    encoder_sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.zipvoice.encoder), sess_opts_);
+    InitEncoder(nullptr, 0);
 
-    buf = ReadFile(config.zipvoice.decoder);
-    InitDecoder(buf.data(), buf.size());
+    decoder_sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.zipvoice.decoder), sess_opts_);
+    InitDecoder(nullptr, 0);
   }
 
   template <typename Manager>
@@ -159,8 +161,15 @@ class OfflineTtsZipvoiceModel::Impl {
 
  private:
   void InitEncoder(void *encoder_data, size_t encoder_data_length) {
-    encoder_sess_ = std::make_unique<Ort::Session>(
-        env_, encoder_data, encoder_data_length, sess_opts_);
+    if (encoder_data) {
+      encoder_sess_ = std::make_unique<Ort::Session>(
+          env_, encoder_data, encoder_data_length, sess_opts_);
+    } else if (!encoder_sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the encoder session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
     GetInputNames(encoder_sess_.get(), &encoder_input_names_,
                   &encoder_names_ptr_);
     GetOutputNames(encoder_sess_.get(), &encoder_output_names_,
@@ -200,8 +209,15 @@ class OfflineTtsZipvoiceModel::Impl {
   }
 
   void InitDecoder(void *decoder_data, size_t decoder_data_length) {
-    decoder_sess_ = std::make_unique<Ort::Session>(
-        env_, decoder_data, decoder_data_length, sess_opts_);
+    if (decoder_data) {
+      decoder_sess_ = std::make_unique<Ort::Session>(
+          env_, decoder_data, decoder_data_length, sess_opts_);
+    } else if (!decoder_sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the decoder session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
     GetInputNames(decoder_sess_.get(), &decoder_input_names_,
                   &decoder_input_names_ptr_);
     GetOutputNames(decoder_sess_.get(), &decoder_output_names_,

--- a/sherpa-onnx/csrc/offline-websocket-server-impl.cc
+++ b/sherpa-onnx/csrc/offline-websocket-server-impl.cc
@@ -31,18 +31,18 @@ void OfflineWebsocketDecoderConfig::Register(ParseOptions *po) {
 void OfflineWebsocketDecoderConfig::Validate() const {
   if (!recognizer_config.Validate()) {
     SHERPA_ONNX_LOGE("Error in recognizer config");
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   if (max_batch_size <= 0) {
     SHERPA_ONNX_LOGE("Expect --max-batch-size > 0. Given: %d", max_batch_size);
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   if (max_utterance_length <= 0) {
     SHERPA_ONNX_LOGE("Expect --max-utterance-length > 0. Given: %f",
                      max_utterance_length);
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 }
 

--- a/sherpa-onnx/csrc/offline-websocket-server.cc
+++ b/sherpa-onnx/csrc/offline-websocket-server.cc
@@ -71,7 +71,7 @@ int32_t main(int32_t argc, char *argv[]) {
 
   if (argc == 1) {
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   po.Read(argc, argv);
@@ -79,7 +79,7 @@ int32_t main(int32_t argc, char *argv[]) {
   if (po.NumArgs() != 0) {
     SHERPA_ONNX_LOGE("Unrecognized positional arguments!");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   config.Validate();

--- a/sherpa-onnx/csrc/offline-wenet-ctc-model.cc
+++ b/sherpa-onnx/csrc/offline-wenet-ctc-model.cc
@@ -34,8 +34,9 @@ class OfflineWenetCtcModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config_.wenet_ctc.model);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config_.wenet_ctc.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -65,8 +66,15 @@ class OfflineWenetCtcModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/offline-whisper-greedy-search-decoder.cc
+++ b/sherpa-onnx/csrc/offline-whisper-greedy-search-decoder.cc
@@ -56,7 +56,7 @@ OfflineWhisperGreedySearchDecoder::Decode(Ort::Value cross_k,
 
       if (!lang2id.count(config_.language)) {
         SHERPA_ONNX_LOGE("Invalid language: %s", config_.language.c_str());
-        exit(-1);
+        SHERPA_ONNX_EXIT(-1);
       }
 
       int32_t lang_id = lang2id.at(config_.language);

--- a/sherpa-onnx/csrc/offline-whisper-model.cc
+++ b/sherpa-onnx/csrc/offline-whisper-model.cc
@@ -379,7 +379,7 @@ class OfflineWhisperModel::Impl {
         SHERPA_ONNX_LOGE("# lang_id: %d != # lang_code: %d",
                          static_cast<int32_t>(all_language_tokens_.size()),
                          static_cast<int32_t>(all_language_codes_.size()));
-        exit(-1);
+        SHERPA_ONNX_EXIT(-1);
       }
 
       for (int32_t i = 0;

--- a/sherpa-onnx/csrc/offline-zipformer-audio-tagging-model.cc
+++ b/sherpa-onnx/csrc/offline-zipformer-audio-tagging-model.cc
@@ -3,6 +3,7 @@
 // Copyright (c)  2024  Xiaomi Corporation
 
 #include "sherpa-onnx/csrc/offline-zipformer-audio-tagging-model.h"
+#include "sherpa-onnx/csrc/macros.h"
 
 #include <memory>
 #include <string>
@@ -23,8 +24,9 @@ class OfflineZipformerAudioTaggingModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config_.zipformer.model);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config_.zipformer.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
 #if __ANDROID_API__ >= 9
@@ -54,8 +56,15 @@ class OfflineZipformerAudioTaggingModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/offline-zipformer-ctc-model.cc
+++ b/sherpa-onnx/csrc/offline-zipformer-ctc-model.cc
@@ -34,8 +34,9 @@ class OfflineZipformerCtcModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config_.zipformer_ctc.model);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config_.zipformer_ctc.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -64,8 +65,15 @@ class OfflineZipformerCtcModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/online-cnn-bilstm-model.cc
+++ b/sherpa-onnx/csrc/online-cnn-bilstm-model.cc
@@ -3,6 +3,7 @@
 // Copyright (c) 2024 Jian You (jianyou@cisco.com, Cisco Systems)
 
 #include "sherpa-onnx/csrc/online-cnn-bilstm-model.h"
+#include "sherpa-onnx/csrc/macros.h"
 
 #include <memory>
 #include <string>
@@ -32,8 +33,9 @@ class OnlineCNNBiLSTMModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    auto buf = ReadFile(config_.cnn_bilstm);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config_.cnn_bilstm), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -66,8 +68,15 @@ class OnlineCNNBiLSTMModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/online-conformer-transducer-model.cc
+++ b/sherpa-onnx/csrc/online-conformer-transducer-model.cc
@@ -39,20 +39,17 @@ OnlineConformerTransducerModel::OnlineConformerTransducerModel(
       config_(config),
       sess_opts_(GetSessionOptions(config)),
       allocator_{} {
-  {
-    auto buf = ReadFile(config.transducer.encoder);
-    InitEncoder(buf.data(), buf.size());
-  }
+  encoder_sess_ = std::make_unique<Ort::Session>(
+      env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.encoder), sess_opts_);
+  InitEncoder(nullptr, 0);
 
-  {
-    auto buf = ReadFile(config.transducer.decoder);
-    InitDecoder(buf.data(), buf.size());
-  }
+  decoder_sess_ = std::make_unique<Ort::Session>(
+      env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.decoder), sess_opts_);
+  InitDecoder(nullptr, 0);
 
-  {
-    auto buf = ReadFile(config.transducer.joiner);
-    InitJoiner(buf.data(), buf.size());
-  }
+  joiner_sess_ = std::make_unique<Ort::Session>(
+      env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.joiner), sess_opts_);
+  InitJoiner(nullptr, 0);
 }
 
 template <typename Manager>
@@ -80,8 +77,15 @@ OnlineConformerTransducerModel::OnlineConformerTransducerModel(
 
 void OnlineConformerTransducerModel::InitEncoder(void *model_data,
                                                  size_t model_data_length) {
-  encoder_sess_ = std::make_unique<Ort::Session>(env_, model_data,
-                                                 model_data_length, sess_opts_);
+  if (model_data) {
+    encoder_sess_ = std::make_unique<Ort::Session>(
+        env_, model_data, model_data_length, sess_opts_);
+  } else if (!encoder_sess_) {
+    SHERPA_ONNX_LOGE(
+        "Please pass model data or initialize the encoder outside of "
+        "this function");
+    SHERPA_ONNX_EXIT(-1);
+  }
 
   GetInputNames(encoder_sess_.get(), &encoder_input_names_,
                 &encoder_input_names_ptr_);
@@ -114,8 +118,15 @@ void OnlineConformerTransducerModel::InitEncoder(void *model_data,
 
 void OnlineConformerTransducerModel::InitDecoder(void *model_data,
                                                  size_t model_data_length) {
-  decoder_sess_ = std::make_unique<Ort::Session>(env_, model_data,
-                                                 model_data_length, sess_opts_);
+  if (model_data) {
+    decoder_sess_ = std::make_unique<Ort::Session>(
+        env_, model_data, model_data_length, sess_opts_);
+  } else if (!decoder_sess_) {
+    SHERPA_ONNX_LOGE(
+        "Please pass model data or initialize the decoder outside of "
+        "this function");
+    SHERPA_ONNX_EXIT(-1);
+  }
 
   GetInputNames(decoder_sess_.get(), &decoder_input_names_,
                 &decoder_input_names_ptr_);
@@ -143,8 +154,15 @@ void OnlineConformerTransducerModel::InitDecoder(void *model_data,
 
 void OnlineConformerTransducerModel::InitJoiner(void *model_data,
                                                 size_t model_data_length) {
-  joiner_sess_ = std::make_unique<Ort::Session>(env_, model_data,
-                                                model_data_length, sess_opts_);
+  if (model_data) {
+    joiner_sess_ = std::make_unique<Ort::Session>(
+        env_, model_data, model_data_length, sess_opts_);
+  } else if (!joiner_sess_) {
+    SHERPA_ONNX_LOGE(
+        "Please pass model data or initialize the joiner outside of "
+        "this function");
+    SHERPA_ONNX_EXIT(-1);
+  }
 
   GetInputNames(joiner_sess_.get(), &joiner_input_names_,
                 &joiner_input_names_ptr_);

--- a/sherpa-onnx/csrc/online-ctc-fst-decoder.cc
+++ b/sherpa-onnx/csrc/online-ctc-fst-decoder.cc
@@ -98,13 +98,13 @@ void OnlineCtcFstDecoder::Decode(const float *log_probs, int32_t batch_size,
   if (batch_size != results->size()) {
     SHERPA_ONNX_LOGE("Size mismatch! log_probs.size(0) %d, results.size(0): %d",
                      batch_size, static_cast<int32_t>(results->size()));
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   if (batch_size != n) {
     SHERPA_ONNX_LOGE("Size mismatch! log_probs.size(0) %d, n: %d", batch_size,
                      n);
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   const float *p = log_probs;

--- a/sherpa-onnx/csrc/online-ctc-greedy-search-decoder.cc
+++ b/sherpa-onnx/csrc/online-ctc-greedy-search-decoder.cc
@@ -19,7 +19,7 @@ void OnlineCtcGreedySearchDecoder::Decode(
   if (batch_size != results->size()) {
     SHERPA_ONNX_LOGE("Size mismatch! log_probs.size(0) %d, results.size(0): %d",
                      batch_size, static_cast<int32_t>(results->size()));
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   const float *p = log_probs;

--- a/sherpa-onnx/csrc/online-ebranchformer-transducer-model.cc
+++ b/sherpa-onnx/csrc/online-ebranchformer-transducer-model.cc
@@ -44,20 +44,17 @@ OnlineEbranchformerTransducerModel::OnlineEbranchformerTransducerModel(
       joiner_sess_opts_(GetSessionOptions(config, "joiner")),
       config_(config),
       allocator_{} {
-  {
-    auto buf = ReadFile(config.transducer.encoder);
-    InitEncoder(buf.data(), buf.size());
-  }
+  encoder_sess_ = std::make_unique<Ort::Session>(
+      env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.encoder), encoder_sess_opts_);
+  InitEncoder(nullptr, 0);
 
-  {
-    auto buf = ReadFile(config.transducer.decoder);
-    InitDecoder(buf.data(), buf.size());
-  }
+  decoder_sess_ = std::make_unique<Ort::Session>(
+      env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.decoder), decoder_sess_opts_);
+  InitDecoder(nullptr, 0);
 
-  {
-    auto buf = ReadFile(config.transducer.joiner);
-    InitJoiner(buf.data(), buf.size());
-  }
+  joiner_sess_ = std::make_unique<Ort::Session>(
+      env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.joiner), joiner_sess_opts_);
+  InitJoiner(nullptr, 0);
 }
 
 template <typename Manager>
@@ -87,8 +84,15 @@ OnlineEbranchformerTransducerModel::OnlineEbranchformerTransducerModel(
 
 void OnlineEbranchformerTransducerModel::InitEncoder(void *model_data,
                                                      size_t model_data_length) {
-  encoder_sess_ = std::make_unique<Ort::Session>(
-      env_, model_data, model_data_length, encoder_sess_opts_);
+  if (model_data) {
+    encoder_sess_ = std::make_unique<Ort::Session>(
+        env_, model_data, model_data_length, encoder_sess_opts_);
+  } else if (!encoder_sess_) {
+    SHERPA_ONNX_LOGE(
+        "Please pass model data or initialize the encoder outside of "
+        "this function");
+    SHERPA_ONNX_EXIT(-1);
+  }
 
   GetInputNames(encoder_sess_.get(), &encoder_input_names_,
                 &encoder_input_names_ptr_);
@@ -154,8 +158,15 @@ void OnlineEbranchformerTransducerModel::InitEncoder(void *model_data,
 
 void OnlineEbranchformerTransducerModel::InitDecoder(void *model_data,
                                                      size_t model_data_length) {
-  decoder_sess_ = std::make_unique<Ort::Session>(
-      env_, model_data, model_data_length, decoder_sess_opts_);
+  if (model_data) {
+    decoder_sess_ = std::make_unique<Ort::Session>(
+        env_, model_data, model_data_length, decoder_sess_opts_);
+  } else if (!decoder_sess_) {
+    SHERPA_ONNX_LOGE(
+        "Please pass model data or initialize the decoder outside of "
+        "this function");
+    SHERPA_ONNX_EXIT(-1);
+  }
 
   GetInputNames(decoder_sess_.get(), &decoder_input_names_,
                 &decoder_input_names_ptr_);
@@ -179,8 +190,15 @@ void OnlineEbranchformerTransducerModel::InitDecoder(void *model_data,
 
 void OnlineEbranchformerTransducerModel::InitJoiner(void *model_data,
                                                     size_t model_data_length) {
-  joiner_sess_ = std::make_unique<Ort::Session>(
-      env_, model_data, model_data_length, joiner_sess_opts_);
+  if (model_data) {
+    joiner_sess_ = std::make_unique<Ort::Session>(
+        env_, model_data, model_data_length, joiner_sess_opts_);
+  } else if (!joiner_sess_) {
+    SHERPA_ONNX_LOGE(
+        "Please pass model data or initialize the joiner outside of "
+        "this function");
+    SHERPA_ONNX_EXIT(-1);
+  }
 
   GetInputNames(joiner_sess_.get(), &joiner_input_names_,
                 &joiner_input_names_ptr_);

--- a/sherpa-onnx/csrc/online-lstm-transducer-model.cc
+++ b/sherpa-onnx/csrc/online-lstm-transducer-model.cc
@@ -27,6 +27,7 @@
 #include "sherpa-onnx/csrc/online-transducer-decoder.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"
 #include "sherpa-onnx/csrc/session.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 #include "sherpa-onnx/csrc/unbind.h"
 
 namespace sherpa_onnx {
@@ -37,20 +38,17 @@ OnlineLstmTransducerModel::OnlineLstmTransducerModel(
       config_(config),
       sess_opts_(GetSessionOptions(config)),
       allocator_{} {
-  {
-    auto buf = ReadFile(config.transducer.encoder);
-    InitEncoder(buf.data(), buf.size());
-  }
+  encoder_sess_ = std::make_unique<Ort::Session>(
+      env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.encoder), sess_opts_);
+  InitEncoder(nullptr, 0);
 
-  {
-    auto buf = ReadFile(config.transducer.decoder);
-    InitDecoder(buf.data(), buf.size());
-  }
+  decoder_sess_ = std::make_unique<Ort::Session>(
+      env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.decoder), sess_opts_);
+  InitDecoder(nullptr, 0);
 
-  {
-    auto buf = ReadFile(config.transducer.joiner);
-    InitJoiner(buf.data(), buf.size());
-  }
+  joiner_sess_ = std::make_unique<Ort::Session>(
+      env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.joiner), sess_opts_);
+  InitJoiner(nullptr, 0);
 }
 
 template <typename Manager>
@@ -78,8 +76,15 @@ OnlineLstmTransducerModel::OnlineLstmTransducerModel(
 
 void OnlineLstmTransducerModel::InitEncoder(void *model_data,
                                             size_t model_data_length) {
-  encoder_sess_ = std::make_unique<Ort::Session>(env_, model_data,
-                                                 model_data_length, sess_opts_);
+  if (model_data) {
+    encoder_sess_ = std::make_unique<Ort::Session>(
+        env_, model_data, model_data_length, sess_opts_);
+  } else if (!encoder_sess_) {
+    SHERPA_ONNX_LOGE(
+        "Please pass model data or initialize the encoder outside of "
+        "this function");
+    SHERPA_ONNX_EXIT(-1);
+  }
 
   GetInputNames(encoder_sess_.get(), &encoder_input_names_,
                 &encoder_input_names_ptr_);
@@ -110,8 +115,15 @@ void OnlineLstmTransducerModel::InitEncoder(void *model_data,
 
 void OnlineLstmTransducerModel::InitDecoder(void *model_data,
                                             size_t model_data_length) {
-  decoder_sess_ = std::make_unique<Ort::Session>(env_, model_data,
-                                                 model_data_length, sess_opts_);
+  if (model_data) {
+    decoder_sess_ = std::make_unique<Ort::Session>(
+        env_, model_data, model_data_length, sess_opts_);
+  } else if (!decoder_sess_) {
+    SHERPA_ONNX_LOGE(
+        "Please pass model data or initialize the decoder outside of "
+        "this function");
+    SHERPA_ONNX_EXIT(-1);
+  }
 
   GetInputNames(decoder_sess_.get(), &decoder_input_names_,
                 &decoder_input_names_ptr_);
@@ -135,8 +147,15 @@ void OnlineLstmTransducerModel::InitDecoder(void *model_data,
 
 void OnlineLstmTransducerModel::InitJoiner(void *model_data,
                                            size_t model_data_length) {
-  joiner_sess_ = std::make_unique<Ort::Session>(env_, model_data,
-                                                model_data_length, sess_opts_);
+  if (model_data) {
+    joiner_sess_ = std::make_unique<Ort::Session>(
+        env_, model_data, model_data_length, sess_opts_);
+  } else if (!joiner_sess_) {
+    SHERPA_ONNX_LOGE(
+        "Please pass model data or initialize the joiner outside of "
+        "this function");
+    SHERPA_ONNX_EXIT(-1);
+  }
 
   GetInputNames(joiner_sess_.get(), &joiner_input_names_,
                 &joiner_input_names_ptr_);

--- a/sherpa-onnx/csrc/online-nemo-ctc-model.cc
+++ b/sherpa-onnx/csrc/online-nemo-ctc-model.cc
@@ -38,10 +38,9 @@ class OnlineNeMoCtcModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    {
-      auto buf = ReadFile(config.nemo_ctc.model);
-      Init(buf.data(), buf.size());
-    }
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.nemo_ctc.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -197,8 +196,15 @@ class OnlineNeMoCtcModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/online-paraformer-model.cc
+++ b/sherpa-onnx/csrc/online-paraformer-model.cc
@@ -35,15 +35,13 @@ class OnlineParaformerModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    {
-      auto buf = ReadFile(config.paraformer.encoder);
-      InitEncoder(buf.data(), buf.size());
-    }
+    encoder_sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.paraformer.encoder), sess_opts_);
+    InitEncoder(nullptr, 0);
 
-    {
-      auto buf = ReadFile(config.paraformer.decoder);
-      InitDecoder(buf.data(), buf.size());
-    }
+    decoder_sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.paraformer.decoder), sess_opts_);
+    InitDecoder(nullptr, 0);
   }
 
   template <typename Manager>
@@ -116,8 +114,15 @@ class OnlineParaformerModel::Impl {
 
  private:
   void InitEncoder(void *model_data, size_t model_data_length) {
-    encoder_sess_ = std::make_unique<Ort::Session>(
-        env_, model_data, model_data_length, sess_opts_);
+    if (model_data) {
+      encoder_sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!encoder_sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the encoder session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(encoder_sess_.get(), &encoder_input_names_,
                   &encoder_input_names_ptr_);
@@ -155,8 +160,15 @@ class OnlineParaformerModel::Impl {
   }
 
   void InitDecoder(void *model_data, size_t model_data_length) {
-    decoder_sess_ = std::make_unique<Ort::Session>(
-        env_, model_data, model_data_length, sess_opts_);
+    if (model_data) {
+      decoder_sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!decoder_sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the decoder session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(decoder_sess_.get(), &decoder_input_names_,
                   &decoder_input_names_ptr_);

--- a/sherpa-onnx/csrc/online-recognizer-ctc-impl.h
+++ b/sherpa-onnx/csrc/online-recognizer-ctc-impl.h
@@ -279,7 +279,7 @@ class OnlineRecognizerCtcImpl : public OnlineRecognizerImpl {
       SHERPA_ONNX_LOGE(
           "We expect that tokens.txt contains "
           "the symbol <blk> or <eps> or <blank> and its ID.");
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     int32_t blank_id = 0;
@@ -302,7 +302,7 @@ class OnlineRecognizerCtcImpl : public OnlineRecognizerImpl {
       SHERPA_ONNX_LOGE(
           "Unsupported decoding method: %s for streaming CTC models",
           config_.decoding_method.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
   }
 

--- a/sherpa-onnx/csrc/online-recognizer-impl.cc
+++ b/sherpa-onnx/csrc/online-recognizer-impl.cc
@@ -27,6 +27,7 @@
 #include "sherpa-onnx/csrc/online-recognizer-transducer-impl.h"
 #include "sherpa-onnx/csrc/online-recognizer-transducer-nemo-impl.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"
+#include "sherpa-onnx/csrc/session.h"
 #include "sherpa-onnx/csrc/text-utils.h"
 
 #if SHERPA_ONNX_ENABLE_RKNN
@@ -66,9 +67,9 @@ std::unique_ptr<OnlineRecognizerImpl> OnlineRecognizerImpl::Create(
     sess_opts.SetIntraOpNumThreads(1);
     sess_opts.SetInterOpNumThreads(1);
 
-    auto decoder_model = ReadFile(config.model_config.transducer.decoder);
-    auto sess = std::make_unique<Ort::Session>(env, decoder_model.data(),
-                                               decoder_model.size(), sess_opts);
+    auto sess = std::make_unique<Ort::Session>(
+        env, SHERPA_ONNX_TO_ORT_PATH(config.model_config.transducer.decoder),
+        sess_opts);
 
     size_t node_count = sess->GetOutputCount();
 

--- a/sherpa-onnx/csrc/online-recognizer-impl.h
+++ b/sherpa-onnx/csrc/online-recognizer-impl.h
@@ -38,7 +38,7 @@ class OnlineRecognizerImpl {
   virtual std::unique_ptr<OnlineStream> CreateStream(
       const std::string &hotwords) const {
     SHERPA_ONNX_LOGE("Only transducer models support contextual biasing.");
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   virtual bool IsReady(OnlineStream *s) const = 0;
@@ -46,7 +46,7 @@ class OnlineRecognizerImpl {
   virtual void WarmpUpRecognizer(int32_t warmup, int32_t mbs) const {
     // ToDo extending to other  models
     SHERPA_ONNX_LOGE("Only zipformer2 model supports Warm up for now.");
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   virtual void DecodeStreams(OnlineStream **ss, int32_t n) const = 0;

--- a/sherpa-onnx/csrc/online-recognizer-paraformer-impl.h
+++ b/sherpa-onnx/csrc/online-recognizer-paraformer-impl.h
@@ -113,7 +113,7 @@ class OnlineRecognizerParaformerImpl : public OnlineRecognizerImpl {
           "Unsupported decoding method: %s. Support only greedy_search at "
           "present",
           config.decoding_method.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     // Paraformer models assume input samples are in the range
@@ -136,7 +136,7 @@ class OnlineRecognizerParaformerImpl : public OnlineRecognizerImpl {
     if (config.decoding_method != "greedy_search") {
       SHERPA_ONNX_LOGE("Unsupported decoding method: %s",
                        config.decoding_method.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     // Paraformer models assume input samples are in the range

--- a/sherpa-onnx/csrc/online-recognizer-transducer-impl.h
+++ b/sherpa-onnx/csrc/online-recognizer-transducer-impl.h
@@ -132,7 +132,7 @@ class OnlineRecognizerTransducerImpl : public OnlineRecognizerImpl {
     } else {
       SHERPA_ONNX_LOGE("Unsupported decoding method: %s",
                        config.decoding_method.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (model_->UseWhisperFeature()) {
@@ -187,7 +187,7 @@ class OnlineRecognizerTransducerImpl : public OnlineRecognizerImpl {
     } else {
       SHERPA_ONNX_LOGE("Unsupported decoding method: %s",
                        config.decoding_method.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (model_->UseWhisperFeature()) {
@@ -443,7 +443,7 @@ class OnlineRecognizerTransducerImpl : public OnlineRecognizerImpl {
     if (!is) {
       SHERPA_ONNX_LOGE("Open hotwords file failed: %s",
                        config_.hotwords_file.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (!EncodeHotwords(is, config_.model_config.modeling_unit, sym_,
@@ -467,7 +467,7 @@ class OnlineRecognizerTransducerImpl : public OnlineRecognizerImpl {
     if (!is) {
       SHERPA_ONNX_LOGE("Open hotwords file failed: %s",
                        config_.hotwords_file.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (!EncodeHotwords(is, config_.model_config.modeling_unit, sym_,

--- a/sherpa-onnx/csrc/online-recognizer-transducer-nemo-impl.h
+++ b/sherpa-onnx/csrc/online-recognizer-transducer-nemo-impl.h
@@ -55,7 +55,7 @@ class OnlineRecognizerTransducerNeMoImpl : public OnlineRecognizerImpl {
     } else {
       SHERPA_ONNX_LOGE("Unsupported decoding method: %s",
                        config.decoding_method.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
     PostInit();
   }
@@ -79,7 +79,7 @@ class OnlineRecognizerTransducerNeMoImpl : public OnlineRecognizerImpl {
     } else {
       SHERPA_ONNX_LOGE("Unsupported decoding method: %s",
                        config.decoding_method.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     PostInit();
@@ -227,18 +227,18 @@ class OnlineRecognizerTransducerNeMoImpl : public OnlineRecognizerImpl {
     // check the blank ID
     if (!symbol_table_.Contains("<blk>")) {
       SHERPA_ONNX_LOGE("tokens.txt does not include the blank token <blk>");
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (symbol_table_["<blk>"] != vocab_size - 1) {
       SHERPA_ONNX_LOGE("<blk> is not the last token!");
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (symbol_table_.NumSymbols() != vocab_size) {
       SHERPA_ONNX_LOGE("number of lines in tokens.txt %d != %d (vocab_size)",
                        symbol_table_.NumSymbols(), vocab_size);
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
   }
 

--- a/sherpa-onnx/csrc/online-rnn-lm.cc
+++ b/sherpa-onnx/csrc/online-rnn-lm.cc
@@ -163,10 +163,8 @@ class OnlineRnnLM::Impl {
 
  private:
   void Init(const OnlineLMConfig &config) {
-    auto buf = ReadFile(config_.model);
-
-    sess_ = std::make_unique<Ort::Session>(env_, buf.data(), buf.size(),
-                                           sess_opts_);
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config_.model), sess_opts_);
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
     GetOutputNames(sess_.get(), &output_names_, &output_names_ptr_);

--- a/sherpa-onnx/csrc/online-t-one-ctc-model.cc
+++ b/sherpa-onnx/csrc/online-t-one-ctc-model.cc
@@ -37,10 +37,9 @@ class OnlineToneCtcModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    {
-      auto buf = ReadFile(config.t_one_ctc.model);
-      Init(buf.data(), buf.size());
-    }
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.t_one_ctc.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -157,8 +156,15 @@ class OnlineToneCtcModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/online-transducer-decoder.h
+++ b/sherpa-onnx/csrc/online-transducer-decoder.h
@@ -99,7 +99,7 @@ class OnlineTransducerDecoder {
                       std::vector<OnlineTransducerDecoderResult> * /*result*/) {
     SHERPA_ONNX_LOGE(
         "This interface is for OnlineTransducerModifiedBeamSearchDecoder.");
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   // used for endpointing. We need to keep decoder_out after reset

--- a/sherpa-onnx/csrc/online-transducer-greedy-search-decoder.cc
+++ b/sherpa-onnx/csrc/online-transducer-greedy-search-decoder.cc
@@ -82,7 +82,7 @@ void OnlineTransducerGreedySearchDecoder::Decode(
         "Size mismatch! encoder_out.size(0) %d, result.size(0): %d",
         static_cast<int32_t>(encoder_out_shape[0]),
         static_cast<int32_t>(result->size()));
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   int32_t batch_size = static_cast<int32_t>(encoder_out_shape[0]);

--- a/sherpa-onnx/csrc/online-transducer-greedy-search-nemo-decoder.cc
+++ b/sherpa-onnx/csrc/online-transducer-greedy-search-nemo-decoder.cc
@@ -112,7 +112,7 @@ void OnlineTransducerGreedySearchNeMoDecoder::Decode(Ort::Value encoder_out,
   if (batch_size != n) {
     SHERPA_ONNX_LOGE("Size mismatch! encoder_out.size(0) %d, n: %d",
                      static_cast<int32_t>(shape[0]), n);
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   int32_t dim1 = static_cast<int32_t>(shape[1]);  // T

--- a/sherpa-onnx/csrc/online-transducer-model.cc
+++ b/sherpa-onnx/csrc/online-transducer-model.cc
@@ -27,6 +27,8 @@
 #include "sherpa-onnx/csrc/online-zipformer-transducer-model.h"
 #include "sherpa-onnx/csrc/online-zipformer2-transducer-model.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"
+#include "sherpa-onnx/csrc/session.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 
 namespace {
 
@@ -42,6 +44,54 @@ enum class ModelType : std::uint8_t {
 }  // namespace
 
 namespace sherpa_onnx {
+
+static ModelType GetModelType(const std::string &model_path, bool debug) {
+  Ort::Env env(ORT_LOGGING_LEVEL_ERROR);
+  Ort::SessionOptions sess_opts;
+  sess_opts.SetIntraOpNumThreads(1);
+  sess_opts.SetInterOpNumThreads(1);
+
+  auto sess = std::make_unique<Ort::Session>(
+      env, SHERPA_ONNX_TO_ORT_PATH(model_path), sess_opts);
+
+
+  Ort::ModelMetadata meta_data = sess->GetModelMetadata();
+  if (debug) {
+    std::ostringstream os;
+    PrintModelMetadata(os, meta_data);
+#if __OHOS__
+    SHERPA_ONNX_LOGE("%{public}s", os.str().c_str());
+#else
+    SHERPA_ONNX_LOGE("%s", os.str().c_str());
+#endif
+  }
+
+  Ort::AllocatorWithDefaultOptions allocator;
+  auto model_type =
+      LookupCustomModelMetaData(meta_data, "model_type", allocator);
+  if (model_type.empty()) {
+    SHERPA_ONNX_LOGE(
+        "No model_type in the metadata!\n"
+        "Please make sure you are using the latest export-onnx.py from icefall "
+        "to export your transducer models");
+    return ModelType::kUnknown;
+  }
+
+  if (model_type == "conformer") {
+    return ModelType::kConformer;
+  } else if (model_type == "ebranchformer") {
+    return ModelType::kEbranchformer;
+  } else if (model_type == "lstm") {
+    return ModelType::kLstm;
+  } else if (model_type == "zipformer") {
+    return ModelType::kZipformer;
+  } else if (model_type == "zipformer2") {
+    return ModelType::kZipformer2;
+  } else {
+    SHERPA_ONNX_LOGE("Unsupported model_type: %s", model_type.c_str());
+    return ModelType::kUnknown;
+  }
+}
 
 static ModelType GetModelType(char *model_data, size_t model_data_length,
                               bool debug) {
@@ -114,9 +164,7 @@ std::unique_ptr<OnlineTransducerModel> OnlineTransducerModel::Create(
   ModelType model_type = ModelType::kUnknown;
 
   {
-    auto buffer = ReadFile(config.transducer.encoder);
-
-    model_type = GetModelType(buffer.data(), buffer.size(), config.debug);
+    model_type = GetModelType(config.transducer.encoder, config.debug);
   }
 
   switch (model_type) {

--- a/sherpa-onnx/csrc/online-transducer-modified-beam-search-decoder.cc
+++ b/sherpa-onnx/csrc/online-transducer-modified-beam-search-decoder.cc
@@ -4,6 +4,7 @@
 // Copyright (c)  2023  Xiaomi Corporation
 
 #include "sherpa-onnx/csrc/online-transducer-modified-beam-search-decoder.h"
+#include "sherpa-onnx/csrc/macros.h"
 
 #include <algorithm>
 #include <utility>
@@ -86,7 +87,7 @@ void OnlineTransducerModifiedBeamSearchDecoder::Decode(
         "Size mismatch! encoder_out.size(0) %d, result.size(0): %d\n",
         static_cast<int32_t>(encoder_out_shape[0]),
         static_cast<int32_t>(result->size()));
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   int32_t batch_size = static_cast<int32_t>(encoder_out_shape[0]);

--- a/sherpa-onnx/csrc/online-websocket-client.cc
+++ b/sherpa-onnx/csrc/online-websocket-client.cc
@@ -66,7 +66,7 @@ class Client {
     if (ec) {
       SHERPA_ONNX_LOGE("Could not create connection to %s because %s",
                        uri_.str().c_str(), ec.message().c_str());
-      exit(EXIT_FAILURE);
+      SHERPA_ONNX_EXIT(EXIT_FAILURE);
     }
 
     c_.connect(con);
@@ -86,7 +86,7 @@ class Client {
       c_.close(hdl, websocketpp::close::status::normal, "I'm exiting now", ec);
       if (ec) {
         SHERPA_ONNX_LOGE("Failed to close because %s", ec.message().c_str());
-        exit(EXIT_FAILURE);
+        SHERPA_ONNX_EXIT(EXIT_FAILURE);
       }
     } else {
       SHERPA_ONNX_LOGE("%s", payload.c_str());
@@ -123,7 +123,7 @@ class Client {
       if (ec) {
         SHERPA_ONNX_LOGE("Failed to send audio samples because %s",
                          ec.message().c_str());
-        exit(EXIT_FAILURE);
+        SHERPA_ONNX_EXIT(EXIT_FAILURE);
       }
 
       ec.clear();
@@ -142,7 +142,7 @@ class Client {
         if (ec) {
           SHERPA_ONNX_LOGE("Failed to send audio samples because %s",
                            ec.message().c_str());
-          exit(EXIT_FAILURE);
+          SHERPA_ONNX_EXIT(EXIT_FAILURE);
         }
         ec.clear();
       }
@@ -154,7 +154,7 @@ class Client {
       if (ec) {
         SHERPA_ONNX_LOGE("Failed to send audio samples because %s",
                          ec.message().c_str());
-        exit(EXIT_FAILURE);
+        SHERPA_ONNX_EXIT(EXIT_FAILURE);
       }
     } else {
       asio::post(io_, [this, hdl, start_time]() {

--- a/sherpa-onnx/csrc/online-websocket-server-impl.cc
+++ b/sherpa-onnx/csrc/online-websocket-server-impl.cc
@@ -3,6 +3,7 @@
 // Copyright (c)  2022-2023  Xiaomi Corporation
 
 #include "sherpa-onnx/csrc/online-websocket-server-impl.h"
+#include "sherpa-onnx/csrc/macros.h"
 
 #include <iostream>
 #include <memory>
@@ -262,13 +263,13 @@ void OnlineWebsocketServer::Run(uint16_t port) {
     } else {
       SHERPA_ONNX_LOGE("Only Zipformer2 has warmup support for now.");
       SHERPA_ONNX_LOGE("Given: %s", model_type.c_str());
-      exit(0);
+      SHERPA_ONNX_EXIT(0);
     }
   } else if (warm_up == 0) {
     SHERPA_ONNX_LOGE("Starting without warmup!");
   } else {
     SHERPA_ONNX_LOGE("Invalid Warm up Value!. Expected 0 < warm_up < 100");
-    exit(0);
+    SHERPA_ONNX_EXIT(0);
   }
   decoder_.Run();
 }

--- a/sherpa-onnx/csrc/online-websocket-server.cc
+++ b/sherpa-onnx/csrc/online-websocket-server.cc
@@ -59,7 +59,7 @@ int32_t main(int32_t argc, char *argv[]) {
 
   if (argc == 1) {
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   po.Read(argc, argv);
@@ -67,7 +67,7 @@ int32_t main(int32_t argc, char *argv[]) {
   if (po.NumArgs() != 0) {
     SHERPA_ONNX_LOGE("Unrecognized positional arguments!");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   config.Validate();

--- a/sherpa-onnx/csrc/online-wenet-ctc-model.cc
+++ b/sherpa-onnx/csrc/online-wenet-ctc-model.cc
@@ -35,10 +35,9 @@ class OnlineWenetCtcModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    {
-      auto buf = ReadFile(config.wenet_ctc.model);
-      Init(buf.data(), buf.size());
-    }
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.wenet_ctc.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -134,8 +133,15 @@ class OnlineWenetCtcModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/online-zipformer-transducer-model.cc
+++ b/sherpa-onnx/csrc/online-zipformer-transducer-model.cc
@@ -39,20 +39,17 @@ OnlineZipformerTransducerModel::OnlineZipformerTransducerModel(
       config_(config),
       sess_opts_(GetSessionOptions(config)),
       allocator_{} {
-  {
-    auto buf = ReadFile(config.transducer.encoder);
-    InitEncoder(buf.data(), buf.size());
-  }
+  encoder_sess_ = std::make_unique<Ort::Session>(
+      env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.encoder), sess_opts_);
+  InitEncoder(nullptr, 0);
 
-  {
-    auto buf = ReadFile(config.transducer.decoder);
-    InitDecoder(buf.data(), buf.size());
-  }
+  decoder_sess_ = std::make_unique<Ort::Session>(
+      env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.decoder), sess_opts_);
+  InitDecoder(nullptr, 0);
 
-  {
-    auto buf = ReadFile(config.transducer.joiner);
-    InitJoiner(buf.data(), buf.size());
-  }
+  joiner_sess_ = std::make_unique<Ort::Session>(
+      env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.joiner), sess_opts_);
+  InitJoiner(nullptr, 0);
 }
 
 template <typename Manager>
@@ -80,8 +77,15 @@ OnlineZipformerTransducerModel::OnlineZipformerTransducerModel(
 
 void OnlineZipformerTransducerModel::InitEncoder(void *model_data,
                                                  size_t model_data_length) {
-  encoder_sess_ = std::make_unique<Ort::Session>(env_, model_data,
-                                                 model_data_length, sess_opts_);
+  if (model_data) {
+    encoder_sess_ = std::make_unique<Ort::Session>(
+        env_, model_data, model_data_length, sess_opts_);
+  } else if (!encoder_sess_) {
+    SHERPA_ONNX_LOGE(
+        "Please pass model data or initialize the encoder outside of "
+        "this function");
+    SHERPA_ONNX_EXIT(-1);
+  }
 
   GetInputNames(encoder_sess_.get(), &encoder_input_names_,
                 &encoder_input_names_ptr_);
@@ -142,8 +146,15 @@ void OnlineZipformerTransducerModel::InitEncoder(void *model_data,
 
 void OnlineZipformerTransducerModel::InitDecoder(void *model_data,
                                                  size_t model_data_length) {
-  decoder_sess_ = std::make_unique<Ort::Session>(env_, model_data,
-                                                 model_data_length, sess_opts_);
+  if (model_data) {
+    decoder_sess_ = std::make_unique<Ort::Session>(
+        env_, model_data, model_data_length, sess_opts_);
+  } else if (!decoder_sess_) {
+    SHERPA_ONNX_LOGE(
+        "Please pass model data or initialize the decoder outside of "
+        "this function");
+    SHERPA_ONNX_EXIT(-1);
+  }
 
   GetInputNames(decoder_sess_.get(), &decoder_input_names_,
                 &decoder_input_names_ptr_);
@@ -171,8 +182,15 @@ void OnlineZipformerTransducerModel::InitDecoder(void *model_data,
 
 void OnlineZipformerTransducerModel::InitJoiner(void *model_data,
                                                 size_t model_data_length) {
-  joiner_sess_ = std::make_unique<Ort::Session>(env_, model_data,
-                                                model_data_length, sess_opts_);
+  if (model_data) {
+    joiner_sess_ = std::make_unique<Ort::Session>(
+        env_, model_data, model_data_length, sess_opts_);
+  } else if (!joiner_sess_) {
+    SHERPA_ONNX_LOGE(
+        "Please pass model data or initialize the joiner outside of "
+        "this function");
+    SHERPA_ONNX_EXIT(-1);
+  }
 
   GetInputNames(joiner_sess_.get(), &joiner_input_names_,
                 &joiner_input_names_ptr_);

--- a/sherpa-onnx/csrc/online-zipformer2-ctc-model.cc
+++ b/sherpa-onnx/csrc/online-zipformer2-ctc-model.cc
@@ -39,10 +39,9 @@ class OnlineZipformer2CtcModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    {
-      auto buf = ReadFile(config.zipformer2_ctc.model);
-      Init(buf.data(), buf.size());
-    }
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.zipformer2_ctc.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -251,8 +250,15 @@ class OnlineZipformer2CtcModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 

--- a/sherpa-onnx/csrc/online-zipformer2-transducer-model.cc
+++ b/sherpa-onnx/csrc/online-zipformer2-transducer-model.cc
@@ -43,20 +43,17 @@ OnlineZipformer2TransducerModel::OnlineZipformer2TransducerModel(
       joiner_sess_opts_(GetSessionOptions(config, "joiner")),
       config_(config),
       allocator_{} {
-  {
-    auto buf = ReadFile(config.transducer.encoder);
-    InitEncoder(buf.data(), buf.size());
-  }
+  encoder_sess_ = std::make_unique<Ort::Session>(
+      env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.encoder), encoder_sess_opts_);
+  InitEncoder(nullptr, 0);
 
-  {
-    auto buf = ReadFile(config.transducer.decoder);
-    InitDecoder(buf.data(), buf.size());
-  }
+  decoder_sess_ = std::make_unique<Ort::Session>(
+      env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.decoder), decoder_sess_opts_);
+  InitDecoder(nullptr, 0);
 
-  {
-    auto buf = ReadFile(config.transducer.joiner);
-    InitJoiner(buf.data(), buf.size());
-  }
+  joiner_sess_ = std::make_unique<Ort::Session>(
+      env_, SHERPA_ONNX_TO_ORT_PATH(config.transducer.joiner), joiner_sess_opts_);
+  InitJoiner(nullptr, 0);
 }
 
 template <typename Manager>
@@ -86,8 +83,15 @@ OnlineZipformer2TransducerModel::OnlineZipformer2TransducerModel(
 
 void OnlineZipformer2TransducerModel::InitEncoder(void *model_data,
                                                   size_t model_data_length) {
-  encoder_sess_ = std::make_unique<Ort::Session>(
-      env_, model_data, model_data_length, encoder_sess_opts_);
+  if (model_data) {
+    encoder_sess_ = std::make_unique<Ort::Session>(
+        env_, model_data, model_data_length, encoder_sess_opts_);
+  } else if (!encoder_sess_) {
+    SHERPA_ONNX_LOGE(
+        "Please pass model data or initialize the encoder outside of "
+        "this function");
+    SHERPA_ONNX_EXIT(-1);
+  }
 
   GetInputNames(encoder_sess_.get(), &encoder_input_names_,
                 &encoder_input_names_ptr_);
@@ -159,8 +163,15 @@ void OnlineZipformer2TransducerModel::InitEncoder(void *model_data,
 
 void OnlineZipformer2TransducerModel::InitDecoder(void *model_data,
                                                   size_t model_data_length) {
-  decoder_sess_ = std::make_unique<Ort::Session>(
-      env_, model_data, model_data_length, decoder_sess_opts_);
+  if (model_data) {
+    decoder_sess_ = std::make_unique<Ort::Session>(
+        env_, model_data, model_data_length, decoder_sess_opts_);
+  } else if (!decoder_sess_) {
+    SHERPA_ONNX_LOGE(
+        "Please pass model data or initialize the decoder outside of "
+        "this function");
+    SHERPA_ONNX_EXIT(-1);
+  }
 
   GetInputNames(decoder_sess_.get(), &decoder_input_names_,
                 &decoder_input_names_ptr_);
@@ -184,8 +195,15 @@ void OnlineZipformer2TransducerModel::InitDecoder(void *model_data,
 
 void OnlineZipformer2TransducerModel::InitJoiner(void *model_data,
                                                  size_t model_data_length) {
-  joiner_sess_ = std::make_unique<Ort::Session>(
-      env_, model_data, model_data_length, joiner_sess_opts_);
+  if (model_data) {
+    joiner_sess_ = std::make_unique<Ort::Session>(
+        env_, model_data, model_data_length, joiner_sess_opts_);
+  } else if (!joiner_sess_) {
+    SHERPA_ONNX_LOGE(
+        "Please pass model data or initialize the joiner outside of "
+        "this function");
+    SHERPA_ONNX_EXIT(-1);
+  }
 
   GetInputNames(joiner_sess_.get(), &joiner_input_names_,
                 &joiner_input_names_ptr_);

--- a/sherpa-onnx/csrc/parse-options.cc
+++ b/sherpa-onnx/csrc/parse-options.cc
@@ -178,12 +178,12 @@ void ParseOptions::RegisterSpecific(const std::string &name,
 void ParseOptions::DisableOption(const std::string &name) {
   if (argv_ != nullptr) {
     SHERPA_ONNX_LOGE("DisableOption must not be called after calling Read().");
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
   if (doc_map_.erase(name) == 0) {
     SHERPA_ONNX_LOGE("Option %s was not registered so cannot be disabled: ",
                      name.c_str());
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
   bool_map_.erase(name);
   int_map_.erase(name);
@@ -199,7 +199,7 @@ int32_t ParseOptions::NumArgs() const { return positional_args_.size(); }
 std::string ParseOptions::GetArg(int32_t i) const {
   if (i < 1 || i > static_cast<int32_t>(positional_args_.size())) {
     SHERPA_ONNX_LOGE("ParseOptions::GetArg, invalid index %d", i);
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   return positional_args_[i - 1];
@@ -326,7 +326,7 @@ int32_t ParseOptions::Read(int32_t argc, const char *const *argv) {
         ReadConfigFile(value);
       } else if (key == "help") {
         PrintUsage();
-        exit(0);
+        SHERPA_ONNX_EXIT(0);
       }
     }
   }
@@ -349,7 +349,7 @@ int32_t ParseOptions::Read(int32_t argc, const char *const *argv) {
       if (!SetOption(key, value, has_equal_sign)) {
         PrintUsage(true);
         SHERPA_ONNX_LOGE("Invalid option %s", argv[i]);
-        exit(-1);
+        SHERPA_ONNX_EXIT(-1);
       }
     } else {
       break;
@@ -437,7 +437,7 @@ void ParseOptions::PrintConfig(std::ostream &os) const {
     } else {
       SHERPA_ONNX_LOGE("PrintConfig: unrecognized option %s [code error]",
                        key.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
     os << '\n';
   }
@@ -448,7 +448,7 @@ void ParseOptions::ReadConfigFile(const std::string &filename) {
   std::ifstream is(filename.c_str(), std::ifstream::in);
   if (!is.good()) {
     SHERPA_ONNX_LOGE("Cannot open config file: %s", filename.c_str());
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   std::string line, key, value;
@@ -471,7 +471,7 @@ void ParseOptions::ReadConfigFile(const std::string &filename) {
           "be of the form --x=y.  Note: config files intended to "
           "be sourced by shell scripts lack the '--'.",
           filename.c_str(), line_number);
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     // parse option
@@ -483,7 +483,7 @@ void ParseOptions::ReadConfigFile(const std::string &filename) {
       PrintUsage(true);
       SHERPA_ONNX_LOGE("Invalid option %s in config file %s: line %d",
                        line.c_str(), filename.c_str(), line_number);
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
   }
 }
@@ -501,7 +501,7 @@ void ParseOptions::SplitLongArg(const std::string &in, std::string *key,
   } else if (pos == 2) {  // we also don't allow empty keys: --=value
     PrintUsage(true);
     SHERPA_ONNX_LOGE("Invalid option (no key): %s", in.c_str());
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   } else {                         // normal case: --option=value
     *key = in.substr(2, pos - 2);  // 2 because starts with --.
     *value = in.substr(pos + 1);
@@ -543,7 +543,7 @@ bool ParseOptions::SetOption(const std::string &key, const std::string &value,
   if (bool_map_.end() != bool_map_.find(key)) {
     if (has_equal_sign && value.empty()) {
       SHERPA_ONNX_LOGE("Invalid option --%s=", key.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
     *(bool_map_[key]) = ToBool(value);
   } else if (int_map_.end() != int_map_.find(key)) {
@@ -560,7 +560,7 @@ bool ParseOptions::SetOption(const std::string &key, const std::string &value,
     if (!has_equal_sign) {
       SHERPA_ONNX_LOGE("Invalid option --%s (option format is --x=y).",
                        key.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
     *(string_map_[key]) = value;
   } else {
@@ -584,7 +584,7 @@ bool ParseOptions::ToBool(std::string str) const {
   SHERPA_ONNX_LOGE(
       "Invalid format for boolean argument [expected true or false]: %s",
       str.c_str());
-  exit(-1);
+  SHERPA_ONNX_EXIT(-1);
   return false;  // never reached
 }
 
@@ -592,7 +592,7 @@ int32_t ParseOptions::ToInt(const std::string &str) const {
   int32_t ret = 0;
   if (!ConvertStringToInteger(str, &ret)) {
     SHERPA_ONNX_LOGE("Invalid integer option \"%s\"", str.c_str());
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
   return ret;
 }
@@ -601,7 +601,7 @@ int64_t ParseOptions::ToInt64(const std::string &str) const {
   int64_t ret = 0;
   if (!ConvertStringToInteger(str, &ret)) {
     SHERPA_ONNX_LOGE("Invalid integer int64 option \"%s\"", str.c_str());
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
   return ret;
 }
@@ -610,7 +610,7 @@ uint32_t ParseOptions::ToUint(const std::string &str) const {
   uint32_t ret = 0;
   if (!ConvertStringToInteger(str, &ret)) {
     SHERPA_ONNX_LOGE("Invalid integer option \"%s\"", str.c_str());
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
   return ret;
 }
@@ -619,7 +619,7 @@ float ParseOptions::ToFloat(const std::string &str) const {
   float ret = 0;
   if (!ConvertStringToReal(str, &ret)) {
     SHERPA_ONNX_LOGE("Invalid floating-point option \"%s\"", str.c_str());
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
   return ret;
 }
@@ -628,7 +628,7 @@ double ParseOptions::ToDouble(const std::string &str) const {
   double ret = 0;
   if (!ConvertStringToReal(str, &ret)) {
     SHERPA_ONNX_LOGE("Invalid floating-point option \"%s\"", str.c_str());
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
   return ret;
 }

--- a/sherpa-onnx/csrc/resample.cc
+++ b/sherpa-onnx/csrc/resample.cc
@@ -31,6 +31,8 @@
 #include <type_traits>
 #include <vector>
 
+#include "sherpa-onnx/csrc/macros.h"
+
 #ifndef M_2PI
 #define M_2PI 6.283185307179586476925286766559005
 #endif
@@ -47,7 +49,7 @@ static I Gcd(I m, I n) {
   if (m == 0 || n == 0) {
     if (m == 0 && n == 0) {  // gcd not defined, as all integers are divisors.
       fprintf(stderr, "Undefined GCD since m = 0, n = 0.\n");
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
     return (m == 0 ? (n > 0 ? n : -n) : (m > 0 ? m : -m));
     // return absolute value of whichever is nonzero

--- a/sherpa-onnx/csrc/session.cc
+++ b/sherpa-onnx/csrc/session.cc
@@ -203,7 +203,7 @@ Ort::SessionOptions GetSessionOptionsImpl(
         SHERPA_ONNX_LOGE(
             "Tensorrt support for Online models only,"
             "Must be extended for offline and others");
-        exit(1);
+        SHERPA_ONNX_EXIT(1);
       }
       auto trt_config = provider_config->trt_config;
       struct TrtPairs {

--- a/sherpa-onnx/csrc/sherpa-onnx-alsa-offline-audio-tagging.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-alsa-offline-audio-tagging.cc
@@ -64,7 +64,7 @@ static void Record(const char *device_name, int32_t expected_sample_rate) {
   if (alsa.GetExpectedSampleRate() != expected_sample_rate) {
     fprintf(stderr, "sample rate: %d != %d\n", alsa.GetExpectedSampleRate(),
             expected_sample_rate);
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   int32_t chunk = 0.1 * alsa.GetActualSampleRate();
@@ -127,7 +127,7 @@ as the device_name.
   if (po.NumArgs() != 1) {
     fprintf(stderr, "Please provide only 1 argument: the device name\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());

--- a/sherpa-onnx/csrc/sherpa-onnx-alsa-offline-speaker-identification.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-alsa-offline-speaker-identification.cc
@@ -69,7 +69,7 @@ static void Record(const char *device_name, int32_t expected_sample_rate) {
   if (alsa.GetExpectedSampleRate() != expected_sample_rate) {
     fprintf(stderr, "sample rate: %d != %d\n", alsa.GetExpectedSampleRate(),
             expected_sample_rate);
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   int32_t chunk = 0.1 * alsa.GetActualSampleRate();
@@ -100,7 +100,7 @@ static std::vector<std::vector<float>> ComputeEmbeddings(
 
     if (!is_ok) {
       fprintf(stderr, "Failed to read '%s'\n", f.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     auto s = extractor->CreateStream();
@@ -119,7 +119,7 @@ ReadSpeakerFile(const std::string &filename) {
   std::ifstream is(filename);
   if (!is) {
     fprintf(stderr, "Failed to open %s", filename.c_str());
-    exit(0);
+    SHERPA_ONNX_EXIT(0);
   }
 
   std::string line;
@@ -134,7 +134,7 @@ ReadSpeakerFile(const std::string &filename) {
     iss >> name >> path;
     if (!iss || !iss.eof() || name.empty() || path.empty()) {
       fprintf(stderr, "Invalid line: %s\n", line.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
     ans[name].push_back(path);
   }
@@ -218,7 +218,7 @@ as the device_name.
   if (po.NumArgs() != 1) {
     fprintf(stderr, "Please provide only 1 argument: the device name\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());

--- a/sherpa-onnx/csrc/sherpa-onnx-alsa-offline.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-alsa-offline.cc
@@ -66,7 +66,7 @@ static void Record(const char *device_name, int32_t expected_sample_rate) {
   if (alsa.GetExpectedSampleRate() != expected_sample_rate) {
     fprintf(stderr, "sample rate: %d != %d\n", alsa.GetExpectedSampleRate(),
             expected_sample_rate);
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   int32_t chunk = 0.1 * alsa.GetActualSampleRate();
@@ -148,7 +148,7 @@ as the device_name.
   if (po.NumArgs() != 1) {
     fprintf(stderr, "Please provide only 1 argument: the device name\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());

--- a/sherpa-onnx/csrc/sherpa-onnx-alsa.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-alsa.cc
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/alsa.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/display.h"
 #include "sherpa-onnx/csrc/online-recognizer.h"
 #include "sherpa-onnx/csrc/parse-options.h"
@@ -69,7 +70,7 @@ as the device_name.
   if (po.NumArgs() != 1) {
     fprintf(stderr, "Please provide only 1 argument: the device name\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());
@@ -89,7 +90,7 @@ as the device_name.
   if (alsa.GetExpectedSampleRate() != expected_sample_rate) {
     fprintf(stderr, "sample rate: %d != %d\n", alsa.GetExpectedSampleRate(),
             expected_sample_rate);
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   fprintf(stderr, "Started! Please speak\n");

--- a/sherpa-onnx/csrc/sherpa-onnx-keyword-spotter-alsa.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-keyword-spotter-alsa.cc
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/alsa.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/display.h"
 #include "sherpa-onnx/csrc/keyword-spotter.h"
 #include "sherpa-onnx/csrc/parse-options.h"
@@ -68,7 +69,7 @@ as the device_name.
   if (po.NumArgs() != 1) {
     fprintf(stderr, "Please provide only 1 argument: the device name\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());
@@ -88,7 +89,7 @@ as the device_name.
   if (alsa.GetExpectedSampleRate() != expected_sample_rate) {
     fprintf(stderr, "sample rate: %d != %d\n", alsa.GetExpectedSampleRate(),
             expected_sample_rate);
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   int32_t chunk = 0.1 * alsa.GetActualSampleRate();

--- a/sherpa-onnx/csrc/sherpa-onnx-keyword-spotter-microphone.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-keyword-spotter-microphone.cc
@@ -10,6 +10,7 @@
 
 #include "portaudio.h"  // NOLINT
 #include "sherpa-onnx/csrc/display.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/keyword-spotter.h"
 #include "sherpa-onnx/csrc/microphone.h"
 
@@ -64,7 +65,7 @@ for a list of pre-trained models to download.
   po.Read(argc, argv);
   if (po.NumArgs() != 0) {
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());
@@ -84,7 +85,7 @@ for a list of pre-trained models to download.
     fprintf(stderr, "No default input device found\n");
     fprintf(stderr, "If you are using Linux, please switch to \n");
     fprintf(stderr, " ./bin/sherpa-onnx-keyword-spotter-alsa \n");
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   const char *pDeviceIndex = std::getenv("SHERPA_ONNX_MIC_DEVICE");
@@ -104,7 +105,7 @@ for a list of pre-trained models to download.
   if (!mic.OpenDevice(device_index, mic_sample_rate, 1, RecordCallback,
                       s.get())) {
     fprintf(stderr, "portaudio error: %d\n", device_index);
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   int32_t keyword_index = 0;

--- a/sherpa-onnx/csrc/sherpa-onnx-keyword-spotter.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-keyword-spotter.cc
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/keyword-spotter.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/online-stream.h"
 #include "sherpa-onnx/csrc/parse-options.h"
 #include "sherpa-onnx/csrc/wave-reader.h"
@@ -58,7 +59,7 @@ for a list of pre-trained models to download.
   po.Read(argc, argv);
   if (po.NumArgs() < 1) {
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());

--- a/sherpa-onnx/csrc/sherpa-onnx-microphone-offline-audio-tagging.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-microphone-offline-audio-tagging.cc
@@ -106,7 +106,7 @@ for more models.
   if (po.NumArgs() != 0) {
     fprintf(stderr, "\nThis program does not support positional arguments\n\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());
@@ -127,7 +127,7 @@ for more models.
     fprintf(stderr, "No default input device found\n");
     fprintf(stderr, "If you are using Linux, please switch to \n");
     fprintf(stderr, " ./bin/sherpa-onnx-alsa-offline-audio-tagging \n");
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   const char *pDeviceIndex = std::getenv("SHERPA_ONNX_MIC_DEVICE");
@@ -147,7 +147,7 @@ for more models.
   if (!mic.OpenDevice(device_index, mic_sample_rate, 1, RecordCallback,
                       nullptr /* user_data */)) {
     fprintf(stderr, "portaudio error: %d\n", device_index);
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   std::thread t(DetectKeyPress);

--- a/sherpa-onnx/csrc/sherpa-onnx-microphone-offline-speaker-identification.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-microphone-offline-speaker-identification.cc
@@ -98,7 +98,7 @@ static std::vector<std::vector<float>> ComputeEmbeddings(
 
     if (!is_ok) {
       fprintf(stderr, "Failed to read '%s'\n", f.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     auto s = extractor->CreateStream();
@@ -117,7 +117,7 @@ ReadSpeakerFile(const std::string &filename) {
   std::ifstream is(filename);
   if (!is) {
     fprintf(stderr, "Failed to open %s", filename.c_str());
-    exit(0);
+    SHERPA_ONNX_EXIT(0);
   }
 
   std::string line;
@@ -132,7 +132,7 @@ ReadSpeakerFile(const std::string &filename) {
     iss >> name >> path;
     if (!iss || !iss.eof() || name.empty() || path.empty()) {
       fprintf(stderr, "Invalid line: %s\n", line.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
     ans[name].push_back(path);
   }
@@ -199,7 +199,7 @@ Note that `zh` means Chinese, while `en` means English.
     fprintf(stderr,
             "This program does not support any positional arguments.\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());
@@ -230,7 +230,7 @@ Note that `zh` means Chinese, while `en` means English.
     fprintf(stderr, "If you are using Linux, please switch to \n");
     fprintf(stderr,
             " ./bin/sherpa-onnx-alsa-offline-speaker-identification \n");
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   const char *pDeviceIndex = std::getenv("SHERPA_ONNX_MIC_DEVICE");
@@ -251,7 +251,7 @@ Note that `zh` means Chinese, while `en` means English.
   if (!mic.OpenDevice(device_index, mic_sample_rate, 1, RecordCallback,
                       nullptr /* user_data */)) {
     fprintf(stderr, "portaudio error: %d\n", device_index);
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   std::thread t(DetectKeyPress);

--- a/sherpa-onnx/csrc/sherpa-onnx-microphone-offline.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-microphone-offline.cc
@@ -122,7 +122,7 @@ for a list of pre-trained models to download.
   po.Read(argc, argv);
   if (po.NumArgs() != 0) {
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());
@@ -143,7 +143,7 @@ for a list of pre-trained models to download.
     fprintf(stderr, "No default input device found\n");
     fprintf(stderr, "If you are using Linux, please switch to \n");
     fprintf(stderr, " ./bin/sherpa-onnx-alsa-offline \n");
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   const char *pDeviceIndex = std::getenv("SHERPA_ONNX_MIC_DEVICE");
@@ -164,7 +164,7 @@ for a list of pre-trained models to download.
   if (!mic.OpenDevice(device_index, mic_sample_rate, 1, RecordCallback,
                       nullptr /* user_data */)) {
     fprintf(stderr, "portaudio error: %d\n", device_index);
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   std::thread t(DetectKeyPress);

--- a/sherpa-onnx/csrc/sherpa-onnx-microphone.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-microphone.cc
@@ -14,6 +14,7 @@
 
 #include "portaudio.h"  // NOLINT
 #include "sherpa-onnx/csrc/display.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/microphone.h"
 #include "sherpa-onnx/csrc/online-recognizer.h"
 
@@ -93,7 +94,7 @@ for a list of pre-trained models to download.
   po.Read(argc, argv);
   if (po.NumArgs() != 0) {
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());
@@ -113,7 +114,7 @@ for a list of pre-trained models to download.
     fprintf(stderr, "No default input device found\n");
     fprintf(stderr, "If you are using Linux, please switch to \n");
     fprintf(stderr, " ./bin/sherpa-onnx-alsa \n");
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   const char *pDeviceIndex = std::getenv("SHERPA_ONNX_MIC_DEVICE");
@@ -134,7 +135,7 @@ for a list of pre-trained models to download.
   if (!mic.OpenDevice(device_index, mic_sample_rate, 1, RecordCallback,
                       s.get())) {
     fprintf(stderr, "portaudio error: %d\n", device_index);
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   std::string last_text;

--- a/sherpa-onnx/csrc/sherpa-onnx-offline-audio-tagging.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-offline-audio-tagging.cc
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/audio-tagging.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/parse-options.h"
 #include "sherpa-onnx/csrc/wave-reader.h"
 
@@ -41,7 +42,7 @@ for more models.
   if (po.NumArgs() != 1) {
     fprintf(stderr, "\nError: Please provide 1 wave file\n\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());

--- a/sherpa-onnx/csrc/sherpa-onnx-offline-denoiser.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-offline-denoiser.cc
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/offline-speech-denoiser.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/wave-reader.h"
 #include "sherpa-onnx/csrc/wave-writer.h"
 
@@ -64,20 +65,20 @@ wget https://github.com/k2-fsa/sherpa-onnx/releases/download/speech-enhancement-
   if (po.NumArgs() != 0) {
     fprintf(stderr, "Please don't give positional arguments\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
   fprintf(stderr, "%s\n", config.ToString().c_str());
 
   if (input_wave.empty()) {
     fprintf(stderr, "Please provide --input-wav\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   if (output_wave.empty()) {
     fprintf(stderr, "Please provide --output-wav\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   sherpa_onnx::OfflineSpeechDenoiser denoiser(config);

--- a/sherpa-onnx/csrc/sherpa-onnx-offline-language-identification.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-offline-language-identification.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/parse-options.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/spoken-language-identification.h"
 #include "sherpa-onnx/csrc/wave-reader.h"
 
@@ -52,7 +53,7 @@ for a list of pre-trained models to download.
   if (po.NumArgs() != 1) {
     fprintf(stderr, "Error: Please provide 1 wave file.\n\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());

--- a/sherpa-onnx/csrc/sherpa-onnx-offline-parallel.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-offline-parallel.cc
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/offline-recognizer.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/parse-options.h"
 #include "sherpa-onnx/csrc/wave-reader.h"
 
@@ -243,7 +244,7 @@ for a list of pre-trained models to download.
   if (po.NumArgs() < 1 && wav_scp.empty()) {
     fprintf(stderr, "Error: Please provide at least 1 wave file.\n\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());

--- a/sherpa-onnx/csrc/sherpa-onnx-offline-punctuation.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-offline-punctuation.cc
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "sherpa-onnx/csrc/offline-punctuation.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/parse-options.h"
 
 int main(int32_t argc, char *argv[]) {
@@ -37,7 +38,7 @@ The output text should look like below:
             "Error: Please provide only 1 position argument containing the "
             "input text.\n\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());

--- a/sherpa-onnx/csrc/sherpa-onnx-offline-source-separation.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-offline-source-separation.cc
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "sherpa-onnx/csrc/offline-source-separation.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/wave-reader.h"
 #include "sherpa-onnx/csrc/wave-writer.h"
 
@@ -64,31 +65,31 @@ wget https://github.com/k2-fsa/sherpa-onnx/releases/download/source-separation-m
   if (po.NumArgs() != 0) {
     fprintf(stderr, "Please don't give positional arguments\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
   fprintf(stderr, "%s\n", config.ToString().c_str());
 
   if (input_wave.empty()) {
     fprintf(stderr, "Please provide --input-wav\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   if (output_vocals_wave.empty()) {
     fprintf(stderr, "Please provide --output-vocals-wav\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   if (output_accompaniment_wave.empty()) {
     fprintf(stderr, "Please provide --output-accompaniment-wav\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   if (!config.Validate()) {
     fprintf(stderr, "Errors in config!\n");
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   bool is_ok = false;
@@ -119,7 +120,7 @@ wget https://github.com/k2-fsa/sherpa-onnx/releases/download/source-separation-m
 
   if (!is_ok) {
     fprintf(stderr, "Failed to write to '%s'\n", output_vocals_wave.c_str());
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   is_ok = sherpa_onnx::WriteWave(output_accompaniment_wave, output.sample_rate,
@@ -130,7 +131,7 @@ wget https://github.com/k2-fsa/sherpa-onnx/releases/download/source-separation-m
   if (!is_ok) {
     fprintf(stderr, "Failed to write to '%s'\n",
             output_accompaniment_wave.c_str());
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "Done\n");

--- a/sherpa-onnx/csrc/sherpa-onnx-offline-tts-play-alsa.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-offline-tts-play-alsa.cc
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/alsa-play.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/offline-tts.h"
 #include "sherpa-onnx/csrc/parse-options.h"
 #include "sherpa-onnx/csrc/wave-reader.h"
@@ -41,7 +42,7 @@ static bool g_killed = false;
 
 static void Handler(int32_t /*sig*/) {
   if (g_killed) {
-    exit(0);
+    SHERPA_ONNX_EXIT(0);
   }
 
   g_killed = true;
@@ -226,7 +227,7 @@ or details.
   if (po.NumArgs() == 0) {
     fprintf(stderr, "Error: Please provide the text to generate audio.\n\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   if (po.NumArgs() > 1) {
@@ -234,12 +235,12 @@ or details.
             "Error: Accept only one positional argument. Please use single "
             "quotes to wrap your text\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   if (!config.Validate()) {
     fprintf(stderr, "Errors in config!\n");
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   if (config.max_num_sentences != 1) {
@@ -273,7 +274,7 @@ or details.
     if (reference_audio.empty()) {
       fprintf(stderr,
               "You need to provide --reference-audio for this TTS model");
-      exit(EXIT_FAILURE);
+      SHERPA_ONNX_EXIT(EXIT_FAILURE);
     }
 
     int32_t sample_rate;
@@ -282,7 +283,7 @@ or details.
         sherpa_onnx::ReadWave(reference_audio, &sample_rate, &is_ok);
     if (!is_ok) {
       fprintf(stderr, "Failed to read '%s'", reference_audio.c_str());
-      exit(EXIT_FAILURE);
+      SHERPA_ONNX_EXIT(EXIT_FAILURE);
     }
 
     gen_config.reference_audio = std::move(samples);
@@ -293,7 +294,7 @@ or details.
     if (reference_text.empty()) {
       fprintf(stderr,
               "You need to provide --reference-text for ZipVoice TTS");
-      exit(EXIT_FAILURE);
+      SHERPA_ONNX_EXIT(EXIT_FAILURE);
     }
     gen_config.reference_text = reference_text;
   }
@@ -308,7 +309,7 @@ or details.
     fprintf(
         stderr,
         "Error in generating audio. Please read previous error messages.\n");
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   float elapsed_seconds =
@@ -327,7 +328,7 @@ or details.
                                    audio.samples.data(), audio.samples.size());
   if (!ok) {
     fprintf(stderr, "Failed to write wave to %s\n", output_filename.c_str());
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "The text is: %s. Speaker ID: %d\n\n", po.GetArg(1).c_str(),

--- a/sherpa-onnx/csrc/sherpa-onnx-offline-tts-play.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-offline-tts-play.cc
@@ -18,6 +18,7 @@
 
 #include "portaudio.h"  // NOLINT
 #include "sherpa-onnx/csrc/microphone.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/offline-tts.h"
 #include "sherpa-onnx/csrc/parse-options.h"
 #include "sherpa-onnx/csrc/wave-reader.h"
@@ -44,7 +45,7 @@ static bool g_killed = false;
 
 static void Handler(int32_t /*sig*/) {
   if (g_killed) {
-    exit(0);
+    SHERPA_ONNX_EXIT(0);
   }
 
   g_killed = true;
@@ -313,7 +314,7 @@ or details.
   if (po.NumArgs() == 0) {
     fprintf(stderr, "Error: Please provide the text to generate audio.\n\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   if (po.NumArgs() > 1) {
@@ -321,12 +322,12 @@ or details.
             "Error: Accept only one positional argument. Please use single "
             "quotes to wrap your text\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   if (!config.Validate()) {
     fprintf(stderr, "Errors in config!\n");
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   sherpa_onnx::Microphone mic;
@@ -339,7 +340,7 @@ or details.
   param.device = Pa_GetDefaultOutputDevice();
   if (param.device == paNoDevice) {
     fprintf(stderr, "No default output device found\n");
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
   fprintf(stderr, "Use default device: %d\n", param.device);
 
@@ -378,7 +379,7 @@ or details.
     if (reference_audio.empty()) {
       fprintf(stderr,
               "You need to provide --reference-audio for this TTS model");
-      exit(EXIT_FAILURE);
+      SHERPA_ONNX_EXIT(EXIT_FAILURE);
     }
 
     int32_t sample_rate;
@@ -387,7 +388,7 @@ or details.
         sherpa_onnx::ReadWave(reference_audio, &sample_rate, &is_ok);
     if (!is_ok) {
       fprintf(stderr, "Failed to read '%s'", reference_audio.c_str());
-      exit(EXIT_FAILURE);
+      SHERPA_ONNX_EXIT(EXIT_FAILURE);
     }
 
     gen_config.reference_audio = std::move(samples);
@@ -398,7 +399,7 @@ or details.
     if (reference_text.empty()) {
       fprintf(stderr,
               "You need to provide --reference-text for ZipVoice TTS");
-      exit(EXIT_FAILURE);
+      SHERPA_ONNX_EXIT(EXIT_FAILURE);
     }
     gen_config.reference_text = reference_text;
   }
@@ -412,7 +413,7 @@ or details.
     fprintf(
         stderr,
         "Error in generating audio. Please read previous error messages.\n");
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   float elapsed_seconds =
@@ -431,7 +432,7 @@ or details.
                                    audio.samples.data(), audio.samples.size());
   if (!ok) {
     fprintf(stderr, "Failed to write wave to %s\n", output_filename.c_str());
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "The text is: %s. Speaker ID: %d\n\n", po.GetArg(1).c_str(),

--- a/sherpa-onnx/csrc/sherpa-onnx-offline-tts.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-offline-tts.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "sherpa-onnx/csrc/offline-tts.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/parse-options.h"
 #include "sherpa-onnx/csrc/wave-reader.h"
 #include "sherpa-onnx/csrc/wave-writer.h"
@@ -145,7 +146,7 @@ or details.
   if (po.NumArgs() == 0) {
     fprintf(stderr, "Error: Please provide the text to generate audio.\n\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   if (po.NumArgs() > 1) {
@@ -153,7 +154,7 @@ or details.
             "Error: Accept only one positional argument. Please use single "
             "quotes to wrap your text.\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   if (config.model.debug) {
@@ -162,7 +163,7 @@ or details.
 
   if (!config.Validate()) {
     fprintf(stderr, "Errors in config!\n");
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   sherpa_onnx::OfflineTts tts(config);
@@ -185,7 +186,7 @@ or details.
     if (reference_audio.empty()) {
       fprintf(stderr,
               "You need to provide --reference-audio for this TTS model");
-      exit(EXIT_FAILURE);
+      SHERPA_ONNX_EXIT(EXIT_FAILURE);
     }
 
     int32_t sample_rate;
@@ -194,7 +195,7 @@ or details.
         sherpa_onnx::ReadWave(reference_audio, &sample_rate, &is_ok);
     if (!is_ok) {
       fprintf(stderr, "Failed to read '%s'", reference_audio.c_str());
-      exit(EXIT_FAILURE);
+      SHERPA_ONNX_EXIT(EXIT_FAILURE);
     }
 
     gen_config.reference_audio = std::move(samples);
@@ -205,7 +206,7 @@ or details.
     if (reference_text.empty()) {
       fprintf(stderr,
               "You need to provide --reference-text for ZipVoice TTS");
-      exit(EXIT_FAILURE);
+      SHERPA_ONNX_EXIT(EXIT_FAILURE);
     }
     gen_config.reference_text = reference_text;
   }
@@ -218,7 +219,7 @@ or details.
     fprintf(
         stderr,
         "Error in generating audio. Please read previous error messages.\n");
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   float elapsed_seconds =
@@ -238,7 +239,7 @@ or details.
                                    audio.samples.data(), audio.samples.size());
   if (!ok) {
     fprintf(stderr, "Failed to write wave to %s\n", output_filename.c_str());
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "The text is: %s. Speaker ID: %d\n", po.GetArg(1).c_str(),

--- a/sherpa-onnx/csrc/sherpa-onnx-offline.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-offline.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/offline-recognizer.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/parse-options.h"
 #include "sherpa-onnx/csrc/wave-reader.h"
 
@@ -123,7 +124,7 @@ for a list of pre-trained models to download.
   if (po.NumArgs() < 1) {
     fprintf(stderr, "Error: Please provide at least 1 wave file.\n\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());

--- a/sherpa-onnx/csrc/sherpa-onnx-online-denoiser.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-online-denoiser.cc
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/online-speech-denoiser.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/wave-reader.h"
 #include "sherpa-onnx/csrc/wave-writer.h"
 
@@ -72,7 +73,7 @@ Usage:
   if (po.NumArgs() != 0) {
     fprintf(stderr, "Please don't give positional arguments\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());
@@ -85,13 +86,13 @@ Usage:
   if (input_wave.empty()) {
     fprintf(stderr, "Please provide --input-wav\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   if (output_wave.empty()) {
     fprintf(stderr, "Please provide --output-wav\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   if (chunk_duration_ms <= 0) {

--- a/sherpa-onnx/csrc/sherpa-onnx-online-punctuation.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-online-punctuation.cc
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "sherpa-onnx/csrc/online-punctuation.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/parse-options.h"
 
 int main(int32_t argc, char *argv[]) {
@@ -40,7 +41,7 @@ The output text should look like below:
             "Error: Please provide only 1 positional argument containing the "
             "input text.\n\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());

--- a/sherpa-onnx/csrc/sherpa-onnx-vad-alsa-offline-asr.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-vad-alsa-offline-asr.cc
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/alsa.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/circular-buffer.h"
 #include "sherpa-onnx/csrc/offline-recognizer.h"
 #include "sherpa-onnx/csrc/resample.h"
@@ -98,7 +99,7 @@ as the device_name.
   if (po.NumArgs() != 1) {
     fprintf(stderr, "Please provide only 1 argument: the device name\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", vad_config.ToString().c_str());
@@ -129,7 +130,7 @@ as the device_name.
   if (alsa.GetExpectedSampleRate() != sample_rate) {
     fprintf(stderr, "sample rate: %d != %d\n", alsa.GetExpectedSampleRate(),
             sample_rate);
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   fprintf(stderr, "Started. Please speak\n");

--- a/sherpa-onnx/csrc/sherpa-onnx-vad-alsa.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-vad-alsa.cc
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/alsa.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/voice-activity-detector.h"
 #include "sherpa-onnx/csrc/wave-writer.h"
 
@@ -65,7 +66,7 @@ as the device_name.
   if (po.NumArgs() != 1) {
     fprintf(stderr, "Please provide only 1 argument: the device name\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());
@@ -84,7 +85,7 @@ as the device_name.
   if (alsa.GetExpectedSampleRate() != sample_rate) {
     fprintf(stderr, "sample rate: %d != %d\n", alsa.GetExpectedSampleRate(),
             sample_rate);
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   auto vad = std::make_unique<sherpa_onnx::VoiceActivityDetector>(config);

--- a/sherpa-onnx/csrc/sherpa-onnx-vad-microphone-offline-asr.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-vad-microphone-offline-asr.cc
@@ -14,6 +14,7 @@
 
 #include "portaudio.h"  // NOLINT
 #include "sherpa-onnx/csrc/circular-buffer.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/microphone.h"
 #include "sherpa-onnx/csrc/offline-recognizer.h"
 #include "sherpa-onnx/csrc/resample.h"
@@ -94,7 +95,7 @@ to download models for offline ASR.
   po.Read(argc, argv);
   if (po.NumArgs() != 0) {
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", vad_config.ToString().c_str());
@@ -122,7 +123,7 @@ to download models for offline ASR.
     fprintf(stderr,
             "  If you are using Linux, please try "
             "./build/bin/sherpa-onnx-vad-alsa-offline-asr\n");
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   const char *pDeviceIndex = std::getenv("SHERPA_ONNX_MIC_DEVICE");
@@ -142,7 +143,7 @@ to download models for offline ASR.
   if (!mic.OpenDevice(device_index, mic_sample_rate, 1, RecordCallback,
                       nullptr)) {
     fprintf(stderr, "Failed to open device %d\n", device_index);
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   float sample_rate = 16000;

--- a/sherpa-onnx/csrc/sherpa-onnx-vad-microphone-simulated-streaming-asr.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-vad-microphone-simulated-streaming-asr.cc
@@ -17,6 +17,7 @@
 
 #include "portaudio.h"  // NOLINT
 #include "sherpa-onnx/csrc/circular-buffer.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/microphone.h"
 #include "sherpa-onnx/csrc/offline-recognizer.h"
 #include "sherpa-onnx/csrc/resample.h"
@@ -116,13 +117,13 @@ A model with RTF < 0.2 should work with this program.
 
   if (argc == 1) {
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   po.Read(argc, argv);
   if (po.NumArgs() != 0) {
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stdout, "%s\n", vad_config.ToString().c_str());
@@ -147,7 +148,7 @@ A model with RTF < 0.2 should work with this program.
   int32_t device_index = Pa_GetDefaultInputDevice();
   if (device_index == paNoDevice) {
     fprintf(stdout, "No default input device found\n");
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   if (user_device_index >= 0) {
@@ -168,7 +169,7 @@ A model with RTF < 0.2 should work with this program.
   if (!mic.OpenDevice(device_index, mic_sample_rate, 1, RecordCallback,
                       nullptr)) {
     fprintf(stdout, "Failed to open device %d\n", device_index);
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   float sample_rate = 16000;

--- a/sherpa-onnx/csrc/sherpa-onnx-vad-microphone.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-vad-microphone.cc
@@ -14,6 +14,7 @@
 
 #include "portaudio.h"  // NOLINT
 #include "sherpa-onnx/csrc/circular-buffer.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/microphone.h"
 #include "sherpa-onnx/csrc/resample.h"
 #include "sherpa-onnx/csrc/voice-activity-detector.h"
@@ -65,7 +66,7 @@ wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/silero_v
   po.Read(argc, argv);
   if (po.NumArgs() != 0) {
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());
@@ -82,7 +83,7 @@ wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/silero_v
     fprintf(stderr, "No default input device found\n");
     fprintf(stderr, "If you are using Linux, please switch to \n");
     fprintf(stderr, " ./bin/sherpa-onnx-vad-alsa \n");
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   const char *pDeviceIndex = std::getenv("SHERPA_ONNX_MIC_DEVICE");
@@ -101,7 +102,7 @@ wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/silero_v
   if (!mic.OpenDevice(device_index, mic_sample_rate, 1, RecordCallback,
                       nullptr)) {
     fprintf(stderr, "Failed to open microphone device %d\n", device_index);
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   float sample_rate = 16000;

--- a/sherpa-onnx/csrc/sherpa-onnx-vad-with-offline-asr.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-vad-with-offline-asr.cc
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/offline-recognizer.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/parse-options.h"
 #include "sherpa-onnx/csrc/resample.h"
 #include "sherpa-onnx/csrc/voice-activity-detector.h"
@@ -154,7 +155,7 @@ for a list of pre-trained models to download.
     fprintf(stderr, "Error: Please provide at only 1 wave file. Given: %d\n\n",
             po.NumArgs());
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", vad_config.ToString().c_str());

--- a/sherpa-onnx/csrc/sherpa-onnx-vad-with-online-asr.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-vad-with-online-asr.cc
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/online-recognizer.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/online-stream.h"
 #include "sherpa-onnx/csrc/parse-options.h"
 #include "sherpa-onnx/csrc/resample.h"
@@ -92,7 +93,7 @@ for a list of pre-trained models to download.
     fprintf(stderr, "Error: Please provide exactly 1 wave file. Given: %d\n\n",
             po.NumArgs());
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", vad_config.ToString().c_str());

--- a/sherpa-onnx/csrc/sherpa-onnx-vad.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-vad.cc
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/voice-activity-detector.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/wave-reader.h"
 #include "sherpa-onnx/csrc/wave-writer.h"
 
@@ -44,7 +45,7 @@ input.wav should be 16kHz.
         stderr,
         "Please provide only 2 argument2: the input wav and the output wav\n");
     po.PrintUsage();
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());

--- a/sherpa-onnx/csrc/sherpa-onnx.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx.cc
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/online-recognizer.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/online-stream.h"
 #include "sherpa-onnx/csrc/parse-options.h"
 #include "sherpa-onnx/csrc/symbol-table.h"
@@ -87,7 +88,7 @@ for a list of pre-trained models to download.
   if (po.NumArgs() < 1) {
     po.PrintUsage();
     fprintf(stderr, "Error! Please provide at lease 1 wav file\n");
-    exit(EXIT_FAILURE);
+    SHERPA_ONNX_EXIT(EXIT_FAILURE);
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());

--- a/sherpa-onnx/csrc/silero-vad-model.cc
+++ b/sherpa-onnx/csrc/silero-vad-model.cc
@@ -23,6 +23,7 @@
 #include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"
 #include "sherpa-onnx/csrc/session.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 
 namespace sherpa_onnx {
 
@@ -34,13 +35,14 @@ class SileroVadModel::Impl {
         sess_opts_(GetSessionOptions(config)),
         allocator_{},
         sample_rate_(config.sample_rate) {
-    auto buf = ReadFile(config.silero_vad.model);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.silero_vad.model), sess_opts_);
+    Init(nullptr, 0);
 
     if (sample_rate_ != 16000) {
       SHERPA_ONNX_LOGE("Expected sample rate 16000. Given: %d",
                        config.sample_rate);
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     min_silence_samples_ =
@@ -62,7 +64,7 @@ class SileroVadModel::Impl {
     if (sample_rate_ != 16000) {
       SHERPA_ONNX_LOGE("Expected sample rate 16000. Given: %d",
                        config.sample_rate);
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     min_silence_samples_ =
@@ -95,7 +97,7 @@ class SileroVadModel::Impl {
   bool IsSpeech(const float *samples, int32_t n) {
     if (n != WindowSize()) {
       SHERPA_ONNX_LOGE("n: %d != window_size: %d", n, WindowSize());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     float prob = Run(samples, n);
@@ -190,8 +192,15 @@ class SileroVadModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
     GetOutputNames(sess_.get(), &output_names_, &output_names_ptr_);
@@ -209,11 +218,11 @@ class SileroVadModel::Impl {
       if (config_.silero_vad.window_size != 512) {
         SHERPA_ONNX_LOGE(
             "For silero_vad  v5, we require window_size to be 512 for 16kHz");
-        exit(-1);
+        SHERPA_ONNX_EXIT(-1);
       }
     } else {
       SHERPA_ONNX_LOGE("Unsupported silero vad model");
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     Check();
@@ -285,51 +294,51 @@ class SileroVadModel::Impl {
     if (input_names_.size() != 4) {
       SHERPA_ONNX_LOGE("Expect 4 inputs. Given: %d",
                        static_cast<int32_t>(input_names_.size()));
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (input_names_[0] != "input") {
       SHERPA_ONNX_LOGE("Input[0]: %s. Expected: input",
                        input_names_[0].c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (input_names_[1] != "sr") {
       SHERPA_ONNX_LOGE("Input[1]: %s. Expected: sr", input_names_[1].c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (input_names_[2] != "h") {
       SHERPA_ONNX_LOGE("Input[2]: %s. Expected: h", input_names_[2].c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (input_names_[3] != "c") {
       SHERPA_ONNX_LOGE("Input[3]: %s. Expected: c", input_names_[3].c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     // Now for outputs
     if (output_names_.size() != 3) {
       SHERPA_ONNX_LOGE("Expect 3 outputs. Given: %d",
                        static_cast<int32_t>(output_names_.size()));
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (output_names_[0] != "output") {
       SHERPA_ONNX_LOGE("Output[0]: %s. Expected: output",
                        output_names_[0].c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (output_names_[1] != "hn") {
       SHERPA_ONNX_LOGE("Output[1]: %s. Expected: sr", output_names_[1].c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (output_names_[2] != "cn") {
       SHERPA_ONNX_LOGE("Output[2]: %s. Expected: sr", output_names_[2].c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
   }
 
@@ -337,43 +346,43 @@ class SileroVadModel::Impl {
     if (input_names_.size() != 3) {
       SHERPA_ONNX_LOGE("Expect 3 inputs. Given: %d",
                        static_cast<int32_t>(input_names_.size()));
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (input_names_[0] != "input") {
       SHERPA_ONNX_LOGE("Input[0]: %s. Expected: input",
                        input_names_[0].c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (input_names_[1] != "state") {
       SHERPA_ONNX_LOGE("Input[1]: %s. Expected: state",
                        input_names_[1].c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (input_names_[2] != "sr") {
       SHERPA_ONNX_LOGE("Input[2]: %s. Expected: sr", input_names_[2].c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     // Now for outputs
     if (output_names_.size() != 2) {
       SHERPA_ONNX_LOGE("Expect 2 outputs. Given: %d",
                        static_cast<int32_t>(output_names_.size()));
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (output_names_[0] != "output") {
       SHERPA_ONNX_LOGE("Output[0]: %s. Expected: output",
                        output_names_[0].c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
 
     if (output_names_[1] != "stateN") {
       SHERPA_ONNX_LOGE("Output[1]: %s. Expected: stateN",
                        output_names_[1].c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
   }
 

--- a/sherpa-onnx/csrc/speaker-embedding-extractor-general-impl.h
+++ b/sherpa-onnx/csrc/speaker-embedding-extractor-general-impl.h
@@ -11,6 +11,7 @@
 
 #include "Eigen/Dense"
 #include "sherpa-onnx/csrc/speaker-embedding-extractor-impl.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/speaker-embedding-extractor-model.h"
 
 namespace sherpa_onnx {
@@ -76,7 +77,7 @@ class SpeakerEmbeddingExtractorGeneralImpl
         SHERPA_ONNX_LOGE("Unsupported feature_normalize_type: %s",
                          meta_data.feature_normalize_type.c_str());
 #endif
-        exit(-1);
+        SHERPA_ONNX_EXIT(-1);
       }
     }
 

--- a/sherpa-onnx/csrc/speaker-embedding-extractor-impl.cc
+++ b/sherpa-onnx/csrc/speaker-embedding-extractor-impl.cc
@@ -17,8 +17,10 @@
 #include "sherpa-onnx/csrc/file-utils.h"
 #include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"
+#include "sherpa-onnx/csrc/session.h"
 #include "sherpa-onnx/csrc/speaker-embedding-extractor-general-impl.h"
 #include "sherpa-onnx/csrc/speaker-embedding-extractor-nemo-impl.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 
 namespace sherpa_onnx {
 
@@ -32,6 +34,57 @@ enum class ModelType : std::uint8_t {
 };
 
 }  // namespace
+
+static ModelType GetModelType(const std::string &model_path, bool debug) {
+  Ort::Env env(ORT_LOGGING_LEVEL_ERROR);
+  Ort::SessionOptions sess_opts;
+  sess_opts.SetIntraOpNumThreads(1);
+  sess_opts.SetInterOpNumThreads(1);
+
+  auto sess = std::make_unique<Ort::Session>(
+      env, SHERPA_ONNX_TO_ORT_PATH(model_path), sess_opts);
+
+
+  Ort::ModelMetadata meta_data = sess->GetModelMetadata();
+  if (debug) {
+    std::ostringstream os;
+    PrintModelMetadata(os, meta_data);
+#if __OHOS__
+    SHERPA_ONNX_LOGE("%{public}s", os.str().c_str());
+#else
+    SHERPA_ONNX_LOGE("%s", os.str().c_str());
+#endif
+  }
+
+  Ort::AllocatorWithDefaultOptions allocator;
+  auto model_type =
+      LookupCustomModelMetaData(meta_data, "framework", allocator);
+  if (model_type.empty()) {
+    SHERPA_ONNX_LOGE(
+        "No model_type in the metadata!\n"
+        "Please make sure you have added metadata to the model.\n\n"
+        "For instance, you can use\n"
+        "https://github.com/k2-fsa/sherpa-onnx/blob/master/scripts/wespeaker/"
+        "add_meta_data.py"
+        "to add metadata to models from WeSpeaker\n");
+    return ModelType::kUnknown;
+  }
+
+  if (model_type == "wespeaker") {
+    return ModelType::kWeSpeaker;
+  } else if (model_type == "3d-speaker") {
+    return ModelType::k3dSpeaker;
+  } else if (model_type == "nemo") {
+    return ModelType::kNeMo;
+  } else {
+#if __OHOS__
+    SHERPA_ONNX_LOGE("Unsupported model_type: %{public}s", model_type.c_str());
+#else
+    SHERPA_ONNX_LOGE("Unsupported model_type: %s", model_type.c_str());
+#endif
+    return ModelType::kUnknown;
+  }
+}
 
 static ModelType GetModelType(char *model_data, size_t model_data_length,
                               bool debug) {
@@ -90,9 +143,7 @@ SpeakerEmbeddingExtractorImpl::Create(
   ModelType model_type = ModelType::kUnknown;
 
   {
-    auto buffer = ReadFile(config.model);
-
-    model_type = GetModelType(buffer.data(), buffer.size(), config.debug);
+    model_type = GetModelType(config.model, config.debug);
   }
 
   switch (model_type) {

--- a/sherpa-onnx/csrc/speaker-embedding-extractor-model.cc
+++ b/sherpa-onnx/csrc/speaker-embedding-extractor-model.cc
@@ -23,6 +23,7 @@
 #include "sherpa-onnx/csrc/onnx-utils.h"
 #include "sherpa-onnx/csrc/session.h"
 #include "sherpa-onnx/csrc/speaker-embedding-extractor-model-meta-data.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 
 namespace sherpa_onnx {
 
@@ -33,10 +34,9 @@ class SpeakerEmbeddingExtractorModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    {
-      auto buf = ReadFile(config.model);
-      Init(buf.data(), buf.size());
-    }
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -66,8 +66,15 @@ class SpeakerEmbeddingExtractorModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 
@@ -106,7 +113,7 @@ class SpeakerEmbeddingExtractorModel::Impl {
       SHERPA_ONNX_LOGE("Expect a wespeaker or a 3d-speaker model, given: %s",
                        framework.c_str());
 #endif
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
   }
 

--- a/sherpa-onnx/csrc/speaker-embedding-extractor-nemo-impl.h
+++ b/sherpa-onnx/csrc/speaker-embedding-extractor-nemo-impl.h
@@ -11,6 +11,7 @@
 
 #include "Eigen/Dense"
 #include "sherpa-onnx/csrc/speaker-embedding-extractor-impl.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/speaker-embedding-extractor-nemo-model.h"
 #include "sherpa-onnx/csrc/transpose.h"
 
@@ -85,7 +86,7 @@ class SpeakerEmbeddingExtractorNeMoImpl : public SpeakerEmbeddingExtractorImpl {
         SHERPA_ONNX_LOGE("Unsupported feature_normalize_type: %s",
                          meta_data.feature_normalize_type.c_str());
 #endif
-        exit(-1);
+        SHERPA_ONNX_EXIT(-1);
       }
     }
 

--- a/sherpa-onnx/csrc/speaker-embedding-extractor-nemo-model.cc
+++ b/sherpa-onnx/csrc/speaker-embedding-extractor-nemo-model.cc
@@ -23,6 +23,7 @@
 #include "sherpa-onnx/csrc/onnx-utils.h"
 #include "sherpa-onnx/csrc/session.h"
 #include "sherpa-onnx/csrc/speaker-embedding-extractor-nemo-model-meta-data.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 
 namespace sherpa_onnx {
 
@@ -33,10 +34,9 @@ class SpeakerEmbeddingExtractorNeMoModel::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config)),
         allocator_{} {
-    {
-      auto buf = ReadFile(config.model);
-      Init(buf.data(), buf.size());
-    }
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -71,8 +71,15 @@ class SpeakerEmbeddingExtractorNeMoModel::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 
@@ -113,7 +120,7 @@ class SpeakerEmbeddingExtractorNeMoModel::Impl {
 #else
       SHERPA_ONNX_LOGE("Expect a NeMo model, given: %s", framework.c_str());
 #endif
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
   }
 

--- a/sherpa-onnx/csrc/spoken-language-identification-impl.cc
+++ b/sherpa-onnx/csrc/spoken-language-identification-impl.cc
@@ -13,7 +13,9 @@
 #include "sherpa-onnx/csrc/file-utils.h"
 #include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"
+#include "sherpa-onnx/csrc/session.h"
 #include "sherpa-onnx/csrc/spoken-language-identification-whisper-impl.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 
 namespace sherpa_onnx {
 
@@ -24,6 +26,43 @@ enum class ModelType : std::uint8_t {
   kUnknown,
 };
 
+}
+
+static ModelType GetModelType(const std::string &model_path, bool debug) {
+  Ort::Env env(ORT_LOGGING_LEVEL_ERROR);
+  Ort::SessionOptions sess_opts;
+
+  auto sess = std::make_unique<Ort::Session>(
+      env, SHERPA_ONNX_TO_ORT_PATH(model_path), sess_opts);
+
+
+  Ort::ModelMetadata meta_data = sess->GetModelMetadata();
+  if (debug) {
+    std::ostringstream os;
+    PrintModelMetadata(os, meta_data);
+    SHERPA_ONNX_LOGE("%s", os.str().c_str());
+  }
+
+  Ort::AllocatorWithDefaultOptions allocator;
+  auto model_type =
+      LookupCustomModelMetaData(meta_data, "model_type", allocator);
+  if (model_type.empty()) {
+    SHERPA_ONNX_LOGE(
+        "No model_type in the metadata!\n"
+        "Please make sure you have added metadata to the model.\n\n"
+        "For instance, you can use\n"
+        "https://github.com/k2-fsa/sherpa-onnx/blob/master/scripts/whisper/"
+        "export-onnx.py "
+        "to add metadata to models from whisper\n");
+    return ModelType::kUnknown;
+  }
+
+  if (model_type.find("whisper") == 0) {
+    return ModelType::kWhisper;
+  } else {
+    SHERPA_ONNX_LOGE("Unsupported model_type: %s", model_type.c_str());
+    return ModelType::kUnknown;
+  }
 }
 
 static ModelType GetModelType(char *model_data, size_t model_data_length,
@@ -70,11 +109,9 @@ SpokenLanguageIdentificationImpl::Create(
   {
     if (config.whisper.encoder.empty()) {
       SHERPA_ONNX_LOGE("Only whisper models are supported at present");
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
-    auto buffer = ReadFile(config.whisper.encoder);
-
-    model_type = GetModelType(buffer.data(), buffer.size(), config.debug);
+    model_type = GetModelType(config.whisper.encoder, config.debug);
   }
 
   switch (model_type) {
@@ -98,7 +135,7 @@ SpokenLanguageIdentificationImpl::Create(
   {
     if (config.whisper.encoder.empty()) {
       SHERPA_ONNX_LOGE("Only whisper models are supported at present");
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
     auto buffer = ReadFile(mgr, config.whisper.encoder);
 

--- a/sherpa-onnx/csrc/spoken-language-identification-whisper-impl.h
+++ b/sherpa-onnx/csrc/spoken-language-identification-whisper-impl.h
@@ -17,6 +17,7 @@
 #endif
 
 #include "sherpa-onnx/csrc/offline-whisper-model.h"
+#include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/spoken-language-identification-impl.h"
 #include "sherpa-onnx/csrc/transpose.h"
 
@@ -119,7 +120,7 @@ class SpokenLanguageIdentificationWhisperImpl
           "Only whisper multilingual models can be used for spoken language "
           "identification. Given: %s,%s",
           config_.whisper.encoder.c_str(), config_.whisper.decoder.c_str());
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
   }
 

--- a/sherpa-onnx/csrc/stack.cc
+++ b/sherpa-onnx/csrc/stack.cc
@@ -51,7 +51,7 @@ Ort::Value Stack(OrtAllocator *allocator,
       SHERPA_ONNX_LOGE("Shape for tensor %d: ", i);
       PrintShape(s);
 
-      exit(-1);
+      SHERPA_ONNX_EXIT(-1);
     }
   }
 

--- a/sherpa-onnx/csrc/symbol-table.cc
+++ b/sherpa-onnx/csrc/symbol-table.cc
@@ -3,6 +3,7 @@
 // Copyright (c)  2022-2023  Xiaomi Corporation
 
 #include "sherpa-onnx/csrc/symbol-table.h"
+#include "sherpa-onnx/csrc/macros.h"
 
 #include <algorithm>
 #include <cassert>

--- a/sherpa-onnx/csrc/ten-vad-model.cc
+++ b/sherpa-onnx/csrc/ten-vad-model.cc
@@ -41,8 +41,9 @@ class TenVadModel::Impl {
         sess_opts_(GetSessionOptions(config)),
         allocator_{},
         sample_rate_(config.sample_rate) {
-    auto buf = ReadFile(config.ten_vad.model);
-    Init(buf.data(), buf.size());
+    sess_ = std::make_unique<Ort::Session>(
+        env_, SHERPA_ONNX_TO_ORT_PATH(config.ten_vad.model), sess_opts_);
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -208,8 +209,15 @@ class TenVadModel::Impl {
 
     min_speech_samples_ = sample_rate_ * config_.ten_vad.min_speech_duration;
 
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(
+          env_, model_data, model_data_length, sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of "
+          "this function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
     GetOutputNames(sess_.get(), &output_names_, &output_names_ptr_);

--- a/sherpa-onnx/csrc/transducer-keyword-decoder.cc
+++ b/sherpa-onnx/csrc/transducer-keyword-decoder.cc
@@ -3,6 +3,7 @@
 // Copyright (c)  2023-2024  Xiaomi Corporation
 
 #include "sherpa-onnx/csrc/transducer-keyword-decoder.h"
+#include "sherpa-onnx/csrc/macros.h"
 
 #include <algorithm>
 #include <cmath>
@@ -38,7 +39,7 @@ void TransducerKeywordDecoder::Decode(
         "Size mismatch! encoder_out.size(0) %d, result.size(0): %d\n",
         static_cast<int32_t>(encoder_out_shape[0]),
         static_cast<int32_t>(result->size()));
-    exit(-1);
+    SHERPA_ONNX_EXIT(-1);
   }
 
   int32_t batch_size = static_cast<int32_t>(encoder_out_shape[0]);

--- a/sherpa-onnx/csrc/utils.cc
+++ b/sherpa-onnx/csrc/utils.cc
@@ -177,7 +177,7 @@ bool EncodeHotwords(std::istream &is, const std::string &modeling_unit,
               "given "
               "%s",
               modeling_unit.c_str());
-          exit(-1);
+          SHERPA_ONNX_EXIT(-1);
         }
         for (const auto &w : SplitUtf8(word)) {
           if (isalpha(w[0])) {

--- a/sherpa-onnx/csrc/vocoder.cc
+++ b/sherpa-onnx/csrc/vocoder.cc
@@ -20,6 +20,8 @@
 #include "sherpa-onnx/csrc/hifigan-vocoder.h"
 #include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"
+#include "sherpa-onnx/csrc/session.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 #include "sherpa-onnx/csrc/vocos-vocoder.h"
 
 namespace sherpa_onnx {
@@ -33,6 +35,48 @@ enum class ModelType : std::uint8_t {
 };
 
 }  // namespace
+
+static ModelType GetModelType(const std::string &model_path, bool debug) {
+  Ort::Env env(ORT_LOGGING_LEVEL_ERROR);
+  Ort::SessionOptions sess_opts;
+  sess_opts.SetIntraOpNumThreads(1);
+  sess_opts.SetInterOpNumThreads(1);
+
+  auto sess = std::make_unique<Ort::Session>(
+      env, SHERPA_ONNX_TO_ORT_PATH(model_path), sess_opts);
+
+
+  Ort::ModelMetadata meta_data = sess->GetModelMetadata();
+  if (debug) {
+    std::ostringstream os;
+    PrintModelMetadata(os, meta_data);
+#if __OHOS__
+    SHERPA_ONNX_LOGE("%{public}s", os.str().c_str());
+#else
+    SHERPA_ONNX_LOGE("%s", os.str().c_str());
+#endif
+  }
+
+  Ort::AllocatorWithDefaultOptions allocator;
+  auto model_type =
+      LookupCustomModelMetaData(meta_data, "model_type", allocator);
+  if (model_type.empty()) {
+    SHERPA_ONNX_LOGE(
+        "No model_type in the metadata!\n"
+        "Please make sure you are using the vocoder from "
+        "https://github.com/k2-fsa/sherpa-onnx/releases/tag/vocoder-models");
+    return ModelType::kUnknown;
+  }
+
+  if (model_type == "hifigan") {
+    return ModelType::kHifigan;
+  } else if (model_type == "vocos" || model_type == "matcha-tts vocos") {
+    return ModelType::kVocoos;
+  } else {
+    SHERPA_ONNX_LOGE("Unsupported model_type: %s", model_type.c_str());
+    return ModelType::kUnknown;
+  }
+}
 
 static ModelType GetModelType(char *model_data, size_t model_data_length,
                               bool debug) {
@@ -77,16 +121,15 @@ static ModelType GetModelType(char *model_data, size_t model_data_length,
 }
 
 std::unique_ptr<Vocoder> Vocoder::Create(const OfflineTtsModelConfig &config) {
-  std::vector<char> buffer;
+  auto model_type = ModelType::kUnknown;
   if (!config.matcha.vocoder.empty()) {
-    buffer = ReadFile(config.matcha.vocoder);
+    model_type = GetModelType(config.matcha.vocoder, config.debug);
   } else if (!config.zipvoice.vocoder.empty()) {
-    buffer = ReadFile(config.zipvoice.vocoder);
+    model_type = GetModelType(config.zipvoice.vocoder, config.debug);
   } else {
     SHERPA_ONNX_LOGE("No vocoder model provided in the config!");
     SHERPA_ONNX_EXIT(-1);
   }
-  auto model_type = GetModelType(buffer.data(), buffer.size(), config.debug);
 
   switch (model_type) {
     case ModelType::kHifigan:

--- a/sherpa-onnx/csrc/vocos-vocoder.cc
+++ b/sherpa-onnx/csrc/vocos-vocoder.cc
@@ -23,6 +23,7 @@
 #include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"
 #include "sherpa-onnx/csrc/session.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 
 namespace sherpa_onnx {
 
@@ -43,16 +44,17 @@ class VocosVocoder::Impl {
         env_(ORT_LOGGING_LEVEL_ERROR),
         sess_opts_(GetSessionOptions(config.num_threads, config.provider)),
         allocator_{} {
-    std::vector<char> buffer;
     if (!config.matcha.vocoder.empty()) {
-      buffer = ReadFile(config.matcha.vocoder);
+      sess_ = std::make_unique<Ort::Session>(
+          env_, SHERPA_ONNX_TO_ORT_PATH(config.matcha.vocoder), sess_opts_);
     } else if (!config.zipvoice.vocoder.empty()) {
-      buffer = ReadFile(config.zipvoice.vocoder);
+      sess_ = std::make_unique<Ort::Session>(
+          env_, SHERPA_ONNX_TO_ORT_PATH(config.zipvoice.vocoder), sess_opts_);
     } else {
       SHERPA_ONNX_LOGE("No vocoder model provided in the config!");
       SHERPA_ONNX_EXIT(-1);
     }
-    Init(buffer.data(), buffer.size());
+    Init(nullptr, 0);
   }
 
   template <typename Manager>
@@ -124,8 +126,15 @@ class VocosVocoder::Impl {
 
  private:
   void Init(void *model_data, size_t model_data_length) {
-    sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
-                                           sess_opts_);
+    if (model_data) {
+      sess_ = std::make_unique<Ort::Session>(env_, model_data, model_data_length,
+                                             sess_opts_);
+    } else if (!sess_) {
+      SHERPA_ONNX_LOGE(
+          "Please pass model data or initialize the session outside of this "
+          "function");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     GetInputNames(sess_.get(), &input_names_, &input_names_ptr_);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved process termination handling with buffer flushing across the codebase
  * Refactored model session initialization to use file paths instead of in-memory buffers
  * Standardized error exit paths across multiple model implementations and utility functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->