### PR TITLE
Fix incorrect URL in dotnet README

### DIFF
--- a/scripts/dotnet/README.md
+++ b/scripts/dotnet/README.md
@@ -13,5 +13,5 @@ See the documentation https://k2-fsa.github.io/sherpa/onnx/index.html
 for details.
 
 Please see
-https://github.com/k2-fsa/sherpa-onnx/tree/dot-net/dotnet-examples
+https://github.com/k2-fsa/sherpa-onnx/tree/master/dotnet-examples
 for how to use C# APIs of this package.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation reference link to point to the correct repository location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->