### PR TITLE
Use onnxruntime 1.24.3 for Android

### DIFF
--- a/build-android-arm64-v8a.sh
+++ b/build-android-arm64-v8a.sh
@@ -68,7 +68,7 @@ fi
 
 echo "ANDROID_NDK: $ANDROID_NDK"
 sleep 1
-onnxruntime_version=1.23.2
+onnxruntime_version=1.24.3
 
 if [ $BUILD_SHARED_LIBS == ON ]; then
   if [ ! -f $onnxruntime_version/jni/arm64-v8a/libonnxruntime.so ]; then

--- a/build-android-armv7-eabi.sh
+++ b/build-android-armv7-eabi.sh
@@ -69,7 +69,7 @@ fi
 echo "ANDROID_NDK: $ANDROID_NDK"
 sleep 1
 
-onnxruntime_version=1.23.2
+onnxruntime_version=1.24.3
 
 if [ $BUILD_SHARED_LIBS == ON ]; then
   if [ ! -f $onnxruntime_version/jni/armeabi-v7a/libonnxruntime.so ]; then

--- a/build-android-x86-64.sh
+++ b/build-android-x86-64.sh
@@ -69,7 +69,7 @@ fi
 echo "ANDROID_NDK: $ANDROID_NDK"
 sleep 1
 
-onnxruntime_version=1.23.2
+onnxruntime_version=1.24.3
 
 if [ $BUILD_SHARED_LIBS == ON ]; then
   if [ ! -f $onnxruntime_version/jni/x86_64/libonnxruntime.so ]; then

--- a/build-android-x86.sh
+++ b/build-android-x86.sh
@@ -49,7 +49,7 @@ fi
 echo "ANDROID_NDK: $ANDROID_NDK"
 sleep 1
 
-onnxruntime_version=1.23.2
+onnxruntime_version=1.24.3
 
 if [ ! -f $onnxruntime_version/jni/x86/libonnxruntime.so ]; then
   mkdir -p $onnxruntime_version

--- a/sherpa-onnx/kotlin-api/OfflineRecognizer.kt
+++ b/sherpa-onnx/kotlin-api/OfflineRecognizer.kt
@@ -822,6 +822,7 @@ fun getOfflineModelConfig(type: Int): OfflineModelConfig? {
                     tokenizer = "$modelDir/Qwen3-0.6B",
                 ),
                 tokens = "",
+                numThreads=3,
             )
         }
 


### PR DESCRIPTION
Fixes #3490 

Will release a new version today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ONNX Runtime dependency to v1.24.3 across all Android build configurations (arm64-v8a, armv7-eabi, x86-64, and x86).
  * Updated FunASR Nano model configuration with threading optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->