### PR TITLE
Expose ONNX Runtime memory arena options in session/public API

### DIFF
--- a/sherpa-onnx/c-api/c-api.cc
+++ b/sherpa-onnx/c-api/c-api.cc
@@ -69,6 +69,12 @@ struct SherpaOnnxDisplay {
 
 #define SHERPA_ONNX_OR(x, y) (x ? x : y)
 
+// -1: use default, 0: false, non-zero: true
+static inline bool SherpaOnnxResolveOptionalBool(int32_t v,
+                                                 bool default_value) {
+  return v < 0 ? default_value : (v != 0);
+}
+
 static sherpa_onnx::OnlineRecognizerConfig GetOnlineRecognizerConfig(
     const SherpaOnnxOnlineRecognizerConfig *config) {
   sherpa_onnx::OnlineRecognizerConfig recognizer_config;
@@ -112,9 +118,11 @@ static sherpa_onnx::OnlineRecognizerConfig GetOnlineRecognizerConfig(
   recognizer_config.model_config.provider_config.provider =
       SHERPA_ONNX_OR(config->model_config.provider, "cpu");
   recognizer_config.model_config.provider_config.enable_cpu_mem_arena =
-      SHERPA_ONNX_OR(config->model_config.enable_cpu_mem_arena, 1);
+      SherpaOnnxResolveOptionalBool(
+          config->model_config.enable_cpu_mem_arena, true);
   recognizer_config.model_config.provider_config.enable_mem_pattern =
-      SHERPA_ONNX_OR(config->model_config.enable_mem_pattern, 1);
+      SherpaOnnxResolveOptionalBool(config->model_config.enable_mem_pattern,
+                                    true);
 
   if (recognizer_config.model_config.provider_config.provider.empty()) {
     recognizer_config.model_config.provider_config.provider = "cpu";
@@ -477,9 +485,11 @@ static sherpa_onnx::OfflineRecognizerConfig GetOfflineRecognizerConfig(
   recognizer_config.model_config.provider =
       SHERPA_ONNX_OR(config->model_config.provider, "cpu");
   recognizer_config.model_config.enable_cpu_mem_arena =
-      SHERPA_ONNX_OR(config->model_config.enable_cpu_mem_arena, 1);
+      SherpaOnnxResolveOptionalBool(
+          config->model_config.enable_cpu_mem_arena, true);
   recognizer_config.model_config.enable_mem_pattern =
-      SHERPA_ONNX_OR(config->model_config.enable_mem_pattern, 1);
+      SherpaOnnxResolveOptionalBool(config->model_config.enable_mem_pattern,
+                                    true);
   if (recognizer_config.model_config.provider.empty()) {
     recognizer_config.model_config.provider = "cpu";
   }
@@ -987,9 +997,11 @@ static sherpa_onnx::KeywordSpotterConfig GetKeywordSpotterConfig(
   spotter_config.model_config.provider_config.provider =
       SHERPA_ONNX_OR(config->model_config.provider, "cpu");
   spotter_config.model_config.provider_config.enable_cpu_mem_arena =
-      SHERPA_ONNX_OR(config->model_config.enable_cpu_mem_arena, 1);
+      SherpaOnnxResolveOptionalBool(
+          config->model_config.enable_cpu_mem_arena, true);
   spotter_config.model_config.provider_config.enable_mem_pattern =
-      SHERPA_ONNX_OR(config->model_config.enable_mem_pattern, 1);
+      SherpaOnnxResolveOptionalBool(config->model_config.enable_mem_pattern,
+                                    true);
   if (spotter_config.model_config.provider_config.provider.empty()) {
     spotter_config.model_config.provider_config.provider = "cpu";
   }
@@ -1278,8 +1290,9 @@ static sherpa_onnx::VadModelConfig GetVadModelConfig(
   vad_config.num_threads = SHERPA_ONNX_OR(config->num_threads, 1);
   vad_config.provider = SHERPA_ONNX_OR(config->provider, "cpu");
   vad_config.enable_cpu_mem_arena =
-      SHERPA_ONNX_OR(config->enable_cpu_mem_arena, 1);
-  vad_config.enable_mem_pattern = SHERPA_ONNX_OR(config->enable_mem_pattern, 1);
+      SherpaOnnxResolveOptionalBool(config->enable_cpu_mem_arena, true);
+  vad_config.enable_mem_pattern =
+      SherpaOnnxResolveOptionalBool(config->enable_mem_pattern, true);
   if (vad_config.provider.empty()) {
     vad_config.provider = "cpu";
   }
@@ -2121,9 +2134,9 @@ SherpaOnnxCreateSpokenLanguageIdentification(
   slid_config.debug = config->debug;
   slid_config.provider = SHERPA_ONNX_OR(config->provider, "cpu");
   slid_config.enable_cpu_mem_arena =
-      SHERPA_ONNX_OR(config->enable_cpu_mem_arena, 1);
+      SherpaOnnxResolveOptionalBool(config->enable_cpu_mem_arena, true);
   slid_config.enable_mem_pattern =
-      SHERPA_ONNX_OR(config->enable_mem_pattern, 1);
+      SherpaOnnxResolveOptionalBool(config->enable_mem_pattern, true);
   if (slid_config.provider.empty()) {
     slid_config.provider = "cpu";
   }
@@ -2198,8 +2211,10 @@ GetSpeakerEmbeddingExtractorConfig(
   c.num_threads = SHERPA_ONNX_OR(config->num_threads, 1);
   c.debug = config->debug;
   c.provider = SHERPA_ONNX_OR(config->provider, "cpu");
-  c.enable_cpu_mem_arena = SHERPA_ONNX_OR(config->enable_cpu_mem_arena, 1);
-  c.enable_mem_pattern = SHERPA_ONNX_OR(config->enable_mem_pattern, 1);
+  c.enable_cpu_mem_arena =
+      SherpaOnnxResolveOptionalBool(config->enable_cpu_mem_arena, true);
+  c.enable_mem_pattern =
+      SherpaOnnxResolveOptionalBool(config->enable_mem_pattern, true);
   if (c.provider.empty()) {
     c.provider = "cpu";
   }

--- a/sherpa-onnx/c-api/c-api.cc
+++ b/sherpa-onnx/c-api/c-api.cc
@@ -69,10 +69,10 @@ struct SherpaOnnxDisplay {
 
 #define SHERPA_ONNX_OR(x, y) (x ? x : y)
 
-// -1: use default, 0: false, non-zero: true
+// 0: use default, negative: false, positive: true
 static inline bool SherpaOnnxResolveOptionalBool(int32_t v,
                                                  bool default_value) {
-  return v < 0 ? default_value : (v != 0);
+  return v == 0 ? default_value : (v > 0);
 }
 
 static sherpa_onnx::OnlineRecognizerConfig GetOnlineRecognizerConfig(

--- a/sherpa-onnx/c-api/c-api.cc
+++ b/sherpa-onnx/c-api/c-api.cc
@@ -1568,6 +1568,10 @@ static sherpa_onnx::OfflineTtsConfig GetOfflineTtsConfig(
       SHERPA_ONNX_OR(config->model.supertonic.voice_style, "");
 
   tts_config.model.num_threads = SHERPA_ONNX_OR(config->model.num_threads, 1);
+  tts_config.model.enable_cpu_mem_arena =
+      SherpaOnnxResolveOptionalBool(config->model.enable_cpu_mem_arena, true);
+  tts_config.model.enable_mem_pattern =
+      SherpaOnnxResolveOptionalBool(config->model.enable_mem_pattern, true);
   tts_config.model.debug = config->model.debug;
   tts_config.model.provider = SHERPA_ONNX_OR(config->model.provider, "cpu");
   if (tts_config.model.provider.empty()) {
@@ -2565,6 +2569,10 @@ static sherpa_onnx::OfflinePunctuationConfig GetOfflinePunctuationConfig(
   sherpa_onnx::OfflinePunctuationConfig c;
   c.model.ct_transformer = SHERPA_ONNX_OR(config->model.ct_transformer, "");
   c.model.num_threads = SHERPA_ONNX_OR(config->model.num_threads, 1);
+  c.model.enable_cpu_mem_arena =
+      SherpaOnnxResolveOptionalBool(config->model.enable_cpu_mem_arena, true);
+  c.model.enable_mem_pattern =
+      SherpaOnnxResolveOptionalBool(config->model.enable_mem_pattern, true);
   c.model.debug = config->model.debug;
   c.model.provider = SHERPA_ONNX_OR(config->model.provider, "cpu");
   if (c.model.provider.empty()) {
@@ -2785,6 +2793,10 @@ static sherpa_onnx::OfflineSpeechDenoiserConfig GetOfflineSpeechDenoiserConfig(
   sherpa_onnx::OfflineSpeechDenoiserConfig c;
   c.model.gtcrn.model = SHERPA_ONNX_OR(config->model.gtcrn.model, "");
   c.model.num_threads = SHERPA_ONNX_OR(config->model.num_threads, 1);
+  c.model.enable_cpu_mem_arena =
+      SherpaOnnxResolveOptionalBool(config->model.enable_cpu_mem_arena, true);
+  c.model.enable_mem_pattern =
+      SherpaOnnxResolveOptionalBool(config->model.enable_mem_pattern, true);
   c.model.debug = config->model.debug;
   c.model.provider = SHERPA_ONNX_OR(config->model.provider, "cpu");
   c.model.dpdfnet.model = SHERPA_ONNX_OR(config->model.dpdfnet.model, "");

--- a/sherpa-onnx/c-api/c-api.cc
+++ b/sherpa-onnx/c-api/c-api.cc
@@ -111,6 +111,10 @@ static sherpa_onnx::OnlineRecognizerConfig GetOnlineRecognizerConfig(
       SHERPA_ONNX_OR(config->model_config.num_threads, 1);
   recognizer_config.model_config.provider_config.provider =
       SHERPA_ONNX_OR(config->model_config.provider, "cpu");
+  recognizer_config.model_config.provider_config.enable_cpu_mem_arena =
+      SHERPA_ONNX_OR(config->model_config.enable_cpu_mem_arena, 1);
+  recognizer_config.model_config.provider_config.enable_mem_pattern =
+      SHERPA_ONNX_OR(config->model_config.enable_mem_pattern, 1);
 
   if (recognizer_config.model_config.provider_config.provider.empty()) {
     recognizer_config.model_config.provider_config.provider = "cpu";
@@ -472,6 +476,10 @@ static sherpa_onnx::OfflineRecognizerConfig GetOfflineRecognizerConfig(
   recognizer_config.model_config.debug = config->model_config.debug;
   recognizer_config.model_config.provider =
       SHERPA_ONNX_OR(config->model_config.provider, "cpu");
+  recognizer_config.model_config.enable_cpu_mem_arena =
+      SHERPA_ONNX_OR(config->model_config.enable_cpu_mem_arena, 1);
+  recognizer_config.model_config.enable_mem_pattern =
+      SHERPA_ONNX_OR(config->model_config.enable_mem_pattern, 1);
   if (recognizer_config.model_config.provider.empty()) {
     recognizer_config.model_config.provider = "cpu";
   }
@@ -978,6 +986,10 @@ static sherpa_onnx::KeywordSpotterConfig GetKeywordSpotterConfig(
       SHERPA_ONNX_OR(config->model_config.num_threads, 1);
   spotter_config.model_config.provider_config.provider =
       SHERPA_ONNX_OR(config->model_config.provider, "cpu");
+  spotter_config.model_config.provider_config.enable_cpu_mem_arena =
+      SHERPA_ONNX_OR(config->model_config.enable_cpu_mem_arena, 1);
+  spotter_config.model_config.provider_config.enable_mem_pattern =
+      SHERPA_ONNX_OR(config->model_config.enable_mem_pattern, 1);
   if (spotter_config.model_config.provider_config.provider.empty()) {
     spotter_config.model_config.provider_config.provider = "cpu";
   }
@@ -1265,6 +1277,9 @@ static sherpa_onnx::VadModelConfig GetVadModelConfig(
   vad_config.sample_rate = SHERPA_ONNX_OR(config->sample_rate, 16000);
   vad_config.num_threads = SHERPA_ONNX_OR(config->num_threads, 1);
   vad_config.provider = SHERPA_ONNX_OR(config->provider, "cpu");
+  vad_config.enable_cpu_mem_arena =
+      SHERPA_ONNX_OR(config->enable_cpu_mem_arena, 1);
+  vad_config.enable_mem_pattern = SHERPA_ONNX_OR(config->enable_mem_pattern, 1);
   if (vad_config.provider.empty()) {
     vad_config.provider = "cpu";
   }
@@ -2105,6 +2120,10 @@ SherpaOnnxCreateSpokenLanguageIdentification(
   slid_config.num_threads = SHERPA_ONNX_OR(config->num_threads, 1);
   slid_config.debug = config->debug;
   slid_config.provider = SHERPA_ONNX_OR(config->provider, "cpu");
+  slid_config.enable_cpu_mem_arena =
+      SHERPA_ONNX_OR(config->enable_cpu_mem_arena, 1);
+  slid_config.enable_mem_pattern =
+      SHERPA_ONNX_OR(config->enable_mem_pattern, 1);
   if (slid_config.provider.empty()) {
     slid_config.provider = "cpu";
   }
@@ -2179,6 +2198,8 @@ GetSpeakerEmbeddingExtractorConfig(
   c.num_threads = SHERPA_ONNX_OR(config->num_threads, 1);
   c.debug = config->debug;
   c.provider = SHERPA_ONNX_OR(config->provider, "cpu");
+  c.enable_cpu_mem_arena = SHERPA_ONNX_OR(config->enable_cpu_mem_arena, 1);
+  c.enable_mem_pattern = SHERPA_ONNX_OR(config->enable_mem_pattern, 1);
   if (c.provider.empty()) {
     c.provider = "cpu";
   }

--- a/sherpa-onnx/c-api/c-api.h
+++ b/sherpa-onnx/c-api/c-api.h
@@ -242,9 +242,9 @@ typedef struct SherpaOnnxOnlineModelConfig {
   int32_t num_threads;
   /** Execution provider, for example "cpu", "cuda", or "coreml". */
   const char *provider;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print model debug information. */
   int32_t debug;
@@ -1063,9 +1063,9 @@ typedef struct SherpaOnnxOfflineModelConfig {
   const char *tokens;
   /** Number of backend threads. */
   int32_t num_threads;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
@@ -1934,9 +1934,9 @@ typedef struct SherpaOnnxVadModelConfig {
   int32_t num_threads;
   /** Execution provider, for example "cpu" or "cuda". */
   const char *provider;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
@@ -2381,9 +2381,9 @@ typedef struct SherpaOnnxOfflineTtsModelConfig {
   SherpaOnnxOfflineTtsVitsModelConfig vits;
   /** Number of backend threads. */
   int32_t num_threads;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
@@ -2942,9 +2942,9 @@ typedef struct SherpaOnnxSpokenLanguageIdentificationConfig {
   SherpaOnnxSpokenLanguageIdentificationWhisperConfig whisper;
   /** Number of inference threads. */
   int32_t num_threads;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
@@ -3063,9 +3063,9 @@ typedef struct SherpaOnnxSpeakerEmbeddingExtractorConfig {
   const char *model;
   /** Number of inference threads. */
   int32_t num_threads;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
@@ -3415,9 +3415,9 @@ typedef struct SherpaOnnxAudioTaggingModelConfig {
   const char *ced;
   /** Number of inference threads. */
   int32_t num_threads;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
@@ -3552,9 +3552,9 @@ typedef struct SherpaOnnxOfflinePunctuationModelConfig {
   const char *ct_transformer;
   /** Number of inference threads. */
   int32_t num_threads;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
@@ -3629,9 +3629,9 @@ typedef struct SherpaOnnxOnlinePunctuationModelConfig {
   const char *bpe_vocab;
   /** Number of inference threads. */
   int32_t num_threads;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
@@ -3811,9 +3811,9 @@ typedef struct SherpaOnnxOfflineSpeakerSegmentationModelConfig {
   SherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig pyannote;
   /** Number of inference threads. */
   int32_t num_threads;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
@@ -4075,9 +4075,9 @@ typedef struct SherpaOnnxOfflineSpeechDenoiserModelConfig {
   SherpaOnnxOfflineSpeechDenoiserGtcrnModelConfig gtcrn;
   /** Number of inference threads. */
   int32_t num_threads;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
@@ -4292,9 +4292,9 @@ typedef struct SherpaOnnxOfflineSourceSeparationModelConfig {
   SherpaOnnxOfflineSourceSeparationSpleeterModelConfig spleeter;
   SherpaOnnxOfflineSourceSeparationUvrModelConfig uvr;
   int32_t num_threads;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
+  /** 0: use default, negative: false, positive: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   int32_t debug;
   const char *provider;

--- a/sherpa-onnx/c-api/c-api.h
+++ b/sherpa-onnx/c-api/c-api.h
@@ -242,6 +242,10 @@ typedef struct SherpaOnnxOnlineModelConfig {
   int32_t num_threads;
   /** Execution provider, for example "cpu", "cuda", or "coreml". */
   const char *provider;
+  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  int32_t enable_cpu_mem_arena;
+  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  int32_t enable_mem_pattern;
   /** Non-zero to print model debug information. */
   int32_t debug;
   /** Optional explicit model type override. */
@@ -1059,6 +1063,10 @@ typedef struct SherpaOnnxOfflineModelConfig {
   const char *tokens;
   /** Number of backend threads. */
   int32_t num_threads;
+  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  int32_t enable_cpu_mem_arena;
+  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
   /** Execution provider, for example "cpu" or "cuda". */
@@ -1926,6 +1934,10 @@ typedef struct SherpaOnnxVadModelConfig {
   int32_t num_threads;
   /** Execution provider, for example "cpu" or "cuda". */
   const char *provider;
+  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  int32_t enable_cpu_mem_arena;
+  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
   /** Ten VAD configuration. */
@@ -2369,6 +2381,10 @@ typedef struct SherpaOnnxOfflineTtsModelConfig {
   SherpaOnnxOfflineTtsVitsModelConfig vits;
   /** Number of backend threads. */
   int32_t num_threads;
+  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  int32_t enable_cpu_mem_arena;
+  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
   /** Execution provider, for example "cpu" or "cuda". */
@@ -2926,6 +2942,10 @@ typedef struct SherpaOnnxSpokenLanguageIdentificationConfig {
   SherpaOnnxSpokenLanguageIdentificationWhisperConfig whisper;
   /** Number of inference threads. */
   int32_t num_threads;
+  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  int32_t enable_cpu_mem_arena;
+  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
   /** Execution provider such as `"cpu"`. */
@@ -3043,6 +3063,10 @@ typedef struct SherpaOnnxSpeakerEmbeddingExtractorConfig {
   const char *model;
   /** Number of inference threads. */
   int32_t num_threads;
+  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  int32_t enable_cpu_mem_arena;
+  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
   /** Execution provider such as `"cpu"`. */
@@ -3391,6 +3415,10 @@ typedef struct SherpaOnnxAudioTaggingModelConfig {
   const char *ced;
   /** Number of inference threads. */
   int32_t num_threads;
+  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  int32_t enable_cpu_mem_arena;
+  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
   /** Execution provider such as `"cpu"`. */
@@ -3524,6 +3552,10 @@ typedef struct SherpaOnnxOfflinePunctuationModelConfig {
   const char *ct_transformer;
   /** Number of inference threads. */
   int32_t num_threads;
+  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  int32_t enable_cpu_mem_arena;
+  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
   /** Execution provider such as `"cpu"`. */
@@ -3597,6 +3629,10 @@ typedef struct SherpaOnnxOnlinePunctuationModelConfig {
   const char *bpe_vocab;
   /** Number of inference threads. */
   int32_t num_threads;
+  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  int32_t enable_cpu_mem_arena;
+  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
   /** Execution provider such as `"cpu"`. */
@@ -3775,6 +3811,10 @@ typedef struct SherpaOnnxOfflineSpeakerSegmentationModelConfig {
   SherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig pyannote;
   /** Number of inference threads. */
   int32_t num_threads;
+  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  int32_t enable_cpu_mem_arena;
+  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
   /** Execution provider such as `"cpu"`. */
@@ -4035,6 +4075,10 @@ typedef struct SherpaOnnxOfflineSpeechDenoiserModelConfig {
   SherpaOnnxOfflineSpeechDenoiserGtcrnModelConfig gtcrn;
   /** Number of inference threads. */
   int32_t num_threads;
+  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  int32_t enable_cpu_mem_arena;
+  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
   /** Execution provider such as `"cpu"`. */
@@ -4248,6 +4292,8 @@ typedef struct SherpaOnnxOfflineSourceSeparationModelConfig {
   SherpaOnnxOfflineSourceSeparationSpleeterModelConfig spleeter;
   SherpaOnnxOfflineSourceSeparationUvrModelConfig uvr;
   int32_t num_threads;
+  int32_t enable_cpu_mem_arena;
+  int32_t enable_mem_pattern;
   int32_t debug;
   const char *provider;
 } SherpaOnnxOfflineSourceSeparationModelConfig;

--- a/sherpa-onnx/c-api/c-api.h
+++ b/sherpa-onnx/c-api/c-api.h
@@ -242,9 +242,9 @@ typedef struct SherpaOnnxOnlineModelConfig {
   int32_t num_threads;
   /** Execution provider, for example "cpu", "cuda", or "coreml". */
   const char *provider;
-  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print model debug information. */
   int32_t debug;
@@ -1063,9 +1063,9 @@ typedef struct SherpaOnnxOfflineModelConfig {
   const char *tokens;
   /** Number of backend threads. */
   int32_t num_threads;
-  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
@@ -1934,9 +1934,9 @@ typedef struct SherpaOnnxVadModelConfig {
   int32_t num_threads;
   /** Execution provider, for example "cpu" or "cuda". */
   const char *provider;
-  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
@@ -2381,9 +2381,9 @@ typedef struct SherpaOnnxOfflineTtsModelConfig {
   SherpaOnnxOfflineTtsVitsModelConfig vits;
   /** Number of backend threads. */
   int32_t num_threads;
-  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
@@ -2942,9 +2942,9 @@ typedef struct SherpaOnnxSpokenLanguageIdentificationConfig {
   SherpaOnnxSpokenLanguageIdentificationWhisperConfig whisper;
   /** Number of inference threads. */
   int32_t num_threads;
-  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
@@ -3063,9 +3063,9 @@ typedef struct SherpaOnnxSpeakerEmbeddingExtractorConfig {
   const char *model;
   /** Number of inference threads. */
   int32_t num_threads;
-  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
@@ -3415,9 +3415,9 @@ typedef struct SherpaOnnxAudioTaggingModelConfig {
   const char *ced;
   /** Number of inference threads. */
   int32_t num_threads;
-  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
@@ -3552,9 +3552,9 @@ typedef struct SherpaOnnxOfflinePunctuationModelConfig {
   const char *ct_transformer;
   /** Number of inference threads. */
   int32_t num_threads;
-  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
@@ -3629,9 +3629,9 @@ typedef struct SherpaOnnxOnlinePunctuationModelConfig {
   const char *bpe_vocab;
   /** Number of inference threads. */
   int32_t num_threads;
-  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
@@ -3811,9 +3811,9 @@ typedef struct SherpaOnnxOfflineSpeakerSegmentationModelConfig {
   SherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig pyannote;
   /** Number of inference threads. */
   int32_t num_threads;
-  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
@@ -4075,9 +4075,9 @@ typedef struct SherpaOnnxOfflineSpeechDenoiserModelConfig {
   SherpaOnnxOfflineSpeechDenoiserGtcrnModelConfig gtcrn;
   /** Number of inference threads. */
   int32_t num_threads;
-  /** Non-zero to enable the ONNX Runtime CPU memory arena. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
-  /** Non-zero to enable the ONNX Runtime memory pattern optimization. */
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   /** Non-zero to print debug information. */
   int32_t debug;
@@ -4292,7 +4292,9 @@ typedef struct SherpaOnnxOfflineSourceSeparationModelConfig {
   SherpaOnnxOfflineSourceSeparationSpleeterModelConfig spleeter;
   SherpaOnnxOfflineSourceSeparationUvrModelConfig uvr;
   int32_t num_threads;
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime CPU memory arena. */
   int32_t enable_cpu_mem_arena;
+  /** -1: use default, 0: false, non-zero: true for the ONNX Runtime memory pattern optimization. */
   int32_t enable_mem_pattern;
   int32_t debug;
   const char *provider;

--- a/sherpa-onnx/c-api/cxx-api.cc
+++ b/sherpa-onnx/c-api/cxx-api.cc
@@ -103,6 +103,9 @@ OnlineRecognizer OnlineRecognizer::Create(
   c.model_config.tokens = config.model_config.tokens.c_str();
   c.model_config.num_threads = config.model_config.num_threads;
   c.model_config.provider = config.model_config.provider.c_str();
+  c.model_config.enable_cpu_mem_arena =
+      config.model_config.enable_cpu_mem_arena;
+  c.model_config.enable_mem_pattern = config.model_config.enable_mem_pattern;
   c.model_config.debug = config.model_config.debug;
   c.model_config.model_type = config.model_config.model_type.c_str();
   c.model_config.modeling_unit = config.model_config.modeling_unit.c_str();
@@ -270,6 +273,9 @@ static SherpaOnnxOfflineRecognizerConfig Convert(
 
   c.model_config.tokens = config.model_config.tokens.c_str();
   c.model_config.num_threads = config.model_config.num_threads;
+  c.model_config.enable_cpu_mem_arena =
+      config.model_config.enable_cpu_mem_arena;
+  c.model_config.enable_mem_pattern = config.model_config.enable_mem_pattern;
   c.model_config.debug = config.model_config.debug;
   c.model_config.provider = config.model_config.provider.c_str();
   c.model_config.model_type = config.model_config.model_type.c_str();
@@ -692,6 +698,9 @@ KeywordSpotter KeywordSpotter::Create(const KeywordSpotterConfig &config) {
   c.model_config.tokens = config.model_config.tokens.c_str();
   c.model_config.num_threads = config.model_config.num_threads;
   c.model_config.provider = config.model_config.provider.c_str();
+  c.model_config.enable_cpu_mem_arena =
+      config.model_config.enable_cpu_mem_arena;
+  c.model_config.enable_mem_pattern = config.model_config.enable_mem_pattern;
   c.model_config.debug = config.model_config.debug;
   c.model_config.model_type = config.model_config.model_type.c_str();
   c.model_config.modeling_unit = config.model_config.modeling_unit.c_str();
@@ -937,6 +946,8 @@ VoiceActivityDetector VoiceActivityDetector::Create(
   c.sample_rate = config.sample_rate;
   c.num_threads = config.num_threads;
   c.provider = config.provider.c_str();
+  c.enable_cpu_mem_arena = config.enable_cpu_mem_arena;
+  c.enable_mem_pattern = config.enable_mem_pattern;
   c.debug = config.debug;
 
   auto p = SherpaOnnxCreateVoiceActivityDetector(&c, buffer_size_in_seconds);

--- a/sherpa-onnx/c-api/cxx-api.h
+++ b/sherpa-onnx/c-api/cxx-api.h
@@ -134,6 +134,10 @@ struct OnlineModelConfig {
   int32_t num_threads = 1;
   /** Execution provider such as `"cpu"`. */
   std::string provider = "cpu";
+  /** Enable the ONNX Runtime CPU memory arena. */
+  bool enable_cpu_mem_arena = true;
+  /** Enable the ONNX Runtime memory pattern optimization. */
+  bool enable_mem_pattern = true;
   /** Enable verbose debug logging. */
   bool debug = false;
   /** Optional explicit model type hint. */
@@ -1360,10 +1364,14 @@ struct VadModelConfig {
 
   /** Input sample rate in Hz. */
   int32_t sample_rate = 16000;
-  /** Number of inference threads. */
+  /** Number of backend threads. */
   int32_t num_threads = 1;
   /** Execution provider such as `"cpu"`. */
   std::string provider = "cpu";
+  /** Enable the ONNX Runtime CPU memory arena. */
+  bool enable_cpu_mem_arena = true;
+  /** Enable the ONNX Runtime memory pattern optimization. */
+  bool enable_mem_pattern = true;
   /** Enable verbose debug logging. */
   bool debug = false;
 };

--- a/sherpa-onnx/c-api/cxx-api.h
+++ b/sherpa-onnx/c-api/cxx-api.h
@@ -644,6 +644,10 @@ struct OfflineModelConfig {
   std::string tokens;
   /** Number of inference threads. */
   int32_t num_threads = 1;
+  /** Enable the ONNX Runtime CPU memory arena. */
+  bool enable_cpu_mem_arena = true;
+  /** Enable the ONNX Runtime memory pattern optimization. */
+  bool enable_mem_pattern = true;
   /** Enable verbose debug logging. */
   bool debug = false;
   /** Execution provider such as `"cpu"`. */

--- a/sherpa-onnx/csrc/audio-tagging-model-config.h
+++ b/sherpa-onnx/csrc/audio-tagging-model-config.h
@@ -16,6 +16,8 @@ struct AudioTaggingModelConfig {
   std::string ced;
 
   int32_t num_threads = 1;
+  bool enable_cpu_mem_arena = true;
+  bool enable_mem_pattern = true;
   bool debug = false;
   std::string provider = "cpu";
 
@@ -24,10 +26,13 @@ struct AudioTaggingModelConfig {
   AudioTaggingModelConfig(
       const OfflineZipformerAudioTaggingModelConfig &zipformer,
       const std::string &ced, int32_t num_threads, bool debug,
-      const std::string &provider)
+      const std::string &provider, bool enable_cpu_mem_arena = true,
+      bool enable_mem_pattern = true)
       : zipformer(zipformer),
         ced(ced),
         num_threads(num_threads),
+        enable_cpu_mem_arena(enable_cpu_mem_arena),
+        enable_mem_pattern(enable_mem_pattern),
         debug(debug),
         provider(provider) {}
 

--- a/sherpa-onnx/csrc/offline-model-config.h
+++ b/sherpa-onnx/csrc/offline-model-config.h
@@ -52,6 +52,8 @@ struct OfflineModelConfig {
   int32_t num_threads = 2;
   bool debug = false;
   std::string provider = "cpu";
+  bool enable_cpu_mem_arena = true;
+  bool enable_mem_pattern = true;
 
   // With the help of this field, we only need to load the model once
   // instead of twice; and therefore it reduces initialization time.
@@ -88,9 +90,12 @@ struct OfflineModelConfig {
                      const OfflineQwen3ASRModelConfig &qwen3_asr,
                      const std::string &telespeech_ctc,
                      const std::string &tokens, int32_t num_threads, bool debug,
-                     const std::string &provider, const std::string &model_type,
-                     const std::string &modeling_unit,
-                     const std::string &bpe_vocab)
+                     const std::string &provider,
+                     bool enable_cpu_mem_arena = true,
+                     bool enable_mem_pattern = true,
+                     const std::string &model_type = "",
+                     const std::string &modeling_unit = "cjkchar",
+                     const std::string &bpe_vocab = "")
       : transducer(transducer),
         paraformer(paraformer),
         nemo_ctc(nemo_ctc),
@@ -114,6 +119,8 @@ struct OfflineModelConfig {
         num_threads(num_threads),
         debug(debug),
         provider(provider),
+        enable_cpu_mem_arena(enable_cpu_mem_arena),
+        enable_mem_pattern(enable_mem_pattern),
         model_type(model_type),
         modeling_unit(modeling_unit),
         bpe_vocab(bpe_vocab) {}

--- a/sherpa-onnx/csrc/offline-punctuation-model-config.h
+++ b/sherpa-onnx/csrc/offline-punctuation-model-config.h
@@ -16,16 +16,22 @@ struct OfflinePunctuationModelConfig {
   int32_t num_threads = 1;
   bool debug = false;
   std::string provider = "cpu";
+  bool enable_cpu_mem_arena = true;
+  bool enable_mem_pattern = true;
 
   OfflinePunctuationModelConfig() = default;
 
   OfflinePunctuationModelConfig(const std::string &ct_transformer,
                                 int32_t num_threads, bool debug,
-                                const std::string &provider)
+                                const std::string &provider,
+                                bool enable_cpu_mem_arena = true,
+                                bool enable_mem_pattern = true)
       : ct_transformer(ct_transformer),
         num_threads(num_threads),
         debug(debug),
-        provider(provider) {}
+        provider(provider),
+        enable_cpu_mem_arena(enable_cpu_mem_arena),
+        enable_mem_pattern(enable_mem_pattern) {}
 
   void Register(ParseOptions *po);
   bool Validate() const;

--- a/sherpa-onnx/csrc/offline-source-separation-model-config.h
+++ b/sherpa-onnx/csrc/offline-source-separation-model-config.h
@@ -18,6 +18,8 @@ struct OfflineSourceSeparationModelConfig {
   OfflineSourceSeparationUvrModelConfig uvr;
 
   int32_t num_threads = 1;
+  bool enable_cpu_mem_arena = true;
+  bool enable_mem_pattern = true;
   bool debug = false;
   std::string provider = "cpu";
 
@@ -26,10 +28,13 @@ struct OfflineSourceSeparationModelConfig {
   OfflineSourceSeparationModelConfig(
       const OfflineSourceSeparationSpleeterModelConfig &spleeter,
       const OfflineSourceSeparationUvrModelConfig &uvr, int32_t num_threads,
-      bool debug, const std::string &provider)
+      bool debug, const std::string &provider,
+      bool enable_cpu_mem_arena = true, bool enable_mem_pattern = true)
       : spleeter(spleeter),
         uvr(uvr),
         num_threads(num_threads),
+        enable_cpu_mem_arena(enable_cpu_mem_arena),
+        enable_mem_pattern(enable_mem_pattern),
         debug(debug),
         provider(provider) {}
 

--- a/sherpa-onnx/csrc/offline-speaker-segmentation-model-config.h
+++ b/sherpa-onnx/csrc/offline-speaker-segmentation-model-config.h
@@ -15,6 +15,8 @@ struct OfflineSpeakerSegmentationModelConfig {
   OfflineSpeakerSegmentationPyannoteModelConfig pyannote;
 
   int32_t num_threads = 1;
+  bool enable_cpu_mem_arena = true;
+  bool enable_mem_pattern = true;
   bool debug = false;
   std::string provider = "cpu";
 
@@ -22,9 +24,12 @@ struct OfflineSpeakerSegmentationModelConfig {
 
   explicit OfflineSpeakerSegmentationModelConfig(
       const OfflineSpeakerSegmentationPyannoteModelConfig &pyannote,
-      int32_t num_threads, bool debug, const std::string &provider)
+      int32_t num_threads, bool debug, const std::string &provider,
+      bool enable_cpu_mem_arena = true, bool enable_mem_pattern = true)
       : pyannote(pyannote),
         num_threads(num_threads),
+        enable_cpu_mem_arena(enable_cpu_mem_arena),
+        enable_mem_pattern(enable_mem_pattern),
         debug(debug),
         provider(provider) {}
 

--- a/sherpa-onnx/csrc/offline-speech-denoiser-model-config.h
+++ b/sherpa-onnx/csrc/offline-speech-denoiser-model-config.h
@@ -17,6 +17,8 @@ struct OfflineSpeechDenoiserModelConfig {
   OfflineSpeechDenoiserDpdfNetModelConfig dpdfnet;
 
   int32_t num_threads = 1;
+  bool enable_cpu_mem_arena = true;
+  bool enable_mem_pattern = true;
   bool debug = false;
   std::string provider = "cpu";
 
@@ -25,10 +27,13 @@ struct OfflineSpeechDenoiserModelConfig {
   OfflineSpeechDenoiserModelConfig(
       const OfflineSpeechDenoiserGtcrnModelConfig &gtcrn,
       const OfflineSpeechDenoiserDpdfNetModelConfig &dpdfnet,
-      int32_t num_threads, bool debug, const std::string &provider)
+      int32_t num_threads, bool debug, const std::string &provider,
+      bool enable_cpu_mem_arena = true, bool enable_mem_pattern = true)
       : gtcrn(gtcrn),
         dpdfnet(dpdfnet),
         num_threads(num_threads),
+        enable_cpu_mem_arena(enable_cpu_mem_arena),
+        enable_mem_pattern(enable_mem_pattern),
         debug(debug),
         provider(provider) {}
 

--- a/sherpa-onnx/csrc/offline-tts-model-config.h
+++ b/sherpa-onnx/csrc/offline-tts-model-config.h
@@ -28,6 +28,8 @@ struct OfflineTtsModelConfig {
   OfflineTtsSupertonicModelConfig supertonic;
 
   int32_t num_threads = 1;
+  bool enable_cpu_mem_arena = true;
+  bool enable_mem_pattern = true;
   bool debug = false;
   std::string provider = "cpu";
 
@@ -40,7 +42,8 @@ struct OfflineTtsModelConfig {
                         const OfflineTtsKittenModelConfig &kitten,
                         const OfflineTtsPocketModelConfig &pocket,
                         const OfflineTtsSupertonicModelConfig &supertonic,
-                        int32_t num_threads, bool debug,
+                        int32_t num_threads, bool enable_cpu_mem_arena,
+                        bool enable_mem_pattern, bool debug,
                         const std::string &provider)
       : vits(vits),
         matcha(matcha),
@@ -50,6 +53,8 @@ struct OfflineTtsModelConfig {
         pocket(pocket),
         supertonic(supertonic),
         num_threads(num_threads),
+        enable_cpu_mem_arena(enable_cpu_mem_arena),
+        enable_mem_pattern(enable_mem_pattern),
         debug(debug),
         provider(provider) {}
 

--- a/sherpa-onnx/csrc/online-punctuation-model-config.h
+++ b/sherpa-onnx/csrc/online-punctuation-model-config.h
@@ -16,6 +16,8 @@ struct OnlinePunctuationModelConfig {
   std::string bpe_vocab;
 
   int32_t num_threads = 1;
+  bool enable_cpu_mem_arena = true;
+  bool enable_mem_pattern = true;
   bool debug = false;
   std::string provider = "cpu";
 
@@ -24,10 +26,14 @@ struct OnlinePunctuationModelConfig {
   OnlinePunctuationModelConfig(const std::string &cnn_bilstm,
                                const std::string &bpe_vocab,
                                int32_t num_threads, bool debug,
-                               const std::string &provider)
+                               const std::string &provider,
+                               bool enable_cpu_mem_arena = true,
+                               bool enable_mem_pattern = true)
       : cnn_bilstm(cnn_bilstm),
         bpe_vocab(bpe_vocab),
         num_threads(num_threads),
+        enable_cpu_mem_arena(enable_cpu_mem_arena),
+        enable_mem_pattern(enable_mem_pattern),
         debug(debug),
         provider(provider) {}
 

--- a/sherpa-onnx/csrc/provider-config.cc
+++ b/sherpa-onnx/csrc/provider-config.cc
@@ -110,6 +110,10 @@ void ProviderConfig::Register(ParseOptions *po) {
   po->Register("device", &device, "GPU device index for CUDA and Trt EP");
   po->Register("provider", &provider,
                "Specify a provider to use: cpu, cuda, coreml");
+  po->Register("enable-cpu-mem-arena", &enable_cpu_mem_arena,
+               "Enable ONNX Runtime CPU memory arena.");
+  po->Register("enable-mem-pattern", &enable_mem_pattern,
+               "Enable ONNX Runtime memory pattern optimization.");
 }
 
 bool ProviderConfig::Validate() const {
@@ -135,6 +139,10 @@ std::string ProviderConfig::ToString() const {
   os << "ProviderConfig(";
   os << "device=" << device << ", ";
   os << "provider=\"" << provider << "\", ";
+  os << "enable_cpu_mem_arena=\""
+     << (enable_cpu_mem_arena ? "True" : "False") << "\", ";
+  os << "enable_mem_pattern=\""
+     << (enable_mem_pattern ? "True" : "False") << "\", ";
   os << "cuda_config=" << cuda_config.ToString() << ", ";
   os << "trt_config=" << trt_config.ToString() << ")";
   return os.str();

--- a/sherpa-onnx/csrc/provider-config.h
+++ b/sherpa-onnx/csrc/provider-config.h
@@ -69,18 +69,28 @@ struct ProviderConfig {
   CudaConfig cuda_config;
   std::string provider = "cpu";
   int32_t device = 0;
+  bool enable_cpu_mem_arena = true;
+  bool enable_mem_pattern = true;
   // device only used for cuda and trt
 
   ProviderConfig() = default;
-  ProviderConfig(const std::string &provider, int32_t device)
-      : provider(provider), device(device) {}
+  ProviderConfig(const std::string &provider, int32_t device,
+                 bool enable_cpu_mem_arena = true,
+                 bool enable_mem_pattern = true)
+      : provider(provider),
+        device(device),
+        enable_cpu_mem_arena(enable_cpu_mem_arena),
+        enable_mem_pattern(enable_mem_pattern) {}
   ProviderConfig(const TensorrtConfig &trt_config,
                  const CudaConfig &cuda_config, const std::string &provider,
-                 int32_t device)
+                 int32_t device, bool enable_cpu_mem_arena = true,
+                 bool enable_mem_pattern = true)
       : trt_config(trt_config),
         cuda_config(cuda_config),
         provider(provider),
-        device(device) {}
+        device(device),
+        enable_cpu_mem_arena(enable_cpu_mem_arena),
+        enable_mem_pattern(enable_mem_pattern) {}
 
   void Register(ParseOptions *po);
   bool Validate() const;

--- a/sherpa-onnx/csrc/session.cc
+++ b/sherpa-onnx/csrc/session.cc
@@ -146,6 +146,14 @@ Ort::SessionOptions GetSessionOptionsImpl(
 
   sess_opts.SetInterOpNumThreads(num_threads);
 
+  if (provider_config != nullptr && !provider_config->enable_mem_pattern) {
+    sess_opts.DisableMemPattern();
+  }
+
+  if (provider_config != nullptr && !provider_config->enable_cpu_mem_arena) {
+    sess_opts.DisableCpuMemArena();
+  }
+
   std::vector<std::string> available_providers = Ort::GetAvailableProviders();
   std::ostringstream os;
   for (const auto &ep : available_providers) {

--- a/sherpa-onnx/csrc/session.h
+++ b/sherpa-onnx/csrc/session.h
@@ -11,6 +11,7 @@
 #include "sherpa-onnx/csrc/offline-lm-config.h"
 #include "sherpa-onnx/csrc/online-lm-config.h"
 #include "sherpa-onnx/csrc/online-model-config.h"
+#include "sherpa-onnx/csrc/provider-config.h"
 
 namespace sherpa_onnx {
 
@@ -31,7 +32,13 @@ Ort::SessionOptions GetSessionOptions(int32_t num_threads,
 
 template <typename T>
 Ort::SessionOptions GetSessionOptions(const T &config) {
-  return GetSessionOptionsImpl(config.num_threads, config.provider);
+  ProviderConfig provider_config;
+  provider_config.provider = config.provider;
+  provider_config.enable_cpu_mem_arena = config.enable_cpu_mem_arena;
+  provider_config.enable_mem_pattern = config.enable_mem_pattern;
+
+  return GetSessionOptionsImpl(config.num_threads, config.provider,
+                               &provider_config);
 }
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/speaker-embedding-extractor.h
+++ b/sherpa-onnx/csrc/speaker-embedding-extractor.h
@@ -19,14 +19,20 @@ struct SpeakerEmbeddingExtractorConfig {
   int32_t num_threads = 1;
   bool debug = false;
   std::string provider = "cpu";
+  bool enable_cpu_mem_arena = true;
+  bool enable_mem_pattern = true;
 
   SpeakerEmbeddingExtractorConfig() = default;
   SpeakerEmbeddingExtractorConfig(const std::string &model, int32_t num_threads,
-                                  bool debug, const std::string &provider)
+                                  bool debug, const std::string &provider,
+                                  bool enable_cpu_mem_arena = true,
+                                  bool enable_mem_pattern = true)
       : model(model),
         num_threads(num_threads),
         debug(debug),
-        provider(provider) {}
+        provider(provider),
+        enable_cpu_mem_arena(enable_cpu_mem_arena),
+        enable_mem_pattern(enable_mem_pattern) {}
 
   void Register(ParseOptions *po);
   bool Validate() const;

--- a/sherpa-onnx/csrc/spoken-language-identification.h
+++ b/sherpa-onnx/csrc/spoken-language-identification.h
@@ -52,16 +52,21 @@ struct SpokenLanguageIdentificationConfig {
   int32_t num_threads = 1;
   bool debug = false;
   std::string provider = "cpu";
+  bool enable_cpu_mem_arena = true;
+  bool enable_mem_pattern = true;
 
   SpokenLanguageIdentificationConfig() = default;
 
   SpokenLanguageIdentificationConfig(
       const SpokenLanguageIdentificationWhisperConfig &whisper,
-      int32_t num_threads, bool debug, const std::string &provider)
+      int32_t num_threads, bool debug, const std::string &provider,
+      bool enable_cpu_mem_arena = true, bool enable_mem_pattern = true)
       : whisper(whisper),
         num_threads(num_threads),
         debug(debug),
-        provider(provider) {}
+        provider(provider),
+        enable_cpu_mem_arena(enable_cpu_mem_arena),
+        enable_mem_pattern(enable_mem_pattern) {}
 
   void Register(ParseOptions *po);
   bool Validate() const;

--- a/sherpa-onnx/csrc/vad-model-config.h
+++ b/sherpa-onnx/csrc/vad-model-config.h
@@ -19,6 +19,8 @@ struct VadModelConfig {
   int32_t sample_rate = 16000;
   int32_t num_threads = 1;
   std::string provider = "cpu";
+  bool enable_cpu_mem_arena = true;
+  bool enable_mem_pattern = true;
 
   // true to show debug information when loading models
   bool debug = false;
@@ -27,12 +29,15 @@ struct VadModelConfig {
 
   VadModelConfig(const SileroVadModelConfig &silero_vad,
                  const TenVadModelConfig &ten_vad, int32_t sample_rate,
-                 int32_t num_threads, const std::string &provider, bool debug)
+                 int32_t num_threads, const std::string &provider,
+                 bool enable_cpu_mem_arena, bool enable_mem_pattern, bool debug)
       : silero_vad(silero_vad),
         ten_vad(ten_vad),
         sample_rate(sample_rate),
         num_threads(num_threads),
         provider(provider),
+        enable_cpu_mem_arena(enable_cpu_mem_arena),
+        enable_mem_pattern(enable_mem_pattern),
         debug(debug) {}
 
   void Register(ParseOptions *po);

--- a/sherpa-onnx/csrc/vad-model-config.h
+++ b/sherpa-onnx/csrc/vad-model-config.h
@@ -30,7 +30,8 @@ struct VadModelConfig {
   VadModelConfig(const SileroVadModelConfig &silero_vad,
                  const TenVadModelConfig &ten_vad, int32_t sample_rate,
                  int32_t num_threads, const std::string &provider,
-                 bool enable_cpu_mem_arena, bool enable_mem_pattern, bool debug)
+                 bool enable_cpu_mem_arena = true,
+                 bool enable_mem_pattern = true, bool debug = false)
       : silero_vad(silero_vad),
         ten_vad(ten_vad),
         sample_rate(sample_rate),


### PR DESCRIPTION
This PR exposes ONNX Runtime memory allocation settings so users can control:

- `enable_mem_pattern`
- `enable_cpu_mem_arena`

The main motivation is to allow bindings and downstream users to disable ONNX Runtime memory arena behavior when needed, while keeping the current default behavior unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tri-state toggles for ONNX Runtime CPU memory arena and memory pattern across many model configs (ASR, VAD, TTS, spoken-language ID, speaker embedding, keyword spotting, audio tagging, punctuation, speaker segmentation, denoiser, source separation). Defaults are enabled; configs can explicitly enable, disable, or inherit the default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->