### PR TITLE
Update onnxruntime to use v1.24.4

### DIFF
--- a/.github/workflows/build-wheels-linux-cuda.yaml
+++ b/.github/workflows/build-wheels-linux-cuda.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
-        onnxruntime_version: ["1.17.1", "1.23.2"]
+        onnxruntime_version: ["1.17.1", "1.24.4"]
 
     steps:
       - uses: actions/checkout@v4
@@ -80,7 +80,7 @@ jobs:
           export SHERPA_ONNXRUNTIME_LIB_DIR=$PWD/onnxruntime-linux-x64-gpu-$onnxruntime_version-patched/lib
           export SHERPA_ONNXRUNTIME_INCLUDE_DIR=$PWD/onnxruntime-linux-x64-gpu-$onnxruntime_version-patched/include
 
-          if [[ $onnxruntime_version == "1.23.2" ]]; then
+          if [[ $onnxruntime_version == "1.24.4" ]]; then
             export SHERPA_ONNX_CUDA_VERSION="12.cudnn9"
           fi
 

--- a/.github/workflows/build-wheels-win64-cuda.yaml
+++ b/.github/workflows/build-wheels-win64-cuda.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [windows-2022]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
-        onnxruntime_version: ["1.17.1", "1.23.2"]
+        onnxruntime_version: ["1.17.1", "1.24.4"]
 
     steps:
       - uses: actions/checkout@v4
@@ -52,7 +52,7 @@ jobs:
           export SHERPA_ONNXRUNTIME_LIB_DIR=$PWD/onnxruntime-win-x64-gpu-$onnxruntime_version/lib
           export SHERPA_ONNXRUNTIME_INCLUDE_DIR=$PWD/onnxruntime-win-x64-gpu-$onnxruntime_version/include
 
-          if [[ $onnxruntime_version == "1.23.2" ]]; then
+          if [[ $onnxruntime_version == "1.24.4" ]]; then
             export SHERPA_ONNX_CUDA_VERSION="12.cudnn9"
           fi
 

--- a/.github/workflows/jar.yaml
+++ b/.github/workflows/jar.yaml
@@ -101,7 +101,7 @@ jobs:
           dst=sherpa-onnx/java-api/resources/sherpa-onnx/native/osx-aarch64
 
           mkdir -p $dst
-          cp -v $src/lib/libonnxruntime.1.23.2.dylib $dst/
+          cp -v $src/lib/libonnxruntime.1.24.4.dylib $dst/
           cp -v $src/lib/libsherpa-onnx-jni.dylib $dst/
 
           ls -lh $dst
@@ -119,7 +119,7 @@ jobs:
           dst=sherpa-onnx/java-api/resources/sherpa-onnx/native/osx-x64
 
           mkdir -p $dst
-          cp -v $src/lib/libonnxruntime.1.23.2.dylib $dst/
+          cp -v $src/lib/libonnxruntime.1.24.4.dylib $dst/
           cp -v $src/lib/libsherpa-onnx-jni.dylib $dst/
 
           ls -lh $dst

--- a/.github/workflows/linux-gpu.yaml
+++ b/.github/workflows/linux-gpu.yaml
@@ -36,7 +36,7 @@ jobs:
         os: [ubuntu-latest]
         # build_type: [Release, Debug]
         build_type: [Release]
-        onnxruntime_version: ["1.17.1", "1.23.2"]
+        onnxruntime_version: ["1.17.1", "1.24.4"]
 
     steps:
       - uses: actions/checkout@v4
@@ -143,7 +143,7 @@ jobs:
           dst=sherpa-onnx-${SHERPA_ONNX_VERSION}-linux-x64-gpu
 
           onnxruntime_version=${{ matrix.onnxruntime_version }}
-          if [[ $onnxruntime_version == "1.23.2" ]]; then
+          if [[ $onnxruntime_version == "1.24.4" ]]; then
             dst=sherpa-onnx-${SHERPA_ONNX_VERSION}-cuda-12.x-cudnn-9.x-linux-x64-gpu
           fi
 

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -137,7 +137,7 @@ jobs:
             rm ./lib/*.a
             rm ./lib/libonnxruntime.dylib
             cd lib
-            ln -s libonnxruntime.1.23.2.dylib libonnxruntime.dylib
+            ln -s libonnxruntime.1.24.4.dylib libonnxruntime.dylib
             cd ..
           fi
 

--- a/.github/workflows/test-onnxruntime-version.yaml
+++ b/.github/workflows/test-onnxruntime-version.yaml
@@ -73,7 +73,6 @@ jobs:
 
           cmake \
             -D BUILD_SHARED_LIBS=ON \
-            -D CMAKE_OSX_ARCHITECTURES='arm64;x86_64' \
             -D CMAKE_INSTALL_PREFIX=./install \
             ..
 

--- a/.github/workflows/test-onnxruntime-version.yaml
+++ b/.github/workflows/test-onnxruntime-version.yaml
@@ -22,7 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        version: ["1.11.0", "1.11.1", "1.12.0", "1.12.1", "1.13.1", "1.14.0", "1.14.1", "1.15.0", "1.15.1", "1.16.1", "1.16.2", "1.17.0", "1.17.1", "1.17.3", "1.18.0", "1.18.1", "1.19.0", "1.19.2", "1.20.0", "1.20.1", "1.20.2", "1.21.0", "1.21.1", "1.22.0", "1.22.1", "1.22.2", "1.23.0", "1.23.1", "1.23.2"]
+        # version: ["1.11.0", "1.11.1", "1.12.0", "1.12.1", "1.13.1", "1.14.0", "1.14.1", "1.15.0", "1.15.1", "1.16.1", "1.16.2", "1.17.0", "1.17.1", "1.17.3", "1.18.0", "1.18.1", "1.19.0", "1.19.2", "1.20.0", "1.20.1", "1.20.2", "1.21.0", "1.21.1", "1.22.0", "1.22.1", "1.22.2", "1.23.0", "1.23.1", "1.23.2", "1.24.4"]
+        version: ["1.24.4"]
 
     steps:
       - uses: actions/checkout@v4
@@ -44,21 +45,22 @@ jobs:
         shell: bash
         run: |
           version=${{ matrix.version }}
-          curl -SL -O https://github.com/microsoft/onnxruntime/releases/download/v${version}/onnxruntime-osx-universal2-${version}.tgz
-          tar xvf onnxruntime-osx-universal2-${version}.tgz
-          ls -lh onnxruntime-osx-universal2-${version}
+          curl -SL -O https://github.com/microsoft/onnxruntime/releases/download/v${version}/onnxruntime-osx-arm64-${version}.tgz
 
-          ls -lh onnxruntime-osx-universal2-${version}
+          tar xvf onnxruntime-osx-arm64-${version}.tgz
+          ls -lh onnxruntime-osx-arm64-${version}
+
+          ls -lh onnxruntime-osx-arm64-${version}
           echo "---"
-          ls -lh onnxruntime-osx-universal2-${version}/include
+          ls -lh onnxruntime-osx-arm64-${version}/include
           echo "---"
-          ls -lh onnxruntime-osx-universal2-${version}/lib
+          ls -lh onnxruntime-osx-arm64-${version}/lib
 
       - name: Configure CMake
         shell: bash
         run: |
           version=${{ matrix.version }}
-          onnxruntime_dir=$PWD/onnxruntime-osx-universal2-${version}
+          onnxruntime_dir=$PWD/onnxruntime-osx-arm64-${version}
           export SHERPA_ONNXRUNTIME_LIB_DIR=$onnxruntime_dir/lib/
           export SHERPA_ONNXRUNTIME_INCLUDE_DIR=$onnxruntime_dir/include/
 
@@ -79,7 +81,7 @@ jobs:
         shell: bash
         run: |
           version=${{ matrix.version }}
-          onnxruntime_dir=$PWD/onnxruntime-osx-universal2-${version}
+          onnxruntime_dir=$PWD/onnxruntime-osx-arm64-${version}
           export SHERPA_ONNXRUNTIME_LIB_DIR=$onnxruntime_dir/lib/
           export SHERPA_ONNXRUNTIME_INCLUDE_DIR=$onnxruntime_dir/include/
 
@@ -112,7 +114,7 @@ jobs:
         run: |
           SHERPA_ONNX_VERSION=v$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
 
-          dst=sherpa-onnx-${SHERPA_ONNX_VERSION}-onnxruntime-${{ matrix.version }}-osx-universal2-shared
+          dst=sherpa-onnx-${SHERPA_ONNX_VERSION}-onnxruntime-${{ matrix.version }}-osx-arm64-shared
           mkdir $dst
 
           cp -a build/install/bin $dst/
@@ -131,7 +133,7 @@ jobs:
         with:
           file_glob: true
           overwrite: true
-          file: sherpa-onnx-*osx-universal2*.tar.bz2
+          file: sherpa-onnx-*osx-arm64*.tar.bz2
 
       - name: Test offline Cohere Transcribe
         if: matrix.build_type != 'Debug' && !startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/windows-x64-cuda.yaml
+++ b/.github/workflows/windows-x64-cuda.yaml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2022]
-        onnxruntime_version: ["1.17.1", "1.23.2"]
+        onnxruntime_version: ["1.17.1", "1.24.4"]
 
     steps:
       - uses: actions/checkout@v4
@@ -84,7 +84,7 @@ jobs:
           dst=sherpa-onnx-${SHERPA_ONNX_VERSION}-win-x64-cuda
 
           onnxruntime_version=${{ matrix.onnxruntime_version }}
-          if [[ $onnxruntime_version == "1.23.2" ]]; then
+          if [[ $onnxruntime_version == "1.24.4" ]]; then
             dst=sherpa-onnx-${SHERPA_ONNX_VERSION}-cuda-12.x-cudnn-9.x-win-x64-cuda
           fi
 

--- a/cmake/onnxruntime-linux-aarch64-static.cmake
+++ b/cmake/onnxruntime-linux-aarch64-static.cmake
@@ -14,19 +14,19 @@ if(BUILD_SHARED_LIBS)
   message(FATAL_ERROR "This file is for building static libraries. BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 endif()
 
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.23.2/onnxruntime-linux-aarch64-static_lib-1.23.2-glibc2_17.zip")
-set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.23.2/onnxruntime-linux-aarch64-static_lib-1.23.2-glibc2_17.zip")
-set(onnxruntime_HASH "SHA256=7a603d836aa27d37197eb76f055d3c9e4e81d3a5a343c60000d7b6345bc6c80f")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/onnxruntime-linux-aarch64-static_lib-1.24.4-glibc2_17.zip")
+set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.24.4/onnxruntime-linux-aarch64-static_lib-1.24.4-glibc2_17.zip")
+set(onnxruntime_HASH "SHA256=14fb3e231f33ceab1d488d3f5daf0549e48202420f52a6b9d8eb582809506f85")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-linux-aarch64-static_lib-1.23.2-glibc2_17.zip
-  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-aarch64-static_lib-1.23.2-glibc2_17.zip
-  ${CMAKE_BINARY_DIR}/onnxruntime-linux-aarch64-static_lib-1.23.2-glibc2_17.zip
-  /tmp/onnxruntime-linux-aarch64-static_lib-1.23.2-glibc2_17.zip
-  /star-fj/fangjun/download/github/onnxruntime-linux-aarch64-static_lib-1.23.2-glibc2_17.zip
+  $ENV{HOME}/Downloads/onnxruntime-linux-aarch64-static_lib-1.24.4-glibc2_17.zip
+  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-aarch64-static_lib-1.24.4-glibc2_17.zip
+  ${CMAKE_BINARY_DIR}/onnxruntime-linux-aarch64-static_lib-1.24.4-glibc2_17.zip
+  /tmp/onnxruntime-linux-aarch64-static_lib-1.24.4-glibc2_17.zip
+  /star-fj/fangjun/download/github/onnxruntime-linux-aarch64-static_lib-1.24.4-glibc2_17.zip
 )
 
 foreach(f IN LISTS possible_file_locations)

--- a/cmake/onnxruntime-linux-aarch64.cmake
+++ b/cmake/onnxruntime-linux-aarch64.cmake
@@ -14,19 +14,19 @@ if(NOT BUILD_SHARED_LIBS)
   message(FATAL_ERROR "This file is for building shared libraries. BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 endif()
 
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.23.2/onnxruntime-linux-aarch64-glibc2_17-Release-1.23.2.zip")
-set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.23.2/onnxruntime-linux-aarch64-glibc2_17-Release-1.23.2.zip")
-set(onnxruntime_HASH "SHA256=2a40a5323827bc59844d00ffdd3697d5e30dccb691233054bace0dc61cfa8341")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/onnxruntime-linux-aarch64-glibc2_17-Release-1.24.4.zip")
+set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.24.4/onnxruntime-linux-aarch64-glibc2_17-Release-1.24.4.zip")
+set(onnxruntime_HASH "SHA256=c6a1971a8bfc8eaa07d48478d796245a747e75f510859574c9253dc7f1e9dc9a")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-linux-aarch64-glibc2_17-Release-1.23.2.zip
-  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-aarch64-glibc2_17-Release-1.23.2.zip
-  ${CMAKE_BINARY_DIR}/onnxruntime-linux-aarch64-glibc2_17-Release-1.23.2.zip
-  /tmp/onnxruntime-linux-aarch64-glibc2_17-Release-1.23.2.zip
-  /star-fj/fangjun/download/github/onnxruntime-linux-aarch64-glibc2_17-Release-1.23.2.zip
+  $ENV{HOME}/Downloads/onnxruntime-linux-aarch64-glibc2_17-Release-1.24.4.zip
+  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-aarch64-glibc2_17-Release-1.24.4.zip
+  ${CMAKE_BINARY_DIR}/onnxruntime-linux-aarch64-glibc2_17-Release-1.24.4.zip
+  /tmp/onnxruntime-linux-aarch64-glibc2_17-Release-1.24.4.zip
+  /star-fj/fangjun/download/github/onnxruntime-linux-aarch64-glibc2_17-Release-1.24.4.zip
 )
 
 foreach(f IN LISTS possible_file_locations)

--- a/cmake/onnxruntime-linux-arm-static.cmake
+++ b/cmake/onnxruntime-linux-arm-static.cmake
@@ -15,19 +15,19 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 # requires gcc 11
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.23.2/onnxruntime-linux-arm-static_lib-1.23.2.zip")
-set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-linux-arm-static_lib-1.23.2.zip")
-set(onnxruntime_HASH "SHA256=334a51dbdc6812f91ee88356cedca14b097ed2907c80aa2b91670680e155ad9f")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/onnxruntime-linux-arm-static_lib-1.24.4.zip")
+set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.24.4/onnxruntime-linux-arm-static_lib-1.24.4.zip")
+set(onnxruntime_HASH "SHA256=c21be2d3321e845faf675900e68c0fed30ac7b0712c7ae2fe1c1c72d592f6439")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-linux-arm-static_lib-1.23.2.zip
-  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-arm-static_lib-1.23.2.zip
-  ${CMAKE_BINARY_DIR}/onnxruntime-linux-arm-static_lib-1.23.2.zip
-  /tmp/onnxruntime-linux-arm-static_lib-1.23.2.zip
-  /star-fj/fangjun/download/github/onnxruntime-linux-arm-static_lib-1.23.2.zip
+  $ENV{HOME}/Downloads/onnxruntime-linux-arm-static_lib-1.24.4.zip
+  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-arm-static_lib-1.24.4.zip
+  ${CMAKE_BINARY_DIR}/onnxruntime-linux-arm-static_lib-1.24.4.zip
+  /tmp/onnxruntime-linux-arm-static_lib-1.24.4.zip
+  /star-fj/fangjun/download/github/onnxruntime-linux-arm-static_lib-1.24.4.zip
 )
 
 foreach(f IN LISTS possible_file_locations)

--- a/cmake/onnxruntime-linux-arm.cmake
+++ b/cmake/onnxruntime-linux-arm.cmake
@@ -15,19 +15,19 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 
 # requires gcc 11
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.23.2/onnxruntime-linux-arm-1.23.2.zip")
-set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.23.2/onnxruntime-linux-arm-1.23.2.zip")
-set(onnxruntime_HASH "SHA256=c00aae409731930433badaf7d629499b9a1dcfac4dd67ad6b6a4838349bd6ba5")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/onnxruntime-linux-arm-1.24.4.zip")
+set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.24.4/onnxruntime-linux-arm-1.24.4.zip")
+set(onnxruntime_HASH "SHA256=60ea23faa2ae4b153e3c471142f0fc666a52342dea2cc5df8b4cbb3ce776e82b")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-linux-arm-1.23.2.zip
-  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-arm-1.23.2.zip
-  ${CMAKE_BINARY_DIR}/onnxruntime-linux-arm-1.23.2.zip
-  /tmp/onnxruntime-linux-arm-1.23.2.zip
-  /star-fj/fangjun/download/github/onnxruntime-linux-arm-1.23.2.zip
+  $ENV{HOME}/Downloads/onnxruntime-linux-arm-1.24.4.zip
+  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-arm-1.24.4.zip
+  ${CMAKE_BINARY_DIR}/onnxruntime-linux-arm-1.24.4.zip
+  /tmp/onnxruntime-linux-arm-1.24.4.zip
+  /star-fj/fangjun/download/github/onnxruntime-linux-arm-1.24.4.zip
 )
 
 foreach(f IN LISTS possible_file_locations)

--- a/cmake/onnxruntime-linux-x86_64-gpu.cmake
+++ b/cmake/onnxruntime-linux-x86_64-gpu.cmake
@@ -20,19 +20,19 @@ endif()
 
 
 # Requires CUDA 12, cudnn 9
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.23.2/onnxruntime-linux-x64-gpu-1.23.2-patched.zip")
-set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.23.2/onnxruntime-linux-x64-gpu-1.23.2-patched.zip")
-set(onnxruntime_HASH "SHA256=e2f622513212304447e34512b99ae4eabb4fd8870dd1baac895f222179dede19")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/onnxruntime-linux-x64-gpu-1.24.4.tgz")
+set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.24.4/onnxruntime-linux-x64-gpu-1.24.4.tgz")
+set(onnxruntime_HASH "SHA256=c5f804ff5d239b436fa59e9f2fb288a39f7eb9552f6a636c8b71e792e91a8808")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-linux-x64-gpu-1.23.2-patched.zip
-  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-x64-gpu-1.23.2-patched.zip
-  ${CMAKE_BINARY_DIR}/onnxruntime-linux-x64-gpu-1.23.2-patched.zip
-  /tmp/onnxruntime-linux-x64-gpu-1.23.2-patched.zip
-  /star-fj/fangjun/download/github/onnxruntime-linux-x64-gpu-1.23.2-patched.zip
+  $ENV{HOME}/Downloads/onnxruntime-linux-x64-gpu-1.24.4.tgz
+  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-x64-gpu-1.24.4.tgz
+  ${CMAKE_BINARY_DIR}/onnxruntime-linux-x64-gpu-1.24.4.tgz
+  /tmp/onnxruntime-linux-x64-gpu-1.24.4.tgz
+  /star-fj/fangjun/download/github/onnxruntime-linux-x64-gpu-1.24.4.tgz
 )
 
 foreach(f IN LISTS possible_file_locations)

--- a/cmake/onnxruntime-linux-x86_64-static.cmake
+++ b/cmake/onnxruntime-linux-x86_64-static.cmake
@@ -14,19 +14,19 @@ if(BUILD_SHARED_LIBS)
   message(FATAL_ERROR "This file is for building static libraries. BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 endif()
 
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.23.2/onnxruntime-linux-x64-static_lib-1.23.2-glibc2_17.zip")
-set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.23.2/onnxruntime-linux-x64-static_lib-1.23.2-glibc2_17.zip")
-set(onnxruntime_HASH "SHA256=93a52b9d93a0932259a03090291be861ba21ad4b1b58057d3a0f57a4c4108671")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/onnxruntime-linux-x64-static_lib-1.24.4-glibc2_17.zip")
+set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.24.4/onnxruntime-linux-x64-static_lib-1.24.4-glibc2_17.zip")
+set(onnxruntime_HASH "SHA256=4244051e004612f5e83a41d02c22c23ad5b2e97eab49bc83fd20832567cb9f70")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-linux-x64-static_lib-1.23.2-glibc2_17.zip
-  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-x64-static_lib-1.23.2-glibc2_17.zip
-  ${CMAKE_BINARY_DIR}/onnxruntime-linux-x64-static_lib-1.23.2-glibc2_17.zip
-  /tmp/onnxruntime-linux-x64-static_lib-1.23.2-glibc2_17.zip
-  /star-fj/fangjun/download/github/onnxruntime-linux-x64-static_lib-1.23.2-glibc2_17.zip
+  $ENV{HOME}/Downloads/onnxruntime-linux-x64-static_lib-1.24.4-glibc2_17.zip
+  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-x64-static_lib-1.24.4-glibc2_17.zip
+  ${CMAKE_BINARY_DIR}/onnxruntime-linux-x64-static_lib-1.24.4-glibc2_17.zip
+  /tmp/onnxruntime-linux-x64-static_lib-1.24.4-glibc2_17.zip
+  /star-fj/fangjun/download/github/onnxruntime-linux-x64-static_lib-1.24.4-glibc2_17.zip
 )
 
 foreach(f IN LISTS possible_file_locations)

--- a/cmake/onnxruntime-linux-x86_64.cmake
+++ b/cmake/onnxruntime-linux-x86_64.cmake
@@ -14,19 +14,19 @@ if(NOT BUILD_SHARED_LIBS)
   message(FATAL_ERROR "This file is for building shared libraries. BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 endif()
 
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.23.2/onnxruntime-linux-x64-glibc2_17-Release-1.23.2.zip")
-set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.23.2/onnxruntime-linux-x64-glibc2_17-Release-1.23.2.zip")
-set(onnxruntime_HASH "SHA256=77ea3532dfdd8d5c66918429f7eacd80c1fea834941a14746adf3109f8e7b830")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/onnxruntime-linux-x64-glibc2_17-Release-1.24.4.zip")
+set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.24.4/onnxruntime-linux-x64-glibc2_17-Release-1.24.4.zip")
+set(onnxruntime_HASH "SHA256=2cacf5084737b30f61a5c8a60efa0408b26f3e8ca6cc0dc312fe4d52d07724f9")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-linux-x64-glibc2_17-Release-1.23.2.zip
-  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-x64-glibc2_17-Release-1.23.2.zip
-  ${CMAKE_BINARY_DIR}/onnxruntime-linux-x64-glibc2_17-Release-1.23.2.zip
-  /tmp/onnxruntime-linux-x64-glibc2_17-Release-1.23.2.zip
-  /star-fj/fangjun/download/github/onnxruntime-linux-x64-glibc2_17-Release-1.23.2.zip
+  $ENV{HOME}/Downloads/onnxruntime-linux-x64-glibc2_17-Release-1.24.4.zip
+  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-x64-glibc2_17-Release-1.24.4.zip
+  ${CMAKE_BINARY_DIR}/onnxruntime-linux-x64-glibc2_17-Release-1.24.4.zip
+  /tmp/onnxruntime-linux-x64-glibc2_17-Release-1.24.4.zip
+  /star-fj/fangjun/download/github/onnxruntime-linux-x64-glibc2_17-Release-1.24.4.zip
 )
 
 foreach(f IN LISTS possible_file_locations)

--- a/cmake/onnxruntime-osx-arm64-static.cmake
+++ b/cmake/onnxruntime-osx-arm64-static.cmake
@@ -12,18 +12,18 @@ if(BUILD_SHARED_LIBS)
   message(FATAL_ERROR "This file is for building static libraries. BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 endif()
 
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.23.2/onnxruntime-osx-arm64-static_lib-1.23.2.zip")
-set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.23.2/onnxruntime-osx-arm64-static_lib-1.23.2.zip")
-set(onnxruntime_HASH "SHA256=febeb7116f075409c554434a317cd51a2efb26abbf364c2ed77191f728a56633")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/onnxruntime-osx-arm64-static_lib-1.24.4.zip")
+set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.24.4/onnxruntime-osx-arm64-static_lib-1.24.4.zip")
+set(onnxruntime_HASH "SHA256=4752fa848d9d36143e3942537ff71736d2e581ce192a528482f7edd8d02c9ebf")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-osx-arm64-static_lib-1.23.2.zip
-  ${CMAKE_SOURCE_DIR}/onnxruntime-osx-arm64-static_lib-1.23.2.zip
-  ${CMAKE_BINARY_DIR}/onnxruntime-osx-arm64-static_lib-1.23.2.zip
-  /tmp/onnxruntime-osx-arm64-static_lib-1.23.2.zip
+  $ENV{HOME}/Downloads/onnxruntime-osx-arm64-static_lib-1.24.4.zip
+  ${CMAKE_SOURCE_DIR}/onnxruntime-osx-arm64-static_lib-1.24.4.zip
+  ${CMAKE_BINARY_DIR}/onnxruntime-osx-arm64-static_lib-1.24.4.zip
+  /tmp/onnxruntime-osx-arm64-static_lib-1.24.4.zip
 )
 
 foreach(f IN LISTS possible_file_locations)

--- a/cmake/onnxruntime-osx-arm64-static.cmake
+++ b/cmake/onnxruntime-osx-arm64-static.cmake
@@ -53,7 +53,7 @@ message(STATUS "onnxruntime is downloaded to ${onnxruntime_SOURCE_DIR}")
 # for static libraries, we use onnxruntime_lib_files directly below
 include_directories(${onnxruntime_SOURCE_DIR}/include)
 
-file(GLOB onnxruntime_lib_files "${onnxruntime_SOURCE_DIR}/lib/lib*.a")
+file(GLOB onnxruntime_lib_files "${onnxruntime_SOURCE_DIR}/lib/libonnxruntime.a")
 
 set(onnxruntime_lib_files ${onnxruntime_lib_files} PARENT_SCOPE)
 

--- a/cmake/onnxruntime-osx-arm64.cmake
+++ b/cmake/onnxruntime-osx-arm64.cmake
@@ -12,18 +12,18 @@ if(NOT BUILD_SHARED_LIBS)
   message(FATAL_ERROR "This file is for building shared libraries. BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 endif()
 
-set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-osx-arm64-1.23.2.tgz")
-set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.23.2/onnxruntime-osx-arm64-1.23.2.tgz")
-set(onnxruntime_HASH "SHA256=b4d513ab2b26f088c66891dbbc1408166708773d7cc4163de7bdca0e9bbb7856")
+set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.24.4/onnxruntime-osx-arm64-1.24.4.tgz")
+set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.24.4/onnxruntime-osx-arm64-1.24.4.tgz")
+set(onnxruntime_HASH "SHA256=93787795f47e1eee369182e43ed51b9e5da0878ab0346aecf4258979b8bba989")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-osx-arm64-1.23.2.tgz
-  ${CMAKE_SOURCE_DIR}/onnxruntime-osx-arm64-1.23.2.tgz
-  ${CMAKE_BINARY_DIR}/onnxruntime-osx-arm64-1.23.2.tgz
-  /tmp/onnxruntime-osx-arm64-1.23.2.tgz
+  $ENV{HOME}/Downloads/onnxruntime-osx-arm64-1.24.4.tgz
+  ${CMAKE_SOURCE_DIR}/onnxruntime-osx-arm64-1.24.4.tgz
+  ${CMAKE_BINARY_DIR}/onnxruntime-osx-arm64-1.24.4.tgz
+  /tmp/onnxruntime-osx-arm64-1.24.4.tgz
 )
 
 foreach(f IN LISTS possible_file_locations)

--- a/cmake/onnxruntime-osx-universal-static.cmake
+++ b/cmake/onnxruntime-osx-universal-static.cmake
@@ -13,18 +13,18 @@ if(BUILD_SHARED_LIBS)
   message(FATAL_ERROR "This file is for building static libraries. BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 endif()
 
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.23.2/onnxruntime-osx-universal2-static_lib-1.23.2.zip")
-set(onnxruntime_URL2  "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.23.2/onnxruntime-osx-universal2-static_lib-1.23.2.zip")
-set(onnxruntime_HASH "SHA256=9ea206a621d6e5550ddb9de0b96c4f666b074620f5c685b0479b5fa02c0bba76")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/onnxruntime-osx-universal2-static_lib-1.24.4.zip")
+set(onnxruntime_URL2  "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.24.4/onnxruntime-osx-universal2-static_lib-1.24.4.zip")
+set(onnxruntime_HASH "SHA256=df4e20a6583ddc81fae7b1dfa776f6c06fa9c7cd32a3af44c9369c9e75731426")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-osx-universal2-static_lib-1.23.2.zip
-  ${CMAKE_SOURCE_DIR}/onnxruntime-osx-universal2-static_lib-1.23.2.zip
-  ${CMAKE_BINARY_DIR}/onnxruntime-osx-universal2-static_lib-1.23.2.zip
-  /tmp/onnxruntime-osx-universal2-static_lib-1.23.2.zip
+  $ENV{HOME}/Downloads/onnxruntime-osx-universal2-static_lib-1.24.4.zip
+  ${CMAKE_SOURCE_DIR}/onnxruntime-osx-universal2-static_lib-1.24.4.zip
+  ${CMAKE_BINARY_DIR}/onnxruntime-osx-universal2-static_lib-1.24.4.zip
+  /tmp/onnxruntime-osx-universal2-static_lib-1.24.4.zip
 )
 
 foreach(f IN LISTS possible_file_locations)

--- a/cmake/onnxruntime-osx-universal-static.cmake
+++ b/cmake/onnxruntime-osx-universal-static.cmake
@@ -54,7 +54,7 @@ message(STATUS "onnxruntime is downloaded to ${onnxruntime_SOURCE_DIR}")
 # for static libraries, we use onnxruntime_lib_files directly below
 include_directories(${onnxruntime_SOURCE_DIR}/include)
 
-file(GLOB onnxruntime_lib_files "${onnxruntime_SOURCE_DIR}/lib/lib*.a")
+file(GLOB onnxruntime_lib_files "${onnxruntime_SOURCE_DIR}/lib/libonnxruntime.a")
 
 set(onnxruntime_lib_files ${onnxruntime_lib_files} PARENT_SCOPE)
 

--- a/cmake/onnxruntime-osx-universal.cmake
+++ b/cmake/onnxruntime-osx-universal.cmake
@@ -13,18 +13,18 @@ if(NOT BUILD_SHARED_LIBS)
   message(FATAL_ERROR "This file is for building shared libraries. BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 endif()
 
-set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-osx-universal2-1.23.2.tgz")
-set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.23.2/onnxruntime-osx-universal2-1.23.2.tgz")
-set(onnxruntime_HASH "SHA256=49ae8e3a66ccb18d98ad3fe7f5906b6d7887df8a5edd40f49eb2b14e20885809")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/onnxruntime-osx-universal2-1.24.4.zip")
+set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.24.4/onnxruntime-osx-universal2-1.24.4.zip")
+set(onnxruntime_HASH "SHA256=b3f67f521b6cc8d4a6d8f8fa9f33fbc99515559a39a99c1d4210c8f520f9af91")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-osx-universal2-1.23.2.tgz
-  ${CMAKE_SOURCE_DIR}/onnxruntime-osx-universal2-1.23.2.tgz
-  ${CMAKE_BINARY_DIR}/onnxruntime-osx-universal2-1.23.2.tgz
-  /tmp/onnxruntime-osx-universal2-1.23.2.tgz
+  $ENV{HOME}/Downloads/onnxruntime-osx-universal2-1.24.4.zip
+  ${CMAKE_SOURCE_DIR}/onnxruntime-osx-universal2-1.24.4.zip
+  ${CMAKE_BINARY_DIR}/onnxruntime-osx-universal2-1.24.4.zip
+  /tmp/onnxruntime-osx-universal2-1.24.4.zip
 )
 
 foreach(f IN LISTS possible_file_locations)

--- a/cmake/onnxruntime-osx-x86_64-static.cmake
+++ b/cmake/onnxruntime-osx-x86_64-static.cmake
@@ -12,18 +12,18 @@ if(BUILD_SHARED_LIBS)
   message(FATAL_ERROR "This file is for building static libraries. BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 endif()
 
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.23.2/onnxruntime-osx-x86_64-static_lib-1.23.2.zip")
-set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.23.2/onnxruntime-osx-x86_64-static_lib-1.23.2.zip")
-set(onnxruntime_HASH "SHA256=dc632688d5b48e478742ba1ae2d9ebc78ab6cee18fa6eb61e2fb03b8a80d1b66")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/onnxruntime-osx-x86_64-static_lib-1.24.4.zip")
+set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.24.4/onnxruntime-osx-x86_64-static_lib-1.24.4.zip")
+set(onnxruntime_HASH "SHA256=9b4f42ee1e2032524c575e0614f174533949383688f473c1a780e86f858455af")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-osx-x86_64-static_lib-1.23.2.zip
-  ${CMAKE_SOURCE_DIR}/onnxruntime-osx-x86_64-static_lib-1.23.2.zip
-  ${CMAKE_BINARY_DIR}/onnxruntime-osx-x86_64-static_lib-1.23.2.zip
-  /tmp/onnxruntime-osx-x86_64-static_lib-1.23.2.zip
+  $ENV{HOME}/Downloads/onnxruntime-osx-x86_64-static_lib-1.24.4.zip
+  ${CMAKE_SOURCE_DIR}/onnxruntime-osx-x86_64-static_lib-1.24.4.zip
+  ${CMAKE_BINARY_DIR}/onnxruntime-osx-x86_64-static_lib-1.24.4.zip
+  /tmp/onnxruntime-osx-x86_64-static_lib-1.24.4.zip
 )
 
 foreach(f IN LISTS possible_file_locations)

--- a/cmake/onnxruntime-osx-x86_64-static.cmake
+++ b/cmake/onnxruntime-osx-x86_64-static.cmake
@@ -53,7 +53,7 @@ message(STATUS "onnxruntime is downloaded to ${onnxruntime_SOURCE_DIR}")
 # for static libraries, we use onnxruntime_lib_files directly below
 include_directories(${onnxruntime_SOURCE_DIR}/include)
 
-file(GLOB onnxruntime_lib_files "${onnxruntime_SOURCE_DIR}/lib/lib*.a")
+file(GLOB onnxruntime_lib_files "${onnxruntime_SOURCE_DIR}/lib/libonnxruntime.a")
 
 set(onnxruntime_lib_files ${onnxruntime_lib_files} PARENT_SCOPE)
 

--- a/cmake/onnxruntime-osx-x86_64.cmake
+++ b/cmake/onnxruntime-osx-x86_64.cmake
@@ -12,18 +12,18 @@ if(NOT BUILD_SHARED_LIBS)
   message(FATAL_ERROR "This file is for building shared libraries. BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 endif()
 
-set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-osx-x86_64-1.23.2.tgz")
-set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.23.2/onnxruntime-osx-x86_64-1.23.2.tgz")
-set(onnxruntime_HASH "SHA256=d10359e16347b57d9959f7e80a225a5b4a66ed7d7e007274a15cae86836485a6")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/onnxruntime-osx-x86_64-1.24.4.zip")
+set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.24.4/onnxruntime-osx-x86_64-1.24.4.zip")
+set(onnxruntime_HASH "SHA256=433be4f4ba38f9fcc66939f503c310f3e239620643e66f5c4b0b9afb80a662e7")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-osx-x86_64-1.23.2.tgz
-  ${CMAKE_SOURCE_DIR}/onnxruntime-osx-x86_64-1.23.2.tgz
-  ${CMAKE_BINARY_DIR}/onnxruntime-osx-x86_64-1.23.2.tgz
-  /tmp/onnxruntime-osx-x86_64-1.23.2.tgz
+  $ENV{HOME}/Downloads/onnxruntime-osx-x86_64-1.24.4.zip
+  ${CMAKE_SOURCE_DIR}/onnxruntime-osx-x86_64-1.24.4.zip
+  ${CMAKE_BINARY_DIR}/onnxruntime-osx-x86_64-1.24.4.zip
+  /tmp/onnxruntime-osx-x86_64-1.24.4.zip
 )
 
 foreach(f IN LISTS possible_file_locations)

--- a/cmake/onnxruntime-wasm-simd.cmake
+++ b/cmake/onnxruntime-wasm-simd.cmake
@@ -10,19 +10,19 @@ if(BUILD_SHARED_LIBS)
   message(FATAL_ERROR "BUILD_SHARED_LIBS should be OFF for WebAssembly")
 endif()
 
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.17.1/onnxruntime-wasm-static_lib-simd-1.17.1.zip")
-set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/onnxruntime-wasm-static_lib-simd-1.17.1.zip")
-set(onnxruntime_HASH "SHA256=8f07778e4233cf5a61a9d0795d90c5497177fbe8a46b701fda2d8d4e2b11cef8")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/onnxruntime-wasm-static_lib-simd-1.24.4.zip")
+set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.24.4/onnxruntime-wasm-static_lib-simd-1.24.4.zip")
+set(onnxruntime_HASH "SHA256=39826f0fdf636db78b3bc38ef88a7ad0ce3304d7a80186ba0e531701eae32db3")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-wasm-static_lib-simd-1.17.1.zip
-  ${CMAKE_SOURCE_DIR}/onnxruntime-wasm-static_lib-simd-1.17.1.zip
-  ${CMAKE_BINARY_DIR}/onnxruntime-wasm-static_lib-simd-1.17.1.zip
-  /tmp/onnxruntime-wasm-static_lib-simd-1.17.1.zip
-  /star-fj/fangjun/download/github/onnxruntime-wasm-static_lib-simd-1.17.1.zip
+  $ENV{HOME}/Downloads/onnxruntime-wasm-static_lib-simd-1.24.4.zip
+  ${CMAKE_SOURCE_DIR}/onnxruntime-wasm-static_lib-simd-1.24.4.zip
+  ${CMAKE_BINARY_DIR}/onnxruntime-wasm-static_lib-simd-1.24.4.zip
+  /tmp/onnxruntime-wasm-static_lib-simd-1.24.4.zip
+  /star-fj/fangjun/download/github/onnxruntime-wasm-static_lib-simd-1.24.4.zip
 )
 
 foreach(f IN LISTS possible_file_locations)

--- a/cmake/onnxruntime-win-arm64-static.cmake
+++ b/cmake/onnxruntime-win-arm64-static.cmake
@@ -16,16 +16,16 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 # Hashes for static CRT (/MT)
-set(ONNXRUNTIME_HASH_MT_Release "SHA256=03166e5c7a830586b8772ff166611f0806fbc0ca76bcd177113fe3275a8af59b")
-set(ONNXRUNTIME_HASH_MT_Debug "SHA256=61941c8d3058ebb6f9b83c9a99e4ae840708cc99702921d7c950a071f04f26ed")
-set(ONNXRUNTIME_HASH_MT_RelWithDebInfo "SHA256=304bd830680b773ed1fce35758f317f2b50b2278359ede292e33bd67b57290b7")
-set(ONNXRUNTIME_HASH_MT_MinSizeRel "SHA256=c24f46f689f9dbb8d8cd86d4c1d83f091da82d78548371d59446566d787f8cf4")
+set(ONNXRUNTIME_HASH_MT_Release "SHA256=614d3bc6c2baf46bc3d8ff01b54ad43060e127b4fcc037e3ee9dc988918450df")
+set(ONNXRUNTIME_HASH_MT_Debug "SHA256=910af3476be91e6a61eda86b7cd1aac1e8586b883562518a1c0e2e26fdc26b9b")
+set(ONNXRUNTIME_HASH_MT_RelWithDebInfo "SHA256=66a7bd6762e1eed728b0d5cdefe44d553ea2d9e4c7d3bd1034943fae8b0d7fb8")
+set(ONNXRUNTIME_HASH_MT_MinSizeRel "SHA256=3217016a446f818c0ec8bb993f1062d2bd22596f300e2b675ed9397afd949df5")
 
 # Hashes for dynamic CRT (/MD)
-set(ONNXRUNTIME_HASH_MD_Release "SHA256=26bae6d13335ecb229baa545d8c3b910998ace4f3617a4046640b9e6ef208dd7")
-set(ONNXRUNTIME_HASH_MD_Debug "SHA256=f3e6d4550ac00c9f8f7ef647974087627f41d063e9899b67a028cca6c34521ab")
-set(ONNXRUNTIME_HASH_MD_RelWithDebInfo "SHA256=ddef98c48243b0d7209edb9d416566405fd793551f63962fbb4f049b899136b0")
-set(ONNXRUNTIME_HASH_MD_MinSizeRel "SHA256=4b28704e04f25b0839004ca828306f387814ada953750c4103f7076768fcf8a1")
+set(ONNXRUNTIME_HASH_MD_Release "SHA256=c59ea6fc8296bfe7c9b93f465641e9619c9e9011a9d57f006195e76cc7cb1853")
+set(ONNXRUNTIME_HASH_MD_Debug "SHA256=7ccd9ab60ed147997441ae12f9d56e1ed248e594ced6c63bc65598e094f9187b")
+set(ONNXRUNTIME_HASH_MD_RelWithDebInfo "SHA256=ea14a6f74544068a6ad7f8158fddc540cc3d9992271d8cca440c6898b8fbe1d7")
+set(ONNXRUNTIME_HASH_MD_MinSizeRel "SHA256=e10310fed0c28912d747a292495fc34f3d10c2272b3866a474d45bcfba5beac8")
 
 if(NOT CMAKE_BUILD_TYPE MATCHES "^(Release|Debug|RelWithDebInfo|MinSizeRel)$")
   message(FATAL_ERROR "Supported CMAKE_BUILD_TYPE values are: Release, Debug, RelWithDebInfo, MinSizeRel. Given ${CMAKE_BUILD_TYPE}")
@@ -40,8 +40,8 @@ endif()
 message(STATUS "Use MSVC CRT: ${onnxruntime_crt}")
 
 set(onnxruntime_HASH "${ONNXRUNTIME_HASH_${onnxruntime_crt}_${CMAKE_BUILD_TYPE}}")
-set(onnxruntime_filename "onnxruntime-win-arm64-static_lib-${onnxruntime_crt}-${CMAKE_BUILD_TYPE}-1.23.2.tar.bz2")
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.23.2/${onnxruntime_filename}")
+set(onnxruntime_filename "onnxruntime-win-arm64-static_lib-${onnxruntime_crt}-${CMAKE_BUILD_TYPE}-1.24.4.tar.bz2")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/${onnxruntime_filename}")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.

--- a/cmake/onnxruntime-win-arm64.cmake
+++ b/cmake/onnxruntime-win-arm64.cmake
@@ -20,16 +20,16 @@ if(NOT CMAKE_BUILD_TYPE MATCHES "^(Release|Debug|RelWithDebInfo|MinSizeRel)$")
 endif()
 
 # Hashes for static CRT (/MT)
-set(ONNXRUNTIME_HASH_MT_Debug "SHA256=c9329ff4e8acdd0a07b40465d6521e15bb21eb0a4d9bc7843803e460dc4d02f0")
-set(ONNXRUNTIME_HASH_MT_RelWithDebInfo "SHA256=342470bef5681452fb9add5668debc5e79b5cd01a8c8866fc7c47f81dbd8eb70")
-set(ONNXRUNTIME_HASH_MT_MinSizeRel "SHA256=7bcbc8fd66fa1b0783dfdbd66eeb9ad4c023a1080ccc01e80412c2347aeddfa1")
-set(ONNXRUNTIME_HASH_MT_Release "SHA256=ee3c257f4c56f91a0a6aa3cce9a29dcd654f432fe5a399246c8bdb86c9bb5900")
+set(ONNXRUNTIME_HASH_MT_Debug "SHA256=170ecd33612c78dc7b44d70cf04cf016716a65876ed93d39737651e81ca2aa84")
+set(ONNXRUNTIME_HASH_MT_RelWithDebInfo "SHA256=49f28e9306d2437e1a2e398a35ec8f42d0cb1871d30c3ccd257f3c9a008e9de7")
+set(ONNXRUNTIME_HASH_MT_MinSizeRel "SHA256=91ed93034af9c8b7dca7f62beadf035f38a49ee1210cfba970cac0d2960c208b")
+set(ONNXRUNTIME_HASH_MT_Release "SHA256=71c5fb2ac8805fc7c72986f31a070422de01a144e78bc8a6a48f3b71472a5e26")
 
 # Hashes for dynamic CRT (/MD)
-set(ONNXRUNTIME_HASH_MD_Debug "SHA256=722f044c84947e37fec7941f5dc38aa8f71cdf0b4bfa57cb590a4ed634b36ddc")
-set(ONNXRUNTIME_HASH_MD_RelWithDebInfo "SHA256=025b0dd682309482b3146b5c3a80e814ad9dec1e93ee8139954857b97d5798a9")
-set(ONNXRUNTIME_HASH_MD_MinSizeRel "SHA256=b8d5d508b21b4604d241ac11384fa6906daf556c6667011d9a8c6806d9549b74")
-set(ONNXRUNTIME_HASH_MD_Release "SHA256=08ed42a71fbce04e10a3192510a2c578a20c1d3a00652187f85002c54db84548")
+set(ONNXRUNTIME_HASH_MD_Debug "SHA256=56c2d1e8204dc8584eef256c50f6fc307db782846aacabfd6b74e3adc2c72dbd")
+set(ONNXRUNTIME_HASH_MD_RelWithDebInfo "SHA256=7e137da58e316a83e4ca438eca205df4ee8a422c43352210ceac9b05d9e313ed")
+set(ONNXRUNTIME_HASH_MD_MinSizeRel "SHA256=8b639696982625949a9616b1395fa6dc927de2f6329607c4c1f01e29d7b79391")
+set(ONNXRUNTIME_HASH_MD_Release "SHA256=d0205fc4aaf1021d805f5ca79914741ee552110e637e84a86233d1286d3a897f")
 
 if(SHERPA_ONNX_USE_STATIC_CRT)
   set(onnxruntime_crt "MT")
@@ -39,8 +39,8 @@ endif()
 
 message(STATUS "Use MSVC CRT: ${onnxruntime_crt}")
 
-set(onnxruntime_filename "onnxruntime-win-arm64-${onnxruntime_crt}-${CMAKE_BUILD_TYPE}-1.23.2.tar.bz2")
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.23.2/${onnxruntime_filename}")
+set(onnxruntime_filename "onnxruntime-win-arm64-${onnxruntime_crt}-${CMAKE_BUILD_TYPE}-1.24.4.tar.bz2")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/${onnxruntime_filename}")
 set(onnxruntime_HASH "${ONNXRUNTIME_HASH_${onnxruntime_crt}_${CMAKE_BUILD_TYPE}}")
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-win-x64-gpu.cmake
+++ b/cmake/onnxruntime-win-x64-gpu.cmake
@@ -20,18 +20,18 @@ if(NOT SHERPA_ONNX_ENABLE_GPU)
 endif()
 
 # Requires cuda 12.x, cudnn 9.x
-set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-win-x64-gpu-1.23.2.zip")
-set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.23.2/onnxruntime-win-x64-gpu-1.23.2.zip")
-set(onnxruntime_HASH "SHA256=e77afdbbc2b8cb6da4e5a50d89841b48c44f3e47dce4fb87b15a2743786d0bb9")
+set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.24.4/onnxruntime-win-x64-gpu-1.24.4.zip")
+set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.24.4/onnxruntime-win-x64-gpu-1.24.4.zip")
+set(onnxruntime_HASH "SHA256=ef3337a0b8184eb8beec310f7c83bd50376b3eefc43aab84ac8e452f6987df0a")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-win-x64-gpu-1.23.2.zip
-  ${CMAKE_SOURCE_DIR}/onnxruntime-win-x64-gpu-1.23.2.zip
-  ${CMAKE_BINARY_DIR}/onnxruntime-win-x64-gpu-1.23.2.zip
-  /tmp/onnxruntime-win-x64-gpu-1.23.2.zip
+  $ENV{HOME}/Downloads/onnxruntime-win-x64-gpu-1.24.4.zip
+  ${CMAKE_SOURCE_DIR}/onnxruntime-win-x64-gpu-1.24.4.zip
+  ${CMAKE_BINARY_DIR}/onnxruntime-win-x64-gpu-1.24.4.zip
+  /tmp/onnxruntime-win-x64-gpu-1.24.4.zip
 )
 
 foreach(f IN LISTS possible_file_locations)

--- a/cmake/onnxruntime-win-x64-static.cmake
+++ b/cmake/onnxruntime-win-x64-static.cmake
@@ -20,16 +20,16 @@ if(NOT CMAKE_BUILD_TYPE MATCHES "^(Release|Debug|RelWithDebInfo|MinSizeRel)$")
 endif()
 
 # Hashes for static CRT (/MT)
-set(ONNXRUNTIME_HASH_MT_Release "SHA256=c853a7646f9ebb0bf900e547141ef3e68d3ec888b27756ecb5f32476a6472391")
-set(ONNXRUNTIME_HASH_MT_Debug "SHA256=efd7c3aa9fa10a380e5534ead76627790dd533142307e3fd1de2d1fba533dd90")
-set(ONNXRUNTIME_HASH_MT_RelWithDebInfo "SHA256=4cf1733121eee79c9f18b048d1f5e9603079931e62af1c878c0d873ecd48900e")
-set(ONNXRUNTIME_HASH_MT_MinSizeRel "SHA256=2d362a781ff98731423688ff5a50a08e1dd0e863e2de5b1d66c6595945a60735")
+set(ONNXRUNTIME_HASH_MT_Release "SHA256=abe61a1a6094c6ed69ae1c81a3acf6dfa65d6ee2ef5b4a73a55660a6f6072ecc")
+set(ONNXRUNTIME_HASH_MT_Debug "SHA256=fabb0ae0fb72e7cfe954c3f020ebbad4dcab9cfc31f529bdbd812dc35541bfbe")
+set(ONNXRUNTIME_HASH_MT_RelWithDebInfo "SHA256=dbc7303940a22ab305332dc1904be0187ddba8b8ab692ba27e5c67de56c10a16")
+set(ONNXRUNTIME_HASH_MT_MinSizeRel "SHA256=0ebc2773e19d679eea88f06c97737ef6f2fed0ef03b90fd13309fa084871dfe7")
 
 # Hashes for dynamic CRT (/MD)
-set(ONNXRUNTIME_HASH_MD_Release "SHA256=f4596146f3aea7d9c557e466eb55af1cf8bb8e9f2a291ce4c428dd93d0501e33")
-set(ONNXRUNTIME_HASH_MD_Debug "SHA256=68aa603aa25fd1cbe7ebef465395d0b685aa66fc8fd2df0b6d6f5a1e88621c60")
-set(ONNXRUNTIME_HASH_MD_RelWithDebInfo "SHA256=ba5ae7bf3b5a29ea348f38516e7c46ff49921eb2a2e81e391f36bc932c4a7a20")
-set(ONNXRUNTIME_HASH_MD_MinSizeRel "SHA256=e57978b5811fcf795e07c33eb69f32fac5cac8b848d32acf1154ce13c9cbcfd7")
+set(ONNXRUNTIME_HASH_MD_Release "SHA256=5e60150c80c52e31722bfa5867b9dfb4ba801400ce774aeeed49d1d2246d6ed5")
+set(ONNXRUNTIME_HASH_MD_Debug "SHA256=7294a808364e86a41ee0ff95f2125cdb4f6a850712881d03938440f3df3f76e6")
+set(ONNXRUNTIME_HASH_MD_RelWithDebInfo "SHA256=4b351f226496bac25f1960fb8a7887381c50c849cc1d84dcc444223883be6714")
+set(ONNXRUNTIME_HASH_MD_MinSizeRel "SHA256=8f05361ad00249b9615c4e039d5c49f72d946f5ba95627fa7a70d04c9d8fad7a")
 
 if(SHERPA_ONNX_USE_STATIC_CRT)
   set(onnxruntime_crt "MT")
@@ -39,9 +39,9 @@ endif()
 
 message(STATUS "Use MSVC CRT: ${onnxruntime_crt}")
 
-set(onnxruntime_filename "onnxruntime-win-x64-static_lib-${onnxruntime_crt}-${CMAKE_BUILD_TYPE}-1.23.2.tar.bz2")
+set(onnxruntime_filename "onnxruntime-win-x64-static_lib-${onnxruntime_crt}-${CMAKE_BUILD_TYPE}-1.24.4.tar.bz2")
 set(onnxruntime_HASH "${ONNXRUNTIME_HASH_${onnxruntime_crt}_${CMAKE_BUILD_TYPE}}")
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.23.2/${onnxruntime_filename}")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/${onnxruntime_filename}")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.

--- a/cmake/onnxruntime-win-x64.cmake
+++ b/cmake/onnxruntime-win-x64.cmake
@@ -20,16 +20,16 @@ if(NOT CMAKE_BUILD_TYPE MATCHES "^(Release|Debug|RelWithDebInfo|MinSizeRel)$")
 endif()
 
 # Hashes for static CRT (/MT)
-set(ONNXRUNTIME_HASH_MT_Debug "SHA256=f63a1dafd63bd911135a47ccc75bd04c06a717de21b96c0d8ddb351714551124")
-set(ONNXRUNTIME_HASH_MT_RelWithDebInfo "SHA256=b5363e34544b1d6bf27161843a72dfc853d80e5f14369242378b2e244d2af632")
-set(ONNXRUNTIME_HASH_MT_MinSizeRel "SHA256=d1d4c76747020eb7ccafd9180da1a5dda0cc7d01b8cfc153fa88a9c205291c93")
-set(ONNXRUNTIME_HASH_MT_Release "SHA256=a5c917196ef3356c343a69cee919a84f40ada6e9bf756b3e6edf3d07afc8a257")
+set(ONNXRUNTIME_HASH_MT_Debug "SHA256=b288113ac7bc41c53218103fb3171bb38b83ba58a83dc132cb56b2b721784f29")
+set(ONNXRUNTIME_HASH_MT_RelWithDebInfo "SHA256=b94fd9c7a0282f2a78a5b62b7b39b64706c0b6e2f56185ae691390ad479fd2fe")
+set(ONNXRUNTIME_HASH_MT_MinSizeRel "SHA256=5060dafe237cd85c5718f4d6c77a7832920db7dc58961cac10d7e7637d83e59a")
+set(ONNXRUNTIME_HASH_MT_Release "SHA256=8e6233057d04470e8a0ca7db266801848d7f6d9390f9273828d772a707911890")
 
 # Hashes for dynamic CRT (/MD)
-set(ONNXRUNTIME_HASH_MD_Debug "SHA256=422d9aeed64c6a5fa8daf3286a2ff39485cb8eceafb0d264179dd250e240f2f0")
-set(ONNXRUNTIME_HASH_MD_RelWithDebInfo "SHA256=1bb3ca8ea37f9ca3bb6417da1756aadd984a76990bafa50950da1b679c7a1e65")
-set(ONNXRUNTIME_HASH_MD_MinSizeRel "SHA256=c1d74a28463eee3297cebf5d6ec06fc7cf207e720dcf81259c3acb0e53534ac3")
-set(ONNXRUNTIME_HASH_MD_Release "SHA256=0fffad34226a8b5bc33e7a130f77a57757f5d6623ca8e2495bc529ec3e959dd1")
+set(ONNXRUNTIME_HASH_MD_Debug "SHA256=8df39bae3f9233a6b4f99b444834972f490cde1484191bac193f81fa5c3136cd")
+set(ONNXRUNTIME_HASH_MD_RelWithDebInfo "SHA256=5652ef18a7853dd828dc3cd9309054c7107eefdf0b32888034f1df0337166293")
+set(ONNXRUNTIME_HASH_MD_MinSizeRel "SHA256=5f231ae0e27d8e787a1fcbdfa76c2c5d5f24ba2d8d35df815f783442d7f74d50")
+set(ONNXRUNTIME_HASH_MD_Release "SHA256=4e7a8342a3de35b3ab7c034ef18ca3e5b3dcff9b4bcd8188e12ac30b30f3adca")
 
 if(SHERPA_ONNX_USE_STATIC_CRT)
   set(onnxruntime_crt "MT")
@@ -39,8 +39,8 @@ endif()
 
 message(STATUS "Use MSVC CRT: ${onnxruntime_crt}")
 
-set(onnxruntime_filename "onnxruntime-win-x64-${onnxruntime_crt}-${CMAKE_BUILD_TYPE}-1.23.2.tar.bz2")
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.23.2/${onnxruntime_filename}")
+set(onnxruntime_filename "onnxruntime-win-x64-${onnxruntime_crt}-${CMAKE_BUILD_TYPE}-1.24.4.tar.bz2")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/${onnxruntime_filename}")
 set(onnxruntime_HASH "${ONNXRUNTIME_HASH_${onnxruntime_crt}_${CMAKE_BUILD_TYPE}}")
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-win-x86-static.cmake
+++ b/cmake/onnxruntime-win-x86-static.cmake
@@ -16,16 +16,16 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 # Hashes for static CRT (/MT)
-set(ONNXRUNTIME_HASH_MT_Release "SHA256=2e4ecb02d37dfb2d0ed4b4e970b9f0b0a0352a6d7cbcd95fdd693a2a2ba7a0db")
-set(ONNXRUNTIME_HASH_MT_Debug "SHA256=18b1030d47f1b0ea744b82b4f6829e991d17b4206c8059d1b2e5393bf7f29b4f")
-set(ONNXRUNTIME_HASH_MT_RelWithDebInfo "SHA256=400b6cff390fb36669abe681d34d307746c2ec0309471fe6046dc5def7ccf17e")
-set(ONNXRUNTIME_HASH_MT_MinSizeRel "SHA256=10e9faf9f22f5c784b00db1fe907ef99af845aa211add13fc8ff8dec6ed1a665")
+set(ONNXRUNTIME_HASH_MT_Release "SHA256=c8b61410a046a87536012fd142397b47a88f0779f46f52cbebd67f79c63b2e28")
+set(ONNXRUNTIME_HASH_MT_Debug "SHA256=724220303bfd9dc2b7c700d638690674ee6a0b151ec927029a93c8910252cf4e")
+set(ONNXRUNTIME_HASH_MT_RelWithDebInfo "SHA256=3f529c7b6d384d4a563e8ad7729eb0b67a55a7f06f8eec94adc4e3cbceb02950")
+set(ONNXRUNTIME_HASH_MT_MinSizeRel "SHA256=d5e5a42dda05717ba94e11d84325f2060c9c0f5c3779a7e1f38a3672c716b848")
 
 # Hashes for dynamic CRT (/MD)
-set(ONNXRUNTIME_HASH_MD_Release "SHA256=8793c5ddd6ac44d784005c05ffc8498c15c7a0f26c6b61c4689b5098823b6dad")
-set(ONNXRUNTIME_HASH_MD_Debug "SHA256=f43082bcc1f34fce1222fa5b68011d30702182e45198ac553e35add6090f3a3c")
-set(ONNXRUNTIME_HASH_MD_RelWithDebInfo "SHA256=96a0be8f1b82c5eff82a8060928dd0a27d1a8a8a94926098bdd6539655393353")
-set(ONNXRUNTIME_HASH_MD_MinSizeRel "SHA256=0fe7fc4cb4dba7afc6c1f622168700b4c98a5c01bcfd64ebe72a9c4bb3db4cc2")
+set(ONNXRUNTIME_HASH_MD_Release "SHA256=b1f90f4d03670f3010b97c8ea34d75b69c8fd573a7ffa43448c72d0025e7870f")
+set(ONNXRUNTIME_HASH_MD_Debug "SHA256=99a468f91945579b928b32ead5b74e1ccdaf44f5550c92bb917223030069a1ec")
+set(ONNXRUNTIME_HASH_MD_RelWithDebInfo "SHA256=d2c972dde08aa27e214a7ebfa94990b0698d26ada8de24d10f01459866d5bb4e")
+set(ONNXRUNTIME_HASH_MD_MinSizeRel "SHA256=f626141c6a729671e90fb7ffead9fb489d5bfd6ec1632270a437446e74680cb4")
 
 if(NOT CMAKE_BUILD_TYPE MATCHES "^(Release|Debug|RelWithDebInfo|MinSizeRel)$")
   message(FATAL_ERROR "Supported CMAKE_BUILD_TYPE values are: Release, Debug, RelWithDebInfo, MinSizeRel. Given ${CMAKE_BUILD_TYPE}")
@@ -40,8 +40,8 @@ endif()
 message(STATUS "Use MSVC CRT: ${onnxruntime_crt}")
 
 set(onnxruntime_HASH "${ONNXRUNTIME_HASH_${onnxruntime_crt}_${CMAKE_BUILD_TYPE}}")
-set(onnxruntime_filename "onnxruntime-win-x86-static_lib-${onnxruntime_crt}-${CMAKE_BUILD_TYPE}-1.23.2.tar.bz2")
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.23.2/${onnxruntime_filename}")
+set(onnxruntime_filename "onnxruntime-win-x86-static_lib-${onnxruntime_crt}-${CMAKE_BUILD_TYPE}-1.24.4.tar.bz2")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/${onnxruntime_filename}")
 
 
 # If you don't have access to the Internet,

--- a/cmake/onnxruntime-win-x86.cmake
+++ b/cmake/onnxruntime-win-x86.cmake
@@ -16,16 +16,16 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 
 # Hashes for static CRT (/MT)
-set(ONNXRUNTIME_HASH_MT_Release "SHA256=07536b6b0c3929df8a41352331357daac99deecf49a7856493c7d24dc036b071")
-set(ONNXRUNTIME_HASH_MT_Debug "SHA256=6f9146c969f2db41049d604a3a6f922a61a7a18e2116d539bce9578da7092037")
-set(ONNXRUNTIME_HASH_MT_RelWithDebInfo "SHA256=d9a40560ca39425fc19c599e2b33b39459660deb030c0dc5ef83ddb7bf5f58d0")
-set(ONNXRUNTIME_HASH_MT_MinSizeRel "SHA256=c5dc5570a8144b152592de69ecf4d2aaa4557a62dc4c47e24f480e26c831bd65")
+set(ONNXRUNTIME_HASH_MT_Release "SHA256=dc394dcca5cf303e92d26db4fe5f2263bc2cb263c838400790bd022ac88d04a2")
+set(ONNXRUNTIME_HASH_MT_Debug "SHA256=6b69bf08ddec6c5a6bb8ec07e7a9a5bb45104e17b7eac89538c8d50e2c3068a5")
+set(ONNXRUNTIME_HASH_MT_RelWithDebInfo "SHA256=fe3f9764b03265b74dceaf9e84e2be4bf9ccfba12528ca86bc7380773769ec83")
+set(ONNXRUNTIME_HASH_MT_MinSizeRel "SHA256=aead4b667ffe03eb9f1c4c68d0d44e63d3e271567217c00957c2c4b272586527")
 
 # Hashes for dynamic CRT (/MD)
-set(ONNXRUNTIME_HASH_MD_Release "SHA256=ce1519a7934204cbf9f3431ba1d67ea1a8e838f743245ac96db9faaaf150581c")
-set(ONNXRUNTIME_HASH_MD_Debug "SHA256=d35d5b5bee5a0483f16e845783902c686c9a186c71c17bcf20d6887a734a6ad9")
-set(ONNXRUNTIME_HASH_MD_RelWithDebInfo "SHA256=e4df40832040419d9b5e7d983420c51e3095987bd20314c9d7a90b4759df2991")
-set(ONNXRUNTIME_HASH_MD_MinSizeRel "SHA256=4ea6d745466f3623a13c0159f09dcf50d6b34e302b219cfc396c6af7122b7b39")
+set(ONNXRUNTIME_HASH_MD_Release "SHA256=3794ff0956bb97b01bffe8ef52db220f47e6fbaa2c35c9dfcc661a2431ab7a14")
+set(ONNXRUNTIME_HASH_MD_Debug "SHA256=a248541cb5bff3833330542621d2eed5dc5107a9587a1d599b6fd0cc5e848819")
+set(ONNXRUNTIME_HASH_MD_RelWithDebInfo "SHA256=a671331a873a989b91fce2403d3d2163712454bb7e5d79cd6a75707950451f37")
+set(ONNXRUNTIME_HASH_MD_MinSizeRel "SHA256=7c672f69078a59abff16261b3a632a338a8952b25f854c714c9a1f8a273ae5c4")
 
 if(NOT CMAKE_BUILD_TYPE MATCHES "^(Release|Debug|RelWithDebInfo|MinSizeRel)$")
   message(FATAL_ERROR "Supported CMAKE_BUILD_TYPE values are: Release, Debug, RelWithDebInfo, MinSizeRel. Given ${CMAKE_BUILD_TYPE}")
@@ -40,8 +40,8 @@ endif()
 message(STATUS "Use MSVC CRT: ${onnxruntime_crt}")
 
 set(onnxruntime_HASH "${ONNXRUNTIME_HASH_${onnxruntime_crt}_${CMAKE_BUILD_TYPE}}")
-set(onnxruntime_filename "onnxruntime-win-x86-${onnxruntime_crt}-${CMAKE_BUILD_TYPE}-1.23.2.tar.bz2")
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.23.2/${onnxruntime_filename}")
+set(onnxruntime_filename "onnxruntime-win-x86-${onnxruntime_crt}-${CMAKE_BUILD_TYPE}-1.24.4.tar.bz2")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/${onnxruntime_filename}")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.

--- a/sherpa-onnx/java-api/readme.md
+++ b/sherpa-onnx/java-api/readme.md
@@ -42,15 +42,15 @@ Sherpa-ONNX does **not** bundle ONNX Runtime. To install it manually:
 1. Download the Linux x64 binary from Microsoft’s GitHub Releases:
 
    ```bash
-   wget https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-linux-x64-1.23.2.tgz
-   tar -xzf onnxruntime-linux-x64-1.23.2.tgz
+   wget https://github.com/microsoft/onnxruntime/releases/download/v1.24.4/onnxruntime-linux-x64-1.24.4.tgz
+   tar -xzf onnxruntime-linux-x64-1.24.4.tgz
    ```
 
 2. Copy and symlink the library into a system directory:
 
    ```bash
-   sudo cp onnxruntime-linux-x64-1.23.2/lib/libonnxruntime.so* /usr/local/lib/
-   sudo ln -sf /usr/local/lib/libonnxruntime.so.1.23.2 /usr/local/lib/libonnxruntime.so
+   sudo cp onnxruntime-linux-x64-1.24.4/lib/libonnxruntime.so* /usr/local/lib/
+   sudo ln -sf /usr/local/lib/libonnxruntime.so.1.24.4 /usr/local/lib/libonnxruntime.so
    ```
 
 3. Update the shared-library cache and verify:
@@ -67,14 +67,14 @@ Sherpa-ONNX also requires you to install ONNX Runtime on macOS:
 1. Download the macOS ARM64 binary:
 
    ```bash
-   wget https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-osx-arm64-1.23.2.tgz
-   tar -xzf onnxruntime-osx-arm64-1.23.2.tgz
+   wget https://github.com/microsoft/onnxruntime/releases/download/v1.24.4/onnxruntime-osx-arm64-1.24.4.tgz
+   tar -xzf onnxruntime-osx-arm64-1.24.4.tgz
    ```
 
 2. Copy the dylib into `/usr/local/lib`:
 
    ```bash
-   sudo cp onnxruntime-osx-arm64-1.23.2/lib/libonnxruntime.1.23.2.dylib /usr/local/lib/
+   sudo cp onnxruntime-osx-arm64-1.24.4/lib/libonnxruntime.1.24.4.dylib /usr/local/lib/
    ```
 
 3. Add `/usr/local/lib` to `dyld`’s search path:

--- a/sherpa-onnx/java-api/readme.zh.md
+++ b/sherpa-onnx/java-api/readme.zh.md
@@ -41,14 +41,14 @@ Sherpa-ONNX 并不包含 ONNX Runtime，需要手动下载并配置：
 1. 从微软官方 GitHub Releases 下载 Linux 64 位二进制包：
 
    ```bash
-   wget https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-linux-x64-1.23.2.tgz
-   tar -xzf onnxruntime-linux-x64-1.23.2.tgz
+   wget https://github.com/microsoft/onnxruntime/releases/download/v1.24.4/onnxruntime-linux-x64-1.24.4.tgz
+   tar -xzf onnxruntime-linux-x64-1.24.4.tgz
    ```
 2. 将解压后的 `libonnxruntime.so` 文件复制到系统库目录，并创建软链接：
 
    ```bash
-   sudo cp onnxruntime-linux-x64-1.23.2/lib/libonnxruntime.so* /usr/local/lib/
-   sudo ln -sf /usr/local/lib/libonnxruntime.so.1.23.2 /usr/local/lib/libonnxruntime.so
+   sudo cp onnxruntime-linux-x64-1.24.4/lib/libonnxruntime.so* /usr/local/lib/
+   sudo ln -sf /usr/local/lib/libonnxruntime.so.1.24.4 /usr/local/lib/libonnxruntime.so
    ```
 3. 更新共享库缓存并验证安装：
 
@@ -64,13 +64,13 @@ Sherpa-ONNX 同样不包含 ONNX Runtime，需要从官方获取并配置：
 1. 下载 macOS ARM64 版本二进制包：
 
    ```bash
-   wget https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-osx-arm64-1.23.2.tgz
-   tar -xzf onnxruntime-osx-arm64-1.23.2.tgz
+   wget https://github.com/microsoft/onnxruntime/releases/download/v1.24.4/onnxruntime-osx-arm64-1.24.4.tgz
+   tar -xzf onnxruntime-osx-arm64-1.24.4.tgz
    ```
-2. 将 `libonnxruntime.1.23.2.dylib` 复制到 `/usr/local/lib`：
+2. 将 `libonnxruntime.1.24.4.dylib` 复制到 `/usr/local/lib`：
 
    ```bash
-   sudo cp onnxruntime-osx-arm64-1.23.2/lib/libonnxruntime.1.23.2.dylib /usr/local/lib/
+   sudo cp onnxruntime-osx-arm64-1.24.4/lib/libonnxruntime.1.24.4.dylib /usr/local/lib/
    ```
 3. 将 `/usr/local/lib` 添加到 `dyld` 的搜索路径：
 

--- a/sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/LibraryUtils.java
+++ b/sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/LibraryUtils.java
@@ -124,8 +124,8 @@ public class LibraryUtils {
             tempDirectory = Files.createTempDirectory("sherpa-onnx-java");
 
             if (Objects.equals(detectedOS, "osx")) {
-                // for macos, we need to first load libonnxruntime.1.23.2.dylib
-                String onnxruntimePath = "sherpa-onnx/native/" + getOsArch() + '/' + "libonnxruntime.1.23.2.dylib";
+                // for macos, we need to first load libonnxruntime.1.24.4.dylib
+                String onnxruntimePath = "sherpa-onnx/native/" + getOsArch() + '/' + "libonnxruntime.1.24.4.dylib";
                 if (!resourceExists(onnxruntimePath)) {
                     if (debug) {
                         System.out.printf("%s does not exist\n", onnxruntimePath);
@@ -134,7 +134,7 @@ public class LibraryUtils {
                     return false;
                 }
 
-                File tempFile = tempDirectory.resolve("libonnxruntime.1.23.2.dylib").toFile();
+                File tempFile = tempDirectory.resolve("libonnxruntime.1.24.4.dylib").toFile();
                 extractResource(onnxruntimePath, tempFile);
                 System.load(tempFile.getAbsolutePath());
             } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded ONNX Runtime from 1.23.2 to 1.24.4 across builds, packaging, CI workflows, CMake fetches, documentation, and Java runtime references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->