### PR TITLE
expose memory-related session options via config

### DIFF
--- a/sherpa-onnx/csrc/session.cc
+++ b/sherpa-onnx/csrc/session.cc
@@ -176,6 +176,24 @@ Ort::SessionOptions GetSessionOptionsImpl(
     config.erase("ProfilingFilePrefix");
   }
 
+  if (config.find("enable_mem_pattern") != config.end()) {
+    int32_t enable_mem_pattern =
+        ToIntOrDefault(config["enable_mem_pattern"], 1);
+    if (enable_mem_pattern == 0) {
+      sess_opts.DisableMemPattern();
+    }
+    config.erase("enable_mem_pattern");
+  }
+
+  if (config.find("enable_cpu_mem_arena") != config.end()) {
+    int32_t enable_cpu_mem_arena =
+        ToIntOrDefault(config["enable_cpu_mem_arena"], 1);
+    if (enable_cpu_mem_arena == 0) {
+      sess_opts.DisableCpuMemArena();
+    }
+    config.erase("enable_cpu_mem_arena");
+  }
+
   // If you want to speed up initialization, please uncomment the following line
   // sess_opts.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_DISABLE_ALL);
 

--- a/sherpa-onnx/csrc/session.cc
+++ b/sherpa-onnx/csrc/session.cc
@@ -176,22 +176,22 @@ Ort::SessionOptions GetSessionOptionsImpl(
     config.erase("ProfilingFilePrefix");
   }
 
-  if (config.find("enable_mem_pattern") != config.end()) {
+  if (config.find("EnableMemPattern") != config.end()) {
     int32_t enable_mem_pattern =
-        ToIntOrDefault(config["enable_mem_pattern"], 1);
+        ToIntOrDefault(config["EnableMemPattern"], 1);
     if (enable_mem_pattern == 0) {
       sess_opts.DisableMemPattern();
     }
-    config.erase("enable_mem_pattern");
+    config.erase("EnableMemPattern");
   }
 
-  if (config.find("enable_cpu_mem_arena") != config.end()) {
+  if (config.find("EnableCpuMemArena") != config.end()) {
     int32_t enable_cpu_mem_arena =
-        ToIntOrDefault(config["enable_cpu_mem_arena"], 1);
+        ToIntOrDefault(config["EnableCpuMemArena"], 1);
     if (enable_cpu_mem_arena == 0) {
       sess_opts.DisableCpuMemArena();
     }
-    config.erase("enable_cpu_mem_arena");
+    config.erase("EnableCpuMemArena");
   }
 
   // If you want to speed up initialization, please uncomment the following line


### PR DESCRIPTION
As discussed here https://github.com/k2-fsa/sherpa-onnx/pull/3500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration options to control memory pattern and CPU memory arena behavior; setting either option to 0 disables the corresponding runtime memory optimization, enabling finer-grained memory tuning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->