### PR TITLE
Update Eigen to v5.0.1

### DIFF
--- a/cmake/eigen.cmake
+++ b/cmake/eigen.cmake
@@ -1,18 +1,17 @@
 function(download_eigen)
   include(FetchContent)
 
-  set(eigen_URL  "https://gitlab.com/libeigen/eigen/-/archive/3.4.1/eigen-3.4.1.tar.gz")
-  set(eigen_URL2 "https://hf-mirror.com/csukuangfj/sherpa-onnx-cmake-deps/resolve/main/eigen-3.4.1.tar.gz")
-  set(eigen_HASH "SHA256=b93c667d1b69265cdb4d9f30ec21f8facbbe8b307cf34c0b9942834c6d4fdbe2")
+  set(eigen_URL  "https://gitlab.com/libeigen/eigen/-/archive/5.0.1/eigen-5.0.1.tar.gz")
+  set(eigen_HASH "SHA256=e9c326dc8c05cd1e044c71f30f1b2e34a6161a3b6ecf445d56b53ff1669e3dec")
 
   # If you don't have access to the Internet,
   # please pre-download eigen
   set(possible_file_locations
-    $ENV{HOME}/Downloads/eigen-3.4.1.tar.gz
-    ${CMAKE_SOURCE_DIR}/eigen-3.4.1.tar.gz
-    ${CMAKE_BINARY_DIR}/eigen-3.4.1.tar.gz
-    /tmp/eigen-3.4.1.tar.gz
-    /star-fj/fangjun/download/github/eigen-3.4.1.tar.gz
+    $ENV{HOME}/Downloads/eigen-5.0.1.tar.gz
+    ${CMAKE_SOURCE_DIR}/eigen-5.0.1.tar.gz
+    ${CMAKE_BINARY_DIR}/eigen-5.0.1.tar.gz
+    /tmp/eigen-5.0.1.tar.gz
+    /star-fj/fangjun/download/github/eigen-5.0.1.tar.gz
   )
 
   foreach(f IN LISTS possible_file_locations)
@@ -20,7 +19,6 @@ function(download_eigen)
       set(eigen_URL  "${f}")
       file(TO_CMAKE_PATH "${eigen_URL}" eigen_URL)
       message(STATUS "Found local downloaded eigen: ${eigen_URL}")
-      set(eigen_URL2)
       break()
     endif()
   endforeach()
@@ -29,7 +27,7 @@ function(download_eigen)
   set(EIGEN_BUILD_DOC OFF CACHE BOOL "" FORCE)
 
   FetchContent_Declare(eigen
-    URL               ${eigen_URL} ${eigen_URL2}
+    URL               ${eigen_URL}
     URL_HASH          ${eigen_HASH}
   )
 

--- a/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
+++ b/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
@@ -515,7 +515,7 @@ class OfflineSpeakerDiarizationPyannoteImpl
 
     if (k != cur_row_index) {
       auto seq = Eigen::seqN(0, cur_row_index);
-      ans = ans(seq, Eigen::all);
+      ans = ans(seq, Eigen::placeholders::all);
     }
 
     return ans;
@@ -596,7 +596,7 @@ class OfflineSpeakerDiarizationPyannoteImpl
 
       auto seq = Eigen::seqN(start, labels[i].rows());
 
-      count(seq, Eigen::all).array() += labels[i].array();
+      count(seq, Eigen::placeholders::all).array() += labels[i].array();
     }
 
     bool has_last_chunk = ((num_samples - window_size) % window_shift) > 0;
@@ -606,7 +606,7 @@ class OfflineSpeakerDiarizationPyannoteImpl
     }
 
     int32_t last_frame = num_samples / receptive_field_shift;
-    return count(Eigen::seq(0, last_frame), Eigen::all);
+    return count(Eigen::seq(0, last_frame), Eigen::placeholders::all);
   }
 
   Matrix2DInt32 FinalizeLabels(const Matrix2DInt32 &count,
@@ -715,7 +715,7 @@ class OfflineSpeakerDiarizationPyannoteImpl
 
     num_frames = (new_num_frames <= num_frames) ? new_num_frames : num_frames;
 
-    return ComputeResult(final_labels(Eigen::seq(0, num_frames), Eigen::all));
+    return ComputeResult(final_labels(Eigen::seq(0, num_frames), Eigen::placeholders::all));
   }
 
   void MergeSegments(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Eigen library dependency from version 3.4.1 to 5.0.1
  * Updated internal code for compatibility with the new Eigen version
  * Removed deprecated fallback mirror URLs for offline installations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->