### PR TITLE
Honor proxy env to download prebuilt archive in rust binding build script

### DIFF
--- a/sherpa-onnx/rust/sherpa-onnx-sys/Cargo.toml
+++ b/sherpa-onnx/rust/sherpa-onnx-sys/Cargo.toml
@@ -27,7 +27,7 @@ shared = []
 [build-dependencies]
 bzip2 = "0.4"
 tar = "0.4"
-ureq = "2.12"
+ureq = { version = "2.12", features = ["proxy-from-env"] }
 
 [package.metadata.docs.rs]
 default-features = false

--- a/sherpa-onnx/rust/sherpa-onnx-sys/build.rs
+++ b/sherpa-onnx/rust/sherpa-onnx-sys/build.rs
@@ -149,7 +149,10 @@ fn download_prebuilt_libs(
             let url = format!("{RELEASE_BASE_URL}/v{version}/{archive_name}");
             eprintln!("Downloading sherpa-onnx libs from {url}");
 
-            let response = ureq::get(&url)
+            let response = ureq::builder()
+                .try_proxy_from_env(true)
+                .build()
+                .get(&url)
                 .call()
                 .map_err(|e| format!("Failed to download sherpa-onnx archive from {url}: {e}"))?;
             let mut reader = response.into_reader();

--- a/sherpa-onnx/rust/sherpa-onnx/README.md
+++ b/sherpa-onnx/rust/sherpa-onnx/README.md
@@ -17,6 +17,8 @@ If `SHERPA_ONNX_LIB_DIR` is not set, the build script automatically downloads a
 matching prebuilt native `-lib` archive from
 [GitHub releases](https://github.com/k2-fsa/sherpa-onnx/releases) and uses it
 for the build.
+The downloader also honors standard proxy environment variables such as
+`HTTPS_PROXY`, `HTTP_PROXY`, and `NO_PROXY` (including lowercase variants).
 
 ## Use shared libraries
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Build process now respects proxy environment variables (HTTPS_PROXY, HTTP_PROXY, NO_PROXY and lowercase variants) when auto-downloading prebuilt libraries.

* **Documentation**
  * README updated to document proxy environment variable support during the build process.

* **Chores**
  * Build dependency configuration adjusted to enable proxy support during the build step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->