### PR TITLE
fix: 修复了 Ascend NPU 上下文导致的崩溃问题

### DIFF
--- a/sherpa-onnx/csrc/ascend/offline-paraformer-model-ascend.cc
+++ b/sherpa-onnx/csrc/ascend/offline-paraformer-model-ascend.cc
@@ -86,6 +86,9 @@ class OfflineParaformerModelAscend::Impl {
     // TODO(fangjun): Support multi clients
     std::lock_guard<std::mutex> lock(mutex_);
 
+    aclError ret_set_ctx = aclrtSetCurrentContext(*context_);
+    SHERPA_ONNX_ASCEND_CHECK(ret_set_ctx, "Failed to call aclrtSetCurrentContext");
+
     features = ApplyLFR(std::move(features));
     if (features.empty()) {
       return {};

--- a/sherpa-onnx/csrc/ascend/offline-sense-voice-model-ascend.cc
+++ b/sherpa-onnx/csrc/ascend/offline-sense-voice-model-ascend.cc
@@ -56,6 +56,9 @@ class OfflineSenseVoiceModelAscend::Impl {
     // TODO(fangjun): Support multi clients
     std::lock_guard<std::mutex> lock(mutex_);
 
+    aclError ret_set_ctx = aclrtSetCurrentContext(*context_);
+    SHERPA_ONNX_ASCEND_CHECK(ret_set_ctx, "Failed to call aclrtSetCurrentContext");
+
     features = ApplyLFR(std::move(features));
     if (features.empty()) {
       return {};

--- a/sherpa-onnx/csrc/ascend/offline-whisper-model-ascend.cc
+++ b/sherpa-onnx/csrc/ascend/offline-whisper-model-ascend.cc
@@ -88,6 +88,9 @@ class OfflineWhisperModelAscend::Impl {
     // TODO(fangjun): Support multi clients
     std::lock_guard<std::mutex> lock(mutex_);
 
+    aclError ret_set_ctx = aclrtSetCurrentContext(*context_);
+    SHERPA_ONNX_ASCEND_CHECK(ret_set_ctx, "Failed to call aclrtSetCurrentContext");
+
     OfflineWhisperDecoderResult r;
 
     if (features.empty()) {

--- a/sherpa-onnx/csrc/ascend/offline-zipformer-ctc-model-ascend.cc
+++ b/sherpa-onnx/csrc/ascend/offline-zipformer-ctc-model-ascend.cc
@@ -51,6 +51,9 @@ class OfflineZipformerCtcModelAscend::Impl {
     // TODO(fangjun): Support multi clients
     std::lock_guard<std::mutex> lock(mutex_);
 
+    aclError ret_set_ctx = aclrtSetCurrentContext(*context_);
+    SHERPA_ONNX_ASCEND_CHECK(ret_set_ctx, "Failed to call aclrtSetCurrentContext");
+
     int32_t num_frames = features.size() / feat_dim_;
 
     if (num_frames != max_num_frames_) {


### PR DESCRIPTION
鲲鹏aarch64 CPU，Ascend 910A NPU卡，CANN 8.2.RC1华为官方容器。使用sherpa-onnx-offline工作正常。sherpa-onnx-offline-websocket-server启动服务正常，使用python客户程序连接时服务崩溃。

root@localhost:/opt/sherpa-onnx/build# ./bin/sherpa-onnx-offline-websocket-server   --port=6006   --num-work-threads=5   --provider=ascend   --paraformer="/data/paraformer/sherpa-onnx-ascend-910B-cann-8.2-paraformer-zh-2025-10-07/encoder.om,/data/paraformer/sherpa-onnx-ascend-910B-cann-8.2-paraformer-zh-2025-10-07/predictor.om,/data/paraformer/sherpa-onnx-ascend-910B-cann-8.2-paraformer-zh-2025-10-07/decoder.om"   --tokens=/data/paraformer/sherpa-onnx-ascend-910B-cann-8.2-paraformer-zh-2025-10-07/tokens.txt   --log-file=./log.txt   --max-batch-size=5
onnxruntime cpuid_info warning: Unknown CPU vendor. cpuinfo_vendor value: 15
/opt/sherpa-onnx/sherpa-onnx/csrc/parse-options.cc:Read:373 ./bin/sherpa-onnx-offline-websocket-server --port=6006 --num-work-threads=5 --provider=ascend --paraformer=/data/paraformer/sherpa-onnx-ascend-910B-cann-8.2-paraformer-zh-2025-10-07/encoder.om,/data/paraformer/sherpa-onnx-ascend-910B-cann-8.2-paraformer-zh-2025-10-07/predictor.om,/data/paraformer/sherpa-onnx-ascend-910B-cann-8.2-paraformer-zh-2025-10-07/decoder.om --tokens=/data/paraformer/sherpa-onnx-ascend-910B-cann-8.2-paraformer-zh-2025-10-07/tokens.txt --log-file=./log.txt --max-batch-size=5

/opt/sherpa-onnx/sherpa-onnx/csrc/offline-websocket-server.cc:main:93 Started!
/opt/sherpa-onnx/sherpa-onnx/csrc/offline-websocket-server.cc:main:94 Listening on: 6006
/opt/sherpa-onnx/sherpa-onnx/csrc/offline-websocket-server.cc:main:95 Number of work threads: 5
[2026-04-13 11:32:21] [connect] WebSocket Connection 192.168.1.41:51694 v13 "Python/3.9 websockets/15.0.1" / 101
/opt/sherpa-onnx/sherpa-onnx/csrc/offline-websocket-server-impl.cc:OnOpen:170 Number of active connections: 1
/opt/sherpa-onnx/sherpa-onnx/csrc/offline-websocket-server-impl.cc:Decode:67 size: 1
/opt/sherpa-onnx/sherpa-onnx/csrc/ascend/offline-paraformer-model-ascend.cc:RunEncoder:149 Return code is: 107002
/opt/sherpa-onnx/sherpa-onnx/csrc/ascend/offline-paraformer-model-ascend.cc:RunEncoder:149 Error message: EE1001: [PID: 118] 2026-04-13-11:32:21.618.180 The argument is invalid.Reason: rtMemcpy execute failed, reason=[context pointer null]
        Solution: 1.Check the input parameter range of the function. 2.Check the function invocation relationship.
        TraceBack (most recent call last):
        ctx is NULL![FUNC:MemCopySync][FILE:api_impl.cc][LINE:2555]
        The argument is invalid.Reason: rtMemcpy execute failed, reason=[context pointer null]
        synchronized memcpy failed, kind = 1, runtime result = 107002[FUNC:ReportCallError][FILE:log_inner.cpp][LINE:161]
        ctx is NULL![FUNC:GetDevErrMsg][FILE:api_impl.cc][LINE:6147]
        The argument is invalid.Reason: rtGetDevMsg execute failed, reason=[context pointer null]

/opt/sherpa-onnx/sherpa-onnx/csrc/ascend/offline-paraformer-model-ascend.cc:RunEncoder:149 Failed to call aclrtMemcpy

错误原因：Ascend NPU 的上下文（aclrtContext）与线程绑定。当多工作线程并发调用模型时，aclrtMemcpy 和 aclmdlExecute调用时当前线程没有有效的上下文。
解决方案：在sherpa-onnx/sherpa-onnx/csrc/ascend/offline-*-model-ascend.cc 4个文件的 std::lock_guard<std::mutex> lock(mutex_); 行之后加上：
aclError ret_set_ctx = aclrtSetCurrentContext(*context_);
SHERPA_ONNX_ASCEND_CHECK(ret_set_ctx, "Failed to call aclrtSetCurrentContext");
经测试在昇腾910A NPU 上正常工作。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of Ascend hardware-accelerated inference across Paraformer, SenseVoice, Whisper, and Zipformer CTC models by strengthening execution context management during runtime operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->