### PR TITLE
Fix an offset-by-one error in pyannote speaker diarization.

### DIFF
--- a/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
+++ b/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
@@ -614,7 +614,7 @@ class OfflineSpeakerDiarizationPyannoteImpl
     if (last_frame >= count.rows()) {
       last_frame = count.rows() - 1;
     }
-    return count(Eigen::seq(0, last_frame), Eigen::placeholders::all);
+    return count(Eigen::seqN(0, last_frame + 1), Eigen::placeholders::all);
   }
 
   Matrix2DInt32 FinalizeLabels(const Matrix2DInt32 &count,
@@ -723,10 +723,10 @@ class OfflineSpeakerDiarizationPyannoteImpl
 
     int32_t new_num_frames = num_samples / receptive_field_shift;
 
-    num_frames = (new_num_frames < num_frames) ? new_num_frames : num_frames - 1;
+    int32_t num_frames_to_keep = std::min(new_num_frames, num_frames);
 
     return ComputeResult(
-        final_labels(Eigen::seq(0, num_frames), Eigen::placeholders::all));
+        final_labels(Eigen::seqN(0, num_frames_to_keep), Eigen::placeholders::all));
   }
 
   void MergeSegments(

--- a/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
+++ b/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
@@ -528,6 +528,11 @@ class OfflineSpeakerDiarizationPyannoteImpl
 
     int32_t k = 0;
     for (const auto &p : chunk_speaker_pair) {
+      if (k >= static_cast<int32_t>(cluster_labels.size())) {
+        SHERPA_ONNX_LOGE("cluster_labels size mismatch: k=%d, size=%d", k,
+                         static_cast<int32_t>(cluster_labels.size()));
+        break;
+      }
       ans[p] = cluster_labels[k];
       k += 1;
     }
@@ -606,6 +611,9 @@ class OfflineSpeakerDiarizationPyannoteImpl
     }
 
     int32_t last_frame = num_samples / receptive_field_shift;
+    if (last_frame >= count.rows()) {
+      last_frame = count.rows() - 1;
+    }
     return count(Eigen::seq(0, last_frame), Eigen::placeholders::all);
   }
 
@@ -625,7 +633,9 @@ class OfflineSpeakerDiarizationPyannoteImpl
       auto top_k = TopkIndex(&count(i, 0), num_cols, k);
 
       for (int32_t m : top_k) {
-        ans(i, m) = 1;
+        if (m >= 0 && m < num_cols) {
+          ans(i, m) = 1;
+        }
       }
     }
 
@@ -713,9 +723,10 @@ class OfflineSpeakerDiarizationPyannoteImpl
 
     int32_t new_num_frames = num_samples / receptive_field_shift;
 
-    num_frames = (new_num_frames <= num_frames) ? new_num_frames : num_frames;
+    num_frames = (new_num_frames < num_frames) ? new_num_frames : num_frames - 1;
 
-    return ComputeResult(final_labels(Eigen::seq(0, num_frames), Eigen::placeholders::all));
+    return ComputeResult(
+        final_labels(Eigen::seq(0, num_frames), Eigen::placeholders::all));
   }
 
   void MergeSegments(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of speaker diarization by adding boundary checks and guards to prevent out-of-range frame and label assignments, clamping frame selections, and ensuring safe handling of edge cases during chunk processing to avoid potential errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->