### PR TITLE
Fix publishing dart packages for Android

### DIFF
--- a/.github/workflows/release-dart-package.yaml
+++ b/.github/workflows/release-dart-package.yaml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   build_linux_libs_x64:
+    # if: false
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -439,11 +440,11 @@ jobs:
           flutter pub publish --dry-run
           flutter pub publish --force
 
-  sherpa_onnx_android:
+  sherpa_onnx_android_arm64:
     # if: false
     permissions:
       id-token: write # Required for authentication using OIDC
-    name: sherpa_onnx_android
+    name: sherpa_onnx_android_arm64
     runs-on: ubuntu-latest
 
     steps:
@@ -458,14 +459,14 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ matrix.os }}-flutter-release-package-android
+          key: flutter-release-package-android-arm64
 
       - name: Fix version
         shell: bash
         run: |
           SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
 
-          src_dir=$PWD/flutter/sherpa_onnx_android
+          src_dir=$PWD/flutter/sherpa_onnx_android_arm64
           pushd $src_dir
           v="version: $SHERPA_ONNX_VERSION"
           echo "v: $v"
@@ -477,7 +478,7 @@ jobs:
       - name: Copy extra files
         shell: bash
         run: |
-          dst=flutter/sherpa_onnx_android
+          dst=flutter/sherpa_onnx_android_arm64
 
           mkdir $dst/example
 
@@ -500,6 +501,91 @@ jobs:
 
           ./build-android-arm64-v8a.sh
 
+      - name: Copy pre-built libs
+        shell: bash
+        run: |
+          echo "----arm64-v8a----"
+          cp -v build-android-arm64-v8a/install/lib/lib*.so flutter/sherpa_onnx_android_arm64/android/src/main/jniLibs/arm64-v8a/
+
+          mv -v flutter/sherpa_onnx_android_arm64 /tmp/to_be_published
+
+          ls -lh /tmp/to_be_published
+
+          cd /tmp
+          tar cjfv android_arm64.tar.bz2 ./to_be_published
+          ls -lh android_arm64.tar.bz2
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: android-arm64
+          path: /tmp/android_arm64.tar.bz2
+
+      - name: Setup Flutter SDK
+        uses: flutter-actions/setup-flutter@v3
+        with:
+          channel: stable
+          version: latest
+
+      - uses: dart-lang/setup-dart@v1
+
+      - name: Release
+        shell: bash
+        run: |
+          cd /tmp/to_be_published
+          du -h -d1 .
+
+          flutter pub get
+          flutter pub publish --dry-run
+          flutter pub publish --force
+
+  sherpa_onnx_android_armeabi:
+    # if: false
+    permissions:
+      id-token: write # Required for authentication using OIDC
+    name: sherpa_onnx_android_armeabi
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update version
+        shell: bash
+        run: |
+          ./new-release.sh
+          git diff .
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: flutter-release-package-android-armeabi
+
+      - name: Fix version
+        shell: bash
+        run: |
+          SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+
+          src_dir=$PWD/flutter/sherpa_onnx_android_armeabi
+          pushd $src_dir
+          v="version: $SHERPA_ONNX_VERSION"
+          echo "v: $v"
+          sed -i.bak s"/^version: .*/$v/" ./pubspec.yaml
+          rm *.bak
+          git status
+          git diff
+
+      - name: Copy extra files
+        shell: bash
+        run: |
+          dst=flutter/sherpa_onnx_android_armeabi
+
+          mkdir $dst/example
+
+          cp -v flutter/sherpa_onnx/example/* $dst/example
+          cp -v LICENSE $dst/
+          cp -v CHANGELOG.md $dst/
+
+          git status
+
       - name: Build android-armv7-eabi
         shell: bash
         run: |
@@ -513,6 +599,91 @@ jobs:
 
           ./build-android-armv7-eabi.sh
 
+      - name: Copy pre-built libs
+        shell: bash
+        run: |
+          echo "----armv7-eabi----"
+          cp -v build-android-armv7-eabi/install/lib/lib*.so flutter/sherpa_onnx_android_armeabi/android/src/main/jniLibs/armeabi-v7a/
+
+          mv -v flutter/sherpa_onnx_android_armeabi /tmp/to_be_published
+
+          ls -lh /tmp/to_be_published
+
+          cd /tmp
+          tar cjfv android_armeabi.tar.bz2 ./to_be_published
+          ls -lh android_armeabi.tar.bz2
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: android-armeabi
+          path: /tmp/android_armeabi.tar.bz2
+
+      - name: Setup Flutter SDK
+        uses: flutter-actions/setup-flutter@v3
+        with:
+          channel: stable
+          version: latest
+
+      - uses: dart-lang/setup-dart@v1
+
+      - name: Release
+        shell: bash
+        run: |
+          cd /tmp/to_be_published
+          du -h -d1 .
+
+          flutter pub get
+          flutter pub publish --dry-run
+          flutter pub publish --force
+
+  sherpa_onnx_android_x86:
+    # if: false
+    permissions:
+      id-token: write # Required for authentication using OIDC
+    name: sherpa_onnx_android_x86
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update version
+        shell: bash
+        run: |
+          ./new-release.sh
+          git diff .
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: flutter-release-package-android-x86
+
+      - name: Fix version
+        shell: bash
+        run: |
+          SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+
+          src_dir=$PWD/flutter/sherpa_onnx_android_x86
+          pushd $src_dir
+          v="version: $SHERPA_ONNX_VERSION"
+          echo "v: $v"
+          sed -i.bak s"/^version: .*/$v/" ./pubspec.yaml
+          rm *.bak
+          git status
+          git diff
+
+      - name: Copy extra files
+        shell: bash
+        run: |
+          dst=flutter/sherpa_onnx_android_x86
+
+          mkdir $dst/example
+
+          cp -v flutter/sherpa_onnx/example/* $dst/example
+          cp -v LICENSE $dst/
+          cp -v CHANGELOG.md $dst/
+
+          git status
+
       - name: Build android-x86
         shell: bash
         run: |
@@ -525,6 +696,91 @@ jobs:
           export SHERPA_ONNX_ENABLE_BINARY=OFF
 
           ./build-android-x86.sh
+
+      - name: Copy pre-built libs
+        shell: bash
+        run: |
+          echo "----x86----"
+          cp -v build-android-x86/install/lib/lib*.so flutter/sherpa_onnx_android_x86/android/src/main/jniLibs/x86/
+
+          mv -v flutter/sherpa_onnx_android_x86 /tmp/to_be_published
+
+          ls -lh /tmp/to_be_published
+
+          cd /tmp
+          tar cjfv android_x86.tar.bz2 ./to_be_published
+          ls -lh *.tar.bz2
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: android-x86
+          path: /tmp/android_x86.tar.bz2
+
+      - name: Setup Flutter SDK
+        uses: flutter-actions/setup-flutter@v3
+        with:
+          channel: stable
+          version: latest
+
+      - uses: dart-lang/setup-dart@v1
+
+      - name: Release
+        shell: bash
+        run: |
+          cd /tmp/to_be_published
+          du -h -d1 .
+
+          flutter pub get
+          flutter pub publish --dry-run
+          flutter pub publish --force
+
+  sherpa_onnx_android_x86_64:
+    # if: false
+    permissions:
+      id-token: write # Required for authentication using OIDC
+    name: sherpa_onnx_android_x86_64
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update version
+        shell: bash
+        run: |
+          ./new-release.sh
+          git diff .
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: flutter-release-package-android-x86_64
+
+      - name: Fix version
+        shell: bash
+        run: |
+          SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
+
+          src_dir=$PWD/flutter/sherpa_onnx_android_x86_64
+          pushd $src_dir
+          v="version: $SHERPA_ONNX_VERSION"
+          echo "v: $v"
+          sed -i.bak s"/^version: .*/$v/" ./pubspec.yaml
+          rm *.bak
+          git status
+          git diff
+
+      - name: Copy extra files
+        shell: bash
+        run: |
+          dst=flutter/sherpa_onnx_android_x86_64
+
+          mkdir $dst/example
+
+          cp -v flutter/sherpa_onnx/example/* $dst/example
+          cp -v LICENSE $dst/
+          cp -v CHANGELOG.md $dst/
+
+          git status
 
       - name: Build android-x86-64
         shell: bash
@@ -542,21 +798,21 @@ jobs:
       - name: Copy pre-built libs
         shell: bash
         run: |
-          echo "----arm64-v8a----"
-          cp -v build-android-arm64-v8a/install/lib/lib*.so flutter/sherpa_onnx_android/android/src/main/jniLibs/arm64-v8a/
-
-          echo "----armv7-eabi----"
-          cp -v build-android-armv7-eabi/install/lib/lib*.so flutter/sherpa_onnx_android/android/src/main/jniLibs/armeabi-v7a
-
-          echo "----x86----"
-          cp -v build-android-x86/install/lib/lib*.so flutter/sherpa_onnx_android/android/src/main/jniLibs/x86
-
           echo "----x86_64----"
-          cp -v build-android-x86-64/install/lib/lib*.so flutter/sherpa_onnx_android/android/src/main/jniLibs/x86_64
+          cp -v build-android-x86-64/install/lib/lib*.so flutter/sherpa_onnx_android_x86_64/android/src/main/jniLibs/x86_64/
 
-          mv -v flutter/sherpa_onnx_android /tmp/to_be_published
+          mv -v flutter/sherpa_onnx_android_x86_64 /tmp/to_be_published
 
           ls -lh /tmp/to_be_published
+
+          cd /tmp
+          tar cjfv android_x64.tar.bz2 ./to_be_published
+          ls -lh *.tar.bz2
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: android-x64
+          path: /tmp/android_x64.tar.bz2
 
       - name: Setup Flutter SDK
         uses: flutter-actions/setup-flutter@v3
@@ -661,7 +917,7 @@ jobs:
           flutter pub publish --force
 
   sherpa_onnx:
-    needs: [sherpa_onnx_linux, sherpa_onnx_macos, sherpa_onnx_windows, sherpa_onnx_android, sherpa_onnx_ios]
+    needs: [sherpa_onnx_linux, sherpa_onnx_macos, sherpa_onnx_windows, sherpa_onnx_android_arm64, sherpa_onnx_android_armeabi, sherpa_onnx_android_x86, sherpa_onnx_android_x86_64, sherpa_onnx_ios]
     # if: false
     permissions:
       id-token: write # Required for authentication using OIDC

--- a/.github/workflows/tauri-vad-asr.yaml
+++ b/.github/workflows/tauri-vad-asr.yaml
@@ -36,8 +36,13 @@ jobs:
         run: cargo install tauri-cli
 
       - name: Install Python dependencies
-        run: python3 -m pip install --upgrade pip jinja2
         shell: bash
+        run: |
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
+            python3 -m pip install --upgrade --break-system-packages pip jinja2 pillow
+          else
+            python3 -m pip install --upgrade pip jinja2 pillow
+          fi
 
       - name: Generate build script
         shell: bash

--- a/flutter/notes.md
+++ b/flutter/notes.md
@@ -27,10 +27,13 @@ flutter create --template plugin_ffi --platforms linux sherpa_onnx_linux
 flutter create --template plugin_ffi --platforms linux sherpa_onnx_windows
 ```
 
-5. Create `sherpa_onnx_android`
+5. Create `sherpa_onnx_android_arm64`, `sherpa_onnx_android_armeabi`, `sherpa_onnx_android_x86`, `sherpa_onnx_android_x86_64`
 
 ```bash
-flutter create --template plugin_ffi --platforms android --org com.k2fsa.sherpa.onnx sherpa_onnx_android
+flutter create --template plugin_ffi --platforms android --org com.k2fsa.sherpa.onnx sherpa_onnx_android_arm64
+flutter create --template plugin_ffi --platforms android --org com.k2fsa.sherpa.onnx sherpa_onnx_android_armeabi
+flutter create --template plugin_ffi --platforms android --org com.k2fsa.sherpa.onnx sherpa_onnx_android_x86
+flutter create --template plugin_ffi --platforms android --org com.k2fsa.sherpa.onnx sherpa_onnx_android_x86_64
 ```
 
 6. Create `sherpa_onnx_ios`

--- a/flutter/sherpa_onnx/pubspec.yaml
+++ b/flutter/sherpa_onnx/pubspec.yaml
@@ -30,9 +30,21 @@ dependencies:
   flutter:
     sdk: flutter
 
-  sherpa_onnx_android: ^1.12.39
-  # sherpa_onnx_android:
-  #   path: ../sherpa_onnx_android
+  sherpa_onnx_android_arm64: ^1.12.39
+  # sherpa_onnx_android_arm64:
+  #   path: ../sherpa_onnx_android_arm64
+
+  sherpa_onnx_android_armeabi: ^1.12.39
+  # sherpa_onnx_android_armeabi:
+  #   path: ../sherpa_onnx_android_armeabi
+
+  sherpa_onnx_android_x86: ^1.12.39
+  # sherpa_onnx_android_x86:
+  #   path: ../sherpa_onnx_android_x86
+
+  sherpa_onnx_android_x86_64: ^1.12.39
+  # sherpa_onnx_android_x86_64:
+  #   path: ../sherpa_onnx_android_x86_64
 
   sherpa_onnx_macos: ^1.12.39
   # sherpa_onnx_macos:
@@ -57,7 +69,7 @@ flutter:
   plugin:
     platforms:
       android:
-        default_package: sherpa_onnx_android
+        default_package: sherpa_onnx_android_arm64
 
       ios:
         default_package: sherpa_onnx_ios

--- a/flutter/sherpa_onnx_android/pubspec.yaml
+++ b/flutter/sherpa_onnx_android/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
   Speech recognition, speech synthesis, and speaker recognition using next-gen Kaldi
   with onnxruntime without Internet connection.
 
-version: 0.0.1
+version: 1.12.39
 
 repository: https://github.com/k2-fsa/sherpa-onnx/tree/master/flutter
 

--- a/flutter/sherpa_onnx_android_arm64/README.md
+++ b/flutter/sherpa_onnx_android_arm64/README.md
@@ -1,0 +1,7 @@
+# sherpa_onnx_android_arm64
+
+This is a sub project of [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx).
+
+You are not expected to use this package directly.
+
+Please see the entry point at <https://pub.dev/packages/sherpa_onnx>.

--- a/flutter/sherpa_onnx_android_arm64/android/build.gradle
+++ b/flutter/sherpa_onnx_android_arm64/android/build.gradle
@@ -1,0 +1,48 @@
+// The Android Gradle Plugin builds the native code with the Android NDK.
+
+group = "com.k2fsa.sherpa.onnx.sherpa_onnx_android_arm64"
+version = "1.0"
+
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        // The Android Gradle Plugin knows how to build native code with the NDK.
+        classpath("com.android.tools.build:gradle:7.3.0")
+    }
+}
+
+rootProject.allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+apply plugin: "com.android.library"
+
+android {
+    namespace 'com.k2fsa.sherpa.onnx'
+
+    // Bumping the plugin compileSdk version requires all clients of this plugin
+    // to bump the version in their app.
+    compileSdk = 34
+
+    // Use the NDK version
+    // declared in /android/app/build.gradle file of the Flutter project.
+    // Replace it with a version number if this plugin requires a specific NDK version.
+    // (e.g. ndkVersion "23.1.7779620")
+    ndkVersion = android.ndkVersion
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    defaultConfig {
+        minSdk = 21
+    }
+}

--- a/flutter/sherpa_onnx_android_arm64/android/settings.gradle
+++ b/flutter/sherpa_onnx_android_arm64/android/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'sherpa_onnx_android_arm64'

--- a/flutter/sherpa_onnx_android_arm64/android/src/main/AndroidManifest.xml
+++ b/flutter/sherpa_onnx_android_arm64/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.k2fsa.sherpa.onnx">
+</manifest>

--- a/flutter/sherpa_onnx_android_arm64/pubspec.yaml
+++ b/flutter/sherpa_onnx_android_arm64/pubspec.yaml
@@ -1,7 +1,8 @@
-name: sherpa_onnx_linux
+name: sherpa_onnx_android_arm64
+
 description: >
   Speech recognition, speech synthesis, and speaker recognition using next-gen Kaldi
-  with onnxruntime without Internet connection.
+  with onnxruntime without Internet connection. Android arm64-v8a native libraries.
 
 version: 1.12.39
 
@@ -30,5 +31,5 @@ dependencies:
 flutter:
   plugin:
     platforms:
-      linux:
+      android:
         ffiPlugin: true

--- a/flutter/sherpa_onnx_android_armeabi/README.md
+++ b/flutter/sherpa_onnx_android_armeabi/README.md
@@ -1,0 +1,7 @@
+# sherpa_onnx_android_armeabi
+
+This is a sub project of [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx).
+
+You are not expected to use this package directly.
+
+Please see the entry point at <https://pub.dev/packages/sherpa_onnx>.

--- a/flutter/sherpa_onnx_android_armeabi/android/build.gradle
+++ b/flutter/sherpa_onnx_android_armeabi/android/build.gradle
@@ -1,0 +1,48 @@
+// The Android Gradle Plugin builds the native code with the Android NDK.
+
+group = "com.k2fsa.sherpa.onnx.sherpa_onnx_android_armeabi"
+version = "1.0"
+
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        // The Android Gradle Plugin knows how to build native code with the NDK.
+        classpath("com.android.tools.build:gradle:7.3.0")
+    }
+}
+
+rootProject.allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+apply plugin: "com.android.library"
+
+android {
+    namespace 'com.k2fsa.sherpa.onnx'
+
+    // Bumping the plugin compileSdk version requires all clients of this plugin
+    // to bump the version in their app.
+    compileSdk = 34
+
+    // Use the NDK version
+    // declared in /android/app/build.gradle file of the Flutter project.
+    // Replace it with a version number if this plugin requires a specific NDK version.
+    // (e.g. ndkVersion "23.1.7779620")
+    ndkVersion = android.ndkVersion
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    defaultConfig {
+        minSdk = 21
+    }
+}

--- a/flutter/sherpa_onnx_android_armeabi/android/settings.gradle
+++ b/flutter/sherpa_onnx_android_armeabi/android/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'sherpa_onnx_android_armeabi'

--- a/flutter/sherpa_onnx_android_armeabi/android/src/main/AndroidManifest.xml
+++ b/flutter/sherpa_onnx_android_armeabi/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.k2fsa.sherpa.onnx">
+</manifest>

--- a/flutter/sherpa_onnx_android_armeabi/pubspec.yaml
+++ b/flutter/sherpa_onnx_android_armeabi/pubspec.yaml
@@ -1,7 +1,8 @@
-name: sherpa_onnx_linux
+name: sherpa_onnx_android_armeabi
+
 description: >
   Speech recognition, speech synthesis, and speaker recognition using next-gen Kaldi
-  with onnxruntime without Internet connection.
+  with onnxruntime without Internet connection. Android armeabi-v7a native libraries.
 
 version: 1.12.39
 
@@ -30,5 +31,5 @@ dependencies:
 flutter:
   plugin:
     platforms:
-      linux:
+      android:
         ffiPlugin: true

--- a/flutter/sherpa_onnx_android_x86/README.md
+++ b/flutter/sherpa_onnx_android_x86/README.md
@@ -1,0 +1,7 @@
+# sherpa_onnx_android_x86
+
+This is a sub project of [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx).
+
+You are not expected to use this package directly.
+
+Please see the entry point at <https://pub.dev/packages/sherpa_onnx>.

--- a/flutter/sherpa_onnx_android_x86/android/build.gradle
+++ b/flutter/sherpa_onnx_android_x86/android/build.gradle
@@ -1,0 +1,48 @@
+// The Android Gradle Plugin builds the native code with the Android NDK.
+
+group = "com.k2fsa.sherpa.onnx.sherpa_onnx_android_x86"
+version = "1.0"
+
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        // The Android Gradle Plugin knows how to build native code with the NDK.
+        classpath("com.android.tools.build:gradle:7.3.0")
+    }
+}
+
+rootProject.allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+apply plugin: "com.android.library"
+
+android {
+    namespace 'com.k2fsa.sherpa.onnx'
+
+    // Bumping the plugin compileSdk version requires all clients of this plugin
+    // to bump the version in their app.
+    compileSdk = 34
+
+    // Use the NDK version
+    // declared in /android/app/build.gradle file of the Flutter project.
+    // Replace it with a version number if this plugin requires a specific NDK version.
+    // (e.g. ndkVersion "23.1.7779620")
+    ndkVersion = android.ndkVersion
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    defaultConfig {
+        minSdk = 21
+    }
+}

--- a/flutter/sherpa_onnx_android_x86/android/settings.gradle
+++ b/flutter/sherpa_onnx_android_x86/android/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'sherpa_onnx_android_x86'

--- a/flutter/sherpa_onnx_android_x86/android/src/main/AndroidManifest.xml
+++ b/flutter/sherpa_onnx_android_x86/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.k2fsa.sherpa.onnx">
+</manifest>

--- a/flutter/sherpa_onnx_android_x86/pubspec.yaml
+++ b/flutter/sherpa_onnx_android_x86/pubspec.yaml
@@ -1,7 +1,8 @@
-name: sherpa_onnx_linux
+name: sherpa_onnx_android_x86
+
 description: >
   Speech recognition, speech synthesis, and speaker recognition using next-gen Kaldi
-  with onnxruntime without Internet connection.
+  with onnxruntime without Internet connection. Android x86 native libraries.
 
 version: 1.12.39
 
@@ -30,5 +31,5 @@ dependencies:
 flutter:
   plugin:
     platforms:
-      linux:
+      android:
         ffiPlugin: true

--- a/flutter/sherpa_onnx_android_x86_64/README.md
+++ b/flutter/sherpa_onnx_android_x86_64/README.md
@@ -1,0 +1,7 @@
+# sherpa_onnx_android_x86_64
+
+This is a sub project of [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx).
+
+You are not expected to use this package directly.
+
+Please see the entry point at <https://pub.dev/packages/sherpa_onnx>.

--- a/flutter/sherpa_onnx_android_x86_64/android/build.gradle
+++ b/flutter/sherpa_onnx_android_x86_64/android/build.gradle
@@ -1,0 +1,48 @@
+// The Android Gradle Plugin builds the native code with the Android NDK.
+
+group = "com.k2fsa.sherpa.onnx.sherpa_onnx_android_x86_64"
+version = "1.0"
+
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        // The Android Gradle Plugin knows how to build native code with the NDK.
+        classpath("com.android.tools.build:gradle:7.3.0")
+    }
+}
+
+rootProject.allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+apply plugin: "com.android.library"
+
+android {
+    namespace 'com.k2fsa.sherpa.onnx'
+
+    // Bumping the plugin compileSdk version requires all clients of this plugin
+    // to bump the version in their app.
+    compileSdk = 34
+
+    // Use the NDK version
+    // declared in /android/app/build.gradle file of the Flutter project.
+    // Replace it with a version number if this plugin requires a specific NDK version.
+    // (e.g. ndkVersion "23.1.7779620")
+    ndkVersion = android.ndkVersion
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    defaultConfig {
+        minSdk = 21
+    }
+}

--- a/flutter/sherpa_onnx_android_x86_64/android/settings.gradle
+++ b/flutter/sherpa_onnx_android_x86_64/android/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'sherpa_onnx_android_x86_64'

--- a/flutter/sherpa_onnx_android_x86_64/android/src/main/AndroidManifest.xml
+++ b/flutter/sherpa_onnx_android_x86_64/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.k2fsa.sherpa.onnx">
+</manifest>

--- a/flutter/sherpa_onnx_android_x86_64/pubspec.yaml
+++ b/flutter/sherpa_onnx_android_x86_64/pubspec.yaml
@@ -1,7 +1,8 @@
-name: sherpa_onnx_linux
+name: sherpa_onnx_android_x86_64
+
 description: >
   Speech recognition, speech synthesis, and speaker recognition using next-gen Kaldi
-  with onnxruntime without Internet connection.
+  with onnxruntime without Internet connection. Android x86_64 native libraries.
 
 version: 1.12.39
 
@@ -30,5 +31,5 @@ dependencies:
 flutter:
   plugin:
     platforms:
-      linux:
+      android:
         ffiPlugin: true

--- a/flutter/sherpa_onnx_ios/pubspec.yaml
+++ b/flutter/sherpa_onnx_ios/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
   Speech recognition, speech synthesis, and speaker recognition using next-gen Kaldi
   with onnxruntime without Internet connection.
 
-version: 0.0.1
+version: 1.12.39
 
 repository: https://github.com/k2-fsa/sherpa-onnx/tree/master/flutter
 

--- a/flutter/sherpa_onnx_macos/pubspec.yaml
+++ b/flutter/sherpa_onnx_macos/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
   Speech recognition, speech synthesis, and speaker recognition using next-gen Kaldi
   with onnxruntime without Internet connection.
 
-version: 0.0.1
+version: 1.12.39
 
 repository: https://github.com/k2-fsa/sherpa-onnx/tree/master/flutter
 

--- a/flutter/sherpa_onnx_windows/pubspec.yaml
+++ b/flutter/sherpa_onnx_windows/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
   Speech recognition, speech synthesis, and speaker recognition using next-gen Kaldi
   with onnxruntime without Internet connection.
 
-version: 0.0.1
+version: 1.12.39
 
 repository: https://github.com/k2-fsa/sherpa-onnx/tree/master/flutter
 

--- a/new-release.sh
+++ b/new-release.sh
@@ -46,6 +46,7 @@ sed -i.bak "$replace_str" ./sherpa-onnx/rust/sherpa-onnx/README.md
 
 sed -i.bak "$replace_str" ./tauri-examples/non-streaming-speech-recognition-from-file/package.json
 sed -i.bak "$replace_str" ./tauri-examples/non-streaming-speech-recognition-from-file/src-tauri/Cargo.toml
+sed -i.bak "$replace_str" ./tauri-examples/non-streaming-speech-recognition-from-file/src-tauri/tauri.conf.json
 
 find android -name build.gradle -type f -exec sed -i.bak "s/sherpa-onnx:v$old_version/sherpa-onnx:v$new_version/g" {} \;
 find android -name build.gradle.kts -type f -exec sed -i.bak "s/sherpa-onnx:v$old_version/sherpa-onnx:v$new_version/g" {} \;

--- a/scripts/dart/sherpa-onnx-pubspec.yaml
+++ b/scripts/dart/sherpa-onnx-pubspec.yaml
@@ -29,8 +29,17 @@ dependencies:
   flutter:
     sdk: flutter
 
-  sherpa_onnx_android:
-    path: ../sherpa_onnx_android
+  sherpa_onnx_android_arm64:
+    path: ../sherpa_onnx_android_arm64
+
+  sherpa_onnx_android_armeabi:
+    path: ../sherpa_onnx_android_armeabi
+
+  sherpa_onnx_android_x86:
+    path: ../sherpa_onnx_android_x86
+
+  sherpa_onnx_android_x86_64:
+    path: ../sherpa_onnx_android_x86_64
 
   sherpa_onnx_macos:
     path: ../sherpa_onnx_macos
@@ -45,7 +54,7 @@ flutter:
   plugin:
     platforms:
       android:
-        default_package: sherpa_onnx_android
+        default_package: sherpa_onnx_android_arm64
 
       macos:
         default_package: sherpa_onnx_macos

--- a/scripts/tauri/build-tauri-vad-asr.sh.in
+++ b/scripts/tauri/build-tauri-vad-asr.sh.in
@@ -79,6 +79,10 @@ log "============================================================"
 
 model_name={{ model.model_name }}
 type={{ model.idx }}
+short_name={{ model.short_name }}
+lang={{ model.lang }}
+
+SHERPA_ONNX_VERSION=$(grep "SHERPA_ONNX_VERSION" "${SCRIPT_DIR}/CMakeLists.txt" | cut -d " " -f 2 | cut -d '"' -f 2)
 
 # Download model
 if [ ! -d "$model_name" ]; then
@@ -104,13 +108,22 @@ fi
 # Patch MODEL_TYPE and MODEL_NAME in lib.rs
 cd "${SRC_DIR}"
 sed -i.bak "s/const MODEL_TYPE: u32 = 15;/const MODEL_TYPE: u32 = ${type};/" src/lib.rs
-sed -i.bak "s/const MODEL_NAME: &str = \".*\";/const MODEL_NAME: &str = \"${model_name}\";/" src/lib.rs
+sed -i.bak "s/const MODEL_NAME: \&str = \".*\";/const MODEL_NAME: \&str = \"${model_name}\";/" src/lib.rs
+
+# Windows needs icon.ico — generate from icon.png if missing
+if [[ "$PLATFORM" == windows-* ]] && [ ! -f icons/icon.ico ]; then
+  python3 -c "
+from PIL import Image
+img = Image.open('icons/icon.png')
+img.save('icons/icon.ico', sizes=[(16,16),(32,32),(48,48),(256,256)])
+"
+fi
 
 # Copy model, vad, and rule_fsts into src-tauri/resources/ for Tauri bundling
 mkdir -p "${SRC_DIR}/resources"
 cd "${PROJECT_DIR}"
-cp -a "$model_name" "${SRC_DIR}/resources/"
-cp -a silero_vad.onnx "${SRC_DIR}/resources/"
+cp -av "$model_name" "${SRC_DIR}/resources/"
+cp -av silero_vad.onnx "${SRC_DIR}/resources/"
 {% if model.rule_fsts %}
 cp -a {{ model.rule_fsts }} "${SRC_DIR}/resources/"
 {% endif %}
@@ -128,18 +141,75 @@ log "Building for $PLATFORM (target: $RUST_TARGET)"
 cd "${SRC_DIR}"
 cargo tauri build --target "$RUST_TARGET"
 
-# On macOS, also build the other arch and create universal binary
+DIST_DIR="${PROJECT_DIR}/dist/${model_name}"
+STAGE_DIR="${PROJECT_DIR}/_stage"
+ARTIFACT_PREFIX="vad-asr-${SHERPA_ONNX_VERSION}-${lang}-${short_name}"
+
+mkdir -p "${DIST_DIR}"
+
+# On macOS: build both arches + universal, collect all 3
 if [[ "$PLATFORM" == macos-* ]]; then
   OTHER_TARGET=""
+  NATIVE_ARCH_SUFFIX=""
+  OTHER_ARCH_SUFFIX=""
   case "$PLATFORM" in
-    macos-x86_64) OTHER_TARGET="aarch64-apple-darwin" ;;
-    macos-arm64)  OTHER_TARGET="x86_64-apple-darwin" ;;
+    macos-x86_64)
+      OTHER_TARGET="aarch64-apple-darwin"
+      NATIVE_ARCH_SUFFIX="x64"
+      OTHER_ARCH_SUFFIX="aarch64"
+      ;;
+    macos-arm64)
+      OTHER_TARGET="x86_64-apple-darwin"
+      NATIVE_ARCH_SUFFIX="aarch64"
+      OTHER_ARCH_SUFFIX="x64"
+      ;;
   esac
 
+  # Save current arch (first build) artifacts to staging
+  rm -rf "${STAGE_DIR}"
+  cp -r target/${RUST_TARGET}/release/bundle/*/* "${STAGE_DIR}/" 2>/dev/null || true
+
+  # Rename and move first arch artifacts to dist
+  cd "${STAGE_DIR}"
+  for f in non-streaming-speech-recognition-from-file*; do
+    [ ! -e "$f" ] && continue
+    suffix="${f#non-streaming-speech-recognition-from-file}"
+    # For .app (directory), insert arch suffix before .app
+    suffix=$(echo "$suffix" | sed "s/\.app$/-${NATIVE_ARCH_SUFFIX}.app/")
+    if [ -d "$f" ]; then
+      tar cjf "${DIST_DIR}/${ARTIFACT_PREFIX}${suffix}.tar.bz2" "$f"
+    else
+      mv "$f" "${DIST_DIR}/${ARTIFACT_PREFIX}${suffix}"
+    fi
+  done
+  rm -rf "${STAGE_DIR}"
+  cd "${SRC_DIR}"
+
   if [ -n "$OTHER_TARGET" ]; then
+    # Build other arch
     rustup target add "$OTHER_TARGET"
     log "Building for other macOS arch: $OTHER_TARGET"
     cargo tauri build --target "$OTHER_TARGET"
+
+    # Save other arch artifacts to staging
+    mkdir -p "${STAGE_DIR}"
+    cp -r target/${OTHER_TARGET}/release/bundle/*/* "${STAGE_DIR}/" 2>/dev/null || true
+
+    # Rename and move other arch artifacts to dist
+    cd "${STAGE_DIR}"
+    for f in non-streaming-speech-recognition-from-file*; do
+      [ ! -e "$f" ] && continue
+      suffix="${f#non-streaming-speech-recognition-from-file}"
+      # For .app (directory), insert arch suffix before .app
+      suffix=$(echo "$suffix" | sed "s/\.app$/-${OTHER_ARCH_SUFFIX}.app/")
+      if [ -d "$f" ]; then
+        tar cjf "${DIST_DIR}/${ARTIFACT_PREFIX}${suffix}.tar.bz2" "$f"
+      else
+        mv "$f" "${DIST_DIR}/${ARTIFACT_PREFIX}${suffix}"
+      fi
+    done
+    rm -rf "${STAGE_DIR}"
+    cd "${SRC_DIR}"
 
     # Create universal binary via lipo
     x64_app=$(find target/x86_64-apple-darwin/release/bundle/macos -name "*.app" -maxdepth 1 | head -1)
@@ -166,27 +236,73 @@ if [[ "$PLATFORM" == macos-* ]]; then
         fi
       done
     fi
+
+    # Collect universal artifacts
+    cp -r target/universal2-apple-darwin/release/bundle/*/* "${STAGE_DIR}/" 2>/dev/null || true
+    cd "${STAGE_DIR}"
+    for f in non-streaming-speech-recognition-from-file*; do
+      [ ! -e "$f" ] && continue
+      suffix="${f#non-streaming-speech-recognition-from-file}"
+      # Replace arch-specific suffix in DMG names (e.g., _0.1.0_aarch64.dmg → _0.1.0_universal.dmg)
+      suffix=$(echo "$suffix" | sed 's/_aarch64\./_universal./;s/_x64\./_universal./')
+      # For .app (directory), insert _universal before .app
+      suffix=$(echo "$suffix" | sed 's/\.app$/_universal.app/')
+      if [ -d "$f" ]; then
+        tar cjf "${DIST_DIR}/${ARTIFACT_PREFIX}${suffix}.tar.bz2" "$f"
+      else
+        mv "$f" "${DIST_DIR}/${ARTIFACT_PREFIX}${suffix}"
+      fi
+    done
+    rm -rf "${STAGE_DIR}"
+    cd "${SRC_DIR}"
   fi
-fi
 
-# Collect artifacts
-DIST_DIR="${PROJECT_DIR}/dist/${model_name}/${PLATFORM}"
-mkdir -p "${DIST_DIR}"
-cp -r target/${RUST_TARGET}/release/bundle/* "${DIST_DIR}/" 2>/dev/null || true
+else
+  # Linux / Windows: copy and rename installer bundles
+  cp -r target/${RUST_TARGET}/release/bundle/*/* "${STAGE_DIR}/" 2>/dev/null || true
+  cd "${STAGE_DIR}"
+  for f in non-streaming-speech-recognition-from-file*; do
+    [ ! -e "$f" ] && continue
+    suffix="${f#non-streaming-speech-recognition-from-file}"
+    if [ -d "$f" ]; then
+      tar cjf "${DIST_DIR}/${ARTIFACT_PREFIX}${suffix}.tar.bz2" "$f"
+    else
+      mv "$f" "${DIST_DIR}/${ARTIFACT_PREFIX}${suffix}"
+    fi
+  done
+  rm -rf "${STAGE_DIR}"
+  cd "${SRC_DIR}"
 
-# For macOS universal, also collect the universal binary
-if [[ "$PLATFORM" == macos-* ]]; then
-  UNIVERSAL_DIR="${PROJECT_DIR}/dist/${model_name}/macos-universal"
-  mkdir -p "${UNIVERSAL_DIR}"
-  cp -r target/universal2-apple-darwin/release/bundle/* "${UNIVERSAL_DIR}/" 2>/dev/null || true
+  # Portable archives (no install needed)
+  if [[ "$PLATFORM" == windows-* ]]; then
+    PORTABLE_DIR="${DIST_DIR}/_portable"
+    mkdir -p "${PORTABLE_DIR}"
+    cp -v target/${RUST_TARGET}/release/non-streaming-speech-recognition-from-file.exe "${PORTABLE_DIR}/"
+    cp -a "${SRC_DIR}/resources" "${PORTABLE_DIR}/"
+    cd "${DIST_DIR}"
+    zip -r "${ARTIFACT_PREFIX}-windows-x64.zip" _portable/
+    rm -rf _portable
+    cd "${SRC_DIR}"
+  elif [[ "$PLATFORM" == linux-* ]]; then
+    PORTABLE_DIR="${DIST_DIR}/_portable"
+    mkdir -p "${PORTABLE_DIR}"
+    cp -v target/${RUST_TARGET}/release/non-streaming-speech-recognition-from-file "${PORTABLE_DIR}/"
+    cp -a "${SRC_DIR}/resources" "${PORTABLE_DIR}/"
+    cd "${DIST_DIR}"
+    tar czf "${ARTIFACT_PREFIX}-${PLATFORM}.tar.gz" _portable/
+    rm -rf _portable
+    cd "${SRC_DIR}"
+  fi
 fi
 
 # Restore and clean up
 cd "${SRC_DIR}"
 git checkout src/lib.rs 2>/dev/null || true
+ls -lh resources
 rm -rf resources
+rm -rf "${STAGE_DIR}"
 
 {% endfor %}
 
 log "Done! Artifacts in ${PROJECT_DIR}/dist/"
-ls -lh "${PROJECT_DIR}/dist/"
+ls -lhR "${PROJECT_DIR}/dist/"

--- a/tauri-examples/non-streaming-speech-recognition-from-file/src-tauri/tauri.conf.json
+++ b/tauri-examples/non-streaming-speech-recognition-from-file/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "non-streaming-speech-recognition-from-file",
-  "version": "0.1.0",
+  "version": "1.12.39",
   "identifier": "com.k2fsa.sherpa.onnx.asr.file",
   "build": {
     "frontendDist": "../src"
@@ -26,6 +26,6 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "resources": ["resources/*"]
+    "resources": ["resources/**"]
   }
 }


### PR DESCRIPTION
We separated it into different architectures to stay within the 100 MB file size limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added architecture-specific Android packages for ARM64, ARMv7, x86, and x86_64 variants to enable optimized builds for different device architectures.

* **Chores**
  * Updated Flutter package versions to 1.12.39 across all platforms (iOS, Linux, macOS, Windows, and Android).
  * Updated CI/CD workflows and release automation scripts to support multi-architecture builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->