### PR TITLE
Improve Tauri VAD+ASR example: settings UI, bug fixes, and RTF display

### DIFF
--- a/.github/workflows/tauri-vad-asr.yaml
+++ b/.github/workflows/tauri-vad-asr.yaml
@@ -3,7 +3,7 @@ name: tauri-vad-asr
 on:
   push:
     branches:
-      - fix-rust
+      - fix-tauri
 
   workflow_dispatch:
 

--- a/scripts/tauri/generate-vad-asr.py
+++ b/scripts/tauri/generate-vad-asr.py
@@ -813,9 +813,6 @@ def get_models() -> List[Model]:
                 "embedding": "embedding.int8.onnx",
                 "tokenizer": "Qwen3-0.6B",
             },cmd="""
-            rm -fv $model_name/encoder_adaptor.onnx
-            rm -fv $model_name/llm.onnx
-            rm -fv $model_name/embedding.onnx
             rm -rf $model_name/test_wavs
             rm -fv $model_name/*.py
             rm -fv $model_name/README.md""",
@@ -1041,11 +1038,7 @@ def get_models() -> List[Model]:
                 "decoder": "decoder.int8.onnx",
                 "tokenizer": "tokenizer",
             },cmd="""
-            rm -fv $model_name/conv_frontend.onnx
-            rm -fv $model_name/encoder.onnx
-            rm -fv $model_name/decoder.onnx
             rm -rf $model_name/test_wavs
-            rm -fv $model_name/*.py
             rm -fv $model_name/README.md""",
         ),
     ]

--- a/tauri-examples/non-streaming-speech-recognition-from-file/README.md
+++ b/tauri-examples/non-streaming-speech-recognition-from-file/README.md
@@ -1,36 +1,39 @@
 # Non-Streaming Speech Recognition from File
 
-A Tauri v2 desktop app that transcribes audio and video files using offline ASR
-with Silero VAD.
+A [Tauri v2](https://v2.tauri.app/) desktop app that transcribes audio and video
+files using offline ASR with [Silero VAD](https://github.com/snakers4/silero-vad).
 
-You can download pre-built APPs for this folder at
+Pre-built apps (macOS, Linux, Windows) are available at:
 
-    <https://k2-fsa.github.io/sherpa/onnx/tauri/pre-built-app.html#non-streaming-speech-recognition-from-file>
+> <https://k2-fsa.github.io/sherpa/onnx/tauri/pre-built-app.html#non-streaming-speech-recognition-from-file>
 
 ## Features
 
-- **62+ ASR models** supported (SenseVoice, Paraformer, Whisper, Transducer, Moonshine, etc.)
-- **Audio/video playback** with waveform display
-- **SRT subtitle export**
+- **62+ ASR models** — SenseVoice, Paraformer, Whisper, Transducer, Moonshine, and more
+- **Audio and video input** — MP3, FLAC, AAC, OGG, WAV, AIFF, CAF, MP4, MKV, WebM
+- **Live subtitle overlay** — subtitles sync with playback in real time
+- **Click-to-seek** — click any row in the results table to jump to that segment
+- **SRT subtitle export** — save results as `.srt` files
 - **Segment WAV export** — save individual speech segments as WAV files
+- **Copy results** — copy plain text or timestamped text to clipboard
 - **Progress tracking** with cancellation support
 - **Cross-platform** — macOS (universal), Linux (x64/aarch64), Windows (x64)
-- **Pure-Rust audio decoding** via [symphonia](https://github.com/pdeljanov/Symphonia) — no system dependencies
+- **Pure Rust audio decoding** via [symphonia](https://github.com/pdeljanov/Symphonia) — no system dependencies
 
-## Supported Audio Formats
+## Supported Formats
 
 Any format supported by symphonia:
 
-| Type   | Formats                                    |
-|--------|--------------------------------------------|
-| Audio  | MP3, FLAC, AAC, OGG/Vorbis, WAV, AIFF, ADPCM |
-| Video  | MP4/M4A, MKV, WebM (audio track extracted) |
+| Type  | Formats                                          |
+|-------|--------------------------------------------------|
+| Audio | MP3, FLAC, AAC, OGG/Vorbis, WAV, AIFF, CAF, ADPCM |
+| Video | MP4/M4A, MKV, WebM (audio track extracted)       |
 
 ## Prerequisites
 
 - [Rust](https://www.rust-lang.org/tools/install) (stable)
 - [Node.js](https://nodejs.org/) (for the Tauri CLI)
-- [Tauri CLI prerequisites](https://v2.tauri.app/start/prerequisites/)
+- [Tauri v2 prerequisites](https://v2.tauri.app/start/prerequisites/) (platform-specific system dependencies)
 
 Install npm dependencies:
 
@@ -57,16 +60,16 @@ curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/s
 
 ### 2. Copy assets into src-tauri
 
-Tauri bundles files from `src-tauri/assets/`. Place the entire model
-directory (keeping its original name) and `silero_vad.onnx` inside it:
+Tauri bundles files from `src-tauri/assets/`. Place the model directory
+(keeping its original name) and `silero_vad.onnx` inside it:
 
 ```bash
 mkdir -p src-tauri/assets
 cp -a sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17 src-tauri/assets/
-cp -a silero_vad.onnx src-tauri/assets/
+cp silero_vad.onnx src-tauri/assets/
 ```
 
-This gives:
+Expected layout:
 
 ```
 src-tauri/assets/
@@ -76,26 +79,28 @@ src-tauri/assets/
     └── tokens.txt
 ```
 
-Some models (e.g. SenseVoice) support a homophone replacer. To enable it,
-place `lexicon.txt` and `rule.fst` directly inside `assets/`:
+#### Optional: Homophone replacer
+
+Some models (e.g. SenseVoice) support a homophone replacer for correcting
+commonly confused words. To enable it, place `lexicon.txt` and `replace.fst`
+directly inside `assets/`:
 
 ```bash
-# Optional — only if you want homophone replacement
 curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/hr-files/lexicon.txt
 curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/hr-files/replace.fst
-cp -a lexicon.txt replace.fst src-tauri/assets/
+cp lexicon.txt replace.fst src-tauri/assets/
 ```
 
 The app works fine without these files.
 
-### 3. Build and run
+### 3. Run in development mode
 
 ```bash
 npm run dev
 ```
 
-This opens the app window. Use the file picker to select an audio or video file
-and click **Recognize**.
+This opens the app window. Click **Select Audio/Video File**, pick a file, and
+recognition starts automatically.
 
 ### 4. Build a release binary
 
@@ -107,38 +112,79 @@ The output is in `src-tauri/target/release/bundle/`.
 
 ## Using a Different Model
 
-The app uses `MODEL_TYPE` and `MODEL_NAME` (constants in `src-tauri/src/lib.rs`)
-to select which model to bundle. The defaults are `15` and
-`sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17`.
+The app uses two constants in `src-tauri/src/lib.rs` to select which model
+to bundle:
+
+```rust
+const MODEL_TYPE: u32 = 15;
+const MODEL_NAME: &str = "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17";
+```
 
 To switch models:
 
-1. Choose a model type from `src-tauri/src/model_registry.rs` (types 0–61).
-2. Set `MODEL_TYPE` and `MODEL_NAME` in `src-tauri/src/lib.rs`:
-
-```rust
-const MODEL_TYPE: u32 = 42;
-const MODEL_NAME: &str = "your-model-dir-name";
-```
-
-3. Download the corresponding model and place the entire directory into
-   `src-tauri/assets/`, keeping its original name.
+1. Pick a model type from `src-tauri/src/model_registry.rs` (types 0--61).
+2. Update `MODEL_TYPE` and `MODEL_NAME` in `src-tauri/src/lib.rs`.
+3. Download the corresponding model and place its directory into
+   `src-tauri/assets/`, keeping the original directory name.
+4. Run `npm run dev` to test.
 
 You can also use the build script generator to automate this:
 
 ```bash
-# Generate the model registry from model definitions
 python scripts/tauri/generate-vad-asr.py --gen-registry
-
-# Generate a build script for a specific model shard
 python scripts/tauri/generate-vad-asr.py --total 1 --index 0
 ```
 
+## Architecture
+
+```
+┌──────────────────────────────────────────────────┐
+│  Frontend (HTML + JS)                            │
+│  index.html / main.js / styles.css               │
+│                                                  │
+│  invoke("recognize_file", {path})                │
+│  setInterval → invoke("get_recognition_progress")│
+└──────────────┬───────────────────────────────────┘
+               │ Tauri IPC (invoke)
+┌──────────────▼───────────────────────────────────┐
+│  Backend (Rust)                                  │
+│                                                  │
+│  lib.rs                                          │
+│  ├── recognize_file()  → spawns worker thread    │
+│  ├── run_recognition() → decode → VAD → ASR      │
+│  ├── get_recognition_progress() → poll state     │
+│  ├── cancel_recognition()                        │
+│  ├── export_srt()                                │
+│  └── save_segment_as_wav()                       │
+│                                                  │
+│  model_registry.rs (auto-generated, 62 models)   │
+└──────────────────────────────────────────────────┘
+```
+
+**Processing pipeline:**
+
+1. **symphonia** decodes audio/video packets to mono f32 PCM (streaming, not buffered).
+2. **LinearResampler** resamples to 16 kHz if the native sample rate differs.
+3. **Silero VAD** processes 512-sample (32 ms) windows and detects speech segments.
+4. **OfflineRecognizer** transcribes each speech segment.
+5. Results are accumulated and polled by the frontend every 200 ms.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "Models are still loading" on startup | Models load in a background thread. Wait a few seconds. Large models take longer. |
+| "Failed to create recognizer" | Check that `src-tauri/assets/<MODEL_NAME>/` exists and contains the expected `.onnx` and `tokens.txt` files. |
+| "Unsupported format" | The audio format may not be enabled in `Cargo.toml`'s symphonia features. Check the `[dependencies.symphonia]` section. |
+| Black rectangle in player | Normal for audio-only files — the `<video>` element shows controls but no picture. |
+| App crashes on startup | Run `npm run dev` and check stderr for `[init]` or `[build_models]` log lines. |
+
 ## How It Works
 
-1. Click **Select Audio File** to choose an audio/video file via native dialog.
-2. The file is decoded by symphonia to mono f32 PCM samples.
+1. Click **Select Audio/Video File** to choose a file via the native dialog.
+2. The file is decoded packet-by-packet by symphonia to mono f32 PCM samples.
 3. Audio is resampled to 16 kHz (required by Silero VAD).
 4. Audio is fed to the VAD in 512-sample (32 ms) chunks.
-5. Each detected speech segment is decoded by the offline recognizer.
+5. Each detected speech segment (> 100 ms) is decoded by the offline recognizer.
 6. Results are displayed in a table with start/end timestamps and text.
+7. Click any row to seek the player to that segment. Subtitles overlay the player.

--- a/tauri-examples/non-streaming-speech-recognition-from-file/README.md
+++ b/tauri-examples/non-streaming-speech-recognition-from-file/README.md
@@ -7,6 +7,16 @@ Pre-built apps (macOS, Linux, Windows) are available at:
 
 > <https://k2-fsa.github.io/sherpa/onnx/tauri/pre-built-app.html#non-streaming-speech-recognition-from-file>
 
+## Screenshots
+
+|1|2|3|
+|---|---|---|
+|<img width="1800" height="1392" alt="Screenshot 2026-04-20 at 14 59 39" src="https://github.com/user-attachments/assets/81369094-0e8a-4be5-b15e-f83d16821be0" />|<img width="1768" height="1388" alt="Screenshot 2026-04-20 at 14 59 49" src="https://github.com/user-attachments/assets/62923691-9446-476b-838b-df3b5565d1a2" />|<img width="1798" height="1398" alt="Screenshot 2026-04-20 at 15 00 00" src="https://github.com/user-attachments/assets/a199c25e-1d1a-4907-9971-a779a0919c44" />|
+
+## Video Demo
+
+<https://www.bilibili.com/video/BV1cXoKBhEdz>
+
 ## Features
 
 - **62+ ASR models** — SenseVoice, Paraformer, Whisper, Transducer, Moonshine, and more
@@ -112,7 +122,7 @@ The output is in `src-tauri/target/release/bundle/`.
 
 ## Using a Different Model
 
-The app uses two constants in `src-tauri/src/lib.rs` to select which model
+The app uses two constants in [`src-tauri/src/lib.rs`](src-tauri/src/lib.rs) to select which model
 to bundle:
 
 ```rust
@@ -122,8 +132,8 @@ const MODEL_NAME: &str = "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-1
 
 To switch models:
 
-1. Pick a model type from `src-tauri/src/model_registry.rs` (types 0--61).
-2. Update `MODEL_TYPE` and `MODEL_NAME` in `src-tauri/src/lib.rs`.
+1. Pick a model type from [`src-tauri/src/model_registry.rs`](src-tauri/src/model_registry.rs) (types 0--61).
+2. Update `MODEL_TYPE` and `MODEL_NAME` in [`src-tauri/src/lib.rs`](src-tauri/src/lib.rs).
 3. Download the corresponding model and place its directory into
    `src-tauri/assets/`, keeping the original directory name.
 4. Run `npm run dev` to test.

--- a/tauri-examples/non-streaming-speech-recognition-from-file/src-tauri/Cargo.lock
+++ b/tauri-examples/non-streaming-speech-recognition-from-file/src-tauri/Cargo.lock
@@ -2009,7 +2009,6 @@ name = "non-streaming-speech-recognition-from-file"
 version = "1.12.39"
 dependencies = [
  "serde",
- "serde_json",
  "sherpa-onnx",
  "symphonia",
  "tauri",
@@ -3489,6 +3488,7 @@ dependencies = [
  "symphonia-codec-pcm",
  "symphonia-codec-vorbis",
  "symphonia-core",
+ "symphonia-format-caf",
  "symphonia-format-isomp4",
  "symphonia-format-mkv",
  "symphonia-format-ogg",
@@ -3573,6 +3573,17 @@ dependencies = [
  "bytemuck",
  "lazy_static",
  "log",
+]
+
+[[package]]
+name = "symphonia-format-caf"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8faf379316b6b6e6bbc274d00e7a592e0d63ff1a7e182ce8ba25e24edd3d096"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
 ]
 
 [[package]]

--- a/tauri-examples/non-streaming-speech-recognition-from-file/src-tauri/Cargo.toml
+++ b/tauri-examples/non-streaming-speech-recognition-from-file/src-tauri/Cargo.toml
@@ -34,4 +34,6 @@ symphonia = { version = "0.5.5", features = [
     "mkv",
     "pcm",
     "adpcm",
+    "aiff",
+    "caf",
 ] }

--- a/tauri-examples/non-streaming-speech-recognition-from-file/src-tauri/src/lib.rs
+++ b/tauri-examples/non-streaming-speech-recognition-from-file/src-tauri/src/lib.rs
@@ -53,6 +53,8 @@ struct ProcessingState {
     percent: u32,
     status: String,
     segments: Vec<SegmentResult>,
+    elapsed_secs: f32,
+    audio_duration_secs: f32,
 }
 
 /// Shared application state, created once at startup.
@@ -72,6 +74,8 @@ struct AppState {
     init_error: Arc<Mutex<String>>,
     num_threads: Arc<AtomicU32>,
     settings: Arc<Mutex<VadSettings>>,
+    elapsed_secs: Arc<Mutex<f32>>,
+    audio_duration_secs: Arc<Mutex<f32>>,
 }
 
 /// Open an audio/video file and return the format reader, decoder, and track info.
@@ -207,6 +211,8 @@ fn recognize_file(path: String, state: tauri::State<'_, AppState>) -> Result<(),
     *state.status.lock().map_err(|e| e.to_string())? = "processing".to_string();
     state.segments.lock().map_err(|e| e.to_string())?.clear();
     *state.audio_path.lock().map_err(|e| e.to_string())? = path.clone();
+    *state.elapsed_secs.lock().map_err(|e| e.to_string())? = 0.0;
+    *state.audio_duration_secs.lock().map_err(|e| e.to_string())? = 0.0;
 
     // Clone Arc handles for the worker thread
     let recognizer = Arc::clone(&state.recognizer);
@@ -216,8 +222,11 @@ fn recognize_file(path: String, state: tauri::State<'_, AppState>) -> Result<(),
     let progress = Arc::clone(&state.progress);
     let status = Arc::clone(&state.status);
     let segments = Arc::clone(&state.segments);
+    let elapsed_secs = Arc::clone(&state.elapsed_secs);
+    let audio_duration_secs = Arc::clone(&state.audio_duration_secs);
 
     std::thread::spawn(move || {
+        let start_time = std::time::Instant::now();
         let result = run_recognition(
             &path,
             &recognizer,
@@ -226,13 +235,21 @@ fn recognize_file(path: String, state: tauri::State<'_, AppState>) -> Result<(),
             &progress,
             &segments,
         );
+        let elapsed = start_time.elapsed().as_secs_f32();
+
+        if let Ok(mut e) = elapsed_secs.lock() {
+            *e = elapsed;
+        }
 
         let Ok(mut s) = status.lock() else {
             running.store(false, Ordering::SeqCst);
             return;
         };
         match result {
-            Ok(()) => {
+            Ok(audio_dur) => {
+                if let Ok(mut d) = audio_duration_secs.lock() {
+                    *d = audio_dur;
+                }
                 if cancelled.load(Ordering::Relaxed) {
                     *s = "cancelled".to_string();
                 } else {
@@ -251,6 +268,7 @@ fn recognize_file(path: String, state: tauri::State<'_, AppState>) -> Result<(),
 }
 
 /// Stream audio through VAD + ASR without buffering the entire file.
+/// Returns the audio duration in seconds on success.
 fn run_recognition(
     path: &str,
     recognizer: &Arc<Mutex<Option<OfflineRecognizer>>>,
@@ -258,7 +276,7 @@ fn run_recognition(
     cancelled: &AtomicBool,
     progress: &Arc<AtomicU32>,
     segments: &Arc<Mutex<Vec<SegmentResult>>>,
-) -> Result<(), String> {
+) -> Result<f32, String> {
     let (mut format_reader, mut decoder, track_id, num_channels, native_rate) =
         open_audio_file(path)?;
 
@@ -335,7 +353,7 @@ fn run_recognition(
         while vad_buf.len() >= window_size {
             if cancelled.load(Ordering::Relaxed) {
                 vad.clear();
-                return Ok(());
+                return Ok(decoded_count as f32 / native_rate as f32);
             }
 
             vad.accept_waveform(&vad_buf[..window_size]);
@@ -369,10 +387,11 @@ fn run_recognition(
         }
     }
 
+    let audio_duration = decoded_count as f32 / native_rate as f32;
     let final_count = segments.lock().map(|s| s.len()).unwrap_or(0);
-    eprintln!("[run_recognition] done, total segments: {final_count}");
+    eprintln!("[run_recognition] done, total segments: {final_count}, audio_duration: {audio_duration:.2}s");
 
-    Ok(())
+    Ok(audio_duration)
 }
 
 /// Poll this from the frontend to get current progress and results.
@@ -381,10 +400,14 @@ fn get_recognition_progress(state: tauri::State<'_, AppState>) -> Result<Process
     let percent = state.progress.load(Ordering::Relaxed);
     let status = state.status.lock().map_err(|e| e.to_string())?.clone();
     let segments = state.segments.lock().map_err(|e| e.to_string())?.clone();
+    let elapsed_secs = *state.elapsed_secs.lock().map_err(|e| e.to_string())?;
+    let audio_duration_secs = *state.audio_duration_secs.lock().map_err(|e| e.to_string())?;
     Ok(ProcessingState {
         percent,
         status,
         segments,
+        elapsed_secs,
+        audio_duration_secs,
     })
 }
 
@@ -818,6 +841,8 @@ fn build_app_state() -> AppState {
         init_error: Arc::new(Mutex::new(String::new())),
         num_threads: Arc::new(AtomicU32::new(0)),
         settings: Arc::new(Mutex::new(VadSettings::default())),
+        elapsed_secs: Arc::new(Mutex::new(0.0)),
+        audio_duration_secs: Arc::new(Mutex::new(0.0)),
     }
 }
 

--- a/tauri-examples/non-streaming-speech-recognition-from-file/src-tauri/src/lib.rs
+++ b/tauri-examples/non-streaming-speech-recognition-from-file/src-tauri/src/lib.rs
@@ -1,7 +1,7 @@
 mod model_registry;
 
 use model_registry::get_model_config;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sherpa_onnx::{
     LinearResampler, OfflineRecognizer, SileroVadModelConfig, VadModelConfig,
     VoiceActivityDetector,
@@ -19,6 +19,27 @@ use symphonia::core::probe::Hint;
 /// Which ASR model to bundle. Build scripts patch these via sed.
 const MODEL_TYPE: u32 = 15;
 const MODEL_NAME: &str = "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17";
+
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
+struct VadSettings {
+    threshold: f32,
+    min_silence_duration: f32,
+    min_speech_duration: f32,
+    max_speech_duration: f32,
+    num_threads: i32,
+}
+
+impl Default for VadSettings {
+    fn default() -> Self {
+        Self {
+            threshold: 0.2,
+            min_silence_duration: 0.2,
+            min_speech_duration: 0.2,
+            max_speech_duration: 10.0,
+            num_threads: 2,
+        }
+    }
+}
 
 #[derive(Serialize, Clone)]
 struct SegmentResult {
@@ -50,6 +71,7 @@ struct AppState {
     init_status: Arc<AtomicU8>,
     init_error: Arc<Mutex<String>>,
     num_threads: Arc<AtomicU32>,
+    settings: Arc<Mutex<VadSettings>>,
 }
 
 /// Open an audio/video file and return the format reader, decoder, and track info.
@@ -611,7 +633,7 @@ fn resource_dir() -> PathBuf {
 }
 
 /// Initialize recognizer and VAD. Returns (recognizer, vad, num_threads) or error string.
-fn build_models() -> Result<(OfflineRecognizer, VoiceActivityDetector, u32), String> {
+fn build_models(settings: &VadSettings) -> Result<(OfflineRecognizer, VoiceActivityDetector, u32), String> {
     let dir = resource_dir();
     let model_dir = dir.join(MODEL_NAME);
     let silero_vad_path = dir.join("silero_vad.onnx");
@@ -668,7 +690,8 @@ fn build_models() -> Result<(OfflineRecognizer, VoiceActivityDetector, u32), Str
         asr_config.hr.rule_fsts = hr_rule_fst.to_str().map(|s| s.to_string());
     }
 
-    let num_threads = asr_config.model_config.num_threads as u32;
+    asr_config.model_config.num_threads = settings.num_threads;
+    let num_threads = settings.num_threads as u32;
 
     let silero_vad_str = silero_vad_path
         .to_str()
@@ -678,11 +701,11 @@ fn build_models() -> Result<(OfflineRecognizer, VoiceActivityDetector, u32), Str
     let mut vad_config = VadModelConfig::default();
     vad_config.silero_vad = SileroVadModelConfig {
         model: Some(silero_vad_str),
-        threshold: 0.2,
-        min_silence_duration: 0.2,
-        min_speech_duration: 0.2,
+        threshold: settings.threshold,
+        min_silence_duration: settings.min_silence_duration,
+        min_speech_duration: settings.min_speech_duration,
         window_size: 512,
-        max_speech_duration: 10.0,
+        max_speech_duration: settings.max_speech_duration,
         ..Default::default()
     };
     vad_config.sample_rate = 16000;
@@ -715,6 +738,70 @@ fn build_models() -> Result<(OfflineRecognizer, VoiceActivityDetector, u32), Str
     Ok((recognizer, vad, num_threads))
 }
 
+#[tauri::command]
+fn get_settings(state: tauri::State<'_, AppState>) -> Result<VadSettings, String> {
+    state.settings.lock().map(|s| s.clone()).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn apply_settings(
+    new_settings: VadSettings,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    if state.running.load(Ordering::SeqCst) {
+        return Err("Cannot change settings while recognition is running".to_string());
+    }
+    let init = state.init_status.load(Ordering::Relaxed);
+    if init == 0 {
+        return Err("Models are still loading, please wait".to_string());
+    }
+
+    {
+        let current = state.settings.lock().map_err(|e| e.to_string())?;
+        if *current == new_settings {
+            return Ok(());
+        }
+    }
+
+    // Set init_status to 0 so the frontend shows "Loading models..."
+    state.init_status.store(0, Ordering::Relaxed);
+
+    // Store the new settings
+    *state.settings.lock().map_err(|e| e.to_string())? = new_settings.clone();
+
+    let recognizer_arc = Arc::clone(&state.recognizer);
+    let vad_arc = Arc::clone(&state.vad);
+    let init_status = Arc::clone(&state.init_status);
+    let init_error = Arc::clone(&state.init_error);
+    let init_num_threads = Arc::clone(&state.num_threads);
+
+    std::thread::spawn(move || {
+        eprintln!("[apply_settings] rebuilding models with new settings...");
+        match build_models(&new_settings) {
+            Ok((rec, vad, threads)) => {
+                eprintln!("[apply_settings] models rebuilt, num_threads={threads}");
+                if let Ok(mut r) = recognizer_arc.lock() {
+                    *r = Some(rec);
+                }
+                if let Ok(mut v) = vad_arc.lock() {
+                    *v = Some(vad);
+                }
+                init_num_threads.store(threads, Ordering::Relaxed);
+                init_status.store(1, Ordering::Relaxed);
+            }
+            Err(e) => {
+                eprintln!("[apply_settings] rebuild failed: {e}");
+                if let Ok(mut err) = init_error.lock() {
+                    *err = e;
+                }
+                init_status.store(2, Ordering::Relaxed);
+            }
+        }
+    });
+
+    Ok(())
+}
+
 /// Create AppState with recognizer/VAD set to None.
 /// Models are loaded in a background thread after startup.
 fn build_app_state() -> AppState {
@@ -730,6 +817,7 @@ fn build_app_state() -> AppState {
         init_status: Arc::new(AtomicU8::new(0)), // 0 = pending
         init_error: Arc::new(Mutex::new(String::new())),
         num_threads: Arc::new(AtomicU32::new(0)),
+        settings: Arc::new(Mutex::new(VadSettings::default())),
     }
 }
 
@@ -743,10 +831,12 @@ pub fn run() {
     let init_status = Arc::clone(&state.init_status);
     let init_error = Arc::clone(&state.init_error);
     let init_num_threads = Arc::clone(&state.num_threads);
+    let init_settings = Arc::clone(&state.settings);
 
     std::thread::spawn(move || {
         eprintln!("[init] starting model initialization...");
-        match build_models() {
+        let settings = init_settings.lock().map(|s| s.clone()).unwrap_or_default();
+        match build_models(&settings) {
             Ok((rec, vad, threads)) => {
                 eprintln!("[init] models ready, num_threads={threads}");
                 if let Ok(mut r) = init_recognizer.lock() {
@@ -756,6 +846,9 @@ pub fn run() {
                     *v = Some(vad);
                 }
                 init_num_threads.store(threads, Ordering::Relaxed);
+                if let Ok(mut s) = init_settings.lock() {
+                    s.num_threads = threads as i32;
+                }
                 init_status.store(1, Ordering::Relaxed); // ready
             }
             Err(e) => {
@@ -779,6 +872,8 @@ pub fn run() {
             export_srt,
             save_segment_as_wav,
             get_init_status,
+            get_settings,
+            apply_settings,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/tauri-examples/non-streaming-speech-recognition-from-file/src-tauri/src/lib.rs
+++ b/tauri-examples/non-streaming-speech-recognition-from-file/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ struct ProcessingState {
 struct AppState {
     recognizer: Arc<Mutex<Option<OfflineRecognizer>>>,
     vad: Arc<Mutex<Option<VoiceActivityDetector>>>,
+    running: Arc<AtomicBool>,
     cancelled: Arc<AtomicBool>,
     progress: Arc<AtomicU32>,
     status: Arc<Mutex<String>>,
@@ -94,6 +95,43 @@ fn open_audio_file(
     Ok((format, decoder, track_id, num_channels, sample_rate))
 }
 
+/// Recognize a single VAD speech segment: skip if too short or punctuation-only.
+fn recognize_segment(
+    recognizer: &OfflineRecognizer,
+    segment: &sherpa_onnx::SpeechSegment,
+    segments: &Arc<Mutex<Vec<SegmentResult>>>,
+) {
+    let samples = segment.samples();
+    let duration = samples.len() as f32 / 16000.0;
+    if duration < 0.1 {
+        return;
+    }
+
+    let start_time = segment.start() as f32 / 16000.0;
+    let end_time = start_time + duration;
+
+    let stream = recognizer.create_stream();
+    stream.accept_waveform(16000, samples);
+    recognizer.decode(&stream);
+
+    if let Some(r) = stream.get_result() {
+        let text = r.text.trim().to_string();
+        if !text.is_empty()
+            && !text
+                .chars()
+                .all(|c| c.is_ascii_punctuation() || c.is_ascii_whitespace())
+        {
+            if let Ok(mut segs) = segments.lock() {
+                segs.push(SegmentResult {
+                    start: start_time,
+                    end: end_time,
+                    text,
+                });
+            }
+        }
+    }
+}
+
 /// Decode interleaved AudioBufferRef to mono f32 samples.
 fn decode_to_mono_f32(decoded: &AudioBufferRef, num_channels: usize) -> Vec<f32> {
     let mut buf =
@@ -123,12 +161,18 @@ fn decode_to_mono_f32(decoded: &AudioBufferRef, num_channels: usize) -> Vec<f32>
 /// Streams audio packet-by-packet to avoid loading the entire file into memory.
 #[tauri::command]
 fn recognize_file(path: String, state: tauri::State<'_, AppState>) -> Result<(), String> {
+    if state.running.swap(true, Ordering::SeqCst) {
+        return Err("Recognition is already running".to_string());
+    }
+
     // Check initialization
     let init = state.init_status.load(Ordering::Relaxed);
     if init == 0 {
+        state.running.store(false, Ordering::SeqCst);
         return Err("Models are still loading, please wait".to_string());
     }
     if init == 2 {
+        state.running.store(false, Ordering::SeqCst);
         let err = state.init_error.lock().map_err(|e| e.to_string())?.clone();
         return Err(format!("Initialization failed: {err}"));
     }
@@ -145,6 +189,7 @@ fn recognize_file(path: String, state: tauri::State<'_, AppState>) -> Result<(),
     // Clone Arc handles for the worker thread
     let recognizer = Arc::clone(&state.recognizer);
     let vad = Arc::clone(&state.vad);
+    let running = Arc::clone(&state.running);
     let cancelled = Arc::clone(&state.cancelled);
     let progress = Arc::clone(&state.progress);
     let status = Arc::clone(&state.status);
@@ -160,7 +205,10 @@ fn recognize_file(path: String, state: tauri::State<'_, AppState>) -> Result<(),
             &segments,
         );
 
-        let mut s = status.lock().unwrap();
+        let Ok(mut s) = status.lock() else {
+            running.store(false, Ordering::SeqCst);
+            return;
+        };
         match result {
             Ok(()) => {
                 if cancelled.load(Ordering::Relaxed) {
@@ -174,6 +222,7 @@ fn recognize_file(path: String, state: tauri::State<'_, AppState>) -> Result<(),
                 *s = format!("error: {e}");
             }
         }
+        running.store(false, Ordering::SeqCst);
     });
 
     Ok(())
@@ -271,32 +320,7 @@ fn run_recognition(
             vad_buf.drain(..window_size);
 
             while let Some(segment) = vad.front() {
-                let seg_samples = segment.samples();
-                let duration = seg_samples.len() as f32 / 16000.0;
-                let start_time = segment.start() as f32 / 16000.0;
-                let end_time = start_time + duration;
-
-                if duration >= 0.1 {
-                    let stream = recognizer.create_stream();
-                    stream.accept_waveform(16000, seg_samples);
-                    recognizer.decode(&stream);
-                    if let Some(r) = stream.get_result() {
-                        let text = r.text.trim().to_string();
-                        if !text.is_empty()
-                            && !text
-                                .chars()
-                                .all(|c| c.is_ascii_punctuation() || c.is_ascii_whitespace())
-                        {
-                            if let Ok(mut segs) = segments.lock() {
-                                segs.push(SegmentResult {
-                                    start: start_time,
-                                    end: end_time,
-                                    text,
-                                });
-                            }
-                        }
-                    }
-                }
+                recognize_segment(recognizer, &segment, segments);
                 vad.pop();
             }
         }
@@ -318,27 +342,7 @@ fn run_recognition(
     if !cancelled.load(Ordering::Relaxed) && !vad_buf.is_empty() {
         vad.flush();
         while let Some(segment) = vad.front() {
-            let seg_samples = segment.samples();
-            let duration = seg_samples.len() as f32 / 16000.0;
-            let start_time = segment.start() as f32 / 16000.0;
-            let end_time = start_time + duration;
-
-            if duration >= 0.1 {
-                let stream = recognizer.create_stream();
-                stream.accept_waveform(16000, seg_samples);
-                recognizer.decode(&stream);
-                if let Some(r) = stream.get_result() {
-                    if !r.text.is_empty() {
-                        if let Ok(mut segs) = segments.lock() {
-                            segs.push(SegmentResult {
-                                start: start_time,
-                                end: end_time,
-                                text: r.text,
-                            });
-                        }
-                    }
-                }
-            }
+            recognize_segment(recognizer, &segment, segments);
             vad.pop();
         }
     }
@@ -549,7 +553,11 @@ struct InitStatus {
 #[tauri::command]
 fn get_init_status(state: tauri::State<'_, AppState>) -> InitStatus {
     let status = state.init_status.load(Ordering::Relaxed);
-    let error = state.init_error.lock().unwrap().clone();
+    let error = state
+        .init_error
+        .lock()
+        .map(|e| e.clone())
+        .unwrap_or_default();
     let num_threads = state.num_threads.load(Ordering::Relaxed);
     InitStatus {
         status,
@@ -713,6 +721,7 @@ fn build_app_state() -> AppState {
     AppState {
         recognizer: Arc::new(Mutex::new(None)),
         vad: Arc::new(Mutex::new(None)),
+        running: Arc::new(AtomicBool::new(false)),
         cancelled: Arc::new(AtomicBool::new(false)),
         progress: Arc::new(AtomicU32::new(0)),
         status: Arc::new(Mutex::new("idle".to_string())),
@@ -740,14 +749,20 @@ pub fn run() {
         match build_models() {
             Ok((rec, vad, threads)) => {
                 eprintln!("[init] models ready, num_threads={threads}");
-                *init_recognizer.lock().unwrap() = Some(rec);
-                *init_vad.lock().unwrap() = Some(vad);
+                if let Ok(mut r) = init_recognizer.lock() {
+                    *r = Some(rec);
+                }
+                if let Ok(mut v) = init_vad.lock() {
+                    *v = Some(vad);
+                }
                 init_num_threads.store(threads, Ordering::Relaxed);
                 init_status.store(1, Ordering::Relaxed); // ready
             }
             Err(e) => {
                 eprintln!("[init] model initialization failed: {e}");
-                *init_error.lock().unwrap() = e;
+                if let Ok(mut err) = init_error.lock() {
+                    *err = e;
+                }
                 init_status.store(2, Ordering::Relaxed); // error
             }
         }

--- a/tauri-examples/non-streaming-speech-recognition-from-file/src/index.html
+++ b/tauri-examples/non-streaming-speech-recognition-from-file/src/index.html
@@ -23,6 +23,7 @@
       <div class="actions">
         <button id="select-btn">Select Audio/Video File</button>
         <button id="cancel-btn" style="display: none">Cancel</button>
+        <button id="settings-btn" title="Settings" disabled>&#9881;</button>
       </div>
 
       <p id="status" class="status"></p>
@@ -61,6 +62,35 @@
           </thead>
           <tbody id="results-body"></tbody>
         </table>
+      </div>
+      <div id="settings-modal" class="modal-overlay" style="display:none">
+        <div class="modal">
+          <h3>VAD &amp; Recognizer Settings</h3>
+          <label>
+            VAD Threshold (0.0 &ndash; 1.0)
+            <input id="set-threshold" type="number" min="0" max="1" step="0.05" />
+          </label>
+          <label>
+            Min Silence Duration (s)
+            <input id="set-min-silence" type="number" min="0" step="0.1" />
+          </label>
+          <label>
+            Min Speech Duration (s)
+            <input id="set-min-speech" type="number" min="0" step="0.1" />
+          </label>
+          <label>
+            Max Speech Duration (s)
+            <input id="set-max-speech" type="number" min="0.5" step="0.5" />
+          </label>
+          <label>
+            Recognizer Threads (1 &ndash; 16)
+            <input id="set-num-threads" type="number" min="1" max="16" step="1" />
+          </label>
+          <div class="modal-actions">
+            <button id="settings-apply">Apply</button>
+            <button id="settings-cancel">Cancel</button>
+          </div>
+        </div>
       </div>
     </main>
   </body>

--- a/tauri-examples/non-streaming-speech-recognition-from-file/src/main.js
+++ b/tauri-examples/non-streaming-speech-recognition-from-file/src/main.js
@@ -332,10 +332,10 @@ function startPolling() {
       progressBar.style.width = state.percent + "%";
       progressLabel.textContent = state.percent + "%";
 
-      // Update results table
+      // Append only new rows instead of rebuilding the entire table
+      const prevLen = lastSegments.length;
       lastSegments = state.segments;
-      resultsBody.innerHTML = "";
-      for (let i = 0; i < state.segments.length; i++) {
+      for (let i = prevLen; i < state.segments.length; i++) {
         const seg = state.segments[i];
         const tr = document.createElement("tr");
         tr.dataset.idx = i;

--- a/tauri-examples/non-streaming-speech-recognition-from-file/src/main.js
+++ b/tauri-examples/non-streaming-speech-recognition-from-file/src/main.js
@@ -374,8 +374,16 @@ function startPolling() {
         cancelBtn.style.display = "none";
         progressBar.style.width = "100%";
         progressLabel.textContent = "100%";
-        statusEl.textContent = `Done. Found ${state.segments.length} segment(s).`;
+
+        const elapsed = state.elapsed_secs;
+        const audioDur = state.audio_duration_secs;
+        const rtf = audioDur > 0 ? (elapsed / audioDur).toFixed(3) : "N/A";
+        statusEl.textContent =
+          `Done. ${state.segments.length} segment(s). ` +
+          `Audio: ${audioDur.toFixed(1)}s, Elapsed: ${elapsed.toFixed(1)}s, ` +
+          `RTF: ${rtf} (=${elapsed.toFixed(1)}/${audioDur.toFixed(1)})`;
         statusEl.className = "status status-done";
+        statsEl.style.display = "none";
       } else if (state.status === "cancelled") {
         clearInterval(pollTimer);
         pollTimer = null;

--- a/tauri-examples/non-streaming-speech-recognition-from-file/src/main.js
+++ b/tauri-examples/non-streaming-speech-recognition-from-file/src/main.js
@@ -17,6 +17,15 @@ const playerWrapper = document.querySelector("#player-wrapper");
 const player = document.querySelector("#player");
 const subtitleOverlay = document.querySelector("#subtitle-overlay");
 const statsEl = document.querySelector("#stats");
+const settingsBtn = document.querySelector("#settings-btn");
+const settingsModal = document.querySelector("#settings-modal");
+const setThreshold = document.querySelector("#set-threshold");
+const setMinSilence = document.querySelector("#set-min-silence");
+const setMinSpeech = document.querySelector("#set-min-speech");
+const setMaxSpeech = document.querySelector("#set-max-speech");
+const setNumThreads = document.querySelector("#set-num-threads");
+const settingsApplyBtn = document.querySelector("#settings-apply");
+const settingsCancelBtn = document.querySelector("#settings-cancel");
 
 let recognizing = false;
 let pollTimer = null;
@@ -40,11 +49,13 @@ function pollInitStatus() {
         modelsReady = true;
         modelThreads = res.num_threads;
         selectBtn.disabled = false;
+        settingsBtn.disabled = false;
         statusEl.textContent = "";
         statusEl.className = "status";
       } else if (res.status === 2) {
         // error
         selectBtn.disabled = true;
+        settingsBtn.disabled = true;
         statusEl.textContent = `Initialization failed: ${res.error}`;
         statusEl.className = "status status-error";
       } else {
@@ -285,6 +296,7 @@ selectBtn.addEventListener("click", async () => {
   // Reset UI
   recognizing = true;
   selectBtn.disabled = true;
+  settingsBtn.disabled = true;
   cancelBtn.style.display = "";
   cancelBtn.disabled = false;
   progressContainer.style.display = "flex";
@@ -306,6 +318,7 @@ selectBtn.addEventListener("click", async () => {
   } catch (err) {
     recognizing = false;
     selectBtn.disabled = false;
+    settingsBtn.disabled = false;
     cancelBtn.style.display = "none";
     progressContainer.style.display = "none";
     statusEl.textContent = `Error: ${err}`;
@@ -357,6 +370,7 @@ function startPolling() {
         pollTimer = null;
         recognizing = false;
         selectBtn.disabled = false;
+        settingsBtn.disabled = false;
         cancelBtn.style.display = "none";
         progressBar.style.width = "100%";
         progressLabel.textContent = "100%";
@@ -367,6 +381,7 @@ function startPolling() {
         pollTimer = null;
         recognizing = false;
         selectBtn.disabled = false;
+        settingsBtn.disabled = false;
         cancelBtn.style.display = "none";
         progressContainer.style.display = "none";
         statusEl.textContent = "Cancelled.";
@@ -376,6 +391,7 @@ function startPolling() {
         pollTimer = null;
         recognizing = false;
         selectBtn.disabled = false;
+        settingsBtn.disabled = false;
         cancelBtn.style.display = "none";
         progressContainer.style.display = "none";
         statusEl.textContent = state.status;
@@ -386,6 +402,7 @@ function startPolling() {
       pollTimer = null;
       recognizing = false;
       selectBtn.disabled = false;
+      settingsBtn.disabled = false;
       cancelBtn.style.display = "none";
       progressContainer.style.display = "none";
       statusEl.textContent = `Poll error: ${err}`;
@@ -393,6 +410,72 @@ function startPolling() {
     }
   }, 200);
 }
+
+// ---------------------------------------------------------------------------
+// Settings modal
+// ---------------------------------------------------------------------------
+
+settingsBtn.addEventListener("click", async () => {
+  if (!modelsReady || recognizing) return;
+
+  try {
+    const s = await invoke("get_settings");
+    setThreshold.value = s.threshold;
+    setMinSilence.value = s.min_silence_duration;
+    setMinSpeech.value = s.min_speech_duration;
+    setMaxSpeech.value = s.max_speech_duration;
+    setNumThreads.value = s.num_threads;
+    settingsModal.style.display = "flex";
+  } catch (err) {
+    flashStatus(`Settings error: ${err}`, true);
+  }
+});
+
+settingsCancelBtn.addEventListener("click", () => {
+  settingsModal.style.display = "none";
+});
+
+settingsModal.addEventListener("click", (e) => {
+  if (e.target === settingsModal) {
+    settingsModal.style.display = "none";
+  }
+});
+
+settingsApplyBtn.addEventListener("click", async () => {
+  const newSettings = {
+    threshold: parseFloat(setThreshold.value),
+    min_silence_duration: parseFloat(setMinSilence.value),
+    min_speech_duration: parseFloat(setMinSpeech.value),
+    max_speech_duration: parseFloat(setMaxSpeech.value),
+    num_threads: parseInt(setNumThreads.value, 10),
+  };
+
+  if (isNaN(newSettings.threshold) || newSettings.threshold < 0 || newSettings.threshold > 1) {
+    flashStatus("Threshold must be between 0.0 and 1.0", true);
+    return;
+  }
+  if (isNaN(newSettings.num_threads) || newSettings.num_threads < 1 || newSettings.num_threads > 16) {
+    flashStatus("Threads must be between 1 and 16", true);
+    return;
+  }
+
+  settingsApplyBtn.disabled = true;
+  try {
+    await invoke("apply_settings", { newSettings });
+    settingsModal.style.display = "none";
+
+    modelsReady = false;
+    selectBtn.disabled = true;
+    settingsBtn.disabled = true;
+    statusEl.textContent = "Reloading models...";
+    statusEl.className = "status status-working";
+    pollInitStatus();
+  } catch (err) {
+    flashStatus(`Apply error: ${err}`, true);
+  } finally {
+    settingsApplyBtn.disabled = false;
+  }
+});
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/tauri-examples/non-streaming-speech-recognition-from-file/src/styles.css
+++ b/tauri-examples/non-streaming-speech-recognition-from-file/src/styles.css
@@ -269,6 +269,81 @@ th {
   font-weight: 600;
 }
 
+#settings-btn {
+  background-color: #475569;
+  padding: 0.6em 0.8em;
+  font-size: 1.1em;
+  line-height: 1;
+}
+
+#settings-btn:hover {
+  background-color: #334155;
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal {
+  background-color: #fff;
+  border-radius: 12px;
+  padding: 1.5em 2em;
+  max-width: 400px;
+  width: 90%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+}
+
+.modal h3 {
+  margin-top: 0;
+  text-align: left;
+}
+
+.modal label {
+  display: block;
+  text-align: left;
+  font-size: 0.9em;
+  color: #555;
+  margin-bottom: 0.8em;
+}
+
+.modal input[type="number"] {
+  display: block;
+  width: 100%;
+  margin-top: 0.3em;
+  padding: 0.4em 0.6em;
+  font-size: 1em;
+  font-family: inherit;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  box-sizing: border-box;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 0.6em;
+  justify-content: flex-end;
+  margin-top: 1.2em;
+}
+
+.modal-actions button {
+  font-size: 0.9em;
+  padding: 0.5em 1.2em;
+}
+
+#settings-cancel {
+  background-color: #475569;
+}
+
+#settings-cancel:hover {
+  background-color: #334155;
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     color: #f6f6f6;
@@ -354,6 +429,36 @@ th {
   }
 
   .save-seg-btn:hover {
+    background-color: #64748b;
+  }
+
+  #settings-btn {
+    background-color: #475569;
+  }
+
+  #settings-btn:hover {
+    background-color: #64748b;
+  }
+
+  .modal {
+    background-color: #3a3a3a;
+  }
+
+  .modal label {
+    color: #bbb;
+  }
+
+  .modal input[type="number"] {
+    background-color: #2f2f2f;
+    border-color: #555;
+    color: #f6f6f6;
+  }
+
+  #settings-cancel {
+    background-color: #475569;
+  }
+
+  #settings-cancel:hover {
     background-color: #64748b;
   }
 }


### PR DESCRIPTION
  - Add a settings modal that lets users configure VAD parameters (threshold, min/max
    silence/speech duration) and recognizer thread count at runtime, with live model
    reload
  - Show RTF (Real-Time Factor), elapsed time, and audio duration when recognition
    completes
  - Fix several bugs: inconsistent text filtering in VAD flush path, potential crash
    from `unwrap()` on poisoned mutexes, missing guard against concurrent recognition
    runs
  - Improve code quality: extract duplicated segment processing into a shared helper,
    use incremental DOM updates instead of full table rebuild on each poll
  - Add missing `aiff` and `caf` symphonia features in Cargo.toml (advertised but
    not enabled)
  - Improve README with screenshots, video demo, architecture diagram, troubleshooting
    table, and clickable file links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable settings UI for VAD/ASR parameters (threshold, speech/silence durations, thread count).
  * Added audio duration and elapsed time display to recognition results.
  * Expanded audio format support to include AIFF and CAF files.

* **Documentation**
  * Enhanced README with architecture overview and troubleshooting guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->