### PR TITLE
Add two Piper Chinese TTS models

### DIFF
--- a/.github/workflows/export-piper.yaml
+++ b/.github/workflows/export-piper.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Generate script
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN0 }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         shell: bash
         run: |
           cd scripts/piper
@@ -67,7 +67,7 @@ jobs:
           export GIT_LFS_SKIP_SMUDGE=1
           export GIT_CLONE_PROTECTION_ACTIVE=false
 
-          git clone https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/sherpa-onnx-tts-samples hf
+          git clone https://csukuangfj2:$HF_TOKEN@huggingface.co/csukuangfj2/sherpa-onnx-tts-samples hf
 
           python3 ./generate.py --total $total --index $index
           chmod +x ./generate.sh
@@ -95,7 +95,7 @@ jobs:
 
       - name: Push generated mp3 files
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN0 }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         uses: nick-fields/retry@v3
         with:
           max_attempts: 20
@@ -108,7 +108,7 @@ jobs:
             git status .
             git add .
             git commit -m 'Add mp3 files'
-            git push https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/sherpa-onnx-tts-samples main
+            git push https://csukuangfj2:$HF_TOKEN@huggingface.co/csukuangfj2/sherpa-onnx-tts-samples main
 
       - name: Show generated model files
         shell: bash

--- a/.github/workflows/export-piper.yaml
+++ b/.github/workflows/export-piper.yaml
@@ -20,15 +20,15 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.10"]
-        total: ["20"]
-        index: [
-          "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
-          "10", "11", "12", "13", "14", "15", "16", "17", "18", "19",
-           ]
+        # total: ["20"]
+        # index: [
+        #   "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+        #   "10", "11", "12", "13", "14", "15", "16", "17", "18", "19",
+        #    ]
         # total: ["2"]
         # index: ["0", "1"]
-        # total: ["1"]
-        # index: ["0"]
+        total: ["1"]
+        index: ["0"]
         # total: ["5"]
         # index: ["0", "1", "2", "3", "4"]
 
@@ -48,7 +48,7 @@ jobs:
 
       - name: Generate script
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN0 }}
         shell: bash
         run: |
           cd scripts/piper
@@ -62,7 +62,7 @@ jobs:
           export GIT_LFS_SKIP_SMUDGE=1
           export GIT_CLONE_PROTECTION_ACTIVE=false
 
-          git clone https://csukuangfj2:$HF_TOKEN@huggingface.co/csukuangfj2/sherpa-onnx-tts-samples hf
+          git clone https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/sherpa-onnx-tts-samples hf
 
           python3 ./generate.py --total $total --index $index
           chmod +x ./generate.sh
@@ -90,7 +90,7 @@ jobs:
 
       - name: Push generated mp3 files
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN0 }}
         uses: nick-fields/retry@v3
         with:
           max_attempts: 20
@@ -103,7 +103,7 @@ jobs:
             git status .
             git add .
             git commit -m 'Add mp3 files'
-            git push https://csukuangfj2:$HF_TOKEN@huggingface.co/csukuangfj2/sherpa-onnx-tts-samples main
+            git push https://csukuangfj:$HF_TOKEN@huggingface.co/csukuangfj/sherpa-onnx-tts-samples main
 
       - name: Show generated model files
         shell: bash

--- a/.github/workflows/export-piper.yaml
+++ b/.github/workflows/export-piper.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [macos-latest]
         python-version: ["3.10"]
         # total: ["20"]
         # index: [
@@ -43,8 +43,25 @@ jobs:
       - name: Install Python dependencies
         shell: bash
         run: |
-          python3 -m pip install --upgrade pip jinja2 iso639-lang onnx==1.17.0 onnxruntime==1.17.1 sherpa-onnx onnxmltools==1.13.0
-          python3 -m pip install "numpy<2" soundfile
+          python3 -m pip install --upgrade \
+            pip jinja2 iso639-lang \
+            onnx==1.17.0 onnxruntime==1.17.1 \
+            sherpa-onnx onnxmltools==1.13.0 \
+            piper-tts unicode_rbnf sentence_stream g2pw pypinyin torch \
+            "numpy<2" soundfile requests
+
+      - name: Generate lexicon
+        shell: bash
+        run: |
+          cd scripts/piper
+          time python3 ./generate_lexicon_zh.py
+
+      - name: Upload lexicon
+        uses: actions/upload-artifact@v4
+        with:
+          name: lexicon-${{ matrix.index }}
+          path: scripts/piper/lexicon-zh.txt
+          retention-days: 7
 
       - name: Generate script
         env:

--- a/.github/workflows/export-piper.yaml
+++ b/.github/workflows/export-piper.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
+        os: [ubuntu-latest]
         python-version: ["3.10"]
         # total: ["20"]
         # index: [
@@ -46,8 +46,10 @@ jobs:
           python3 -m pip install --upgrade \
             pip jinja2 iso639-lang \
             onnx==1.17.0 onnxruntime==1.17.1 \
-            sherpa-onnx onnxmltools==1.13.0 \
+            onnxmltools==1.13.0 \
             "numpy<2" soundfile requests
+
+          python3 -m pip install --verbose sherpa_onnx_bin sherpa_onnx_core sherpa_onnx --no-index -f https://k2-fsa.github.io/sherpa/onnx/cpu.html
 
       - name: Generate script
         env:

--- a/.github/workflows/export-piper.yaml
+++ b/.github/workflows/export-piper.yaml
@@ -20,15 +20,15 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.10"]
-        # total: ["20"]
-        # index: [
-        #   "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
-        #   "10", "11", "12", "13", "14", "15", "16", "17", "18", "19",
-        #    ]
+        total: ["20"]
+        index: [
+          "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+          "10", "11", "12", "13", "14", "15", "16", "17", "18", "19",
+           ]
         # total: ["2"]
         # index: ["0", "1"]
-        total: ["1"]
-        index: ["0"]
+        # total: ["1"]
+        # index: ["0"]
         # total: ["5"]
         # index: ["0", "1", "2", "3", "4"]
 
@@ -185,6 +185,9 @@ jobs:
               vits-piper-zh_CN-xiao_ya-medium
               vits-piper-zh_CN-xiao_ya-medium-int8
               vits-piper-zh_CN-xiao_ya-medium-fp16
+              vits-piper-zh_CN-chaowen-medium
+              vits-piper-zh_CN-chaowen-medium-int8
+              vits-piper-zh_CN-chaowen-medium-fp16
             )
             for d in ${dirs[@]}; do
               src=scripts/piper/release/$d

--- a/.github/workflows/export-piper.yaml
+++ b/.github/workflows/export-piper.yaml
@@ -181,8 +181,10 @@ jobs:
               vits-piper-ar_JO-SA_miro_V2-high-int8
               vits-piper-ar_JO-SA_miro_V2-high-fp16
               vits-piper-ar_JO-SA_miro_V2-high
-              vits-piper-ar_JO-SA_miro_V2-high
               vits-piper-sq_AL-edon-medium
+              vits-piper-zh_CN-xiao_ya-medium
+              vits-piper-zh_CN-xiao_ya-medium-int8
+              vits-piper-zh_CN-xiao_ya-medium-fp16
             )
             for d in ${dirs[@]}; do
               src=scripts/piper/release/$d

--- a/.github/workflows/export-piper.yaml
+++ b/.github/workflows/export-piper.yaml
@@ -47,21 +47,7 @@ jobs:
             pip jinja2 iso639-lang \
             onnx==1.17.0 onnxruntime==1.17.1 \
             sherpa-onnx onnxmltools==1.13.0 \
-            piper-tts unicode_rbnf sentence_stream g2pw pypinyin torch \
             "numpy<2" soundfile requests
-
-      - name: Generate lexicon
-        shell: bash
-        run: |
-          cd scripts/piper
-          time python3 ./generate_lexicon_zh.py
-
-      - name: Upload lexicon
-        uses: actions/upload-artifact@v4
-        with:
-          name: lexicon-${{ matrix.index }}
-          path: scripts/piper/lexicon-zh.txt
-          retention-days: 7
 
       - name: Generate script
         env:

--- a/scripts/apk/generate-tts-apk-script.py
+++ b/scripts/apk/generate-tts-apk-script.py
@@ -277,10 +277,16 @@ def get_piper_models() -> List[TtsModel]:
         TtsModel(model_dir="vits-piper-vi_VN-vais1000-medium"),
         TtsModel(model_dir="vits-piper-vi_VN-vivos-x_low"),
         TtsModel(model_dir="vits-piper-zh_CN-huayan-medium"),
+        TtsModel(model_dir="vits-piper-zh_CN-xiao_ya-medium"),
     ]
 
     for m in models:
-        m.data_dir = m.model_dir + "/" + "espeak-ng-data"
+        if "zh_CN-xiao_ya" in m.model_dir:
+            m.lexion = f"{m.model_dir}/lexicon.txt"
+            m.rule_fsts = f"{m.model_dir}/phone.fst,{m.model_dir}/date.fst,{m.model_dir}/number.fst"
+        else:
+            m.data_dir = m.model_dir + "/" + "espeak-ng-data"
+
         m.model_name = m.model_dir[len("vits-piper-") :] + ".onnx"
         m.lang = m.model_dir.split("-")[2][:2]
 

--- a/scripts/apk/generate-tts-apk-script.py
+++ b/scripts/apk/generate-tts-apk-script.py
@@ -285,7 +285,7 @@ def get_piper_models() -> List[TtsModel]:
         if "zh_CN" in m.model_dir and (
             "xiao_ya" in m.model_dir or "chaowen" in m.model_dir
         ):
-            m.lexion = f"{m.model_dir}/lexicon.txt"
+            m.lexicon = f"{m.model_dir}/lexicon.txt"
             m.rule_fsts = f"{m.model_dir}/phone.fst,{m.model_dir}/date.fst,{m.model_dir}/number.fst"
         else:
             m.data_dir = m.model_dir + "/" + "espeak-ng-data"

--- a/scripts/apk/generate-tts-apk-script.py
+++ b/scripts/apk/generate-tts-apk-script.py
@@ -278,10 +278,13 @@ def get_piper_models() -> List[TtsModel]:
         TtsModel(model_dir="vits-piper-vi_VN-vivos-x_low"),
         TtsModel(model_dir="vits-piper-zh_CN-huayan-medium"),
         TtsModel(model_dir="vits-piper-zh_CN-xiao_ya-medium"),
+        TtsModel(model_dir="vits-piper-zh_CN-chaowen-medium"),
     ]
 
     for m in models:
-        if "zh_CN-xiao_ya" in m.model_dir:
+        if "zh_CN" in m.model_dir and (
+            "xiao_ya" in m.model_dir or "chaowen" in m.model_dir
+        ):
             m.lexion = f"{m.model_dir}/lexicon.txt"
             m.rule_fsts = f"{m.model_dir}/phone.fst,{m.model_dir}/date.fst,{m.model_dir}/number.fst"
         else:

--- a/scripts/piper/add_meta_data.py
+++ b/scripts/piper/add_meta_data.py
@@ -127,6 +127,7 @@ def main():
         "comment": "piper",  # must be piper for models from piper
         "language": lang_iso.name,
         "voice": voice,  # e.g., en-us
+        "version": 1,
         "has_espeak": has_espeak,
         "has_g2pw": has_g2pw,
         "n_speakers": config["num_speakers"],

--- a/scripts/piper/add_meta_data.py
+++ b/scripts/piper/add_meta_data.py
@@ -8,6 +8,11 @@ from typing import Any, Dict
 import onnx
 from iso639 import Lang
 
+# For the following model,
+# https://huggingface.co/rhasspy/piper-voices/blob/main/zh/zh_CN/xiao_ya/medium/zh_CN-xiao_ya-medium.onnx.json
+# it uses g2pw, not espeak-ng.
+# To handle that, we use has_g2pw = 1 in the meta_data
+
 
 def get_args():
     # For en_GB-semaine-medium
@@ -110,13 +115,20 @@ def main():
     else:
         voice = config["espeak"]["voice"]
 
+    has_g2pw = 0
+
+    if config["phoneme_type"] == "pinyin" and voice == "zh":
+        has_espeak = 0
+        has_g2pw = 1
+
     print("add model metadata")
     meta_data = {
         "model_type": "vits",
         "comment": "piper",  # must be piper for models from piper
         "language": lang_iso.name,
         "voice": voice,  # e.g., en-us
-        "has_espeak": 1,
+        "has_espeak": has_espeak,
+        "has_g2pw": has_g2pw,
         "n_speakers": config["num_speakers"],
         "sample_rate": sample_rate,
     }

--- a/scripts/piper/add_meta_data.py
+++ b/scripts/piper/add_meta_data.py
@@ -116,6 +116,7 @@ def main():
         voice = config["espeak"]["voice"]
 
     has_g2pw = 0
+    has_espeak = 1
 
     if config["phoneme_type"] == "pinyin" and voice == "zh":
         has_espeak = 0

--- a/scripts/piper/generate.py
+++ b/scripts/piper/generate.py
@@ -1653,10 +1653,10 @@ def get_zh_models():
         PiperModel(name="xiao_ya", kind="medium", sr=22050, ns=1),
     ]
 
-    for m in vi_VN:
-        m.lang = "vi_VN"
+    for m in zh_CN:
+        m.lang = "zh_CN"
 
-    ans = vi_VN
+    ans = zh_CN
 
     for m in ans:
         m.text = "中国工商银行的副行长和一些行政领导表示，他们去过长江和长白山; 经济不断增长。"

--- a/scripts/piper/generate.py
+++ b/scripts/piper/generate.py
@@ -1659,7 +1659,7 @@ def get_zh_models():
     ans = zh_CN
 
     for m in ans:
-        m.text = "中国工商银行的副行长和一些行政领导表示，他们去过长江和长白山; 经济不断增长。"
+        m.text = "某某银行的副行长和一些行政领导表示，他们去过长江和长白山; 经济不断增长。2024年12月31号，拨打110或者18920240511。123456块钱。当夜幕降临，星光点点，伴随着微风拂面，我在静谧中感受着时光的流转，思念如涟漪荡漾，梦境如画卷展开，我与自然融为一体，沉静在这片宁静的美丽之中，感受着生命的奇迹与温柔."
 
         if m.model_name == "":
             m.model_name = f"{m.lang}-{m.name}-{m.kind}.onnx"
@@ -2214,8 +2214,20 @@ def main():
                 "model": f"{model_dir}/{m.model_name}",
                 "data_dir": f"{model_dir}/espeak-ng-data",
                 "tokens": f"{model_dir}/tokens.txt",
+                "lexion": "",
                 "text": m.text,
+                "rule_fsts": "",
             }
+            if m.lang == "zh_CN" and m.name == "xiao_ya":
+                d = {
+                    "model": f"{model_dir}/{m.model_name}",
+                    "data_dir": "",
+                    "tokens": f"{model_dir}/tokens.txt",
+                    "lexion": f"{model_dir}/lexicon.txt",
+                    "text": m.text,
+                    "rule_fsts": f"{model_dir}/phone.fst,{model_dir}/date.fst,{model_dir}/number.fst",
+                }
+
             for i in range(m.ns):
                 s = template.render(
                     **d,

--- a/scripts/piper/generate.py
+++ b/scripts/piper/generate.py
@@ -2214,7 +2214,7 @@ def main():
                 "model": f"{model_dir}/{m.model_name}",
                 "data_dir": f"{model_dir}/espeak-ng-data",
                 "tokens": f"{model_dir}/tokens.txt",
-                "lexion": "",
+                "lexicon": "",
                 "text": m.text,
                 "rule_fsts": "",
             }

--- a/scripts/piper/generate.py
+++ b/scripts/piper/generate.py
@@ -2218,12 +2218,13 @@ def main():
                 "text": m.text,
                 "rule_fsts": "",
             }
+
             if m.lang == "zh_CN" and m.name == "xiao_ya":
                 d = {
                     "model": f"{model_dir}/{m.model_name}",
                     "data_dir": "",
                     "tokens": f"{model_dir}/tokens.txt",
-                    "lexion": f"{model_dir}/lexicon.txt",
+                    "lexicon": f"{model_dir}/lexicon.txt",
                     "text": m.text,
                     "rule_fsts": f"{model_dir}/phone.fst,{model_dir}/date.fst,{model_dir}/number.fst",
                 }

--- a/scripts/piper/generate.py
+++ b/scripts/piper/generate.py
@@ -1651,6 +1651,7 @@ def get_vi_models():
 def get_zh_models():
     zh_CN = [
         PiperModel(name="xiao_ya", kind="medium", sr=22050, ns=1),
+        PiperModel(name="chaowen", kind="medium", sr=22050, ns=1),
     ]
 
     for m in zh_CN:
@@ -2144,8 +2145,7 @@ def get_all_models():
     ans += get_tr_models()
     ans += get_uk_models()
     ans += get_vi_models()
-
-    ans = get_zh_models()
+    ans += get_zh_models()
 
     for i, m in enumerate(ans):
         m.index = i
@@ -2219,7 +2219,7 @@ def main():
                 "rule_fsts": "",
             }
 
-            if m.lang == "zh_CN" and m.name == "xiao_ya":
+            if m.lang == "zh_CN" and m.name in ("xiao_ya", "chaowen"):
                 d = {
                     "model": f"{model_dir}/{m.model_name}",
                     "data_dir": "",

--- a/scripts/piper/generate.py
+++ b/scripts/piper/generate.py
@@ -2115,6 +2115,8 @@ def get_all_models():
     ans += get_uk_models()
     ans += get_vi_models()
 
+    ans = get_sq_models()
+
     for i, m in enumerate(ans):
         m.index = i
 

--- a/scripts/piper/generate.py
+++ b/scripts/piper/generate.py
@@ -1647,6 +1647,36 @@ def get_vi_models():
     return ans
 
 
+# Chinese
+def get_zh_models():
+    zh_CN = [
+        PiperModel(name="xiao_ya", kind="medium", sr=22050, ns=1),
+    ]
+
+    for m in vi_VN:
+        m.lang = "vi_VN"
+
+    ans = vi_VN
+
+    for m in ans:
+        m.text = "中国工商银行的副行长和一些行政领导表示，他们去过长江和长白山; 经济不断增长。"
+
+        if m.model_name == "":
+            m.model_name = f"{m.lang}-{m.name}-{m.kind}.onnx"
+
+        code = m.lang[:2]
+        if m.cmd == "":
+            m.cmd = f"""
+            wget -qq https://huggingface.co/rhasspy/piper-voices/resolve/main/{code}/{m.lang}/{m.name}/{m.kind}/{m.model_name}
+            wget -qq https://huggingface.co/rhasspy/piper-voices/resolve/main/{code}/{m.lang}/{m.name}/{m.kind}/{m.model_name}.json
+            wget -qq https://huggingface.co/rhasspy/piper-voices/resolve/main/{code}/{m.lang}/{m.name}/{m.kind}/MODEL_CARD
+            """
+        if m.url == "":
+            m.url = f"https://huggingface.co/rhasspy/piper-voices/tree/main/{code}/{m.lang}/{m.name}/{m.kind}"
+
+    return ans
+
+
 # Indonesian
 def get_id_models():
     id_ID = [
@@ -2115,7 +2145,7 @@ def get_all_models():
     ans += get_uk_models()
     ans += get_vi_models()
 
-    ans = get_sq_models()
+    ans = get_zh_models()
 
     for i, m in enumerate(ans):
         m.index = i

--- a/scripts/piper/generate.sh.in
+++ b/scripts/piper/generate.sh.in
@@ -13,6 +13,11 @@ log() {
 
 wget -qq https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/espeak-ng-data.tar.bz2
 wget -qq https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/lexicon-zh-g2pw.txt
+
+wget -qq https://huggingface.co/csukuangfj/icefall-tts-aishell3-vits-low-2024-04-06/resolve/main/data/date.fst
+wget -qq https://huggingface.co/csukuangfj/icefall-tts-aishell3-vits-low-2024-04-06/resolve/main/data/number.fst
+wget -qq https://huggingface.co/csukuangfj/icefall-tts-aishell3-vits-low-2024-04-06/resolve/main/data/phone.fst
+
 tar xf espeak-ng-data.tar.bz2
 rm espeak-ng-data.tar.bz2
 ls -lh lexicon-zh-g2pw.txt
@@ -56,7 +61,12 @@ if [[ $model_name != *zh_CN-xiao_ya-medium* ]]; then
   cp -a ./espeak-ng-data $dst/
 else
   cp lexicon-zh-g2pw.txt $dst/lexicon.txt
+  cp date.fst $dst/
+  cp number.fst $dst/
+  cp phone.fst $dst/
 fi
+
+ls -lh $dst/
 
 cp -a $dst $dst_int8
 cp -a $dst $dst_fp16
@@ -81,14 +91,14 @@ tar cjf ${dst}.tar.bz2 $dst
 tar cjf ${dst_int8}.tar.bz2 $dst_int8
 tar cjf ${dst_fp16}.tar.bz2 $dst_fp16
 
-# if [ -d hf ]; then
-#   mkdir -p hf/piper/mp3/$lang/vits-piper-$lang-$name-$kind
-#   for i in $(seq $num_speakers); do
-#     i=$((i-1))
-#     python3 ./generate_samples-$dst-$i.py
-#   done
-#   ls -lh hf/piper/mp3/$lang/vits-piper-$lang-$name-$kind
-# fi
+if [ -d hf ]; then
+  mkdir -p hf/piper/mp3/$lang/vits-piper-$lang-$name-$kind
+  for i in $(seq $num_speakers); do
+    i=$((i-1))
+    python3 ./generate_samples-$dst-$i.py
+  done
+  ls -lh hf/piper/mp3/$lang/vits-piper-$lang-$name-$kind
+fi
 
 mv $dst release
 mv $dst_int8 release

--- a/scripts/piper/generate.sh.in
+++ b/scripts/piper/generate.sh.in
@@ -50,7 +50,9 @@ mv -v README $dst/ || true
 mv -v README.md $dst/ || true
 mv -v LICENSE.txt $dst/ || true
 mv -v *.json  $dst/
-cp -a ./espeak-ng-data $dst/
+if [[ $model_name != *zh_CN-xiao_ya-medium* ]]; then
+  cp -a ./espeak-ng-data $dst/
+fi
 
 cp -a $dst $dst_int8
 cp -a $dst $dst_fp16

--- a/scripts/piper/generate.sh.in
+++ b/scripts/piper/generate.sh.in
@@ -57,7 +57,7 @@ mv -v README $dst/ || true
 mv -v README.md $dst/ || true
 mv -v LICENSE.txt $dst/ || true
 mv -v *.json  $dst/
-if [[ $model_name != *zh_CN-xiao_ya-medium* ]]; then
+if [[ ! $model_name =~ zh_CN-(xiao_ya|chaowen)-medium ]]; then
   cp -a ./espeak-ng-data $dst/
 else
   cp lexicon-zh-g2pw.txt $dst/lexicon.txt

--- a/scripts/piper/generate.sh.in
+++ b/scripts/piper/generate.sh.in
@@ -95,6 +95,7 @@ if [ -d hf ]; then
   mkdir -p hf/piper/mp3/$lang/vits-piper-$lang-$name-$kind
   for i in $(seq $num_speakers); do
     i=$((i-1))
+    cat ./generate_samples-$dst-$i.py
     python3 ./generate_samples-$dst-$i.py
   done
   ls -lh hf/piper/mp3/$lang/vits-piper-$lang-$name-$kind

--- a/scripts/piper/generate.sh.in
+++ b/scripts/piper/generate.sh.in
@@ -12,8 +12,10 @@ log() {
 }
 
 wget -qq https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/espeak-ng-data.tar.bz2
+wget -qq https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/lexicon-zh-g2pw.txt
 tar xf espeak-ng-data.tar.bz2
 rm espeak-ng-data.tar.bz2
+ls -lh lexicon-zh-g2pw.txt
 
 mkdir -p release
 
@@ -52,6 +54,8 @@ mv -v LICENSE.txt $dst/ || true
 mv -v *.json  $dst/
 if [[ $model_name != *zh_CN-xiao_ya-medium* ]]; then
   cp -a ./espeak-ng-data $dst/
+else
+  cp lexicon-zh-g2pw.txt $dst/lexicon.txt
 fi
 
 cp -a $dst $dst_int8
@@ -77,14 +81,14 @@ tar cjf ${dst}.tar.bz2 $dst
 tar cjf ${dst_int8}.tar.bz2 $dst_int8
 tar cjf ${dst_fp16}.tar.bz2 $dst_fp16
 
-if [ -d hf ]; then
-  mkdir -p hf/piper/mp3/$lang/vits-piper-$lang-$name-$kind
-  for i in $(seq $num_speakers); do
-    i=$((i-1))
-    python3 ./generate_samples-$dst-$i.py
-  done
-  ls -lh hf/piper/mp3/$lang/vits-piper-$lang-$name-$kind
-fi
+# if [ -d hf ]; then
+#   mkdir -p hf/piper/mp3/$lang/vits-piper-$lang-$name-$kind
+#   for i in $(seq $num_speakers); do
+#     i=$((i-1))
+#     python3 ./generate_samples-$dst-$i.py
+#   done
+#   ls -lh hf/piper/mp3/$lang/vits-piper-$lang-$name-$kind
+# fi
 
 mv $dst release
 mv $dst_int8 release

--- a/scripts/piper/generate_lexicon_zh.py
+++ b/scripts/piper/generate_lexicon_zh.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 # Copyright    2026  Xiaomi Corp.        (authors: Fangjun Kuang)
 
+# It may take 100 minutes to generate the lexicon.
+#
+# You can download a pre-generated one from
+# https://github.com/k2-fsa/sherpa-onnx/releases/tag/tts-models
+
 from typing import List, Tuple
 
 from pypinyin import load_phrases_dict, phrases_dict, pinyin_dict
@@ -52,7 +57,7 @@ def save(filename: str, lexicon: List[Tuple[str, str]]):
 def main():
     zh = generate_chinese_lexicon()
 
-    save("lexicon-zh.txt", zh)
+    save("lexicon-zh-g2pw.txt", zh)
 
 
 if __name__ == "__main__":

--- a/scripts/piper/generate_lexicon_zh.py
+++ b/scripts/piper/generate_lexicon_zh.py
@@ -8,7 +8,7 @@
 
 from typing import List, Tuple
 
-from pypinyin import load_phrases_dict, phrases_dict, pinyin_dict
+from pypinyin import phrases_dict, pinyin_dict
 
 from piper.phonemize_chinese import ChinesePhonemizer
 
@@ -29,7 +29,7 @@ def generate_chinese_lexicon():
         tokens = []
         for p in phonemes:
             tokens.append(p)
-            if p in "12345":
+            if p in {"1", "2", "3", "4", "5"}:
                 tokens.append("_")
 
         lexicon.append((w, tokens))
@@ -39,7 +39,7 @@ def generate_chinese_lexicon():
         tokens = []
         for p in phonemes:
             tokens.append(p)
-            if p in "12345":
+            if p in {"1", "2", "3", "4", "5"}:
                 tokens.append("_")
 
         lexicon.append((key, tokens))
@@ -47,10 +47,10 @@ def generate_chinese_lexicon():
     return lexicon
 
 
-def save(filename: str, lexicon: List[Tuple[str, str]]):
+def save(filename: str, lexicon: List[Tuple[str, List[str]]]):
     with open(filename, "w", encoding="utf-8") as f:
         for word, phones in lexicon:
-            tokens = " ".join(list(phones))
+            tokens = " ".join(phones)
             f.write(f"{word} {tokens}\n")
 
 

--- a/scripts/piper/generate_lexicon_zh.py
+++ b/scripts/piper/generate_lexicon_zh.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright    2026  Xiaomi Corp.        (authors: Fangjun Kuang)
+
+from typing import List, Tuple
+
+from pypinyin import load_phrases_dict, phrases_dict, pinyin_dict
+
+from piper.phonemize_chinese import ChinesePhonemizer
+
+
+def generate_chinese_lexicon():
+    word_dict = pinyin_dict.pinyin_dict
+    phrases = phrases_dict.phrases_dict
+
+    phonemizer = ChinesePhonemizer(model_dir="./abc")
+
+    lexicon = []
+    for key in word_dict:
+        if not (0x4E00 <= key <= 0x9FFF):
+            continue
+        w = chr(key)
+
+        phonemes = phonemizer.phonemize(w)[0]
+        tokens = []
+        for p in phonemes:
+            tokens.append(p)
+            if p in "12345":
+                tokens.append("_")
+
+        lexicon.append((w, tokens))
+
+    for key in phrases:
+        phonemes = phonemizer.phonemize(key)[0]
+        tokens = []
+        for p in phonemes:
+            tokens.append(p)
+            if p in "12345":
+                tokens.append("_")
+
+        lexicon.append((key, tokens))
+
+    return lexicon
+
+
+def save(filename: str, lexicon: List[Tuple[str, str]]):
+    with open(filename, "w", encoding="utf-8") as f:
+        for word, phones in lexicon:
+            tokens = " ".join(list(phones))
+            f.write(f"{word} {tokens}\n")
+
+
+def main():
+    zh = generate_chinese_lexicon()
+
+    save("lexicon-zh.txt", zh)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/piper/generate_samples.py.in
+++ b/scripts/piper/generate_samples.py.in
@@ -11,7 +11,7 @@ config = sherpa_onnx.OfflineTtsConfig(
         ),
         num_threads=1,
     ),
-    rule_fsts="./matcha-icefall-zh-baker/phone.fst,./matcha-icefall-zh-baker/date.fst,./matcha-icefall-zh-baker/number.fst",
+    rule_fsts="{{ rule_fsts }}",
 )
 
 if not config.validate():

--- a/scripts/piper/generate_samples.py.in
+++ b/scripts/piper/generate_samples.py.in
@@ -5,12 +5,13 @@ config = sherpa_onnx.OfflineTtsConfig(
     model=sherpa_onnx.OfflineTtsModelConfig(
         vits=sherpa_onnx.OfflineTtsVitsModelConfig(
             model="{{ model }}",
-            lexicon="",
+            lexicon="{{ lexicon }}",
             data_dir="{{ data_dir }}",
             tokens="{{ tokens }}",
         ),
         num_threads=1,
     ),
+    rule_fsts="./matcha-icefall-zh-baker/phone.fst,./matcha-icefall-zh-baker/date.fst,./matcha-icefall-zh-baker/number.fst",
 )
 
 if not config.validate():

--- a/sherpa-onnx/csrc/character-lexicon.cc
+++ b/sherpa-onnx/csrc/character-lexicon.cc
@@ -35,8 +35,9 @@ namespace sherpa_onnx {
 
 class CharacterLexicon::Impl {
  public:
-  Impl(const std::string &lexicon, const std::string &tokens, bool debug)
-      : debug_(debug) {
+  Impl(const std::string &lexicon, const std::string &tokens, bool debug,
+       bool use_g2pw)
+      : debug_(debug), use_g2pw_(use_g2pw) {
     if (lexicon.empty()) {
       SHERPA_ONNX_LOGE("Please provide lexicon.txt for this model");
       SHERPA_ONNX_EXIT(-1);
@@ -55,8 +56,8 @@ class CharacterLexicon::Impl {
 
   template <typename Manager>
   Impl(Manager *mgr, const std::string &lexicon, const std::string &tokens,
-       bool debug)
-      : debug_(debug) {
+       bool debug, bool use_g2pw)
+      : debug_(debug), use_g2pw_(use_g2pw) {
     if (lexicon.empty()) {
       SHERPA_ONNX_LOGE("Please provide lexicon.txt for this model");
       SHERPA_ONNX_EXIT(-1);
@@ -161,6 +162,14 @@ class CharacterLexicon::Impl {
     std::vector<TokenIDs> ans;
     std::vector<int64_t> this_sentence;
 
+    if (use_g2pw_) {
+      // please see
+      // https://github.com/OHF-Voice/piper1-gpl/blob/main/src/piper/phonemize_chinese.py#L296
+      // it adds bos at the beginning of each sentence and adds eos at the end
+      // of each sentence
+      this_sentence.push_back(bos_id_);
+    }
+
     PhraseMatcher matcher(&all_words_, words, debug_);
 
     for (const std::string &w : matcher) {
@@ -177,12 +186,14 @@ class CharacterLexicon::Impl {
       this_sentence.insert(this_sentence.end(), ids.begin(), ids.end());
 
       if (IsPunct(w)) {
+        this_sentence.push_back(eos_id_);
         ans.emplace_back(std::move(this_sentence));
-        this_sentence = {};
+        this_sentence = {bos_id_};
       }
     }  // for (const std::string &w : matcher)
 
     if (!this_sentence.empty()) {
+      this_sentence.push_back(eos_id_);
       ans.emplace_back(std::move(this_sentence));
     }
 
@@ -253,6 +264,12 @@ class CharacterLexicon::Impl {
       for (const auto &p : token2id_) {
         id2token_[p.second] = p.first;
       }
+    }
+
+    if (use_g2pw_) {
+      pad_id_ = token2id_.at("_");
+      bos_id_ = token2id_.at("^");
+      eos_id_ = token2id_.at("$");
     }
   }
 
@@ -325,18 +342,25 @@ class CharacterLexicon::Impl {
   std::unordered_map<int32_t, std::string> id2token_;
 
   bool debug_ = false;
+  bool use_g2pw_ = false;
+
+  int32_t bos_id_ = 0;
+  int32_t eos_id_ = 0;
+  int32_t pad_id_ = 0;
 };
 
 CharacterLexicon::~CharacterLexicon() = default;
 
 CharacterLexicon::CharacterLexicon(const std::string &lexicon,
-                                   const std::string &tokens, bool debug)
-    : impl_(std::make_unique<Impl>(lexicon, tokens, debug)) {}
+                                   const std::string &tokens, bool debug,
+                                   bool use_g2pw /*= false*/)
+    : impl_(std::make_unique<Impl>(lexicon, tokens, debug, use_g2pw)) {}
 
 template <typename Manager>
 CharacterLexicon::CharacterLexicon(Manager *mgr, const std::string &lexicon,
-                                   const std::string &tokens, bool debug)
-    : impl_(std::make_unique<Impl>(mgr, lexicon, tokens, debug)) {}
+                                   const std::string &tokens, bool debug,
+                                   bool use_g2pw /*= false*/)
+    : impl_(std::make_unique<Impl>(mgr, lexicon, tokens, debug, use_g2pw)) {}
 
 std::vector<TokenIDs> CharacterLexicon::ConvertTextToTokenIds(
     const std::string &text, const std::string & /*unused_voice = ""*/) const {
@@ -347,14 +371,16 @@ std::vector<TokenIDs> CharacterLexicon::ConvertTextToTokenIds(
 template CharacterLexicon::CharacterLexicon(AAssetManager *mgr,
                                             const std::string &lexicon,
                                             const std::string &tokens,
-                                            bool debug);
+                                            bool debug, bool use_g2pw);
+
 #endif
 
 #if __OHOS__
 template CharacterLexicon::CharacterLexicon(NativeResourceManager *mgr,
                                             const std::string &lexicon,
                                             const std::string &tokens,
-                                            bool debug);
+                                            bool debug, bool use_g2pw);
+
 #endif
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/character-lexicon.cc
+++ b/sherpa-onnx/csrc/character-lexicon.cc
@@ -186,14 +186,22 @@ class CharacterLexicon::Impl {
       this_sentence.insert(this_sentence.end(), ids.begin(), ids.end());
 
       if (IsPunct(w)) {
-        this_sentence.push_back(eos_id_);
+        if (use_g2pw_) {
+          this_sentence.push_back(eos_id_);
+        }
         ans.emplace_back(std::move(this_sentence));
-        this_sentence = {bos_id_};
+        if (use_g2pw_) {
+          this_sentence = {bos_id_};
+        } else {
+          this_sentence.clear();
+        }
       }
     }  // for (const std::string &w : matcher)
 
     if (!this_sentence.empty()) {
-      this_sentence.push_back(eos_id_);
+      if (use_g2pw_) {
+        this_sentence.push_back(eos_id_);
+      }
       ans.emplace_back(std::move(this_sentence));
     }
 

--- a/sherpa-onnx/csrc/character-lexicon.h
+++ b/sherpa-onnx/csrc/character-lexicon.h
@@ -19,11 +19,12 @@ class CharacterLexicon : public OfflineTtsFrontend {
   ~CharacterLexicon() override;
 
   CharacterLexicon(const std::string &lexicon, const std::string &tokens,
-                   bool debug);
+                   bool debug, bool use_g2pw = false);
 
   template <typename Manager>
   CharacterLexicon(Manager *mgr, const std::string &lexicon,
-                   const std::string &tokens, bool debug);
+                   const std::string &tokens, bool debug,
+                   bool use_g2pw = false);
 
   std::vector<TokenIDs> ConvertTextToTokenIds(
       const std::string &text,

--- a/sherpa-onnx/csrc/offline-tts-vits-impl.h
+++ b/sherpa-onnx/csrc/offline-tts-vits-impl.h
@@ -373,7 +373,7 @@ class OfflineTtsVitsImpl : public OfflineTtsImpl {
     } else if (meta_data.jieba || meta_data.use_g2pw) {
       frontend_ = std::make_unique<CharacterLexicon>(
           mgr, config_.model.vits.lexicon, config_.model.vits.tokens,
-          config_.model.debug);
+          config_.model.debug, meta_data.use_g2pw);
     } else if (meta_data.is_melo_tts && meta_data.language == "English") {
       frontend_ = std::make_unique<MeloTtsLexicon>(
           mgr, config_.model.vits.lexicon, config_.model.vits.tokens,
@@ -413,9 +413,9 @@ class OfflineTtsVitsImpl : public OfflineTtsImpl {
           config_.model.vits.lexicon, config_.model.vits.tokens,
           model_->GetMetaData(), config_.model.debug);
     } else if (meta_data.jieba || meta_data.use_g2pw) {
-      frontend_ = std::make_unique<CharacterLexicon>(config_.model.vits.lexicon,
-                                                     config_.model.vits.tokens,
-                                                     config_.model.debug);
+      frontend_ = std::make_unique<CharacterLexicon>(
+          config_.model.vits.lexicon, config_.model.vits.tokens,
+          config_.model.debug, meta_data.use_g2pw);
     } else if ((meta_data.is_piper || meta_data.is_coqui ||
                 meta_data.is_icefall) &&
                !config_.model.vits.data_dir.empty()) {

--- a/sherpa-onnx/csrc/offline-tts-vits-impl.h
+++ b/sherpa-onnx/csrc/offline-tts-vits-impl.h
@@ -5,8 +5,8 @@
 #define SHERPA_ONNX_CSRC_OFFLINE_TTS_VITS_IMPL_H_
 
 #include <memory>
-#include <string>
 #include <sstream>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -130,8 +130,8 @@ class OfflineTtsVitsImpl : public OfflineTtsImpl {
           tn_list_.push_back(
               std::make_unique<kaldifst::TextNormalizer>(std::move(r)));
         }
-      }    // for (const auto &f : files)
-    }      // if (!config.rule_fars.empty())
+      }  // for (const auto &f : files)
+    }  // if (!config.rule_fars.empty())
   }
 
   int32_t SampleRate() const override {
@@ -305,8 +305,8 @@ class OfflineTtsVitsImpl : public OfflineTtsImpl {
         }
       }
 
-      auto audio = Process(batch_x, batch_tones, sid, speed,
-                           gen_config.silence_scale);
+      auto audio =
+          Process(batch_x, batch_tones, sid, speed, gen_config.silence_scale);
       ans.sample_rate = audio.sample_rate;
       ans.samples.insert(ans.samples.end(), audio.samples.begin(),
                          audio.samples.end());
@@ -370,7 +370,7 @@ class OfflineTtsVitsImpl : public OfflineTtsImpl {
       frontend_ = std::make_unique<MeloTtsLexicon>(
           mgr, config_.model.vits.lexicon, config_.model.vits.tokens,
           model_->GetMetaData(), config_.model.debug);
-    } else if (meta_data.jieba) {
+    } else if (meta_data.jieba || meta_data.use_g2pw) {
       frontend_ = std::make_unique<CharacterLexicon>(
           mgr, config_.model.vits.lexicon, config_.model.vits.tokens,
           config_.model.debug);
@@ -412,7 +412,7 @@ class OfflineTtsVitsImpl : public OfflineTtsImpl {
       frontend_ = std::make_unique<MeloTtsLexicon>(
           config_.model.vits.lexicon, config_.model.vits.tokens,
           model_->GetMetaData(), config_.model.debug);
-    } else if (meta_data.jieba) {
+    } else if (meta_data.jieba || meta_data.use_g2pw) {
       frontend_ = std::make_unique<CharacterLexicon>(config_.model.vits.lexicon,
                                                      config_.model.vits.tokens,
                                                      config_.model.debug);
@@ -437,8 +437,7 @@ class OfflineTtsVitsImpl : public OfflineTtsImpl {
 
   GeneratedAudio Process(const std::vector<std::vector<int64_t>> &tokens,
                          const std::vector<std::vector<int64_t>> &tones,
-                         int32_t sid, float speed,
-                         float silence_scale) const {
+                         int32_t sid, float speed, float silence_scale) const {
     int32_t num_tokens = 0;
     for (const auto &k : tokens) {
       num_tokens += k.size();

--- a/sherpa-onnx/csrc/offline-tts-vits-model-meta-data.h
+++ b/sherpa-onnx/csrc/offline-tts-vits-model-meta-data.h
@@ -23,6 +23,9 @@ struct OfflineTtsVitsModelMetaData {
   bool is_icefall = false;
   bool is_melo_tts = false;
 
+  // for piper zh models using pinyin instead of espeak-ng
+  bool use_g2pw = false;
+
   // for Chinese TTS models from
   // https://github.com/Plachtaa/VITS-fast-fine-tuning
   int32_t jieba = 0;

--- a/sherpa-onnx/csrc/offline-tts-vits-model.cc
+++ b/sherpa-onnx/csrc/offline-tts-vits-model.cc
@@ -122,8 +122,8 @@ class OfflineTtsVitsModel::Impl {
  private:
   void Init(void *model_data, size_t model_data_length) {
     if (model_data) {
-      sess_ = std::make_unique<Ort::Session>(
-          env_, model_data, model_data_length, sess_opts_);
+      sess_ = std::make_unique<Ort::Session>(env_, model_data,
+                                             model_data_length, sess_opts_);
     } else if (!sess_) {
       SHERPA_ONNX_LOGE(
           "Please pass model data or initialize the session outside of "
@@ -187,6 +187,7 @@ class OfflineTtsVitsModel::Impl {
     SHERPA_ONNX_READ_META_DATA_WITH_DEFAULT(meta_data_.use_eos_bos,
                                             "use_eos_bos", 1);
     SHERPA_ONNX_READ_META_DATA_WITH_DEFAULT(meta_data_.pad_id, "pad_id", 0);
+    SHERPA_ONNX_READ_META_DATA_WITH_DEFAULT(meta_data_.use_g2pw, "has_g2pw", 0);
 
     std::string comment;
     SHERPA_ONNX_READ_META_DATA_STR(comment, "comment");


### PR DESCRIPTION
See their doc at
- Male:  https://k2-fsa.github.io/sherpa/onnx/tts/all/Chinese/vits-piper-zh_CN-chaowen-medium.html
- Female: https://k2-fsa.github.io/sherpa/onnx/tts/all/Chinese/vits-piper-zh_CN-xiao_ya-medium.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Chinese (zh_CN) TTS models with pinyin-based phonemization and selectable lexicon/rule-FST support
  * New lexicon generation and packaging to produce zh lexicons and integrate them into model samples and offline configs
  * Model metadata now includes g2pw capability flags and a version field for clearer behavior control

* **Chores**
  * CI workflow and publishing updated to install extra packages and publish additional zh_CN model variants and artifacts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->