### PR TITLE
Fix building Flutter Android APPs

### DIFF
--- a/flutter/notes.md
+++ b/flutter/notes.md
@@ -30,10 +30,10 @@ flutter create --template plugin_ffi --platforms linux sherpa_onnx_windows
 5. Create `sherpa_onnx_android_arm64`, `sherpa_onnx_android_armeabi`, `sherpa_onnx_android_x86`, `sherpa_onnx_android_x86_64`
 
 ```bash
-flutter create --template plugin_ffi --platforms android --org com.k2fsa.sherpa.onnx sherpa_onnx_android_arm64
-flutter create --template plugin_ffi --platforms android --org com.k2fsa.sherpa.onnx sherpa_onnx_android_armeabi
-flutter create --template plugin_ffi --platforms android --org com.k2fsa.sherpa.onnx sherpa_onnx_android_x86
-flutter create --template plugin_ffi --platforms android --org com.k2fsa.sherpa.onnx sherpa_onnx_android_x86_64
+flutter create --template plugin_ffi --platforms android --org com.k2fsa.sherpa.onnx.arm64 sherpa_onnx_android_arm64
+flutter create --template plugin_ffi --platforms android --org com.k2fsa.sherpa.onnx.armeabi sherpa_onnx_android_armeabi
+flutter create --template plugin_ffi --platforms android --org com.k2fsa.sherpa.onnx.x86 sherpa_onnx_android_x86
+flutter create --template plugin_ffi --platforms android --org com.k2fsa.sherpa.onnx.x86_64 sherpa_onnx_android_x86_64
 ```
 
 6. Create `sherpa_onnx_ios`

--- a/flutter/sherpa_onnx_android_arm64/android/build.gradle
+++ b/flutter/sherpa_onnx_android_arm64/android/build.gradle
@@ -25,7 +25,7 @@ rootProject.allprojects {
 apply plugin: "com.android.library"
 
 android {
-    namespace 'com.k2fsa.sherpa.onnx'
+    namespace 'com.k2fsa.sherpa.onnx.arm64'
 
     // Bumping the plugin compileSdk version requires all clients of this plugin
     // to bump the version in their app.

--- a/flutter/sherpa_onnx_android_arm64/android/src/main/AndroidManifest.xml
+++ b/flutter/sherpa_onnx_android_arm64/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.k2fsa.sherpa.onnx">
+  package="com.k2fsa.sherpa.onnx.arm64">
 </manifest>

--- a/flutter/sherpa_onnx_android_armeabi/android/build.gradle
+++ b/flutter/sherpa_onnx_android_armeabi/android/build.gradle
@@ -25,7 +25,7 @@ rootProject.allprojects {
 apply plugin: "com.android.library"
 
 android {
-    namespace 'com.k2fsa.sherpa.onnx'
+    namespace 'com.k2fsa.sherpa.onnx.armeabi'
 
     // Bumping the plugin compileSdk version requires all clients of this plugin
     // to bump the version in their app.

--- a/flutter/sherpa_onnx_android_armeabi/android/src/main/AndroidManifest.xml
+++ b/flutter/sherpa_onnx_android_armeabi/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.k2fsa.sherpa.onnx">
+  package="com.k2fsa.sherpa.onnx.armeabi">
 </manifest>

--- a/flutter/sherpa_onnx_android_x86/android/build.gradle
+++ b/flutter/sherpa_onnx_android_x86/android/build.gradle
@@ -25,7 +25,7 @@ rootProject.allprojects {
 apply plugin: "com.android.library"
 
 android {
-    namespace 'com.k2fsa.sherpa.onnx'
+    namespace 'com.k2fsa.sherpa.onnx.x86'
 
     // Bumping the plugin compileSdk version requires all clients of this plugin
     // to bump the version in their app.

--- a/flutter/sherpa_onnx_android_x86/android/src/main/AndroidManifest.xml
+++ b/flutter/sherpa_onnx_android_x86/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.k2fsa.sherpa.onnx">
+  package="com.k2fsa.sherpa.onnx.x86">
 </manifest>

--- a/flutter/sherpa_onnx_android_x86_64/android/build.gradle
+++ b/flutter/sherpa_onnx_android_x86_64/android/build.gradle
@@ -25,7 +25,7 @@ rootProject.allprojects {
 apply plugin: "com.android.library"
 
 android {
-    namespace 'com.k2fsa.sherpa.onnx'
+    namespace 'com.k2fsa.sherpa.onnx.x86_64'
 
     // Bumping the plugin compileSdk version requires all clients of this plugin
     // to bump the version in their app.

--- a/flutter/sherpa_onnx_android_x86_64/android/src/main/AndroidManifest.xml
+++ b/flutter/sherpa_onnx_android_x86_64/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.k2fsa.sherpa.onnx">
+  package="com.k2fsa.sherpa.onnx.x86_64">
 </manifest>


### PR DESCRIPTION
Fixes #3557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android package namespace identifiers to include architecture-specific suffixes (arm64, armeabi, x86, x86_64) for all Android build variants to prevent namespace conflicts across different architecture builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->