### PR TITLE
fix: add bounds checks to prevent SIGSEGV in speaker diarization

### DIFF
--- a/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
+++ b/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
@@ -149,6 +149,15 @@ class OfflineSpeakerDiarizationPyannoteImpl
       chunk_speaker_pair.reserve(valid_indexes.size());
       sample_indexes.reserve(valid_indexes.size());
       for (auto i : valid_indexes) {
+        if (i < 0 ||
+            i >= static_cast<int32_t>(
+                     chunk_speaker_samples_list_pair.first.size())) {
+          SHERPA_ONNX_LOGE("valid_indexes: index %d out of range [0, %d)",
+                           i,
+                           static_cast<int32_t>(
+                               chunk_speaker_samples_list_pair.first.size()));
+          continue;
+        }
         chunk_speaker_pair.push_back(chunk_speaker_samples_list_pair.first[i]);
         sample_indexes.push_back(
             std::move(chunk_speaker_samples_list_pair.second[i]));
@@ -563,6 +572,15 @@ class OfflineSpeakerDiarizationPyannoteImpl
 
         int32_t new_speaker_index =
             chunk_speaker_to_cluster.at({chunk_index, speaker_index});
+
+        if (new_speaker_index < 0 ||
+            new_speaker_index >= new_label.cols()) {
+          SHERPA_ONNX_LOGE(
+              "ReLabel: new_speaker_index %d out of range [0, %d), skipping",
+              new_speaker_index,
+              static_cast<int32_t>(new_label.cols()));
+          continue;
+        }
 
         for (int32_t k = 0; k != t.cols(); ++k) {
           if (t(speaker_index, k) == 1) {

--- a/sherpa-onnx/csrc/offline-speaker-diarization-result.cc
+++ b/sherpa-onnx/csrc/offline-speaker-diarization-result.cc
@@ -104,9 +104,17 @@ OfflineSpeakerDiarizationResult::SortBySpeaker() const {
            ((a.Speaker() == b.Speaker()) && (a.Start() < b.Start()));
   });
 
-  std::vector<std::vector<OfflineSpeakerDiarizationSegment>> ans(NumSpeakers());
+  int32_t num_speakers = NumSpeakers();
+  std::vector<std::vector<OfflineSpeakerDiarizationSegment>> ans(num_speakers);
   for (auto &s : tmp) {
-    ans[s.Speaker()].push_back(std::move(s));
+    int32_t spk = s.Speaker();
+    if (spk < 0 || spk >= num_speakers) {
+      SHERPA_ONNX_LOGE(
+          "SortBySpeaker: speaker ID %d out of range [0, %d), skipping segment",
+          spk, num_speakers);
+      continue;
+    }
+    ans[spk].push_back(std::move(s));
   }
 
   return ans;


### PR DESCRIPTION
## Summary

Add bounds checking in three locations within the offline speaker diarization pipeline to prevent out-of-bounds array access that causes SIGSEGV during batch processing:

1. **`SortBySpeaker()`** (`offline-speaker-diarization-result.cc`): Validate speaker ID is within `[0, NumSpeakers())` before indexing into the result vector.

2. **`ReLabel()`** (`offline-speaker-diarization-pyannote-impl.h`): Validate `new_speaker_index` is within the Eigen matrix column bounds before writing.

3. **`valid_indexes` iteration** (`offline-speaker-diarization-pyannote-impl.h`): Validate index bounds before accessing `chunk_speaker_samples_list_pair` vectors after NaN embedding filtering.

## Problem

When processing hundreds of audio files in batch mode via `SherpaOnnxOfflineSpeakerDiarizationProcess`, intermittent SIGSEGV crashes occur. The root cause is that `FastClustering::Cluster()` can produce cluster labels that exceed the expected range (`max_cluster_index + 1`), leading to out-of-bounds writes in `ReLabel()` and out-of-bounds reads in `SortBySpeaker()`.

### Reproduction
- Process 50-200+ audio files sequentially through the same `SherpaOnnxOfflineSpeakerDiarization` instance
- Crashes manifest as SIGSEGV with no stack trace (signal in worker thread)
- Timing is non-deterministic, depends on audio content and clustering results

### Impact
Without these checks, the SIGSEGV crashes the entire host process. With the bounds checks, out-of-range speaker IDs are logged and skipped, allowing processing to continue safely.

## Test plan
- [x] Built and tested on macOS arm64 (Apple M2)
- [x] Batch-processed 139 audio files: subprocess crashes reduced from 5 (stock v1.12.40) to 1 (with bounds checks)
- [x] No regression in diarization quality for in-range speaker IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>