### PR TITLE
feat(sense-voice): per-stream use_itn override via Stream::GetOptionInt

### DIFF
--- a/sherpa-onnx/csrc/offline-recognizer-sense-voice-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-sense-voice-impl.h
@@ -191,11 +191,15 @@ class OfflineRecognizerSenseVoiceImpl : public OfflineRecognizerImpl {
     std::vector<int32_t> language_array(n);
     std::fill(language_array.begin(), language_array.end(), language);
 
+    // Per-stream use_itn override via OfflineStream::SetOption("use_itn", "1"|"0").
+    // Falls back to model_config.sense_voice.use_itn when the option is absent.
+    int32_t default_use_itn = config_.model_config.sense_voice.use_itn;
     std::vector<int32_t> text_norm_array(n);
-    std::fill(text_norm_array.begin(), text_norm_array.end(),
-              config_.model_config.sense_voice.use_itn
-                  ? meta_data.with_itn_id
-                  : meta_data.without_itn_id);
+    for (int32_t i = 0; i != n; ++i) {
+      int32_t use_itn = ss[i]->GetOptionInt("use_itn", default_use_itn);
+      text_norm_array[i] =
+          use_itn ? meta_data.with_itn_id : meta_data.without_itn_id;
+    }
 
     Ort::Value language_tensor = Ort::Value::CreateTensor(
         memory_info, language_array.data(), n, features_length_shape.data(),
@@ -318,9 +322,12 @@ class OfflineRecognizerSenseVoiceImpl : public OfflineRecognizerImpl {
                        config_.model_config.sense_voice.language.c_str());
     }
 
-    int32_t text_norm = config_.model_config.sense_voice.use_itn
-                            ? meta_data.with_itn_id
-                            : meta_data.without_itn_id;
+    // Per-stream use_itn override via OfflineStream::SetOption("use_itn", "1"|"0").
+    // Falls back to model_config.sense_voice.use_itn when the option is absent.
+    int32_t use_itn =
+        s->GetOptionInt("use_itn", config_.model_config.sense_voice.use_itn);
+    int32_t text_norm =
+        use_itn ? meta_data.with_itn_id : meta_data.without_itn_id;
 
     Ort::Value language_tensor =
         Ort::Value::CreateTensor(memory_info, &language, 1, &scale_shape, 1);


### PR DESCRIPTION
## Summary

Lets multi-tenant ASR servers select ITN behavior per request without rebuilding the recognizer. Reads `use_itn` from `OfflineStream::GetOptionInt("use_itn", model_default)` on every `Forward()` instead of from `config_.model_config.sense_voice.use_itn` directly.

Both `DecodeStreams` (batch path, lines 194-198) and `DecodeOneStream` (single path, lines 321-323) updated. Batch path now reads per-stream so each stream in a batch can independently override. Backward compatible — callers who never `SetOption("use_itn", ...)` get the existing behavior.

The `OfflineStream::SetOption / GetOptionInt` infrastructure already exists upstream (`offline-stream.h:118-127`), and the C API exposes `SherpaOnnxOfflineStreamSetOption` (`c-api.h:1366`), so callers in any language can do:

```c
SherpaOnnxOfflineStreamSetOption(stream, "use_itn", "1");
// or "0" to override off
// missing key falls back to ModelConfig
```

No new C API, no struct field on `OfflineStream`, no version bump for bindings.

## Why

Multi-tenant ASR services need per-request ITN control — same shape of contract as Whisper API's `enable_text_normalization` or Google STT's `enable_automatic_punctuation`. The current `ModelConfig.SenseVoice.use_itn` baked-in-at-construction model forces production deployments to:

1. Spin up two recognizers (2× memory + 2× warmup) and route per request, **or**
2. Always emit ITN'd text and lossy-reverse downstream (we hit a real bug: `音量调节到百分之五十` got ITN'd to `50%`, our `enablePunctuation=false` postprocessor then stripped `%` as punctuation, then `reverse_itn` mapped `50→五十`, leaving `音量调节到五十` — the "百分之" silently disappeared).

Discussed in #3564.

## Test plan

- [ ] Existing SenseVoice tests still pass with no `SetOption` call (backward compat).
- [ ] New test: `SetOption("use_itn", "1")` and `"0"` produce different outputs on the same audio with the same recognizer instance.
- [ ] Batch path: two streams in the same batch with opposite `use_itn` produce independent results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced speech recognition with per-stream text normalization configuration. Individual streams can now independently customize their text normalization settings, providing greater flexibility when processing multiple concurrent streams, with automatic fallback to model defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->