### PR TITLE
Fix x64 gpu onnxruntime url

### DIFF
--- a/cmake/onnxruntime-linux-x86_64-gpu.cmake
+++ b/cmake/onnxruntime-linux-x86_64-gpu.cmake
@@ -22,7 +22,7 @@ endif()
 # Requires CUDA 12, cudnn 9
 set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/onnxruntime-linux-x64-gpu-1.24.4-patched.zip")
 set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.24.4/onnxruntime-linux-x64-gpu-1.24.4.tgz")
-set(onnxruntime_HASH "SHA256=c5f804ff5d239b436fa59e9f2fb288a39f7eb9552f6a636c8b71e792e91a8808")
+set(onnxruntime_HASH "SHA256=f832c427bed33510dfd40de28094b64de4dc0c11559f4547feeb81cf267b9da3")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.

--- a/cmake/onnxruntime-linux-x86_64-gpu.cmake
+++ b/cmake/onnxruntime-linux-x86_64-gpu.cmake
@@ -20,19 +20,19 @@ endif()
 
 
 # Requires CUDA 12, cudnn 9
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/onnxruntime-linux-x64-gpu-1.24.4.tgz")
+set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.24.4/onnxruntime-linux-x64-gpu_cuda13-1.24.4.tgz")
 set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.24.4/onnxruntime-linux-x64-gpu-1.24.4.tgz")
-set(onnxruntime_HASH "SHA256=c5f804ff5d239b436fa59e9f2fb288a39f7eb9552f6a636c8b71e792e91a8808")
+set(onnxruntime_HASH "SHA256=fdc6eb18317b4eaeda8b3b86595e5da7e853f72bac67ccac9b04ffc20c9f7fe0")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-linux-x64-gpu-1.24.4.tgz
-  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-x64-gpu-1.24.4.tgz
-  ${CMAKE_BINARY_DIR}/onnxruntime-linux-x64-gpu-1.24.4.tgz
-  /tmp/onnxruntime-linux-x64-gpu-1.24.4.tgz
-  /star-fj/fangjun/download/github/onnxruntime-linux-x64-gpu-1.24.4.tgz
+  $ENV{HOME}/Downloads/onnxruntime-linux-x64-gpu_cuda13-1.24.4.tgz
+  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-x64-gpu_cuda13-1.24.4.tgz
+  ${CMAKE_BINARY_DIR}/onnxruntime-linux-x64-gpu_cuda13-1.24.4.tgz
+  /tmp/onnxruntime-linux-x64-gpu_cuda13-1.24.4.tgz
+  /star-fj/fangjun/download/github/onnxruntime-linux-x64-gpu_cuda13-1.24.4.tgz
 )
 
 foreach(f IN LISTS possible_file_locations)

--- a/cmake/onnxruntime-linux-x86_64-gpu.cmake
+++ b/cmake/onnxruntime-linux-x86_64-gpu.cmake
@@ -20,19 +20,19 @@ endif()
 
 
 # Requires CUDA 12, cudnn 9
-set(onnxruntime_URL  "https://github.com/microsoft/onnxruntime/releases/download/v1.24.4/onnxruntime-linux-x64-gpu_cuda13-1.24.4.tgz")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.24.4/onnxruntime-linux-x64-gpu-1.24.4-patched.zip")
 set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj/onnxruntime-libs/resolve/main/1.24.4/onnxruntime-linux-x64-gpu-1.24.4.tgz")
-set(onnxruntime_HASH "SHA256=fdc6eb18317b4eaeda8b3b86595e5da7e853f72bac67ccac9b04ffc20c9f7fe0")
+set(onnxruntime_HASH "SHA256=c5f804ff5d239b436fa59e9f2fb288a39f7eb9552f6a636c8b71e792e91a8808")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-linux-x64-gpu_cuda13-1.24.4.tgz
-  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-x64-gpu_cuda13-1.24.4.tgz
-  ${CMAKE_BINARY_DIR}/onnxruntime-linux-x64-gpu_cuda13-1.24.4.tgz
-  /tmp/onnxruntime-linux-x64-gpu_cuda13-1.24.4.tgz
-  /star-fj/fangjun/download/github/onnxruntime-linux-x64-gpu_cuda13-1.24.4.tgz
+  $ENV{HOME}/Downloads/onnxruntime-linux-x64-gpu-1.24.4-patched.zip
+  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-x64-gpu-1.24.4-patched.zip
+  ${CMAKE_BINARY_DIR}/onnxruntime-linux-x64-gpu-1.24.4-patched.zip
+  /tmp/onnxruntime-linux-x64-gpu-1.24.4-patched.zip
+  /star-fj/fangjun/download/github/onnxruntime-linux-x64-gpu-1.24.4-patched.zip
 )
 
 foreach(f IN LISTS possible_file_locations)


### PR DESCRIPTION
The url of onnxruntime provided by x64-gpu cmake file does not exist at all. Replace the url to the release by microsoft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Linux x86_64 GPU build to use patched onnxruntime ZIP artifacts (1.24.4-patched) alongside existing CUDA 13 targets.
  * Revised download verification checksum to match the patched artifact.
  * Expanded offline/fallback artifact locations to include patched ZIP paths and added an installation step for the extracted onnxruntime library files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->