### PR TITLE
Add KittenTTS v0.8 support

### DIFF
--- a/.github/workflows/export-kitten.yaml
+++ b/.github/workflows/export-kitten.yaml
@@ -20,7 +20,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        version: ["nano_v0_1", "nano_v0_2", "mini_v0_1"]
+        version:
+          [
+            "nano_v0_1",
+            "nano_v0_2",
+            "mini_v0_1",
+            "nano_v0_8_fp32",
+            "nano_v0_8_int8",
+            "micro_v0_8",
+            "mini_v0_8",
+          ]
         python-version: ["3.10"]
 
     steps:
@@ -41,8 +50,23 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         shell: bash
         run: |
-          cd scripts/kitten-tts/${{ matrix.version }}
-          ./run.sh
+          version=${{ matrix.version }}
+          if [[ $version == "nano_v0_8_fp32" ]]; then
+            cd scripts/kitten-tts/v0_8
+            ./run.sh KittenML/kitten-tts-nano-0.8-fp32
+          elif [[ $version == "nano_v0_8_int8" ]]; then
+            cd scripts/kitten-tts/v0_8
+            ./run.sh KittenML/kitten-tts-nano-0.8-int8
+          elif [[ $version == "micro_v0_8" ]]; then
+            cd scripts/kitten-tts/v0_8
+            ./run.sh KittenML/kitten-tts-micro-0.8
+          elif [[ $version == "mini_v0_8" ]]; then
+            cd scripts/kitten-tts/v0_8
+            ./run.sh KittenML/kitten-tts-mini-0.8
+          else
+            cd scripts/kitten-tts/$version
+            ./run.sh
+          fi
 
       - name: Collect results
         shell: bash
@@ -54,6 +78,7 @@ jobs:
           version=${{ matrix.version }}
 
           src=scripts/kitten-tts/$version
+          model_file=model.fp16.onnx
 
           if [[ $version == "nano_v0_1" ]]; then
             d=kitten-nano-en-v0_1-fp16
@@ -61,6 +86,22 @@ jobs:
             d=kitten-nano-en-v0_2-fp16
           elif [[ $version == "mini_v0_1" ]]; then
             d=kitten-mini-en-v0_1-fp16
+          elif [[ $version == "nano_v0_8_fp32" ]]; then
+            src=scripts/kitten-tts/v0_8
+            d=kitten-nano-en-v0_8-fp32
+            model_file=model.fp32.onnx
+          elif [[ $version == "nano_v0_8_int8" ]]; then
+            src=scripts/kitten-tts/v0_8
+            d=kitten-nano-en-v0_8-int8
+            model_file=model.int8.onnx
+          elif [[ $version == "micro_v0_8" ]]; then
+            src=scripts/kitten-tts/v0_8
+            d=kitten-micro-en-v0_8
+            model_file=model.onnx
+          elif [[ $version == "mini_v0_8" ]]; then
+            src=scripts/kitten-tts/v0_8
+            d=kitten-mini-en-v0_8
+            model_file=model.onnx
           else
             echo "version $version"
             exit 1
@@ -69,7 +110,7 @@ jobs:
           mkdir $d
           cp -a LICENSE $d/LICENSE
           cp -a espeak-ng-data $d/
-          cp -v $src/model.fp16.onnx $d/model.fp16.onnx
+          cp -v $src/$model_file $d/$model_file
           cp -v $src/voices.bin $d/
           cp -v $src/tokens.txt $d/
           cp -v $src/../README.md $d/README.md
@@ -114,6 +155,10 @@ jobs:
               kitten-nano-en-v0_1-fp16
               kitten-nano-en-v0_2-fp16
               kitten-mini-en-v0_1-fp16
+              kitten-nano-en-v0_8-fp32
+              kitten-nano-en-v0_8-int8
+              kitten-micro-en-v0_8
+              kitten-mini-en-v0_8
             )
 
             export GIT_LFS_SKIP_SMUDGE=1

--- a/flutter-examples/tts/lib/model.dart
+++ b/flutter-examples/tts/lib/model.dart
@@ -24,7 +24,8 @@ Future<sherpa_onnx.OfflineTts> createOfflineTts() async {
 
   String modelDir = '';
   String modelName = '';
-  String voices = ''; // for Kokoro only
+  String voices = ''; // for Kokoro or Kitten
+  bool isKitten = false;
   String ruleFsts = '';
   String ruleFars = '';
   String lexicon = '';
@@ -97,6 +98,14 @@ Future<sherpa_onnx.OfflineTts> createOfflineTts() async {
   // dataDir = 'kokoro-multi-lang-v1_0/espeak-ng-data';
   // lexicon = 'kokoro-multi-lang-v1_0/lexicon-us-en.txt,kokoro-multi-lang-v1_0/lexicon-zh.txt';
 
+  // Example 10
+  // https://github.com/k2-fsa/sherpa-onnx/releases/tag/tts-models
+  // modelDir = 'kitten-nano-en-v0_8-fp32';
+  // modelName = 'model.fp32.onnx';
+  // voices = 'voices.bin';
+  // dataDir = 'kitten-nano-en-v0_8-fp32/espeak-ng-data';
+  // isKitten = true;
+
   // ============================================================
   // Please don't change the remaining part of this function
   // ============================================================
@@ -148,9 +157,20 @@ Future<sherpa_onnx.OfflineTts> createOfflineTts() async {
 
   late final sherpa_onnx.OfflineTtsVitsModelConfig vits;
   late final sherpa_onnx.OfflineTtsKokoroModelConfig kokoro;
+  late final sherpa_onnx.OfflineTtsKittenModelConfig kitten;
 
-  if (voices != '') {
+  if (isKitten) {
     vits = sherpa_onnx.OfflineTtsVitsModelConfig();
+    kokoro = sherpa_onnx.OfflineTtsKokoroModelConfig();
+    kitten = sherpa_onnx.OfflineTtsKittenModelConfig(
+      model: modelName,
+      voices: voices,
+      tokens: tokens,
+      dataDir: dataDir,
+    );
+  } else if (voices != '') {
+    vits = sherpa_onnx.OfflineTtsVitsModelConfig();
+    kitten = sherpa_onnx.OfflineTtsKittenModelConfig();
     kokoro = sherpa_onnx.OfflineTtsKokoroModelConfig(
       model: modelName,
       voices: voices,
@@ -167,11 +187,13 @@ Future<sherpa_onnx.OfflineTts> createOfflineTts() async {
     );
 
     kokoro = sherpa_onnx.OfflineTtsKokoroModelConfig();
+    kitten = sherpa_onnx.OfflineTtsKittenModelConfig();
   }
 
   final modelConfig = sherpa_onnx.OfflineTtsModelConfig(
     vits: vits,
     kokoro: kokoro,
+    kitten: kitten,
     numThreads: 2,
     debug: true,
     provider: 'cpu',

--- a/scripts/apk/generate-tts-apk-script.py
+++ b/scripts/apk/generate-tts-apk-script.py
@@ -562,6 +562,26 @@ def get_kitten_models() -> List[TtsModel]:
             model_name="model.fp16.onnx",
             lang="en",
         ),
+        TtsModel(
+            model_dir="kitten-nano-en-v0_8-fp32",
+            model_name="model.fp32.onnx",
+            lang="en",
+        ),
+        TtsModel(
+            model_dir="kitten-nano-en-v0_8-int8",
+            model_name="model.int8.onnx",
+            lang="en",
+        ),
+        TtsModel(
+            model_dir="kitten-micro-en-v0_8",
+            model_name="model.onnx",
+            lang="en",
+        ),
+        TtsModel(
+            model_dir="kitten-mini-en-v0_8",
+            model_name="model.onnx",
+            lang="en",
+        ),
     ]
     for m in english_models:
         m.data_dir = f"{m.model_dir}/espeak-ng-data"

--- a/scripts/flutter/build-android-tts.sh.in
+++ b/scripts/flutter/build-android-tts.sh.in
@@ -62,6 +62,11 @@ sed -i.bak s/"modelName = ''"/"modelName = \"$model_name\""/ ./model.dart
   sed -i.bak "s|lexicon = ''|lexicon = \"lexicon.txt\"|" ./model.dart
 {% endif %}
 
+{% if tts_model.is_kitten %}
+  sed -i.bak "s|voices = ''|voices = \"voices.bin\"|" ./model.dart
+  sed -i.bak "s|isKitten = false|isKitten = true|" ./model.dart
+{% endif %}
+
 git status
 
 git diff .

--- a/scripts/flutter/build-linux-tts.sh.in
+++ b/scripts/flutter/build-linux-tts.sh.in
@@ -69,6 +69,11 @@ sed -i.bak s/"modelName = ''"/"modelName = \"$model_name\""/ ./model.dart
   sed -i.bak "s|lexicon = ''|lexicon = \"lexicon.txt\"|" ./model.dart
 {% endif %}
 
+{% if tts_model.is_kitten %}
+  sed -i.bak "s|voices = ''|voices = \"voices.bin\"|" ./model.dart
+  sed -i.bak "s|isKitten = false|isKitten = true|" ./model.dart
+{% endif %}
+
 git status
 
 git diff .

--- a/scripts/flutter/build-macos-tts.sh.in
+++ b/scripts/flutter/build-macos-tts.sh.in
@@ -69,6 +69,11 @@ sed -i.bak s/"modelName = ''"/"modelName = \"$model_name\""/ ./model.dart
   sed -i.bak "s|lexicon = ''|lexicon = \"lexicon.txt\"|" ./model.dart
 {% endif %}
 
+{% if tts_model.is_kitten %}
+  sed -i.bak "s|voices = ''|voices = \"voices.bin\"|" ./model.dart
+  sed -i.bak "s|isKitten = false|isKitten = true|" ./model.dart
+{% endif %}
+
 git status
 
 git diff .

--- a/scripts/flutter/build-windows-tts.sh.in
+++ b/scripts/flutter/build-windows-tts.sh.in
@@ -71,6 +71,11 @@ sed -i.bak s/"modelName = ''"/"modelName = \"$model_name\""/ ./model.dart
   sed -i.bak "s|lexicon = ''|lexicon = \"lexicon.txt\"|" ./model.dart
 {% endif %}
 
+{% if tts_model.is_kitten %}
+  sed -i.bak "s|voices = ''|voices = \"voices.bin\"|" ./model.dart
+  sed -i.bak "s|isKitten = false|isKitten = true|" ./model.dart
+{% endif %}
+
 git status
 
 git diff .

--- a/scripts/flutter/generate-tts.py
+++ b/scripts/flutter/generate-tts.py
@@ -34,6 +34,7 @@ class TtsModel:
     data_dir: Optional[str] = None
     dict_dir: Optional[str] = None
     is_char: bool = False
+    is_kitten: bool = False
 
 
 def get_coqui_models() -> List[TtsModel]:
@@ -364,6 +365,37 @@ def get_vits_models() -> List[TtsModel]:
     return all_models
 
 
+def get_kitten_models() -> List[TtsModel]:
+    models = [
+        TtsModel(
+            model_dir="kitten-nano-en-v0_8-fp32",
+            model_name="model.fp32.onnx",
+            lang="en",
+        ),
+        TtsModel(
+            model_dir="kitten-nano-en-v0_8-int8",
+            model_name="model.int8.onnx",
+            lang="en",
+        ),
+        TtsModel(
+            model_dir="kitten-micro-en-v0_8",
+            model_name="model.onnx",
+            lang="en",
+        ),
+        TtsModel(
+            model_dir="kitten-mini-en-v0_8",
+            model_name="model.onnx",
+            lang="en",
+        ),
+    ]
+
+    for m in models:
+        m.data_dir = f"{m.model_dir}/espeak-ng-data"
+        m.is_kitten = True
+
+    return models
+
+
 def main():
     args = get_args()
     index = args.index
@@ -375,6 +407,7 @@ def main():
     all_model_list += get_piper_models()
     all_model_list += get_mimic3_models()
     all_model_list += get_coqui_models()
+    all_model_list += get_kitten_models()
 
     num_models = len(all_model_list)
 

--- a/scripts/kitten-tts/README.md
+++ b/scripts/kitten-tts/README.md
@@ -1,3 +1,24 @@
 # Introduction
 
 See also https://github.com/KittenML/KittenTTS
+
+## KittenTTS v0.8
+
+Use `v0_8/run.sh` to prepare a sherpa-onnx compatible model directory from
+the upstream Hugging Face assets:
+
+```bash
+cd scripts/kitten-tts/v0_8
+python3 -m pip install numpy onnx
+./run.sh KittenML/kitten-tts-nano-0.8-fp32
+./run.sh KittenML/kitten-tts-nano-0.8-int8
+./run.sh KittenML/kitten-tts-micro-0.8
+./run.sh KittenML/kitten-tts-mini-0.8
+```
+
+The generated `voices.bin` preserves all v0.8 reference rows. The ONNX metadata
+marks v0.8 models with `version=8`, `end_id=10`, `add_pad_after_end=1`, and
+`max_token_len=400` so the runtime selects the same style row as upstream.
+Use package directories like `kitten-mini-en-v0_8`,
+`kitten-micro-en-v0_8`, `kitten-nano-en-v0_8-fp32`, or
+`kitten-nano-en-v0_8-int8`.

--- a/scripts/kitten-tts/v0_8/add_meta_data.py
+++ b/scripts/kitten-tts/v0_8/add_meta_data.py
@@ -86,8 +86,7 @@ def main():
 
     print(model.metadata_props)
 
-    while len(model.metadata_props):
-        model.metadata_props.pop()
+    del model.metadata_props[:]
 
     for key, value in meta_data.items():
         meta = model.metadata_props.add()

--- a/scripts/kitten-tts/v0_8/add_meta_data.py
+++ b/scripts/kitten-tts/v0_8/add_meta_data.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# Copyright    2026  Xiaomi Corp.
+
+import argparse
+
+import numpy as np
+import onnx
+
+from generate_voices_bin import speaker2id
+
+
+NANO_SPEED_PRIORS = {
+    "expr-voice-2-f": 0.8,
+    "expr-voice-2-m": 0.8,
+    "expr-voice-3-m": 0.8,
+    "expr-voice-3-f": 0.8,
+    "expr-voice-4-m": 0.9,
+    "expr-voice-4-f": 0.8,
+    "expr-voice-5-m": 0.8,
+    "expr-voice-5-f": 0.8,
+}
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model",
+        type=str,
+        required=True,
+        help="Input and output ONNX model",
+    )
+    parser.add_argument(
+        "--model-name",
+        type=str,
+        required=True,
+        help="Hugging Face model name, e.g. KittenML/kitten-tts-mini-0.8",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = get_args()
+    print(args.model)
+
+    model = onnx.load(args.model)
+
+    style = np.load("./voices.npz")
+    style_shape = style[next(iter(style.keys()))].shape
+
+    speaker2id_str = ""
+    id2speaker_str = ""
+    sep = ""
+    for s, i in speaker2id.items():
+        speaker2id_str += f"{sep}{s}->{i}"
+        id2speaker_str += f"{sep}{i}->{s}"
+        sep = ","
+
+    if "kitten-tts-nano-0.8" in args.model_name:
+        speed_priors = [NANO_SPEED_PRIORS[s] for s in speaker2id]
+    else:
+        speed_priors = [1.0] * len(speaker2id)
+
+    meta_data = {
+        "model_type": "kitten-tts",
+        "language": "English",
+        "has_espeak": 1,
+        "sample_rate": 24000,
+        "version": 8,
+        "voice": "en-us",
+        "max_token_len": 400,
+        "start_id": 0,
+        "end_id": 10,
+        "pad_id": 0,
+        "add_pad_after_end": 1,
+        "style_dim": ",".join(map(str, style_shape)),
+        "n_speakers": len(speaker2id),
+        "speaker2id": speaker2id_str,
+        "id2speaker": id2speaker_str,
+        "speaker_names": ",".join(map(str, speaker2id.keys())),
+        "speaker_speed_priors": ",".join(map(str, speed_priors)),
+        "model_url": f"https://huggingface.co/{args.model_name}",
+        "see_also": "https://github.com/KittenML/KittenTTS",
+        "maintainer": "k2-fsa",
+        "comment": f"This is {args.model_name} and supports only English",
+    }
+
+    print(model.metadata_props)
+
+    while len(model.metadata_props):
+        model.metadata_props.pop()
+
+    for key, value in meta_data.items():
+        meta = model.metadata_props.add()
+        meta.key = key
+        meta.value = str(value)
+    print("--------------------")
+
+    print(model.metadata_props)
+
+    onnx.save(model, args.model)
+
+    print(f"Please see {args.model}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kitten-tts/v0_8/generate_tokens.py
+++ b/scripts/kitten-tts/v0_8/generate_tokens.py
@@ -9,7 +9,7 @@ def get_vocab():
     _letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
     _letters_ipa = "ɑɐɒæɓʙβɔɕçɗɖðʤəɘɚɛɜɝɞɟʄɡɠɢʛɦɧħɥʜɨɪʝɭɬɫɮʟɱɯɰŋɳɲɴøɵɸθœɶʘɹɺɾɻʀʁɽʂʃʈʧʉʊʋⱱʌɣɤʍχʎʏʑʐʒʔʡʕʢǀǁǂǃˈˌːˑʼʴʰʱʲʷˠˤ˞↓↑→↗↘'̩'ᵻ"
 
-    symbols = [_pad] + list(_punctuation) + list(_letters) + list(_letters_ipa)
+    symbols = [_pad, *_punctuation, *_letters, *_letters_ipa]
     return {symbols[i]: i for i in range(len(symbols))}
 
 

--- a/scripts/kitten-tts/v0_8/generate_tokens.py
+++ b/scripts/kitten-tts/v0_8/generate_tokens.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# Copyright    2026  Xiaomi Corp.
+
+
+def get_vocab():
+    # https://github.com/KittenML/KittenTTS/blob/main/kittentts/onnx_model.py
+    _pad = "$"
+    _punctuation = ';:,.!?¡¿—…"«»"" '
+    _letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+    _letters_ipa = "ɑɐɒæɓʙβɔɕçɗɖðʤəɘɚɛɜɝɞɟʄɡɠɢʛɦɧħɥʜɨɪʝɭɬɫɮʟɱɯɰŋɳɲɴøɵɸθœɶʘɹɺɾɻʀʁɽʂʃʈʧʉʊʋⱱʌɣɤʍχʎʏʑʐʒʔʡʕʢǀǁǂǃˈˌːˑʼʴʰʱʲʷˠˤ˞↓↑→↗↘'̩'ᵻ"
+
+    symbols = [_pad] + list(_punctuation) + list(_letters) + list(_letters_ipa)
+    return {symbols[i]: i for i in range(len(symbols))}
+
+
+def main():
+    token2id = get_vocab()
+    with open("tokens.txt", "w", encoding="utf-8") as f:
+        for s, i in token2id.items():
+            f.write(f"{s} {i}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kitten-tts/v0_8/generate_voices_bin.py
+++ b/scripts/kitten-tts/v0_8/generate_voices_bin.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Copyright    2026  Xiaomi Corp.
+
+from pathlib import Path
+
+import numpy as np
+
+
+speakers = [
+    "expr-voice-2-m",
+    "expr-voice-2-f",
+    "expr-voice-3-m",
+    "expr-voice-3-f",
+    "expr-voice-4-m",
+    "expr-voice-4-f",
+    "expr-voice-5-m",
+    "expr-voice-5-f",
+]
+
+id2speaker = {idx: speaker for idx, speaker in enumerate(speakers)}
+speaker2id = {speaker: idx for idx, speaker in id2speaker.items()}
+
+
+def main():
+    if Path("./voices.bin").is_file():
+        print("./voices.bin exists - skip")
+        return
+
+    voices = np.load("./voices.npz")
+
+    with open("voices.bin", "wb") as f:
+        for speaker in speakers:
+            v = np.asarray(voices[speaker], dtype=np.float32)
+            # v.shape is usually (400, 256) for KittenTTS v0.8.
+            f.write(np.ascontiguousarray(v).tobytes())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kitten-tts/v0_8/run.sh
+++ b/scripts/kitten-tts/v0_8/run.sh
@@ -32,18 +32,22 @@ case ${model_name} in
   *kitten-tts-mini-0.8*)
     onnx_name=kitten_tts_mini_v0_8.onnx
     output_name=model.onnx
+    package_dir=kitten-mini-en-v0_8
     ;;
   *kitten-tts-micro-0.8*)
     onnx_name=kitten_tts_micro_v0_8.onnx
     output_name=model.onnx
+    package_dir=kitten-micro-en-v0_8
     ;;
   *kitten-tts-nano-0.8-int8*)
     onnx_name=kitten_tts_nano_v0_8.onnx
     output_name=model.int8.onnx
+    package_dir=kitten-nano-en-v0_8-int8
     ;;
   *kitten-tts-nano-0.8*)
     onnx_name=kitten_tts_nano_v0_8.onnx
     output_name=model.fp32.onnx
+    package_dir=kitten-nano-en-v0_8-fp32
     ;;
   *)
     echo "Unsupported KittenTTS v0.8 model: ${model_name}"
@@ -66,4 +70,9 @@ cp "${onnx_name}" "${output_name}"
 ./generate_tokens.py
 ./add_meta_data.py --model "./${output_name}" --model-name "${model_name}"
 
+mkdir -p "${package_dir}"
+cp "${output_name}" "${package_dir}/"
+cp voices.bin tokens.txt "${package_dir}/"
+
 ls -lh
+ls -lh "${package_dir}"

--- a/scripts/kitten-tts/v0_8/run.sh
+++ b/scripts/kitten-tts/v0_8/run.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Copyright      2026  Xiaomi Corp.
+
+set -ex
+
+python3 - <<'PY'
+import importlib.util
+import sys
+
+missing = [
+    m for m in ("numpy", "onnx") if importlib.util.find_spec(m) is None
+]
+
+if missing:
+    print(
+        "Missing Python packages: "
+        + ", ".join(missing)
+        + "\nInstall them with:\n"
+        + "  python3 -m pip install numpy onnx",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+PY
+
+model_name=${1:-KittenML/kitten-tts-nano-0.8-fp32}
+
+if [[ ${model_name} != */* ]]; then
+  model_name=KittenML/${model_name}
+fi
+
+case ${model_name} in
+  *kitten-tts-mini-0.8*)
+    onnx_name=kitten_tts_mini_v0_8.onnx
+    output_name=model.onnx
+    ;;
+  *kitten-tts-micro-0.8*)
+    onnx_name=kitten_tts_micro_v0_8.onnx
+    output_name=model.onnx
+    ;;
+  *kitten-tts-nano-0.8-int8*)
+    onnx_name=kitten_tts_nano_v0_8.onnx
+    output_name=model.int8.onnx
+    ;;
+  *kitten-tts-nano-0.8*)
+    onnx_name=kitten_tts_nano_v0_8.onnx
+    output_name=model.fp32.onnx
+    ;;
+  *)
+    echo "Unsupported KittenTTS v0.8 model: ${model_name}"
+    exit 1
+    ;;
+esac
+
+base_url=https://huggingface.co/${model_name}/resolve/main
+
+if [ ! -f ${onnx_name} ]; then
+  curl -SL -O ${base_url}/${onnx_name}
+fi
+
+if [ ! -f voices.npz ]; then
+  curl -SL -O ${base_url}/voices.npz
+fi
+
+cp ${onnx_name} ${output_name}
+./generate_voices_bin.py
+./generate_tokens.py
+./add_meta_data.py --model ./${output_name} --model-name ${model_name}
+
+ls -lh

--- a/scripts/kitten-tts/v0_8/run.sh
+++ b/scripts/kitten-tts/v0_8/run.sh
@@ -53,17 +53,17 @@ esac
 
 base_url=https://huggingface.co/${model_name}/resolve/main
 
-if [ ! -f ${onnx_name} ]; then
-  curl -SL -O ${base_url}/${onnx_name}
+if [ ! -f "${onnx_name}" ]; then
+  curl -SL -O "${base_url}/${onnx_name}"
 fi
 
 if [ ! -f voices.npz ]; then
-  curl -SL -O ${base_url}/voices.npz
+  curl -SL -O "${base_url}/voices.npz"
 fi
 
-cp ${onnx_name} ${output_name}
+cp "${onnx_name}" "${output_name}"
 ./generate_voices_bin.py
 ./generate_tokens.py
-./add_meta_data.py --model ./${output_name} --model-name ${model_name}
+./add_meta_data.py --model "./${output_name}" --model-name "${model_name}"
 
 ls -lh

--- a/sherpa-onnx/csrc/offline-tts-kitten-model-meta-data.h
+++ b/sherpa-onnx/csrc/offline-tts-kitten-model-meta-data.h
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace sherpa_onnx {
 
@@ -19,8 +20,13 @@ struct OfflineTtsKittenModelMetaData {
   int32_t has_espeak = 1;
 
   int32_t max_token_len = 256;
+  int32_t start_id = 0;
+  int32_t end_id = 0;
+  int32_t pad_id = 0;
+  int32_t add_pad_after_end = 0;
 
   std::string voice;
+  std::vector<float> speaker_speed_priors;
 };
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/offline-tts-kitten-model.cc
+++ b/sherpa-onnx/csrc/offline-tts-kitten-model.cc
@@ -68,9 +68,17 @@ class OfflineTtsKittenModel::Impl {
       SHERPA_ONNX_EXIT(-1);
     }
 
-    int32_t sid_int = static_cast<int32_t>(sid);
     int32_t dim1 = style_dim_[1];
     int32_t style_rows = style_dim_[0];
+    int32_t num_speakers =
+        static_cast<int32_t>(styles_.size() / (style_rows * dim1));
+    if (sid < 0 || sid >= num_speakers) {
+      SHERPA_ONNX_LOGE("Invalid speaker id: %d. Valid range: [0, %d)", sid,
+                       num_speakers);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    int32_t sid_int = static_cast<int32_t>(sid);
     int32_t row = SelectStyleRow(x, style_rows);
 
     /*const*/ float *p =
@@ -87,6 +95,15 @@ class OfflineTtsKittenModel::Impl {
     }
 
     if (!meta_data_.speaker_speed_priors.empty()) {
+      if (sid_int >=
+          static_cast<int32_t>(meta_data_.speaker_speed_priors.size())) {
+        SHERPA_ONNX_LOGE(
+            "Missing speaker speed prior for speaker id: %d. Number of priors: "
+            "%d",
+            sid_int,
+            static_cast<int32_t>(meta_data_.speaker_speed_priors.size()));
+        SHERPA_ONNX_EXIT(-1);
+      }
       speed *= meta_data_.speaker_speed_priors[sid_int];
     }
 
@@ -259,12 +276,13 @@ class OfflineTtsKittenModel::Impl {
       --num_content_tokens;
     }
 
-    if (num_content_tokens > 0 && p[num_tokens - 1] == meta_data_.pad_id) {
+    int32_t last = num_tokens - 1;
+    if (num_content_tokens > 0 && p[last] == meta_data_.pad_id) {
       --num_content_tokens;
+      --last;
     }
 
-    if (meta_data_.add_pad_after_end && num_tokens > 1 &&
-        p[num_tokens - 2] == meta_data_.end_id) {
+    if (num_content_tokens > 0 && last >= 0 && p[last] == meta_data_.end_id) {
       --num_content_tokens;
     }
 

--- a/sherpa-onnx/csrc/offline-tts-kitten-model.cc
+++ b/sherpa-onnx/csrc/offline-tts-kitten-model.cc
@@ -5,6 +5,7 @@
 #include "sherpa-onnx/csrc/offline-tts-kitten-model.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
@@ -67,10 +68,13 @@ class OfflineTtsKittenModel::Impl {
       SHERPA_ONNX_EXIT(-1);
     }
 
-    int32_t num_speakers = meta_data_.num_speakers;
+    int32_t sid_int = static_cast<int32_t>(sid);
     int32_t dim1 = style_dim_[1];
+    int32_t style_rows = style_dim_[0];
+    int32_t row = SelectStyleRow(x, style_rows);
 
-    /*const*/ float *p = styles_.data() + sid * dim1;
+    /*const*/ float *p =
+        styles_.data() + (sid_int * style_rows + row) * dim1;
 
     std::array<int64_t, 2> style_embedding_shape = {1, dim1};
     Ort::Value style_embedding = Ort::Value::CreateTensor(
@@ -80,6 +84,10 @@ class OfflineTtsKittenModel::Impl {
     int64_t speed_shape = 1;
     if (config_.kitten.length_scale != 1 && speed == 1) {
       speed = 1. / config_.kitten.length_scale;
+    }
+
+    if (!meta_data_.speaker_speed_priors.empty()) {
+      speed *= meta_data_.speaker_speed_priors[sid_int];
     }
 
     Ort::Value speed_tensor =
@@ -154,6 +162,13 @@ class OfflineTtsKittenModel::Impl {
     SHERPA_ONNX_READ_META_DATA(meta_data_.has_espeak, "has_espeak");
     SHERPA_ONNX_READ_META_DATA_STR_WITH_DEFAULT(meta_data_.voice, "voice",
                                                 "en-us");
+    SHERPA_ONNX_READ_META_DATA_WITH_DEFAULT(meta_data_.max_token_len,
+                                            "max_token_len", 256);
+    SHERPA_ONNX_READ_META_DATA_WITH_DEFAULT(meta_data_.start_id, "start_id", 0);
+    SHERPA_ONNX_READ_META_DATA_WITH_DEFAULT(meta_data_.end_id, "end_id", 0);
+    SHERPA_ONNX_READ_META_DATA_WITH_DEFAULT(meta_data_.pad_id, "pad_id", 0);
+    SHERPA_ONNX_READ_META_DATA_WITH_DEFAULT(meta_data_.add_pad_after_end,
+                                            "add_pad_after_end", 0);
     if (meta_data_.has_espeak != 1) {
       SHERPA_ONNX_LOGE("It should require espeak-ng");
       SHERPA_ONNX_EXIT(-1);
@@ -183,9 +198,25 @@ class OfflineTtsKittenModel::Impl {
       SHERPA_ONNX_EXIT(-1);
     }
 
-    if (style_dim_[0] != 1) {
-      SHERPA_ONNX_LOGE("style_dim[0] should be 1, given: %d", style_dim_[0]);
+    if (style_dim_[0] <= 0) {
+      SHERPA_ONNX_LOGE("style_dim[0] should be > 0, given: %d", style_dim_[0]);
       SHERPA_ONNX_EXIT(-1);
+    }
+
+    auto speaker_speed_priors = LookupCustomModelMetaData(
+        meta_data, "speaker_speed_priors", allocator);
+    if (!speaker_speed_priors.empty()) {
+      bool ret =
+          SplitStringToFloats(speaker_speed_priors.c_str(), ",", true,
+                              &meta_data_.speaker_speed_priors);
+      if (!ret || static_cast<int32_t>(meta_data_.speaker_speed_priors.size()) !=
+                      meta_data_.num_speakers) {
+        SHERPA_ONNX_LOGE(
+            "Invalid value '%s' for 'speaker_speed_priors'. Expected %d "
+            "floats.",
+            speaker_speed_priors.c_str(), meta_data_.num_speakers);
+        SHERPA_ONNX_EXIT(-1);
+      }
     }
 
     int32_t actual_num_floats = voices_data_length / sizeof(float);
@@ -214,6 +245,33 @@ class OfflineTtsKittenModel::Impl {
         reinterpret_cast<const float *>(voices_data) + expected_num_floats);
   }
 
+  int32_t SelectStyleRow(const Ort::Value &x, int32_t style_rows) const {
+    if (style_rows == 1) {
+      return 0;
+    }
+
+    std::vector<int64_t> x_shape = x.GetTensorTypeAndShapeInfo().GetShape();
+    int32_t num_tokens = static_cast<int32_t>(x_shape[1]);
+    int32_t num_content_tokens = num_tokens;
+    const int64_t *p = x.GetTensorData<int64_t>();
+
+    if (num_content_tokens > 0 && p[0] == meta_data_.start_id) {
+      --num_content_tokens;
+    }
+
+    if (num_content_tokens > 0 && p[num_tokens - 1] == meta_data_.pad_id) {
+      --num_content_tokens;
+    }
+
+    if (meta_data_.add_pad_after_end && num_tokens > 1 &&
+        p[num_tokens - 2] == meta_data_.end_id) {
+      --num_content_tokens;
+    }
+
+    num_content_tokens = std::max(num_content_tokens, 0);
+    return std::min(num_content_tokens, style_rows - 1);
+  }
+
  private:
   OfflineTtsModelConfig config_;
   Ort::Env env_;
@@ -231,7 +289,7 @@ class OfflineTtsKittenModel::Impl {
   OfflineTtsKittenModelMetaData meta_data_;
   std::vector<int32_t> style_dim_;
 
-  // (num_speakers, style_dim_[1])
+  // (num_speakers, style_dim_[0], style_dim_[1])
   std::vector<float> styles_;
 };
 

--- a/sherpa-onnx/csrc/piper-phonemize-lexicon.cc
+++ b/sherpa-onnx/csrc/piper-phonemize-lexicon.cc
@@ -238,6 +238,52 @@ static std::vector<std::vector<int64_t>> PiperPhonemesToIdsKokoroOrKitten(
   return ans;
 }
 
+static std::vector<std::vector<int64_t>> PiperPhonemesToIdsKitten(
+    const std::unordered_map<char32_t, int32_t> &token2id,
+    const std::vector<piper::Phoneme> &phonemes,
+    const OfflineTtsKittenModelMetaData &meta_data) {
+  std::vector<std::vector<int64_t>> ans;
+
+  std::vector<int64_t> current;
+  current.reserve(phonemes.size());
+
+  current.push_back(meta_data.start_id);
+
+  int32_t max_current_size_before_token =
+      meta_data.add_pad_after_end ? meta_data.max_token_len - 3
+                                  : meta_data.max_token_len - 1;
+  for (auto p : phonemes) {
+    if (token2id.count(p)) {
+      if (current.size() >
+          static_cast<size_t>(max_current_size_before_token)) {
+        current.push_back(meta_data.end_id);
+        if (meta_data.add_pad_after_end) {
+          current.push_back(meta_data.pad_id);
+        }
+        ans.push_back(std::move(current));
+
+        current.reserve(phonemes.size());
+        current.push_back(meta_data.start_id);
+      }
+
+      current.push_back(token2id.at(p));
+      if (p == '.') {
+        current.push_back(token2id.at(' '));
+      }
+    } else {
+      SHERPA_ONNX_LOGE("Skip unknown phonemes. Unicode codepoint: \\U+%04x.",
+                       static_cast<uint32_t>(p));
+    }
+  }
+
+  current.push_back(meta_data.end_id);
+  if (meta_data.add_pad_after_end) {
+    current.push_back(meta_data.pad_id);
+  }
+  ans.push_back(std::move(current));
+  return ans;
+}
+
 static std::vector<int64_t> CoquiPhonemesToIds(
     const std::unordered_map<char32_t, int32_t> &token2id,
     const std::vector<piper::Phoneme> &phonemes,
@@ -325,6 +371,16 @@ void InitEspeak(const std::string &data_dir) {
     }
   });
 }
+
+std::vector<TokenIDs> ConvertTextToTokenIdsKokoroOrKitten(
+    const std::unordered_map<char32_t, int32_t> &token2id,
+    int32_t max_token_len, const std::string &text,
+    const std::string &voice);
+
+std::vector<TokenIDs> ConvertTextToTokenIdsKitten(
+    const std::unordered_map<char32_t, int32_t> &token2id,
+    const OfflineTtsKittenModelMetaData &meta_data, const std::string &text,
+    const std::string &voice);
 
 PiperPhonemizeLexicon::PiperPhonemizeLexicon(
     const std::string &tokens, const std::string &data_dir,
@@ -450,8 +506,8 @@ std::vector<TokenIDs> PiperPhonemizeLexicon::ConvertTextToTokenIds(
     return ConvertTextToTokenIdsKokoroOrKitten(
         token2id_, kokoro_meta_data_.max_token_len, text, voice);
   } else if (is_kitten_) {
-    return ConvertTextToTokenIdsKokoroOrKitten(
-        token2id_, kitten_meta_data_.max_token_len, text, voice);
+    return ConvertTextToTokenIdsKitten(token2id_, kitten_meta_data_, text,
+                                       voice);
   } else {
     return ConvertTextToTokenIdsVits(text, voice);
   }
@@ -502,6 +558,33 @@ std::vector<TokenIDs> ConvertTextToTokenIdsKokoroOrKitten(
   for (const auto &p : phonemes) {
     auto phoneme_ids =
         PiperPhonemesToIdsKokoroOrKitten(token2id, p, max_token_len);
+
+    for (auto &ids : phoneme_ids) {
+      ans.emplace_back(std::move(ids));
+    }
+  }
+
+  return ans;
+}
+
+std::vector<TokenIDs> ConvertTextToTokenIdsKitten(
+    const std::unordered_map<char32_t, int32_t> &token2id,
+    const OfflineTtsKittenModelMetaData &meta_data, const std::string &text,
+    const std::string &voice /*= ""*/) {
+  piper::eSpeakPhonemeConfig config;
+
+  // ./bin/espeak-ng-bin --path  ./install/share/espeak-ng-data/ --voices
+  // to list available voices
+  config.voice = voice;  // e.g., voice is en-us
+
+  std::vector<std::vector<piper::Phoneme>> phonemes;
+
+  CallPhonemizeEspeak(text, config, &phonemes);
+
+  std::vector<TokenIDs> ans;
+
+  for (const auto &p : phonemes) {
+    auto phoneme_ids = PiperPhonemesToIdsKitten(token2id, p, meta_data);
 
     for (auto &ids : phoneme_ids) {
       ans.emplace_back(std::move(ids));

--- a/sherpa-onnx/csrc/piper-phonemize-lexicon.cc
+++ b/sherpa-onnx/csrc/piper-phonemize-lexicon.cc
@@ -249,13 +249,12 @@ static std::vector<std::vector<int64_t>> PiperPhonemesToIdsKitten(
 
   current.push_back(meta_data.start_id);
 
-  int32_t max_current_size_before_token =
-      meta_data.add_pad_after_end ? meta_data.max_token_len - 3
-                                  : meta_data.max_token_len - 1;
+  int32_t suffix_size = meta_data.add_pad_after_end ? 2 : 1;
   for (auto p : phonemes) {
     if (token2id.count(p)) {
-      if (current.size() >
-          static_cast<size_t>(max_current_size_before_token)) {
+      int32_t emitted_tokens = p == '.' ? 2 : 1;
+      if (static_cast<int32_t>(current.size()) + emitted_tokens + suffix_size >
+          meta_data.max_token_len) {
         current.push_back(meta_data.end_id);
         if (meta_data.add_pad_after_end) {
           current.push_back(meta_data.pad_id);

--- a/swift-api-examples/run-tts-kitten-en.sh
+++ b/swift-api-examples/run-tts-kitten-en.sh
@@ -10,13 +10,24 @@ fi
 # please visit
 # https://k2-fsa.github.io/sherpa/onnx/tts/pretrained_models/kitten.html
 # to download more models
-if [ ! -f ./kitten-nano-en-v0_1-fp16/model.fp16.onnx ]; then
-  curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/kitten-nano-en-v0_1-fp16.tar.bz2
-  tar xf kitten-nano-en-v0_1-fp16.tar.bz2
-  rm kitten-nano-en-v0_1-fp16.tar.bz2
+if [ ! -f ./kitten-mini-en-v0_8/model.onnx ]; then
+  echo "Please generate or copy kitten-mini-en-v0_8 first."
+  echo "For example:"
+  echo "  cd ../scripts/kitten-tts/v0_8"
+  echo "  ./run.sh KittenML/kitten-tts-mini-0.8"
+  echo "  cd ../../../swift-api-examples"
+  echo "  cp -R ../scripts/kitten-tts/v0_8 ./kitten-mini-en-v0_8"
+  exit 1
 fi
 
-if [ ! -e ./tts-kitten-en ]; then
+if [ ! -d ./kitten-mini-en-v0_8/espeak-ng-data ]; then
+  curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/espeak-ng-data.tar.bz2
+  tar xf espeak-ng-data.tar.bz2
+  rm espeak-ng-data.tar.bz2
+  mv espeak-ng-data ./kitten-mini-en-v0_8/
+fi
+
+if [ ! -e ./tts-kitten-en ] || [ ./tts-kitten-en.swift -nt ./tts-kitten-en ] || [ ./SherpaOnnx.swift -nt ./tts-kitten-en ]; then
   # Note: We use -lc++ to link against libc++ instead of libstdc++
   swiftc \
     -lc++ \

--- a/swift-api-examples/run-tts-kitten-en.sh
+++ b/swift-api-examples/run-tts-kitten-en.sh
@@ -7,26 +7,41 @@ if [ ! -d ../build-swift-macos ]; then
   exit 1
 fi
 
-# please visit
-# https://k2-fsa.github.io/sherpa/onnx/tts/pretrained_models/kitten.html
-# to download more models
+model_dir=./kitten-mini-en-v0_8
+
 if [ ! -f ./kitten-mini-en-v0_8/model.onnx ] || \
    [ ! -f ./kitten-mini-en-v0_8/voices.bin ] || \
    [ ! -f ./kitten-mini-en-v0_8/tokens.txt ]; then
-  echo "Please generate or copy kitten-mini-en-v0_8 first."
-  echo "For example:"
-  echo "  cd ../scripts/kitten-tts/v0_8"
-  echo "  ./run.sh KittenML/kitten-tts-mini-0.8"
-  echo "  cd ../../../swift-api-examples"
-  echo "  cp -R ../scripts/kitten-tts/v0_8/kitten-mini-en-v0_8 ."
-  exit 1
+  src_dir=../scripts/kitten-tts/v0_8
+  (
+    cd "${src_dir}"
+    if ! python3 - <<'PY'
+import importlib.util
+import sys
+
+sys.exit(
+    0
+    if importlib.util.find_spec("numpy") and importlib.util.find_spec("onnx")
+    else 1
+)
+PY
+    then
+      python3 -m venv .venv
+      . .venv/bin/activate
+      python3 -m pip install -q numpy onnx
+    fi
+
+    ./run.sh KittenML/kitten-tts-mini-0.8
+  )
+  rm -rf "${model_dir}"
+  cp -R "${src_dir}/kitten-mini-en-v0_8" "${model_dir}"
 fi
 
-if [ ! -d ./kitten-mini-en-v0_8/espeak-ng-data ]; then
+if [ ! -d "${model_dir}/espeak-ng-data" ]; then
   curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/espeak-ng-data.tar.bz2
   tar xf espeak-ng-data.tar.bz2
   rm espeak-ng-data.tar.bz2
-  mv espeak-ng-data ./kitten-mini-en-v0_8/
+  mv espeak-ng-data "${model_dir}/"
 fi
 
 if [ ! -e ./tts-kitten-en ] || [ ./tts-kitten-en.swift -nt ./tts-kitten-en ] || [ ./SherpaOnnx.swift -nt ./tts-kitten-en ]; then

--- a/swift-api-examples/run-tts-kitten-en.sh
+++ b/swift-api-examples/run-tts-kitten-en.sh
@@ -10,13 +10,15 @@ fi
 # please visit
 # https://k2-fsa.github.io/sherpa/onnx/tts/pretrained_models/kitten.html
 # to download more models
-if [ ! -f ./kitten-mini-en-v0_8/model.onnx ]; then
+if [ ! -f ./kitten-mini-en-v0_8/model.onnx ] || \
+   [ ! -f ./kitten-mini-en-v0_8/voices.bin ] || \
+   [ ! -f ./kitten-mini-en-v0_8/tokens.txt ]; then
   echo "Please generate or copy kitten-mini-en-v0_8 first."
   echo "For example:"
   echo "  cd ../scripts/kitten-tts/v0_8"
   echo "  ./run.sh KittenML/kitten-tts-mini-0.8"
   echo "  cd ../../../swift-api-examples"
-  echo "  cp -R ../scripts/kitten-tts/v0_8 ./kitten-mini-en-v0_8"
+  echo "  cp -R ../scripts/kitten-tts/v0_8/kitten-mini-en-v0_8 ."
   exit 1
 fi
 

--- a/swift-api-examples/tts-kitten-en.swift
+++ b/swift-api-examples/tts-kitten-en.swift
@@ -5,10 +5,10 @@ class MyClass {
 }
 
 func run() {
-  let model = "./kitten-nano-en-v0_1-fp16/model.fp16.onnx"
-  let voices = "./kitten-nano-en-v0_1-fp16/voices.bin"
-  let tokens = "./kitten-nano-en-v0_1-fp16/tokens.txt"
-  let dataDir = "./kitten-nano-en-v0_1-fp16/espeak-ng-data"
+  let model = "./kitten-mini-en-v0_8/model.onnx"
+  let voices = "./kitten-mini-en-v0_8/voices.bin"
+  let tokens = "./kitten-mini-en-v0_8/tokens.txt"
+  let dataDir = "./kitten-mini-en-v0_8/espeak-ng-data"
   let kitten = sherpaOnnxOfflineTtsKittenModelConfig(
     model: model,
     voices: voices,

--- a/wasm/tts/sherpa-onnx-tts.js
+++ b/wasm/tts/sherpa-onnx-tts.js
@@ -1060,6 +1060,13 @@ function createOfflineTts(Module, myConfig) {
       offlineTtsPocketModelConfig.vocabJson = './vocab.json';
       offlineTtsPocketModelConfig.tokenScoresJson = './token_scores.json';
       break;
+    case 6:
+      // KittenTTS
+      offlineTtsKittenModelConfig.model = './model.onnx';
+      offlineTtsKittenModelConfig.voices = './voices.bin';
+      offlineTtsKittenModelConfig.tokens = './tokens.txt';
+      offlineTtsKittenModelConfig.dataDir = './espeak-ng-data';
+      break;
   }
 
   const offlineTtsModelConfig = {


### PR DESCRIPTION
## Summary

Add KittenTTS v0.8 support across sherpa-onnx.

This includes:
- Runtime support for KittenTTS v0.8 metadata, token layout, speaker embeddings, and speaker speed priors
- Conversion/package scripts for KittenTTS v0.8 nano, micro, and mini models
- Model registry updates for APK, Flutter, Swift, WASM, and export workflow paths
- Updated Swift KittenTTS example to run with the v0.8 mini model

## Testing

- `python3 -m py_compile scripts/kitten-tts/v0_8/add_meta_data.py scripts/kitten-tts/v0_8/generate_tokens.py scripts/kitten-tts/v0_8/generate_voices_bin.py scripts/apk/generate-tts-apk-script.py scripts/flutter/generate-tts.py`
- `bash -n scripts/kitten-tts/v0_8/run.sh`
- `git diff --check`
- Built macOS Swift xcframework with `./build-swift-macos.sh`
- Ran Swift KittenTTS example and generated `test-kitten-en.wav`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Kitten TTS v0.8 variants (nano/micro/mini, fp32/int8), dynamic style selection at runtime, and asset generation (tokens/voices/metadata); enabled Kitten TTS in Flutter, Swift, and WASM examples.
* **Documentation**
  * Added Kitten TTS v0.8 preparation and usage guide.
* **Chores**
  * CI and build scripts updated to export, package, and preflight new Kitten model artifacts and manage rebuilds.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/k2-fsa/sherpa-onnx/pull/3591)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->