### PR TITLE
Fix building Linux wheels for Python 3.8

### DIFF
--- a/.github/workflows/build-wheels-aarch64-cuda.yaml
+++ b/.github/workflows/build-wheels-aarch64-cuda.yaml
@@ -60,7 +60,7 @@ jobs:
           CIBW_SKIP: "cp27-* cp35-* cp36-* *-win32 pp* *-musllinux* *-manylinux_i686"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ARCHS_LINUX: aarch64
-          CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/${{ matrix.manylinux }}_aarch64
+          CIBW_MANYLINUX_AARCH64_IMAGE: "${{ matrix.python-version == 'cp38' && format('quay.io/pypa/{0}_aarch64:2025.11.29-1', matrix.manylinux) || format('quay.io/pypa/{0}_aarch64', matrix.manylinux) }}"
           #  Don't repair Linux wheels
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: ""
           # From onnxruntime >= 1.17.0, it drops support for CentOS 7.0 and it supports only manylinux_2_28.

--- a/.github/workflows/build-wheels-aarch64-rknn.yaml
+++ b/.github/workflows/build-wheels-aarch64-rknn.yaml
@@ -46,7 +46,7 @@ jobs:
         run: |
             docker run --rm \
               --volume ${{ github.workspace }}/:/k2-fsa/sherpa-onnx \
-              quay.io/pypa/manylinux_2_28_aarch64 \
+              quay.io/pypa/manylinux_2_28_aarch64${{ matrix.python-version == '3.8' && ':2025.11.29-1' || '' }} \
             bash -c '
               uname -a
               which gcc

--- a/.github/workflows/build-wheels-aarch64.yaml
+++ b/.github/workflows/build-wheels-aarch64.yaml
@@ -340,7 +340,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ARCHS_LINUX: aarch64
           # https://quay.io/repository/pypa/manylinux2014_aarch64?tab=tags
-          CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/${{ matrix.manylinux }}_aarch64
+          CIBW_MANYLINUX_AARCH64_IMAGE: "${{ matrix.python-version == 'cp38' && format('quay.io/pypa/{0}_aarch64:2025.11.29-1', matrix.manylinux) || format('quay.io/pypa/{0}_aarch64', matrix.manylinux) }}"
           # From onnxruntime >= 1.17.0, it drops support for CentOS 7.0 and it supports only manylinux_2_28.
           # manylinux_2_24 is no longer supported
           CIBW_REPAIR_WHEEL_COMMAND: >

--- a/.github/workflows/build-wheels-armv7l.yaml
+++ b/.github/workflows/build-wheels-armv7l.yaml
@@ -307,7 +307,7 @@ jobs:
           docker run --rm \
             --platform linux/arm/v7 \
             --volume ${{ github.workspace }}/:/home/runner/work/sherpa-onnx/sherpa-onnx \
-            quay.io/pypa/manylinux_2_35_armv7l \
+            quay.io/pypa/manylinux_2_35_armv7l${{ matrix.python-version == '3.8' && ':2025.11.29-1' || '' }} \
             bash -c '
               find / -name "*gcc*" 2>/dev/null
 

--- a/.github/workflows/build-wheels-linux.yaml
+++ b/.github/workflows/build-wheels-linux.yaml
@@ -346,8 +346,8 @@ jobs:
 
           CIBW_BUILD: "${{ matrix.python-version}}-* "
           CIBW_SKIP: "cp27-* cp35-* cp36-* *-win32 pp* *-musllinux* *-manylinux_i686"
+          CIBW_MANYLINUX_X86_64_IMAGE: "${{ matrix.python-version == 'cp38' && 'quay.io/pypa/manylinux2014_x86_64:2025.11.29-1' || format('quay.io/pypa/{0}_x86_64', matrix.manylinux) }}"
           CIBW_BUILD_VERBOSITY: 3
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/${{ matrix.manylinux }}_x86_64
           CIBW_REPAIR_WHEEL_COMMAND: >
             auditwheel repair -w {dest_dir}
             --exclude libonnxruntime.so

--- a/.github/workflows/nightly-wheel-arm.yaml
+++ b/.github/workflows/nightly-wheel-arm.yaml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   nightly-wheel-arm:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
     name: ${{ matrix.python-version }}
     # see https://github.com/actions/virtual-environments/blob/win19/20210525.0/images/win/Windows2019-Readme.md
     runs-on: ${{ matrix.os}}

--- a/.github/workflows/sanitizer.yaml
+++ b/.github/workflows/sanitizer.yaml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   sanitizer:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
     runs-on: ${{ matrix.os }}
     name: sanitizer
     strategy:

--- a/.github/workflows/test-dart-package.yaml
+++ b/.github/workflows/test-dart-package.yaml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   test_dart_package:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/test-dot-net-nuget.yaml
+++ b/.github/workflows/test-dot-net-nuget.yaml
@@ -21,6 +21,7 @@ permissions:
 
 jobs:
   test-dot-net-nuget:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test-go-package.yaml
+++ b/.github/workflows/test-go-package.yaml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   test-go-package:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
     name: ${{ matrix.os }} ${{matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/test-nodejs-npm.yaml
+++ b/.github/workflows/test-nodejs-npm.yaml
@@ -21,6 +21,7 @@ permissions:
 
 jobs:
   test-nodejs-npm:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test-pip-install.yaml
+++ b/.github/workflows/test-pip-install.yaml
@@ -23,6 +23,7 @@ permissions:
 
 jobs:
   test_pip_install:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} ${{ matrix.python-version }}
     strategy:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image configuration for Python 3.8 builds across multiple architectures (aarch64, armv7l, linux x86_64, CUDA) to use specific pinned image tags for enhanced build consistency.
  * Added repository owner restrictions to CI/CD workflows for package testing and binary wheel building (Dart, .NET, Go, Node.js, pip installation, and ARM-based builds) to limit execution to designated repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->