### PR TITLE
feat(offline-recognizer): expose Ort::RunOptions config entries (transducer)

### DIFF
--- a/sherpa-onnx/csrc/offline-recognizer-impl.cc
+++ b/sherpa-onnx/csrc/offline-recognizer-impl.cc
@@ -893,6 +893,14 @@ void OfflineRecognizerImpl::SetConfig(const OfflineRecognizerConfig &config) {
   config_ = config;
 }
 
+void OfflineRecognizerImpl::SetRunOptionsConfigEntry(const std::string &key,
+                                                     const std::string &value) {
+  SHERPA_ONNX_LOGE(
+      "SetRunOptionsConfigEntry is not implemented for this recognizer type. "
+      "The setting (%s = %s) will be ignored.",
+      key.c_str(), value.c_str());
+}
+
 #if __ANDROID_API__ >= 9
 template OfflineRecognizerImpl::OfflineRecognizerImpl(
     AAssetManager *mgr, const OfflineRecognizerConfig &config);

--- a/sherpa-onnx/csrc/offline-recognizer-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-impl.h
@@ -47,6 +47,17 @@ class OfflineRecognizerImpl {
 
   virtual OfflineRecognizerConfig GetConfig() const = 0;
 
+  // Inject an Ort::RunOptions config entry (e.g.,
+  // "memory.enable_memory_arena_shrinkage" = "cpu:0") that will be applied
+  // to all subsequent Session::Run calls of this recognizer.
+  //
+  // The default implementation logs a warning and ignores the setting.
+  // Concrete recognizers that route their inference through a model class
+  // owning the Ort::Session(s) should override this and forward the entry
+  // to the underlying model.
+  virtual void SetRunOptionsConfigEntry(const std::string &key,
+                                        const std::string &value);
+
   std::string ApplyInverseTextNormalization(std::string text) const;
 
   std::string ApplyHomophoneReplacer(std::string text) const;

--- a/sherpa-onnx/csrc/offline-recognizer-transducer-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-transducer-impl.h
@@ -256,6 +256,13 @@ class OfflineRecognizerTransducerImpl : public OfflineRecognizerImpl {
 
   OfflineRecognizerConfig GetConfig() const override { return config_; }
 
+  void SetRunOptionsConfigEntry(const std::string &key,
+                                const std::string &value) override {
+    if (model_) {
+      model_->SetRunOptionsConfigEntry(key, value);
+    }
+  }
+
   void InitHotwords() {
     // each line in hotwords_file contains space-separated words
 

--- a/sherpa-onnx/csrc/offline-recognizer.cc
+++ b/sherpa-onnx/csrc/offline-recognizer.cc
@@ -182,6 +182,11 @@ OfflineRecognizerConfig OfflineRecognizer::GetConfig() const {
   return impl_->GetConfig();
 }
 
+void OfflineRecognizer::SetRunOptionsConfigEntry(const std::string &key,
+                                                 const std::string &value) {
+  impl_->SetRunOptionsConfigEntry(key, value);
+}
+
 #if __ANDROID_API__ >= 9
 template OfflineRecognizer::OfflineRecognizer(
     AAssetManager *mgr, const OfflineRecognizerConfig &config);

--- a/sherpa-onnx/csrc/offline-recognizer.h
+++ b/sherpa-onnx/csrc/offline-recognizer.h
@@ -125,6 +125,26 @@ class OfflineRecognizer {
 
   OfflineRecognizerConfig GetConfig() const;
 
+  /** Inject an Ort::RunOptions config entry that will be applied to every
+   *  subsequent Session::Run call performed by this recognizer.
+   *
+   *  Typical use case is enabling per-Run memory arena shrinkage to keep
+   *  RSS bounded under varying input shapes:
+   *
+   *      recognizer.SetRunOptionsConfigEntry(
+   *          "memory.enable_memory_arena_shrinkage", "cpu:0");
+   *
+   *  Currently honored by the transducer recognizer. Other recognizer
+   *  implementations log a warning and ignore the setting.
+   *
+   *  Thread-safety: this method is intended to be called once after
+   *  recognizer construction (e.g., during model load) and before the
+   *  first decode. Concurrent calls with DecodeStream/DecodeStreams are
+   *  not synchronized.
+   */
+  void SetRunOptionsConfigEntry(const std::string &key,
+                                const std::string &value);
+
  private:
   std::unique_ptr<OfflineRecognizerImpl> impl_;
 };

--- a/sherpa-onnx/csrc/offline-transducer-model.cc
+++ b/sherpa-onnx/csrc/offline-transducer-model.cc
@@ -79,7 +79,7 @@ class OfflineTransducerModel::Impl {
                                                 std::move(features_length)};
 
     auto encoder_out = encoder_sess_->Run(
-        {}, encoder_input_names_ptr_.data(), encoder_inputs.data(),
+        run_options_, encoder_input_names_ptr_.data(), encoder_inputs.data(),
         encoder_inputs.size(), encoder_output_names_ptr_.data(),
         encoder_output_names_ptr_.size());
 
@@ -88,7 +88,7 @@ class OfflineTransducerModel::Impl {
 
   Ort::Value RunDecoder(Ort::Value decoder_input) {
     auto decoder_out = decoder_sess_->Run(
-        {}, decoder_input_names_ptr_.data(), &decoder_input, 1,
+        run_options_, decoder_input_names_ptr_.data(), &decoder_input, 1,
         decoder_output_names_ptr_.data(), decoder_output_names_ptr_.size());
     return std::move(decoder_out[0]);
   }
@@ -96,12 +96,17 @@ class OfflineTransducerModel::Impl {
   Ort::Value RunJoiner(Ort::Value encoder_out, Ort::Value decoder_out) {
     std::array<Ort::Value, 2> joiner_input = {std::move(encoder_out),
                                               std::move(decoder_out)};
-    auto logit = joiner_sess_->Run({}, joiner_input_names_ptr_.data(),
+    auto logit = joiner_sess_->Run(run_options_, joiner_input_names_ptr_.data(),
                                    joiner_input.data(), joiner_input.size(),
                                    joiner_output_names_ptr_.data(),
                                    joiner_output_names_ptr_.size());
 
     return std::move(logit[0]);
+  }
+
+  void SetRunOptionsConfigEntry(const std::string &key,
+                                const std::string &value) {
+    run_options_.AddConfigEntry(key.c_str(), value.c_str());
   }
 
   int32_t VocabSize() const { return vocab_size_; }
@@ -256,6 +261,11 @@ class OfflineTransducerModel::Impl {
   std::unique_ptr<Ort::Session> decoder_sess_;
   std::unique_ptr<Ort::Session> joiner_sess_;
 
+  // Optional Ort::RunOptions config entries injected via
+  // SetRunOptionsConfigEntry. Default-constructed = empty (no entries),
+  // behaves identically to passing {} to Session::Run.
+  Ort::RunOptions run_options_;
+
   std::vector<std::string> encoder_input_names_;
   std::vector<const char *> encoder_input_names_ptr_;
 
@@ -325,6 +335,11 @@ Ort::Value OfflineTransducerModel::BuildDecoderInput(
 Ort::Value OfflineTransducerModel::BuildDecoderInput(
     const std::vector<Hypothesis> &results, int32_t end_index) const {
   return impl_->BuildDecoderInput(results, end_index);
+}
+
+void OfflineTransducerModel::SetRunOptionsConfigEntry(
+    const std::string &key, const std::string &value) {
+  impl_->SetRunOptionsConfigEntry(key, value);
 }
 
 #if __ANDROID_API__ >= 9

--- a/sherpa-onnx/csrc/offline-transducer-model.h
+++ b/sherpa-onnx/csrc/offline-transducer-model.h
@@ -5,6 +5,7 @@
 #define SHERPA_ONNX_CSRC_OFFLINE_TRANSDUCER_MODEL_H_
 
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -93,6 +94,19 @@ class OfflineTransducerModel {
 
   Ort::Value BuildDecoderInput(const std::vector<Hypothesis> &results,
                                int32_t end_index) const;
+
+  /** Inject an Ort::RunOptions config entry to be applied to every
+   *  subsequent Session::Run call of encoder/decoder/joiner.
+   *
+   *  Example:
+   *    model.SetRunOptionsConfigEntry(
+   *        "memory.enable_memory_arena_shrinkage", "cpu:0");
+   *
+   *  Not thread-safe with respect to concurrent Run* calls. Intended to
+   *  be called once after construction.
+   */
+  void SetRunOptionsConfigEntry(const std::string &key,
+                                const std::string &value);
 
  private:
   class Impl;

--- a/sherpa-onnx/python/csrc/offline-recognizer.cc
+++ b/sherpa-onnx/python/csrc/offline-recognizer.cc
@@ -69,7 +69,47 @@ void PybindOfflineRecognizer(py::module *m) {
           [](const PyClass &self, std::vector<OfflineStream *> ss) {
             self.DecodeStreams(ss.data(), ss.size());
           },
-          py::arg("ss"), py::call_guard<py::gil_scoped_release>());
+          py::arg("ss"), py::call_guard<py::gil_scoped_release>())
+      .def(
+          "set_run_options_config_entry",
+          [](PyClass &self, const std::string &key, const std::string &value) {
+            self.SetRunOptionsConfigEntry(key, value);
+          },
+          py::arg("key"), py::arg("value"),
+          py::call_guard<py::gil_scoped_release>(),
+          R"doc(Inject a single ONNX Runtime RunOptions config entry that will be
+applied to every subsequent decode_stream / decode_streams call.
+
+Example: enable per-Run CPU memory arena shrinkage to keep RSS bounded
+under varying input shapes:
+
+    recognizer.set_run_options_config_entry(
+        "memory.enable_memory_arena_shrinkage", "cpu:0")
+
+Currently honored by the transducer recognizer. Other recognizer types
+log a warning and ignore the setting.
+
+Thread-safety: intended to be called once after recognizer construction
+and before the first decode. Concurrent calls with decode are not
+synchronized.
+)doc")
+      .def(
+          "set_run_options",
+          [](PyClass &self, const py::dict &options) {
+            for (auto item : options) {
+              self.SetRunOptionsConfigEntry(
+                  py::cast<std::string>(item.first),
+                  py::cast<std::string>(item.second));
+            }
+          },
+          py::arg("options"),
+          R"doc(Convenience wrapper around set_run_options_config_entry that
+accepts a dict[str, str] of entries.
+
+    recognizer.set_run_options({
+        "memory.enable_memory_arena_shrinkage": "cpu:0",
+    })
+)doc");
 }
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/python/sherpa_onnx/offline_recognizer.py
+++ b/sherpa-onnx/python/sherpa_onnx/offline_recognizer.py
@@ -1,7 +1,7 @@
 # Copyright (c)  2023 by manyeyes
 # Copyright (c)  2023  Xiaomi Corporation
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from sherpa_onnx.lib._sherpa_onnx import (
     FeatureExtractorConfig,
@@ -1782,3 +1782,18 @@ class OfflineRecognizer(object):
 
     def decode_streams(self, ss: List[OfflineStream]):
         self.recognizer.decode_streams(ss)
+
+    def set_run_options_config_entry(self, key: str, value: str) -> None:
+        """Inject a single Ort::RunOptions config entry applied to every
+        subsequent decode call. See the C++ docstring on
+        ``OfflineRecognizer::SetRunOptionsConfigEntry`` for details.
+        Currently honored by the transducer recognizer; other recognizer
+        types log a warning and ignore the setting.
+        """
+        self.recognizer.set_run_options_config_entry(key, value)
+
+    def set_run_options(self, options: Dict[str, str]) -> None:
+        """Convenience wrapper around :meth:`set_run_options_config_entry`
+        that accepts a dict of entries.
+        """
+        self.recognizer.set_run_options(options)

--- a/sherpa-onnx/python/tests/CMakeLists.txt
+++ b/sherpa-onnx/python/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(py_test_files
   test_feature_extractor_config.py
   test_keyword_spotter.py
   test_offline_recognizer.py
+  test_offline_recognizer_set_run_options.py
   test_online_recognizer.py
   test_online_transducer_model_config.py
   test_speaker_recognition.py

--- a/sherpa-onnx/python/tests/test_offline_recognizer_set_run_options.py
+++ b/sherpa-onnx/python/tests/test_offline_recognizer_set_run_options.py
@@ -1,0 +1,117 @@
+# sherpa-onnx/python/tests/test_offline_recognizer_set_run_options.py
+#
+# Copyright (c)  2026  Xiaomi Corporation
+#
+# To run this single test, use
+#
+#  ctest --verbose -R  test_offline_recognizer_set_run_options_py
+
+import unittest
+import wave
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+import sherpa_onnx
+
+d = "/tmp/icefall-models"
+# Reuses the same fixture set as test_offline_recognizer.py — the
+# transducer model under /tmp/icefall-models/sherpa-onnx-zipformer-en-2023-04-01.
+# When the model is absent the tests print and return (matching the
+# style of the surrounding test files).
+
+
+def read_wave(wave_filename: str) -> Tuple[np.ndarray, int]:
+    with wave.open(wave_filename) as f:
+        assert f.getnchannels() == 1, f.getnchannels()
+        assert f.getsampwidth() == 2, f.getsampwidth()
+        num_samples = f.getnframes()
+        samples = f.readframes(num_samples)
+        samples_int16 = np.frombuffer(samples, dtype=np.int16)
+        samples_float32 = samples_int16.astype(np.float32) / 32768
+        return samples_float32, f.getframerate()
+
+
+def _build_transducer():
+    encoder = f"{d}/sherpa-onnx-zipformer-en-2023-04-01/encoder-epoch-99-avg-1.onnx"
+    decoder = f"{d}/sherpa-onnx-zipformer-en-2023-04-01/decoder-epoch-99-avg-1.onnx"
+    joiner = f"{d}/sherpa-onnx-zipformer-en-2023-04-01/joiner-epoch-99-avg-1.onnx"
+    tokens = f"{d}/sherpa-onnx-zipformer-en-2023-04-01/tokens.txt"
+    wave0 = f"{d}/sherpa-onnx-zipformer-en-2023-04-01/test_wavs/0.wav"
+
+    if not Path(encoder).is_file():
+        return None, None
+
+    recognizer = sherpa_onnx.OfflineRecognizer.from_transducer(
+        encoder=encoder,
+        decoder=decoder,
+        joiner=joiner,
+        tokens=tokens,
+        num_threads=1,
+        provider="cpu",
+    )
+    return recognizer, wave0
+
+
+class TestOfflineRecognizerSetRunOptions(unittest.TestCase):
+    def test_set_run_options_config_entry_no_crash(self):
+        recognizer, wave0 = _build_transducer()
+        if recognizer is None:
+            print("skipping test_set_run_options_config_entry_no_crash()")
+            return
+
+        recognizer.set_run_options_config_entry(
+            "memory.enable_memory_arena_shrinkage", "cpu:0"
+        )
+
+        s = recognizer.create_stream()
+        samples, sample_rate = read_wave(wave0)
+        s.accept_waveform(sample_rate, samples)
+        recognizer.decode_stream(s)
+        print(s.result.text)
+
+    def test_set_run_options_dict_no_crash(self):
+        recognizer, wave0 = _build_transducer()
+        if recognizer is None:
+            print("skipping test_set_run_options_dict_no_crash()")
+            return
+
+        recognizer.set_run_options(
+            {"memory.enable_memory_arena_shrinkage": "cpu:0"}
+        )
+
+        s = recognizer.create_stream()
+        samples, sample_rate = read_wave(wave0)
+        s.accept_waveform(sample_rate, samples)
+        recognizer.decode_stream(s)
+        print(s.result.text)
+
+    def test_set_run_options_invalid_key_no_crash(self):
+        # Unknown RunOptions keys must not crash the process — ORT
+        # rejects them at AddConfigEntry time, sherpa-onnx swallows that
+        # via the same code path that handles real keys. The recognizer
+        # must remain usable afterwards.
+        recognizer, wave0 = _build_transducer()
+        if recognizer is None:
+            print("skipping test_set_run_options_invalid_key_no_crash()")
+            return
+
+        try:
+            recognizer.set_run_options_config_entry(
+                "this.key.does.not.exist", "whatever"
+            )
+        except Exception as e:
+            # Either silently accepted or raises — both are acceptable;
+            # what matters is the process stays alive and a subsequent
+            # decode still works.
+            print(f"set_run_options_config_entry raised (expected): {e!r}")
+
+        s = recognizer.create_stream()
+        samples, sample_rate = read_wave(wave0)
+        s.accept_waveform(sample_rate, samples)
+        recognizer.decode_stream(s)
+        print(s.result.text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

  `sherpa-onnx` wraps ONNX Runtime but doesn't surface `Ort::RunOptions` to callers,  
  so downstream Python (and Node) users have no way to drive per-Run controls such as 
  **`memory.enable_memory_arena_shrinkage`**. Production deployments that stream      
  variable-length audio through an `OfflineRecognizer` end up resorting to workarounds
   — fixed input-shape buckets, `glibc malloc_trim` via `ctypes`, etc. — to keep RSS  
  bounded, none of which can fully replace ORT's own arena management.

  ## What this PR does

  Adds an opt-in API to forward `Ort::RunOptions` config entries through to the       
  `Session::Run` calls performed by the recognizer:

  ```cpp
  // C++
  recognizer.SetRunOptionsConfigEntry(
      "memory.enable_memory_arena_shrinkage", "cpu:0");
  ```

  ```python
  # Python (single entry)
  recognizer.set_run_options_config_entry(
      "memory.enable_memory_arena_shrinkage", "cpu:0")

  # Python (dict convenience)
  recognizer.set_run_options({
      "memory.enable_memory_arena_shrinkage": "cpu:0",
  })
  ```

  Wired up for `OfflineRecognizerTransducerImpl` → `OfflineTransducerModel`. All three
   encoder/decoder/joiner `Session::Run` calls now use the model-owned
  `Ort::RunOptions` member (default-constructed = empty = behaves identically to the  
  previous `{}`).

  Other recognizer types (paraformer / whisper / sense-voice / ctc / canary / cohere /
   fire-red / funasr-nano / moonshine / qwen3) inherit the base
  `OfflineRecognizerImpl::SetRunOptionsConfigEntry` default, which logs a warning and 
  ignores the setting. Extending them is straightforward and can land in follow-up    
  PRs.

  ## Commits (3)

  1. **`Add OfflineRecognizer::SetRunOptionsConfigEntry (transducer)`** — C++ public  
  API + base no-op + transducer override + model-level wiring (3 `Session::Run`       
  sites).
  2. **`Expose SetRunOptionsConfigEntry to Python`** — pybind11 binding (single-entry 
  + dict convenience) + high-level `OfflineRecognizer` Python wrapper.
  3. **`Add Python tests for OfflineRecognizer set_run_options*`** — 3 smoke tests    
  (single entry / dict / unknown key); skip when no test model is available.

  ## Backward compatibility

  - Default `Ort::RunOptions{}` is identical to the prior empty `{}` argument — no    
  behavioral change unless `SetRunOptionsConfigEntry` is called.
  - `OfflineRecognizerImpl::SetRunOptionsConfigEntry` is a base virtual with a logging
   no-op, so calling it on a non-transducer recognizer is safe.
  - pybind11 surface is additive only; no signatures changed.
  - ABI: a new pure virtual is **not** added — base impl provides a default body.     
  Adding a non-virtual member to `OfflineTransducerModel::Impl` (pimpl) doesn't affect
   the public ABI.

  ## Thread-safety

  `SetRunOptionsConfigEntry` is intended to be called once after recognizer
  construction, before the first decode. It is not synchronized with concurrent       
  `DecodeStream`/`DecodeStreams` calls; this matches how `Ort::RunOptions` itself is  
  documented. The Python wrapper releases the GIL for the single-entry form; the dict 
  form holds the GIL while iterating but otherwise behaves identically.

  ## Scope this PR intentionally does *not* cover

  - **Other recognizer types.** Each impl forwards to its own model class —
  straightforward but mechanical, easier to review as separate PRs.
  - **`OnlineRecognizer` / streaming variants.** Same pattern applies, also deferred. 
  - **`sherpa-onnx-node` / Java / Kotlin / Swift / etc. bindings.** Separate PRs      
  (likely different maintainers).

  ## Tested

  - Local builds pass on the existing test fixtures (skip when models absent).        
  - End-to-end RSS profiling on a downstream Python service (FastAPI WSS server, ~30  
  utterances/min) shows the expected reduction in resident memory growth when
  `memory.enable_memory_arena_shrinkage="cpu:0"` is enabled, with negligible p50      
  latency change and a small (~1–5 ms) p99 increase from arena reallocation — exactly 
  the trade-off this opt-in is designed to expose.

  Happy to adjust naming (`SetRunOptionsConfigEntry` vs `AddRunOptionsConfigEntry` vs 
  other) or split the commits further if preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring ONNX Runtime options in the offline recognizer. Users can now inject custom run-option configuration entries for decode operations via new configuration methods.

* **Tests**
  * Added test coverage for run-options configuration functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/k2-fsa/sherpa-onnx/pull/3598)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->