### PR TITLE
Release Supertonic3 TTS models

### DIFF
--- a/.github/workflows/export-supertonic.yaml
+++ b/.github/workflows/export-supertonic.yaml
@@ -3,7 +3,7 @@ name: export-supertonic-3-to-int8-onnx
 on:
   push:
     branches:
-      - ci-supertonic
+      - update-supertonic3-tts
 
   workflow_dispatch:
 


### PR DESCRIPTION
You can find the model at
https://github.com/k2-fsa/sherpa-onnx/releases/tag/tts-models

<img width="2796" height="1546" alt="Screenshot 2026-05-13 at 09 47 02" src="https://github.com/user-attachments/assets/7f01d75f-ba0b-4912-a873-5db130906e28" />


# Usage
## Download

```
wget https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/sherpa-onnx-supertonic-3-tts-int8-2026-05-11.tar.bz2
tar xvf sherpa-onnx-supertonic-3-tts-int8-2026-05-11.tar.bz2
rm sherpa-onnx-supertonic-3-tts-int8-2026-05-11.tar.bz2
```

```
 ls -lh ./sherpa-onnx-supertonic-3-tts-int8-2026-05-11
total 297096
-rw-r--r--@ 1 fangjun  staff   3.5M 13 May 09:37 duration_predictor.int8.onnx
-rw-r--r--@ 1 fangjun  staff   1.0K 13 May 09:37 LICENSE
-rw-r--r--@ 1 fangjun  staff    19K 13 May 09:37 README.md
-rw-r--r--@ 1 fangjun  staff    35M 13 May 09:37 text_encoder.int8.onnx
-rw-r--r--@ 1 fangjun  staff   8.1K 13 May 09:37 tts.json
-rw-r--r--@ 1 fangjun  staff   256K 13 May 09:37 unicode_indexer.bin
-rw-r--r--@ 1 fangjun  staff    75M 13 May 09:37 vector_estimator.int8.onnx
-rw-r--r--@ 1 fangjun  staff    25M 13 May 09:37 vocoder.int8.onnx
-rw-r--r--@ 1 fangjun  staff   505K 13 May 09:37 voice.bin
```

## English
```bash
build/bin/sherpa-onnx-offline-tts \
  --supertonic-duration-predictor=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/duration_predictor.int8.onnx \
  --supertonic-text-encoder=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/text_encoder.int8.onnx \
  --supertonic-vector-estimator=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/vector_estimator.int8.onnx \
  --supertonic-vocoder=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/vocoder.int8.onnx \
  --supertonic-tts-json=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/tts.json \
  --supertonic-unicode-indexer=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/unicode_indexer.bin \
  --supertonic-voice-style=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/voice.bin \
  --sid=9 \
  --debug=1 \
  --lang=en \
  --output-filename=./en-9.wav \
  "Today as always, men fall into two groups: slaves and free men. Whoever does not have two thirds of his day for himself, is a slave, whatever he may be, a statesman, a businessman, an official, or a scholar."
```

logs:
```
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/parse-options.cc:Read:373 build/bin/sherpa-onnx-offline-tts --supertonic-duration-predictor=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/duration_predictor.int8.onnx --supertonic-text-encoder=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/text_encoder.int8.onnx --supertonic-vector-estimator=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/vector_estimator.int8.onnx --supertonic-vocoder=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/vocoder.int8.onnx --supertonic-tts-json=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/tts.json --supertonic-unicode-indexer=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/unicode_indexer.bin --supertonic-voice-style=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/voice.bin --sid=9 --debug=1 --lang=en --output-filename=./en-9.wav 'Today as always, men fall into two groups: slaves and free men. Whoever does not have two thirds of his day for himself, is a slave, whatever he may be, a statesman, a businessman, an official, or a scholar.' 

OfflineTtsModelConfig(vits=OfflineTtsVitsModelConfig(model="", lexicon="", tokens="", data_dir="", noise_scale=0.667, noise_scale_w=0.8, length_scale=1), matcha=OfflineTtsMatchaModelConfig(acoustic_model="", vocoder="", lexicon="", tokens="", data_dir="", noise_scale=1, length_scale=1), kokoro=OfflineTtsKokoroModelConfig(model="", voices="", tokens="", lexicon="", data_dir="", length_scale=1, lang=""), zipvoice=OfflineTtsZipvoiceModelConfig(tokens="", encoder="", decoder="", vocoder="", data_dir="", lexicon="", feat_scale=0.1, t_shift=0.5, target_rms=0.1, guidance_scale=1), kitten=OfflineTtsKittenModelConfig(model="", voices="", tokens="", data_dir="", length_scale=1), pocket=OfflineTtsPocketModelConfig(lm_flow="", lm_main="", encoder="", decoder="", text_conditioner="", vocab_json="", token_scores_json="", voice_embedding_cache_capacity=50), supertonic=OfflineTtsSupertonicModelConfig(duration_predictor="./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/duration_predictor.int8.onnx", text_encoder="./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/text_encoder.int8.onnx", vector_estimator="./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/vector_estimator.int8.onnx", vocoder="./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/vocoder.int8.onnx", tts_json="./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/tts.json", unicode_indexer="./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/unicode_indexer.bin", voice_style="./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/voice.bin"), num_threads=1, debug=True, provider="cpu")
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/offline-tts-supertonic-model.cc:PrintDebugInfo:151 ---supertonic model---
tts_config: /Users/fangjun/open-source/icefall-models/sherpa-onnx-supertonic-3-tts-int8-2026-05-11/tts.json
sample_rate: 44100
base_chunk_size: 512
chunk_compress_factor: 6
latent_dim: 24


/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/offline-tts-supertonic-model.cc:PrintModelInfo:133 ----------duration_predictor----------
Input names: text_ids style_dp text_mask 
Output names: duration 


/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/offline-tts-supertonic-model.cc:PrintModelInfo:133 ----------text_encoder----------
Input names: text_ids style_ttl text_mask 
Output names: text_emb 


/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/offline-tts-supertonic-model.cc:PrintModelInfo:133 ----------vector_estimator----------
Input names: noisy_latent text_emb style_ttl latent_mask text_mask current_step total_step 
Output names: denoised_latent 


/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/offline-tts-supertonic-model.cc:PrintModelInfo:133 ----------vocoder----------
Input names: latent 
Output names: wav_tts 


/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/offline-tts-supertonic-impl.cc:InitVoiceStyle:626 Number of speakers: 10
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/offline-tts-supertonic-impl.cc:Generate:227 GenerationConfig(silence_scale=0.2, speed=1, sid=9, num_steps=5, reference_audio_len=0, reference_sample_rate=0, extra={lang: "en"})
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/offline-tts-supertonic-impl.cc:Process:499 Vocoder output shape: [1, 685056], total elements: 685056, bsz: 1
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/offline-tts-supertonic-impl.cc:Process:541 Audio samples: 684000, min_abs=0.000000, max_abs=0.431060
Number of threads: 1
Elapsed seconds: 2.855 s
Audio duration: 15.510 s
Real-time factor (RTF): 2.855/15.510 = 0.184
The text is: Today as always, men fall into two groups: slaves and free men. Whoever does not have two thirds of his day for himself, is a slave, whatever he may be, a statesman, a businessman, an official, or a scholar.. Speaker ID: 9
Saved to ./en-9.wav successfully!
sample=684000, progress=1.000000

```


https://github.com/user-attachments/assets/8226af44-18a2-4a4f-ab51-ac1a1434d1a0



https://github.com/user-attachments/assets/9baf977c-5308-4540-a8df-975f11e1f2ad


## Japanese
```
build/bin/sherpa-onnx-offline-tts \
  --supertonic-duration-predictor=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/duration_predictor.int8.onnx \
  --supertonic-text-encoder=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/text_encoder.int8.onnx \
  --supertonic-vector-estimator=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/vector_estimator.int8.onnx \
  --supertonic-vocoder=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/vocoder.int8.onnx \
  --supertonic-tts-json=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/tts.json \
  --supertonic-unicode-indexer=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/unicode_indexer.bin \
  --supertonic-voice-style=./sherpa-onnx-supertonic-3-tts-int8-2026-05-11/voice.bin \
  --sid=0 \
  --lang=ja \
  --output-filename=./ja-0.wav \
  "音声合成は文章を自然な声に変換します。"
```


https://github.com/user-attachments/assets/df0ef56a-b294-4452-8e09-077815566bce


https://github.com/user-attachments/assets/00ffb753-311e-49a5-bfa7-23942edbedef


https://github.com/user-attachments/assets/b9b68ba8-c51f-46f2-bca8-772f17c3b02e


https://github.com/user-attachments/assets/4fcdab31-a1b2-4745-af25-52b1db887554

cc @PhamDangNguyen @Anazark @RDD09 @xxyzj10 @Amber1608


Fixes #3581 
Fixes #2152
Fixes #1844

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration for the model export process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/k2-fsa/sherpa-onnx/pull/3609)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->