### PR TITLE
Update Spacemit toolchain download URL and centralize versioning

### DIFF
--- a/.github/workflows/riscv64-spacemit-linux.yaml
+++ b/.github/workflows/riscv64-spacemit-linux.yaml
@@ -24,6 +24,8 @@ jobs:
   riscv64_spacemit_linux:
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} ${{ matrix.lib_type }}
+    env:
+      SPACEMIT_TOOLCHAIN_VERSION: v1.1.2
     strategy:
       fail-fast: false
       matrix:
@@ -67,17 +69,20 @@ jobs:
         uses: actions/cache@v4
         with:
           path: toolchain
-          key: https://archive.spacemit.com/toolchain/spacemit-toolchain-linux-glibc-x86_64-v1.1.2.tar.xz
+          key: ${{ format('https://github.com/spacemit-com/toolchain/releases/download/{0}/spacemit-toolchain-linux-glibc-x86_64-{0}.tar.xz', env.SPACEMIT_TOOLCHAIN_VERSION) }}
 
       - name: Download toolchain
         if: steps.cache-toolchain.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          wget -q https://archive.spacemit.com/toolchain/spacemit-toolchain-linux-glibc-x86_64-v1.1.2.tar.xz
+          toolchain_archive=spacemit-toolchain-linux-glibc-x86_64-${SPACEMIT_TOOLCHAIN_VERSION}.tar.xz
+          toolchain_url=https://github.com/spacemit-com/toolchain/releases/download/${SPACEMIT_TOOLCHAIN_VERSION}/${toolchain_archive}
+
+          wget -q ${toolchain_url}
 
           mkdir $GITHUB_WORKSPACE/toolchain
 
-          tar xvf spacemit-toolchain-linux-glibc-x86_64-v1.1.2.tar.xz --strip-components 1 -C $GITHUB_WORKSPACE/toolchain
+          tar xvf ${toolchain_archive} --strip-components 1 -C $GITHUB_WORKSPACE/toolchain
           ls -lh $GITHUB_WORKSPACE/toolchain/bin
 
       - name: Display toolchain info

--- a/build-riscv64-linux-gnu-spacemit.sh
+++ b/build-riscv64-linux-gnu-spacemit.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -ex
 
-SPACEMIT_TOOLCHAIN=spacemit-toolchain-linux-glibc-x86_64-v1.1.2
-DOWNLOAD_URL="https://archive.spacemit.com/toolchain/${SPACEMIT_TOOLCHAIN}.tar.xz"
-DOWNLOAD_FILE="./riscv-spacemit-toolchain.tar.gz"
+SPACEMIT_TOOLCHAIN_VERSION=v1.1.2
+SPACEMIT_TOOLCHAIN=spacemit-toolchain-linux-glibc-x86_64-${SPACEMIT_TOOLCHAIN_VERSION}
+DOWNLOAD_URL="https://github.com/spacemit-com/toolchain/releases/download/${SPACEMIT_TOOLCHAIN_VERSION}/${SPACEMIT_TOOLCHAIN}.tar.xz"
+DOWNLOAD_FILE="./${SPACEMIT_TOOLCHAIN}.tar.xz"
 
 if [ -n "$RISCV_ROOT_PATH" ] && [ -d "$RISCV_ROOT_PATH" ]; then
     echo "LOCAL RISCV_ROOT_PATH: $RISCV_ROOT_PATH"


### PR DESCRIPTION
https://github.com/spacemit-com/sherpa-onnx/actions/runs/25903004405 checked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated RISC-V64 Linux build toolchain source to use GitHub releases with configurable version management for improved consistency across build pipelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/k2-fsa/sherpa-onnx/pull/3618)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->