### PR TITLE
Fix heap-buffer-overflow in TopkIndex when topk > size

### DIFF
--- a/sherpa-onnx/csrc/math.h
+++ b/sherpa-onnx/csrc/math.h
@@ -110,15 +110,25 @@ void SubtractBlank(T *in, int32_t w, int32_t h, int32_t blank_idx,
 
 template <class T>
 std::vector<int32_t> TopkIndex(const T *vec, int32_t size, int32_t topk) {
+  // Clamp topk to [0, size]: std::partial_sort(begin, begin + k, end, cmp)
+  // requires k in [0, end-begin]. Callers (e.g. FinalizeLabels in
+  // offline-speaker-diarization-pyannote-impl.h) can pass topk > size
+  // on short/degenerate inputs; the unclamped call invokes undefined
+  // behavior by reading past the end of vec_index. A negative topk would
+  // be UB for the same reason.
+  int32_t k_num = std::max<int32_t>(0, std::min<int32_t>(size, topk));
   std::vector<int32_t> vec_index(size);
   std::iota(vec_index.begin(), vec_index.end(), 0);
 
-  std::partial_sort(vec_index.begin(), vec_index.begin() + topk,
+  std::partial_sort(vec_index.begin(), vec_index.begin() + k_num,
                     vec_index.end(), [vec](int32_t index_1, int32_t index_2) {
                       return vec[index_1] > vec[index_2];
                     });
 
-  int32_t k_num = std::min<int32_t>(size, topk);
+  if (k_num == size) {
+    // partial_sort with middle == end fully sorts vec_index; skip the copy.
+    return vec_index;
+  }
   return {vec_index.begin(), vec_index.begin() + k_num};
 }
 


### PR DESCRIPTION
`TopkIndex<T>(vec, size, topk)` in sherpa-onnx/csrc/math.h calls

    std::partial_sort(vec_index.begin(),
                      vec_index.begin() + topk,
                      vec_index.end(), cmp);

`std::partial_sort` requires the middle iterator to be in
`[begin, end]`. When `topk > size`, `begin + topk > end` and the
internal heap operations read past the end of `vec_index`, invoking
undefined behavior and corrupting adjacent heap chunks.

The existing return-value clamp `k_num = std::min(size, topk)` only
sized the returned vector — it did not affect the partial_sort itself.

Trigger
-------

`OfflineSpeakerDiarizationPyannoteImpl::FinalizeLabels`
(offline-speaker-diarization-pyannote-impl.h:624) calls

    TopkIndex(&count(i, 0), num_cols, speakers_per_frame[i]);

For short or degenerate inputs the segmentation model can emit
`speakers_per_frame[i] > num_cols` (more "active speakers" claimed
than there are powerset columns), and the off-by-one fires.

Without AddressSanitizer redzones the past-the-end read sometimes
returns valid-looking memory and sometimes corrupts a free chunk's
header, manifesting later as a SIGABRT or SIGSEGV in libonnxruntime's
session-teardown path (Graph destructor walks an internal hashtable
that ends up double-freeing the poisoned chunk). The downstream
crash is misleading — it looks like an onnxruntime bug but the
corruption was committed during inference by the off-by-one read
here.

ASAN report (excerpt) on a 44-second recording with diarization
enabled:

    ==ERROR: AddressSanitizer: heap-buffer-overflow
    READ of size 4 at <addr> thread T0
        #5 sherpa_onnx::TopkIndex<int> .../math.h:115
        #6 OfflineSpeakerDiarizationPyannoteImpl::FinalizeLabels
              .../offline-speaker-diarization-pyannote-impl.h:624
        #7 OfflineSpeakerDiarizationPyannoteImpl::Process
              .../offline-speaker-diarization-pyannote-impl.h:180

    <addr> is located 0 bytes after 4-byte region [...,...)
    allocated by thread T0 here:
        #7 sherpa_onnx::TopkIndex<int> .../math.h:112
              std::vector<int32_t> vec_index(size);

Fix
---

Clamp `topk` to `size` BEFORE the partial_sort and pass the clamped
value. The return-value clamp can then reuse the same `k_num`.

Validation
----------

A downstream consumer (recmeet) reproduces the bug reliably on a
44-second WAV with diarization enabled:

  * Unpatched, AddressSanitizer build: heap-buffer-overflow on iter 1.
  * Unpatched, production build: SIGABRT/SIGSEGV in libonnxruntime's
    Graph destructor on iter 5-6 of a repeated postprocess loop.
  * Patched, AddressSanitizer build: 10 iterations clean.
  * Patched, production build: 50 iterations clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of top‑results selection: requests for more items than available or negative counts are now handled safely. The result set is correctly limited to available items and returns expected indices consistently, preventing prior undefined behavior in edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/k2-fsa/sherpa-onnx/pull/3628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->