### PR TITLE
Expose token + vocab log probabilities from offline CTC decoder

### DIFF
--- a/sherpa-onnx/c-api/c-api.cc
+++ b/sherpa-onnx/c-api/c-api.cc
@@ -865,6 +865,24 @@ const SherpaOnnxOfflineRecognizerResult *SherpaOnnxGetOfflineStreamResult(
     r->ys_log_probs = nullptr;
   }
 
+  // Copy vocab_log_probs (flattened row-major: count * vocab_size)
+  if (!result.vocab_log_probs.empty() &&
+      static_cast<int32_t>(result.vocab_log_probs.size()) == r->count &&
+      !result.vocab_log_probs[0].empty()) {
+    int32_t vocab_size =
+        static_cast<int32_t>(result.vocab_log_probs[0].size());
+    r->vocab_size = vocab_size;
+    float *flat = new float[r->count * vocab_size];
+    for (int32_t i = 0; i < r->count; ++i) {
+      std::copy(result.vocab_log_probs[i].begin(),
+                result.vocab_log_probs[i].end(), flat + i * vocab_size);
+    }
+    r->vocab_log_probs = flat;
+  } else {
+    r->vocab_log_probs = nullptr;
+    r->vocab_size = 0;
+  }
+
   // Copy segment-level timestamps (from Whisper with segment timestamps)
   auto segment_count = result.segment_texts.size();
   if (segment_count > 0 && result.segment_timestamps.size() == segment_count &&
@@ -908,6 +926,8 @@ const SherpaOnnxOfflineRecognizerResult *SherpaOnnxGetOfflineStreamResult(
     r->segment_texts_arr = nullptr;
   }
 
+  // NB: vocab_log_probs / vocab_size are set above (before the segment block).
+
   return r;
 }
 
@@ -928,6 +948,7 @@ void SherpaOnnxDestroyOfflineRecognizerResult(
     delete[] r->segment_durations;
     delete[] r->segment_texts;
     delete[] r->segment_texts_arr;
+    delete[] r->vocab_log_probs;
     delete r;
   }
 }

--- a/sherpa-onnx/c-api/c-api.h
+++ b/sherpa-onnx/c-api/c-api.h
@@ -1517,6 +1517,21 @@ typedef struct SherpaOnnxOfflineRecognizerResult {
 
   /** Number of segment entries in the segment-level arrays. */
   int32_t segment_count;
+
+  /**
+   * Optional flattened vocabulary log-probability matrix.
+   *
+   * When non-NULL, this is a contiguous row-major array of
+   * @c count * @c vocab_size floats. Row @c i (starting at offset
+   * <code>i * vocab_size</code>) holds the full log-probability distribution
+   * over the vocabulary for the @c i-th emitted token.
+   *
+   * Used for entropy-based confidence estimation.
+   */
+  const float *vocab_log_probs;
+
+  /** Vocabulary size (number of columns in @c vocab_log_probs). */
+  int32_t vocab_size;
 } SherpaOnnxOfflineRecognizerResult;
 
 /**

--- a/sherpa-onnx/csrc/offline-ctc-decoder.h
+++ b/sherpa-onnx/csrc/offline-ctc-decoder.h
@@ -26,6 +26,17 @@ struct OfflineCtcDecoderResult {
   ///
   /// tokens.size() == timestamps.size()
   std::vector<int32_t> timestamps;
+
+  /// Greedy log-probability of tokens[i] (i.e. log p(tokens[i] | frame)).
+  /// Empty when the decoder did not record it.
+  /// If populated, token_log_probs.size() == tokens.size().
+  std::vector<float> token_log_probs;
+
+  /// Full vocabulary log-probability distribution at the emission frame of
+  /// tokens[i]. vocab_log_probs[i].size() == vocab_size.
+  /// Empty when the decoder did not record it.
+  /// If populated, vocab_log_probs.size() == tokens.size().
+  std::vector<std::vector<float>> vocab_log_probs;
 };
 
 class OfflineCtcDecoder {

--- a/sherpa-onnx/csrc/offline-ctc-greedy-search-decoder.cc
+++ b/sherpa-onnx/csrc/offline-ctc-greedy-search-decoder.cc
@@ -37,12 +37,15 @@ std::vector<OfflineCtcDecoderResult> OfflineCtcGreedySearchDecoder::Decode(
           std::max_element(
               static_cast<const float *>(p_log_probs),
               static_cast<const float *>(p_log_probs) + vocab_size)));
-      p_log_probs += vocab_size;
+      float log_prob = p_log_probs[y];
 
       if (y != blank_id_ && y != prev_id) {
         r.tokens.push_back(y);
         r.timestamps.push_back(t);
+        r.token_log_probs.push_back(log_prob);
+        r.vocab_log_probs.emplace_back(p_log_probs, p_log_probs + vocab_size);
       }
+      p_log_probs += vocab_size;
       prev_id = y;
     }  // for (int32_t t = 0; ...)
 

--- a/sherpa-onnx/csrc/offline-recognizer-ctc-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-ctc-impl.h
@@ -77,6 +77,16 @@ OfflineRecognitionResult Convert(const OfflineCtcDecoderResult &src,
 
   r.words = std::move(src.words);
 
+  if (!src.token_log_probs.empty() &&
+      src.token_log_probs.size() == src.tokens.size()) {
+    r.ys_log_probs = src.token_log_probs;
+  }
+
+  if (!src.vocab_log_probs.empty() &&
+      src.vocab_log_probs.size() == src.tokens.size()) {
+    r.vocab_log_probs = src.vocab_log_probs;
+  }
+
   return r;
 }
 

--- a/sherpa-onnx/csrc/offline-stream.h
+++ b/sherpa-onnx/csrc/offline-stream.h
@@ -45,6 +45,13 @@ struct OfflineRecognitionResult {
   /// ys_log_probs[i] contains the log probability (confidence) for tokens[i].
   std::vector<float> ys_log_probs;
 
+  /// vocab_log_probs[i] contains the full log-probability distribution over
+  /// the vocabulary at the emission frame of tokens[i]. Used for entropy-based
+  /// confidence estimation. Empty when not provided by the decoder.
+  /// If populated, vocab_log_probs.size() == tokens.size() and every inner
+  /// vector has the same length (the model vocab size).
+  std::vector<std::vector<float>> vocab_log_probs;
+
   // Word IDs from FST decoding (CTC models with FST decoder only).
   std::vector<int32_t> words;
 


### PR DESCRIPTION
## Summary

The offline CTC greedy decoder (`offline-ctc-greedy-search-decoder.cc`) currently runs `std::max_element` to find the argmax token but discards the log-probability value at that position. As a result, `ys_log_probs` on `OfflineRecognitionResult` (added by #2843 for the offline transducer path) is always empty for CTC models, and no API surface ever sees the full vocab distribution.

This PR exposes both:

- **Per-token greedy log-prob** (`token_log_probs`) — keeps the value that `std::max_element` already computed. Costs one extra `float` per emitted token. Routed into the existing `OfflineRecognitionResult::ys_log_probs` + C struct `ys_log_probs` field via the existing copy logic — no new C API surface needed for this.
- **Full vocab log-probability distribution per emitted token** (`vocab_log_probs`) — copy of the full softmax row at each emitted frame. New fields on `OfflineRecognitionResult`, the C decoder result struct, and the C API result struct (`vocab_log_probs` flat row-major `[count, vocab_size]` + `vocab_size`).

## Motivation

Per-token confidence + full vocab distributions are required for entropy-based confidence estimation (e.g. Tsallis / Rényi over the vocab row — NVIDIA's [recommended approach for ASR confidence](https://developer.nvidia.com/blog/entropy-based-methods-for-word-level-asr-confidence-estimation/)). PR #2897 attempted a broad version of this but was closed when the author's ROVER fusion benchmark didn't show a measurable win in their (multi-system, clinical-audio) setting. We're using it for single-model entropy on where the use case is fundamentally different, and the patch was good. This PR re-submits a focused subset covering only offline CTC, which is the architecture we use.

## Backwards compatibility

- `OfflineRecognitionResult` and `SherpaOnnxOfflineRecognizerResult` only gain trailing fields. Existing consumers see no API/ABI changes.
- New fields stay empty/`nullptr` when callers don't consume them. Memory footprint cost: `O(count * vocab_size * sizeof(float))` per decode — opt-in via reading the field, but unconditionally populated. If that's a concern, happy to gate it on a config flag.
- `ys_log_probs` (which #2843 added for offline transducer) now also flows for offline CTC, matching the field's documentation.

## Testing

Built and tested on Android arm64-v8a (NDK r27) against a NeMo Conformer-CTC model (`EncDecCTCModelBPE`, vocab_size 1025, blank = 1024). On real device, confidence values pass sanity checks:

- Clear English words → 0.82–0.99 per token
- OOV / nonsense → token confidences drop to ~0.15–0.30
- Inference latency unchanged (~150–200 ms on 1s clips)

Happy to add a regression test if the maintainers want one — pointer to the right test fixture would help.

## Not included in this PR (deliberately)

PR #2897's scope covered Whisper, Moonshine, Canary, NeMo transducer, online transducer, and Flutter/Dart bindings in addition to offline CTC. This PR keeps scope tight to offline CTC to maximise the chance of merge; happy to follow up with parallel PRs for the other decoders if this lands and the maintainer is open to it.

Closes / supersedes: a focused subset of #2897.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Offline speech recognition now provides vocabulary log-probability distributions for each decoded token, enabling confidence scoring and entropy analysis of recognition results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/k2-fsa/sherpa-onnx/pull/3630?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->