### PR TITLE
Surface ys_log_probs on OfflineRecognizerResult (Kotlin JNI)

### DIFF
--- a/sherpa-onnx/jni/offline-recognizer.cc
+++ b/sherpa-onnx/jni/offline-recognizer.cc
@@ -644,7 +644,7 @@ Java_com_k2fsa_sherpa_onnx_OfflineRecognizer_getResult(JNIEnv *env,
   jmethodID ctor =
       env->GetMethodID(cls, "<init>",
                        "(Ljava/lang/String;[Ljava/lang/String;[FLjava/lang/"
-                       "String;Ljava/lang/String;Ljava/lang/String;[F)V");
+                       "String;Ljava/lang/String;Ljava/lang/String;[F[F)V");
   jstring jtext = SafeNewStringUTF(env, result.text);
 
   jclass string_cls = env->FindClass("java/lang/String");
@@ -670,8 +670,16 @@ Java_com_k2fsa_sherpa_onnx_OfflineRecognizer_getResult(JNIEnv *env,
   env->SetFloatArrayRegion(jdurations, 0, result.durations.size(),
                            result.durations.data());
 
+  // Per-token log-probabilities. The C++ greedy decoder populates
+  // result.ys_log_probs; surface them to Kotlin so callers can apply
+  // a real confidence-based policy instead of a heuristic proxy.
+  jfloatArray jys_log_probs = env->NewFloatArray(result.ys_log_probs.size());
+  env->SetFloatArrayRegion(jys_log_probs, 0, result.ys_log_probs.size(),
+                           result.ys_log_probs.data());
+
   jobject jresult = env->NewObject(cls, ctor, jtext, jtokens, jtimestamps,
-                                   jlang, jemotion, jevent, jdurations);
+                                   jlang, jemotion, jevent, jdurations,
+                                   jys_log_probs);
 
   env->DeleteLocalRef(jtext);
   env->DeleteLocalRef(jtokens);
@@ -680,6 +688,7 @@ Java_com_k2fsa_sherpa_onnx_OfflineRecognizer_getResult(JNIEnv *env,
   env->DeleteLocalRef(jemotion);
   env->DeleteLocalRef(jevent);
   env->DeleteLocalRef(jdurations);
+  env->DeleteLocalRef(jys_log_probs);
   env->DeleteLocalRef(cls);
 
   return jresult;  // returned object is safe

--- a/sherpa-onnx/kotlin-api/OfflineRecognizer.kt
+++ b/sherpa-onnx/kotlin-api/OfflineRecognizer.kt
@@ -12,6 +12,11 @@ data class OfflineRecognizerResult(
 
     // valid only for TDT models
     val durations: FloatArray,
+
+    // Per-token log-probabilities (confidence). Populated by the
+    // offline transducer greedy decoder; empty for other model types
+    // until the corresponding C++ decoders are extended.
+    val ysLogProbs: FloatArray,
 )
 
 data class OfflineTransducerModelConfig(


### PR DESCRIPTION
## Summary
- Surfaces per-token log-probabilities (`OfflineRecognitionResult::ys_log_probs`) through the offline JNI to the Kotlin `OfflineRecognizerResult` data class as `ysLogProbs: FloatArray`.
- Mirrors PR #2736, which did the same for `OnlineRecognizerResult` (streaming). The offline path is the missing half.
- The C++ side already computes and populates this field in the transducer greedy decoder (see `csrc/offline-transducer-greedy-search-decoder.cc`, lines 68-76); the binding was simply dropping it.

## Why
With the field exposed, downstream callers can compute a real per-token confidence on-device:

- `geo_mean = exp(mean(log_probs))` — joint probability proxy
- `min     = exp(min(log_probs))`   — weakest-link signal

Without it, applications fall back to heuristic proxies (tokens-per-second, timestamp variance) that saturate near 1.0 even on mishearings.

Concrete example from a smoke test with Parakeet TDT 0.6B-v2 on a Qualcomm QCS6490 device (Android arm64-v8a):

| utterance                                       | mean exp(log_p) | min exp(log_p) | notes                       |
|-------------------------------------------------|-----------------|----------------|-----------------------------|
| `Call James Smith` (clean)                      | 0.96            | 0.71           | clean                       |
| `Call the on-call anesthesiologist` (clean)     | 0.97            | 0.81           | clean                       |
| `Call Health Supervisor` (House mis-heard)      | 0.91            | 0.35           | mean hides it; min flags it |
| `Col Cath Lad` (catastrophic mis-hear)          | 0.68            | 0.33           | both flag it                |

The geo-mean alone misses single-token uncertainty; the per-token array unlocks a min-based gate. That's only possible if the values reach Kotlin.

## What changed
- `sherpa-onnx/jni/offline-recognizer.cc`
  - `GetMethodID` signature extended with one extra `[F`.
  - `NewFloatArray` + `SetFloatArrayRegion` for `result.ys_log_probs`.
  - Passed into the Kotlin constructor; `DeleteLocalRef` on cleanup.
- `sherpa-onnx/kotlin-api/OfflineRecognizer.kt`
  - `val ysLogProbs: FloatArray` appended to `OfflineRecognizerResult`.

The field is empty (0-length `jfloatArray`) for non-transducer / non-greedy decoders until the corresponding C++ paths are extended. Documented in the Kotlin comment.

## Compatibility
- C++ behaviour unchanged. `result.ys_log_probs` was already being computed; only the JNI pass-through is new.
- Kotlin data class gains a new field. Source-compatible for any code that reads existing fields (`text`, `tokens`, `timestamps`, etc.); anyone constructing `OfflineRecognizerResult` manually (rare — usually constructed by the JNI) will need to add the field. Symmetric to PR #2736's change to `OnlineRecognizerResult`.

## Test plan
- [x] Builds clean as a local AAR via `build-android-arm64-v8a.sh` on Android NDK 27.
- [x] Smoke-tested on a Qualcomm QCS6490 Android 13 device with Parakeet TDT 0.6B-v2 INT8: `ysLogProbs.size == tokens.size`, values are negative log-probs as expected, `exp(values)` lies in (0, 1].
- [ ] CI build matrix.

## Related
- PR #2736 — the streaming-side equivalent that this PR mirrors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recognition results from offline recognizers now include per-token log-probabilities, enabling detailed confidence analysis at the token level. This feature is populated for offline transducer greedy decoder models.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/k2-fsa/sherpa-onnx/pull/3638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->