### PR TITLE
Add streaming zipformer transducer for Qualcomm NPU with QNN.

### DIFF
--- a/sherpa-onnx/csrc/CMakeLists.txt
+++ b/sherpa-onnx/csrc/CMakeLists.txt
@@ -251,6 +251,7 @@ if(SHERPA_ONNX_ENABLE_QNN)
     ./qnn/offline-sense-voice-model-qnn.cc
     ./qnn/offline-paraformer-model-qnn.cc
     ./qnn/offline-zipformer-ctc-model-qnn.cc
+    ./qnn/online-zipformer-transducer-model-qnn.cc
     ./qnn/qnn-backend.cc
     ./qnn/qnn-model.cc
     ./qnn/utils.cc

--- a/sherpa-onnx/csrc/online-model-config.cc
+++ b/sherpa-onnx/csrc/online-model-config.cc
@@ -93,11 +93,11 @@ bool OnlineModelConfig::Validate() const {
   }
 
   if (provider_config.provider != "qnn") {
-    if (!transducer.encoder.empty() &&
-        (EndsWith(transducer.encoder, ".so") ||
-         EndsWith(transducer.decoder, ".so") ||
-         EndsWith(transducer.joiner, ".so") ||
-         !transducer.qnn_config.context_binary.empty())) {
+    if ((!transducer.encoder.empty() &&
+         (EndsWith(transducer.encoder, ".so") ||
+          EndsWith(transducer.decoder, ".so") ||
+          EndsWith(transducer.joiner, ".so"))) ||
+        !transducer.qnn_config.context_binary.empty()) {
       SHERPA_ONNX_LOGE(
           "--provider is %s, which is not qnn, but you pass QNN model "
           "filenames or QNN context binaries. encoder: '%s', decoder: '%s', "

--- a/sherpa-onnx/csrc/online-model-config.cc
+++ b/sherpa-onnx/csrc/online-model-config.cc
@@ -62,11 +62,15 @@ bool OnlineModelConfig::Validate() const {
   // num_threads == -2 -> Use NPU core 2
   // num_threads == -3 -> Use NPU core 0 and core 1
   // num_threads == -4 -> Use NPU core 0, core 1, and core 2
-  if (provider_config.provider != "rknn") {
+  if (provider_config.provider != "rknn" &&
+      provider_config.provider != "qnn") {
     if (num_threads < 1) {
       SHERPA_ONNX_LOGE("num_threads should be > 0. Given %d", num_threads);
       return false;
     }
+  }
+
+  if (provider_config.provider != "rknn") {
     if (!transducer.encoder.empty() && (EndsWith(transducer.encoder, ".rknn") ||
                                         EndsWith(transducer.decoder, ".rknn") ||
                                         EndsWith(transducer.joiner, ".rknn"))) {
@@ -84,6 +88,23 @@ bool OnlineModelConfig::Validate() const {
           "--provider is %s, which is not rknn, but you pass rknn model "
           "filename for zipformer2_ctc: '%s'",
           provider_config.provider.c_str(), zipformer2_ctc.model.c_str());
+      return false;
+    }
+  }
+
+  if (provider_config.provider != "qnn") {
+    if (!transducer.encoder.empty() &&
+        (EndsWith(transducer.encoder, ".so") ||
+         EndsWith(transducer.decoder, ".so") ||
+         EndsWith(transducer.joiner, ".so") ||
+         !transducer.qnn_config.context_binary.empty())) {
+      SHERPA_ONNX_LOGE(
+          "--provider is %s, which is not qnn, but you pass QNN model "
+          "filenames or QNN context binaries. encoder: '%s', decoder: '%s', "
+          "joiner: '%s', context_binary: '%s'",
+          provider_config.provider.c_str(), transducer.encoder.c_str(),
+          transducer.decoder.c_str(), transducer.joiner.c_str(),
+          transducer.qnn_config.context_binary.c_str());
       return false;
     }
   }
@@ -106,6 +127,19 @@ bool OnlineModelConfig::Validate() const {
           "--provider rknn, but you pass onnx model filename for "
           "zipformer2_ctc: '%s'",
           zipformer2_ctc.model.c_str());
+      return false;
+    }
+  }
+
+  if (provider_config.provider == "qnn") {
+    if (!transducer.encoder.empty() && (EndsWith(transducer.encoder, ".onnx") ||
+                                        EndsWith(transducer.decoder, ".onnx") ||
+                                        EndsWith(transducer.joiner, ".onnx"))) {
+      SHERPA_ONNX_LOGE(
+          "--provider is qnn, but you pass onnx model filenames. "
+          "encoder: '%s', decoder: '%s', joiner: '%s'",
+          transducer.encoder.c_str(), transducer.decoder.c_str(),
+          transducer.joiner.c_str());
       return false;
     }
   }

--- a/sherpa-onnx/csrc/online-recognizer-impl.cc
+++ b/sherpa-onnx/csrc/online-recognizer-impl.cc
@@ -38,6 +38,10 @@
 #include "sherpa-onnx/csrc/rknn/online-recognizer-transducer-rknn-impl.h"
 #endif
 
+#ifdef SHERPA_ONNX_ENABLE_QNN
+#include "sherpa-onnx/csrc/qnn/online-recognizer-zipformer-transducer-qnn-impl.h"
+#endif
+
 namespace sherpa_onnx {
 
 static bool IsNeMoParakeetUnifiedStreaming(const Ort::Session &decoder_sess) {
@@ -66,6 +70,26 @@ std::unique_ptr<OnlineRecognizerImpl> OnlineRecognizerImpl::Create(
     SHERPA_ONNX_LOGE(
         "Please rebuild sherpa-onnx with -DSHERPA_ONNX_ENABLE_RKNN=ON if you "
         "want to use rknn.");
+    SHERPA_ONNX_EXIT(-1);
+    return nullptr;
+#endif
+  }
+
+  if (config.model_config.provider_config.provider == "qnn") {
+#ifdef SHERPA_ONNX_ENABLE_QNN
+    if (!config.model_config.transducer.encoder.empty()) {
+      return std::make_unique<OnlineRecognizerZipformerTransducerQnnImpl>(
+          config);
+    }
+
+    SHERPA_ONNX_LOGE(
+        "Only Zipformer transducers are currently supported by qnn for "
+        "online recognition.");
+    SHERPA_ONNX_EXIT(-1);
+#else
+    SHERPA_ONNX_LOGE(
+        "Please rebuild sherpa-onnx with -DSHERPA_ONNX_ENABLE_QNN=ON if you "
+        "want to use qnn.");
     SHERPA_ONNX_EXIT(-1);
     return nullptr;
 #endif
@@ -132,6 +156,26 @@ std::unique_ptr<OnlineRecognizerImpl> OnlineRecognizerImpl::Create(
     SHERPA_ONNX_LOGE(
         "Please rebuild sherpa-onnx with -DSHERPA_ONNX_ENABLE_RKNN=ON if you "
         "want to use rknn.");
+    SHERPA_ONNX_EXIT(-1);
+    return nullptr;
+#endif
+  }
+
+  if (config.model_config.provider_config.provider == "qnn") {
+#ifdef SHERPA_ONNX_ENABLE_QNN
+    if (!config.model_config.transducer.encoder.empty()) {
+      return std::make_unique<OnlineRecognizerZipformerTransducerQnnImpl>(
+          mgr, config);
+    }
+
+    SHERPA_ONNX_LOGE(
+        "Only Zipformer transducers are currently supported by qnn for "
+        "online recognition.");
+    SHERPA_ONNX_EXIT(-1);
+#else
+    SHERPA_ONNX_LOGE(
+        "Please rebuild sherpa-onnx with -DSHERPA_ONNX_ENABLE_QNN=ON if you "
+        "want to use qnn.");
     SHERPA_ONNX_EXIT(-1);
     return nullptr;
 #endif

--- a/sherpa-onnx/csrc/online-stream-state.h
+++ b/sherpa-onnx/csrc/online-stream-state.h
@@ -1,0 +1,34 @@
+// sherpa-onnx/csrc/online-stream-state.h
+//
+// Copyright (c)  2026  Xiaomi Corporation
+
+#ifndef SHERPA_ONNX_CSRC_ONLINE_STREAM_STATE_H_
+#define SHERPA_ONNX_CSRC_ONLINE_STREAM_STATE_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "sherpa-onnx/csrc/hypothesis.h"
+
+namespace sherpa_onnx {
+
+struct OnlineStreamStateTensor {
+  std::vector<float> float_data;
+  std::vector<int32_t> int32_data;
+};
+
+struct OnlineTransducerDecoderResultNoOrt {
+  int32_t frame_offset = 0;
+  std::vector<int32_t> tokens;
+  int32_t num_trailing_blanks = 0;
+  std::vector<int32_t> timestamps;
+  std::vector<float> ys_probs;
+  std::vector<float> lm_probs;
+  std::vector<float> context_scores;
+  std::vector<float> decoder_out;
+  Hypotheses hyps;
+};
+
+}  // namespace sherpa_onnx
+
+#endif  // SHERPA_ONNX_CSRC_ONLINE_STREAM_STATE_H_

--- a/sherpa-onnx/csrc/online-stream.cc
+++ b/sherpa-onnx/csrc/online-stream.cc
@@ -111,6 +111,18 @@ class OnlineStream::Impl {
 
   std::vector<Ort::Value> &GetStates() { return states_; }
 
+  void SetQnnStates(std::vector<OnlineStreamStateTensor> states) {
+    qnn_states_ = std::move(states);
+  }
+
+  std::vector<OnlineStreamStateTensor> &GetQnnStates() { return qnn_states_; }
+
+  void SetQnnResult(const OnlineTransducerDecoderResultNoOrt &r) {
+    qnn_result_ = r;
+  }
+
+  OnlineTransducerDecoderResultNoOrt &GetQnnResult() { return qnn_result_; }
+
   void SetNeMoDecoderStates(std::vector<Ort::Value> decoder_states) {
     decoder_states_ = std::move(decoder_states);
   }
@@ -190,11 +202,13 @@ class OnlineStream::Impl {
   TransducerKeywordResult empty_keyword_result_;
   OnlineCtcDecoderResult ctc_result_;
   std::vector<Ort::Value> states_;  // states for transducer or ctc models
+  std::vector<OnlineStreamStateTensor> qnn_states_;
   std::vector<Ort::Value> decoder_states_;  // states for nemo transducer models
   std::vector<float> paraformer_feat_cache_;
   std::vector<float> paraformer_encoder_out_cache_;
   std::vector<float> paraformer_alpha_cache_;
   OnlineParaformerDecoderResult paraformer_result_;
+  OnlineTransducerDecoderResultNoOrt qnn_result_;
   std::unordered_map<std::string, std::string> options_;
   std::unique_ptr<kaldi_decoder::FasterDecoder> faster_decoder_;
   int32_t faster_decoder_processed_frames_ = 0;
@@ -279,6 +293,22 @@ void OnlineStream::SetStates(std::vector<Ort::Value> states) {
 
 std::vector<Ort::Value> &OnlineStream::GetStates() {
   return impl_->GetStates();
+}
+
+void OnlineStream::SetQnnStates(std::vector<OnlineStreamStateTensor> states) {
+  impl_->SetQnnStates(std::move(states));
+}
+
+std::vector<OnlineStreamStateTensor> &OnlineStream::GetQnnStates() {
+  return impl_->GetQnnStates();
+}
+
+void OnlineStream::SetQnnResult(const OnlineTransducerDecoderResultNoOrt &r) {
+  impl_->SetQnnResult(r);
+}
+
+OnlineTransducerDecoderResultNoOrt &OnlineStream::GetQnnResult() {
+  return impl_->GetQnnResult();
 }
 
 void OnlineStream::SetNeMoDecoderStates(

--- a/sherpa-onnx/csrc/online-stream.h
+++ b/sherpa-onnx/csrc/online-stream.h
@@ -15,6 +15,7 @@
 #include "sherpa-onnx/csrc/features.h"
 #include "sherpa-onnx/csrc/online-ctc-decoder.h"
 #include "sherpa-onnx/csrc/online-paraformer-decoder.h"
+#include "sherpa-onnx/csrc/online-stream-state.h"
 #include "sherpa-onnx/csrc/online-transducer-decoder.h"
 
 namespace sherpa_onnx {
@@ -91,6 +92,12 @@ class OnlineStream {
 
   void SetStates(std::vector<Ort::Value> states);
   std::vector<Ort::Value> &GetStates();
+
+  void SetQnnStates(std::vector<OnlineStreamStateTensor> states);
+  std::vector<OnlineStreamStateTensor> &GetQnnStates();
+
+  void SetQnnResult(const OnlineTransducerDecoderResultNoOrt &r);
+  OnlineTransducerDecoderResultNoOrt &GetQnnResult();
 
   void SetNeMoDecoderStates(std::vector<Ort::Value> decoder_states);
   std::vector<Ort::Value> &GetNeMoDecoderStates();

--- a/sherpa-onnx/csrc/online-transducer-model-config.cc
+++ b/sherpa-onnx/csrc/online-transducer-model-config.cc
@@ -18,15 +18,15 @@ static bool IsQnnModelLibFile(const std::string &filename) {
 }
 
 static bool ValidateQnnContextBinaries(const std::string &context_binary,
-                                       std::vector<std::string> *filenames) {
-  filenames->clear();
+                                       std::vector<std::string> &filenames) {
+  filenames.clear();
 
   if (context_binary.empty()) {
     return true;
   }
 
-  SplitStringToVector(context_binary, ",", true, filenames);
-  if (filenames->size() != 3) {
+  SplitStringToVector(context_binary, ",", true, &filenames);
+  if (filenames.size() != 3) {
     SHERPA_ONNX_LOGE(
         "For online transducer with QNN, you should provide 3 context "
         "binaries separated by commas. Given '%s'",
@@ -54,7 +54,7 @@ bool OnlineTransducerModelConfig::Validate() const {
   if (uses_qnn) {
     std::vector<std::string> context_binaries;
     if (!ValidateQnnContextBinaries(qnn_config.context_binary,
-                                    &context_binaries)) {
+                                    context_binaries)) {
       return false;
     }
 

--- a/sherpa-onnx/csrc/online-transducer-model-config.cc
+++ b/sherpa-onnx/csrc/online-transducer-model-config.cc
@@ -5,19 +5,107 @@
 
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "sherpa-onnx/csrc/file-utils.h"
 #include "sherpa-onnx/csrc/macros.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 
 namespace sherpa_onnx {
+
+static bool IsQnnModelLibFile(const std::string &filename) {
+  return EndsWith(filename, ".so");
+}
+
+static bool ValidateQnnContextBinaries(const std::string &context_binary,
+                                       std::vector<std::string> *filenames) {
+  filenames->clear();
+
+  if (context_binary.empty()) {
+    return true;
+  }
+
+  SplitStringToVector(context_binary, ",", true, filenames);
+  if (filenames->size() != 3) {
+    SHERPA_ONNX_LOGE(
+        "For online transducer with QNN, you should provide 3 context "
+        "binaries separated by commas. Given '%s'",
+        context_binary.c_str());
+    return false;
+  }
+
+  return true;
+}
 
 void OnlineTransducerModelConfig::Register(ParseOptions *po) {
   po->Register("encoder", &encoder, "Path to encoder.onnx");
   po->Register("decoder", &decoder, "Path to decoder.onnx");
   po->Register("joiner", &joiner, "Path to joiner.onnx");
+
+  ParseOptions p("transducer", po);
+  qnn_config.Register(&p);
 }
 
 bool OnlineTransducerModelConfig::Validate() const {
+  bool uses_qnn = IsQnnModelLibFile(encoder) || IsQnnModelLibFile(decoder) ||
+                  IsQnnModelLibFile(joiner) ||
+                  !qnn_config.context_binary.empty();
+
+  if (uses_qnn) {
+    std::vector<std::string> context_binaries;
+    if (!ValidateQnnContextBinaries(qnn_config.context_binary,
+                                    &context_binaries)) {
+      return false;
+    }
+
+    bool need_model_libs = context_binaries.empty();
+    for (const auto &name : context_binaries) {
+      if (!FileExists(name)) {
+        need_model_libs = true;
+        break;
+      }
+    }
+
+    if (need_model_libs) {
+      if (!EndsWith(encoder, ".so") || !EndsWith(decoder, ".so") ||
+          !EndsWith(joiner, ".so")) {
+        SHERPA_ONNX_LOGE(
+            "For online transducer with QNN, encoder/decoder/joiner should be "
+            "*.so when context binaries are missing. Given encoder: '%s', "
+            "decoder: '%s', joiner: '%s'",
+            encoder.c_str(), decoder.c_str(), joiner.c_str());
+        return false;
+      }
+
+      if (!FileExists(encoder)) {
+        SHERPA_ONNX_LOGE("transducer encoder: '%s' does not exist",
+                         encoder.c_str());
+        return false;
+      }
+
+      if (!FileExists(decoder)) {
+        SHERPA_ONNX_LOGE("transducer decoder: '%s' does not exist",
+                         decoder.c_str());
+        return false;
+      }
+
+      if (!FileExists(joiner)) {
+        SHERPA_ONNX_LOGE("joiner: '%s' does not exist", joiner.c_str());
+        return false;
+      }
+    }
+
+    for (const auto &name : context_binaries) {
+      if (FileExists(name) && !EndsWith(name, ".bin")) {
+        SHERPA_ONNX_LOGE("QNN context binary should end with .bin. Given '%s'",
+                         name.c_str());
+        return false;
+      }
+    }
+
+    return qnn_config.Validate();
+  }
+
   if (!FileExists(encoder)) {
     SHERPA_ONNX_LOGE("transducer encoder: '%s' does not exist",
                      encoder.c_str());
@@ -44,7 +132,11 @@ std::string OnlineTransducerModelConfig::ToString() const {
   os << "OnlineTransducerModelConfig(";
   os << "encoder=\"" << encoder << "\", ";
   os << "decoder=\"" << decoder << "\", ";
-  os << "joiner=\"" << joiner << "\")";
+  os << "joiner=\"" << joiner << "\"";
+  if (!qnn_config.backend_lib.empty()) {
+    os << ", qnn_config=" << qnn_config.ToString();
+  }
+  os << ")";
 
   return os.str();
 }

--- a/sherpa-onnx/csrc/online-transducer-model-config.h
+++ b/sherpa-onnx/csrc/online-transducer-model-config.h
@@ -8,12 +8,15 @@
 
 #include "sherpa-onnx/csrc/parse-options.h"
 
+#include "sherpa-onnx/csrc/qnn-config.h"
+
 namespace sherpa_onnx {
 
 struct OnlineTransducerModelConfig {
   std::string encoder;
   std::string decoder;
   std::string joiner;
+  QnnConfig qnn_config;
 
   OnlineTransducerModelConfig() = default;
   OnlineTransducerModelConfig(const std::string &encoder,

--- a/sherpa-onnx/csrc/provider-config.cc
+++ b/sherpa-onnx/csrc/provider-config.cc
@@ -109,7 +109,7 @@ void ProviderConfig::Register(ParseOptions *po) {
 
   po->Register("device", &device, "GPU device index for CUDA and Trt EP");
   po->Register("provider", &provider,
-               "Specify a provider to use: cpu, cuda, coreml");
+               "Specify a provider to use: cpu, cuda, coreml, trt, rknn, qnn");
 }
 
 bool ProviderConfig::Validate() const {

--- a/sherpa-onnx/csrc/qnn-config.cc
+++ b/sherpa-onnx/csrc/qnn-config.cc
@@ -6,9 +6,11 @@
 
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "sherpa-onnx/csrc/file-utils.h"
 #include "sherpa-onnx/csrc/macros.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 
 namespace sherpa_onnx {
 
@@ -20,11 +22,13 @@ void QnnConfig::Register(ParseOptions *po) {
 
   po->Register(
       "qnn-context-binary", &context_binary,
-      "Path to model.bin. Used only when provider is qnn."
-      "If it exists, libmodel.so is ignored."
-      "If it does not exist, Context binary is saved to this path so that "
-      "it is loaded the next time you run it. You can leave it empty if you "
-      "don't use qnn");
+      "Path to model.bin. Used only when provider is qnn. "
+      "If it exists, libmodel.so is ignored. "
+      "For models with multiple QNN components, you can provide multiple "
+      "context binaries separated by commas. "
+      "If a specified file does not exist, a context binary is saved there so "
+      "that it is loaded the next time you run it. You can leave it empty if "
+      "you don't use qnn");
 
   po->Register("qnn-system-lib", &system_lib,
                "Required and used only when --qnn-context-binary is not empty "
@@ -40,12 +44,20 @@ bool QnnConfig::Validate() const {
   // we don't check whether backend_lib and system_lib exist or not since
   // dlopen() will find them by searching predefined paths
 
-  if (!context_binary.empty() && FileExists(context_binary)) {
-    if (system_lib.empty()) {
-      SHERPA_ONNX_LOGE(
-          "Please provide --qnn-system-lib when you provide "
-          "--qnn-context-binary");
-      return false;
+  if (!context_binary.empty()) {
+    std::vector<std::string> filenames;
+    SplitStringToVector(context_binary, ",", true, &filenames);
+
+    for (const auto &name : filenames) {
+      if (FileExists(name)) {
+        if (system_lib.empty()) {
+          SHERPA_ONNX_LOGE(
+              "Please provide --qnn-system-lib when you provide "
+              "--qnn-context-binary");
+          return false;
+        }
+        break;
+      }
     }
   }
 

--- a/sherpa-onnx/csrc/qnn-config.h
+++ b/sherpa-onnx/csrc/qnn-config.h
@@ -17,7 +17,10 @@ struct QnnConfig {
   std::string backend_lib;
 
   // If it exists, you need to also provide system_lib.
-  // In this case, the model lib, i.e., libmodel.so, is ignored
+  // In this case, the model lib, i.e., libmodel.so, is ignored.
+  //
+  // For models with multiple QNN components, e.g. paraformer or online
+  // transducer, you can provide multiple context binaries separated by commas.
   //
   // If it does not exist and if the user want to save the context binary,
   // it will save it to this path.

--- a/sherpa-onnx/csrc/qnn/online-recognizer-zipformer-transducer-qnn-impl.h
+++ b/sherpa-onnx/csrc/qnn/online-recognizer-zipformer-transducer-qnn-impl.h
@@ -1,0 +1,423 @@
+// sherpa-onnx/csrc/qnn/online-recognizer-zipformer-transducer-qnn-impl.h
+//
+// Copyright (c)  2026  Xiaomi Corporation
+
+#ifndef SHERPA_ONNX_CSRC_QNN_ONLINE_RECOGNIZER_ZIPFORMER_TRANSDUCER_QNN_IMPL_H_
+#define SHERPA_ONNX_CSRC_QNN_ONLINE_RECOGNIZER_ZIPFORMER_TRANSDUCER_QNN_IMPL_H_
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <numeric>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "sherpa-onnx/csrc/endpoint.h"
+#include "sherpa-onnx/csrc/hypothesis.h"
+#include "sherpa-onnx/csrc/log.h"
+#include "sherpa-onnx/csrc/online-recognizer-impl.h"
+#include "sherpa-onnx/csrc/online-recognizer.h"
+#include "sherpa-onnx/csrc/online-stream.h"
+#include "sherpa-onnx/csrc/qnn/online-zipformer-transducer-model-qnn.h"
+#include "sherpa-onnx/csrc/symbol-table.h"
+
+namespace sherpa_onnx {
+
+namespace qnn_impl {
+
+static std::vector<int32_t> GetQnnContext(const std::vector<int32_t> &tokens,
+                                          int32_t context_size) {
+  if (static_cast<int32_t>(tokens.size()) <= context_size) {
+    return tokens;
+  }
+
+  return std::vector<int32_t>(tokens.end() - context_size, tokens.end());
+}
+
+static std::vector<int64_t> ToInt64Tokens(const std::vector<int32_t> &tokens) {
+  return std::vector<int64_t>(tokens.begin(), tokens.end());
+}
+
+static std::vector<int32_t> ToInt32Tokens(const std::vector<int64_t> &tokens) {
+  return std::vector<int32_t>(tokens.begin(), tokens.end());
+}
+
+static std::vector<int32_t> GetQnnContext(const std::vector<int64_t> &tokens,
+                                          int32_t context_size) {
+  return GetQnnContext(ToInt32Tokens(tokens), context_size);
+}
+
+static OnlineRecognizerResult ConvertQnnResult(
+    OnlineTransducerDecoderResultNoOrt src, const SymbolTable &sym_table,
+    float frame_shift_ms, int32_t subsampling_factor, int32_t segment,
+    int32_t frames_since_start, int32_t context_size) {
+  OnlineRecognizerResult r;
+
+  if (static_cast<int32_t>(src.tokens.size()) >= context_size) {
+    src.tokens.erase(src.tokens.begin(), src.tokens.begin() + context_size);
+  }
+
+  r.tokens.reserve(src.tokens.size());
+  r.timestamps.reserve(src.timestamps.size());
+  r.ys_probs = std::move(src.ys_probs);
+
+  std::string text;
+  for (auto i : src.tokens) {
+    auto sym = sym_table[i];
+
+    text.append(sym);
+
+    if (sym.size() == 1 && (sym[0] < 0x20 || sym[0] > 0x7e)) {
+      std::ostringstream os;
+      os << "<0x" << std::hex << std::uppercase
+         << (static_cast<int32_t>(sym[0]) & 0xff) << ">";
+      sym = os.str();
+    }
+
+    r.tokens.push_back(std::move(sym));
+  }
+
+  if (sym_table.IsByteBpe()) {
+    text = sym_table.DecodeByteBpe(text);
+  }
+
+  r.text = std::move(text);
+
+  float frame_shift_s = frame_shift_ms / 1000.f * subsampling_factor;
+  for (auto t : src.timestamps) {
+    r.timestamps.push_back(frame_shift_s * t);
+  }
+
+  r.segment = segment;
+  r.start_time = frames_since_start * frame_shift_ms / 1000.f;
+
+  return r;
+}
+
+class QnnGreedySearchDecoder {
+ public:
+  explicit QnnGreedySearchDecoder(int32_t blank_id) : blank_id_(blank_id) {}
+
+  OnlineTransducerDecoderResultNoOrt GetEmptyResult(
+      const OnlineZipformerTransducerModelQnn &model) const {
+    OnlineTransducerDecoderResultNoOrt r;
+    r.tokens.resize(model.ContextSize(), -1);
+    r.tokens.back() = blank_id_;
+    return r;
+  }
+
+  void Decode(const float *encoder_out, int32_t frame_index,
+              const OnlineZipformerTransducerModelQnn &model,
+              OnlineTransducerDecoderResultNoOrt *r) const {
+    auto logit = model.RunJoiner(encoder_out, r->decoder_out);
+    auto y = static_cast<int32_t>(
+        std::distance(logit.begin(), std::max_element(logit.begin(), logit.end())));
+
+    if (y != blank_id_) {
+      r->tokens.push_back(y);
+      r->timestamps.push_back(frame_index);
+      r->num_trailing_blanks = 0;
+      auto context = GetQnnContext(r->tokens, model.ContextSize());
+      r->decoder_out = model.RunDecoder(context);
+    } else {
+      ++r->num_trailing_blanks;
+    }
+  }
+
+ private:
+  int32_t blank_id_;
+};
+
+class QnnModifiedBeamSearchDecoder {
+ public:
+  QnnModifiedBeamSearchDecoder(int32_t blank_id, int32_t vocab_size,
+                               int32_t beam)
+      : blank_id_(blank_id), vocab_size_(vocab_size), beam_(beam) {}
+
+  OnlineTransducerDecoderResultNoOrt GetEmptyResult(
+      const OnlineZipformerTransducerModelQnn &model) const {
+    OnlineTransducerDecoderResultNoOrt r;
+    std::vector<int32_t> context(model.ContextSize(), -1);
+    context.back() = blank_id_;
+    r.tokens = context;
+    r.hyps = Hypotheses({Hypothesis(ToInt64Tokens(context), 0)});
+    return r;
+  }
+
+  void Decode(const float *encoder_out, int32_t frame_index,
+              const OnlineZipformerTransducerModelQnn &model,
+              OnlineTransducerDecoderResultNoOrt *r) const {
+    Hypotheses next;
+    auto cur = r->hyps.GetTopK(beam_, false);
+
+    for (const auto &hyp : cur) {
+      auto context = GetQnnContext(hyp.ys, model.ContextSize());
+      auto decoder_out = model.RunDecoder(context);
+      auto logit = model.RunJoiner(encoder_out, decoder_out);
+      auto log_probs = LogSoftmax(logit);
+
+      Hypothesis blank_hyp = hyp;
+      blank_hyp.log_prob += log_probs[blank_id_];
+      ++blank_hyp.num_trailing_blanks;
+      next.Add(std::move(blank_hyp));
+
+      std::vector<int32_t> indexes(vocab_size_);
+      std::iota(indexes.begin(), indexes.end(), 0);
+      std::partial_sort(
+          indexes.begin(), indexes.begin() + std::min(beam_, vocab_size_),
+          indexes.end(), [&log_probs](int32_t a, int32_t b) {
+            return log_probs[a] > log_probs[b];
+          });
+
+      int32_t num = std::min(beam_, vocab_size_);
+      for (int32_t i = 0; i != num; ++i) {
+        int32_t y = indexes[i];
+        if (y == blank_id_) {
+          continue;
+        }
+        auto ys = hyp.ys;
+        auto timestamps = hyp.timestamps;
+        ys.push_back(y);
+        timestamps.push_back(frame_index);
+        Hypothesis new_hyp(std::move(ys), hyp.log_prob + log_probs[y]);
+        new_hyp.timestamps = std::move(timestamps);
+        new_hyp.num_trailing_blanks = 0;
+        next.Add(std::move(new_hyp));
+      }
+    }
+
+    r->hyps = Hypotheses(next.GetTopK(beam_, false));
+    const auto &best = r->hyps.GetMostProbable(false);
+    r->tokens = ToInt32Tokens(best.ys);
+    r->timestamps = best.timestamps;
+    r->num_trailing_blanks = best.num_trailing_blanks;
+    r->decoder_out = model.RunDecoder(
+        GetQnnContext(r->tokens, model.ContextSize()));
+  }
+
+ private:
+  static std::vector<float> LogSoftmax(const std::vector<float> &x) {
+    float max_value = *std::max_element(x.begin(), x.end());
+    float sum = 0;
+    for (auto v : x) {
+      sum += std::exp(v - max_value);
+    }
+    float log_sum = std::log(sum) + max_value;
+
+    std::vector<float> ans(x.size());
+    for (size_t i = 0; i != x.size(); ++i) {
+      ans[i] = x[i] - log_sum;
+    }
+    return ans;
+  }
+
+  int32_t blank_id_;
+  int32_t vocab_size_;
+  int32_t beam_;
+};
+
+}  // namespace qnn_impl
+
+class OnlineRecognizerZipformerTransducerQnnImpl
+    : public OnlineRecognizerImpl {
+ public:
+  explicit OnlineRecognizerZipformerTransducerQnnImpl(
+      const OnlineRecognizerConfig &config)
+      : OnlineRecognizerImpl(config),
+        config_(config),
+        endpoint_(config.endpoint_config),
+        model_(std::make_unique<OnlineZipformerTransducerModelQnn>(
+            config.model_config, config.feat_config.feature_dim)),
+        blank_id_(0),
+        greedy_decoder_(blank_id_),
+        modified_beam_search_decoder_(
+            blank_id_, model_->VocabSize(), std::max(1, config.max_active_paths)) {
+    if (!config.model_config.tokens_buf.empty()) {
+      sym_ = SymbolTable(config.model_config.tokens_buf, false);
+    } else {
+      sym_ = SymbolTable(config.model_config.tokens, true);
+    }
+    InitResultTemplate();
+  }
+
+  template <typename Manager>
+  OnlineRecognizerZipformerTransducerQnnImpl(
+      Manager *mgr, const OnlineRecognizerConfig &config)
+      : OnlineRecognizerImpl(mgr, config),
+        config_(config),
+        endpoint_(config.endpoint_config),
+        model_(
+            std::make_unique<OnlineZipformerTransducerModelQnn>(
+                mgr, config.model_config, config.feat_config.feature_dim)),
+        blank_id_(0),
+        greedy_decoder_(blank_id_),
+        modified_beam_search_decoder_(
+            blank_id_, model_->VocabSize(), std::max(1, config.max_active_paths)) {
+    if (!config.model_config.tokens_buf.empty()) {
+      sym_ = SymbolTable(config.model_config.tokens_buf, false);
+    } else {
+      sym_ = SymbolTable(mgr, config.model_config.tokens);
+    }
+    InitResultTemplate();
+  }
+
+  std::unique_ptr<OnlineStream> CreateStream() const override {
+    auto s = std::make_unique<OnlineStream>(config_.feat_config);
+    s->SetQnnStates(model_->GetEncoderInitStates());
+    s->SetQnnResult(result_template_);
+    return s;
+  }
+
+  std::unique_ptr<OnlineStream> CreateStream(
+      const std::string &hotwords) const override {
+    if (!hotwords.empty()) {
+      SHERPA_ONNX_LOGE("hotwords are not supported with qnn transducers");
+      SHERPA_ONNX_EXIT(-1);
+    }
+    return CreateStream();
+  }
+
+  bool IsReady(OnlineStream *s) const override {
+    return s->NumFramesReady() - s->GetNumProcessedFrames() >=
+           model_->ChunkSize();
+  }
+
+  void DecodeStreams(OnlineStream **ss, int32_t n) const override {
+    for (int32_t i = 0; i != n; ++i) {
+      auto *s = ss[i];
+      EnsureInitialized(s);
+
+      std::vector<float> features =
+          s->GetFrames(s->GetNumProcessedFrames(), model_->ChunkSize());
+
+      auto encoder_out = model_->RunEncoder(
+          std::move(features), model_->ChunkSize(), &s->GetQnnStates());
+
+      int32_t num_processed = s->GetNumProcessedFrames();
+      int32_t frame_offset = num_processed / 4;
+
+      int32_t encoder_dim = model_->EncoderDim();
+      int32_t num_encoder_frames =
+          static_cast<int32_t>(encoder_out.size()) / encoder_dim;
+      const float *p = encoder_out.data();
+
+      for (int32_t t = 0; t != num_encoder_frames; ++t) {
+        auto &r = s->GetQnnResult();
+        int32_t frame_index = frame_offset + t;
+        if (config_.decoding_method == "greedy_search") {
+          greedy_decoder_.Decode(p + t * encoder_dim, frame_index, *model_,
+                                 &r);
+        } else {
+          modified_beam_search_decoder_.Decode(
+              p + t * encoder_dim, frame_index, *model_, &r);
+        }
+      }
+
+      s->GetNumProcessedFrames() += model_->ChunkShift();
+    }
+  }
+
+  OnlineRecognizerResult GetResult(OnlineStream *s) const override {
+    EnsureInitialized(s);
+    int32_t frame_shift_ms = 10;
+    int32_t subsampling_factor = 4;
+    auto r = qnn_impl::ConvertQnnResult(
+        s->GetQnnResult(), sym_, frame_shift_ms, subsampling_factor,
+        s->GetCurrentSegment(), s->GetNumFramesSinceStart(),
+        model_->ContextSize());
+    r.text = ApplyInverseTextNormalization(std::move(r.text));
+    r.text = ApplyHomophoneReplacer(std::move(r.text));
+    return r;
+  }
+
+  bool IsEndpoint(OnlineStream *s) const override {
+    EnsureInitialized(s);
+
+    if (!config_.enable_endpoint) {
+      return false;
+    }
+
+    int32_t num_processed_frames = s->GetNumProcessedFrames();
+    float frame_shift_in_seconds = 0.01f;
+    int32_t trailing_silence_frames = s->GetQnnResult().num_trailing_blanks * 4;
+
+    return endpoint_.IsEndpoint(num_processed_frames, trailing_silence_frames,
+                                frame_shift_in_seconds);
+  }
+
+  void Reset(OnlineStream *s) const override {
+    EnsureInitialized(s);
+
+    int32_t context_size = model_->ContextSize();
+
+    const auto &last = s->GetQnnResult();
+    if (!last.tokens.empty() && last.tokens.back() != 0 &&
+        static_cast<int32_t>(last.tokens.size()) > context_size) {
+      s->GetCurrentSegment() += 1;
+    }
+
+    OnlineTransducerDecoderResultNoOrt r = GetEmptyResult();
+
+    if (static_cast<int32_t>(last.tokens.size()) > context_size) {
+      r.tokens = qnn_impl::GetQnnContext(last.tokens, context_size);
+      r.decoder_out = model_->RunDecoder(r.tokens);
+
+      if (config_.decoding_method == "modified_beam_search") {
+        r.hyps = Hypotheses({Hypothesis(qnn_impl::ToInt64Tokens(r.tokens), 0)});
+      }
+    } else if (config_.reset_encoder) {
+      s->SetQnnStates(model_->GetEncoderInitStates());
+    }
+
+    s->Reset();
+    s->SetQnnResult(r);
+  }
+
+ private:
+  void EnsureInitialized(OnlineStream *s) const {
+    if (!s->GetQnnStates().empty()) {
+      return;
+    }
+
+    s->SetQnnStates(model_->GetEncoderInitStates());
+    s->SetQnnResult(result_template_);
+  }
+
+  void InitResultTemplate() {
+    result_template_ = GetEmptyResult();
+  }
+
+  OnlineTransducerDecoderResultNoOrt GetEmptyResult() const {
+    OnlineTransducerDecoderResultNoOrt r;
+    if (config_.decoding_method == "greedy_search") {
+      r = greedy_decoder_.GetEmptyResult(*model_);
+    } else if (config_.decoding_method == "modified_beam_search") {
+      r = modified_beam_search_decoder_.GetEmptyResult(*model_);
+    } else {
+      SHERPA_ONNX_LOGE("Unsupported decoding method for qnn transducer: %s",
+                       config_.decoding_method.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    r.decoder_out =
+        model_->RunDecoder(qnn_impl::GetQnnContext(r.tokens, model_->ContextSize()));
+    return r;
+  }
+
+ private:
+  OnlineRecognizerConfig config_;
+  Endpoint endpoint_;
+  std::unique_ptr<OnlineZipformerTransducerModelQnn> model_;
+  SymbolTable sym_;
+
+  int32_t blank_id_ = 0;
+  qnn_impl::QnnGreedySearchDecoder greedy_decoder_;
+  qnn_impl::QnnModifiedBeamSearchDecoder modified_beam_search_decoder_;
+  OnlineTransducerDecoderResultNoOrt result_template_;
+};
+
+}  // namespace sherpa_onnx
+
+#endif  // SHERPA_ONNX_CSRC_QNN_ONLINE_RECOGNIZER_ZIPFORMER_TRANSDUCER_QNN_IMPL_H_

--- a/sherpa-onnx/csrc/qnn/online-recognizer-zipformer-transducer-qnn-impl.h
+++ b/sherpa-onnx/csrc/qnn/online-recognizer-zipformer-transducer-qnn-impl.h
@@ -27,7 +27,7 @@ namespace sherpa_onnx {
 
 namespace qnn_impl {
 
-static std::vector<int32_t> GetQnnContext(const std::vector<int32_t> &tokens,
+inline std::vector<int32_t> GetQnnContext(const std::vector<int32_t> &tokens,
                                           int32_t context_size) {
   if (static_cast<int32_t>(tokens.size()) <= context_size) {
     return tokens;
@@ -36,20 +36,20 @@ static std::vector<int32_t> GetQnnContext(const std::vector<int32_t> &tokens,
   return std::vector<int32_t>(tokens.end() - context_size, tokens.end());
 }
 
-static std::vector<int64_t> ToInt64Tokens(const std::vector<int32_t> &tokens) {
+inline std::vector<int64_t> ToInt64Tokens(const std::vector<int32_t> &tokens) {
   return std::vector<int64_t>(tokens.begin(), tokens.end());
 }
 
-static std::vector<int32_t> ToInt32Tokens(const std::vector<int64_t> &tokens) {
+inline std::vector<int32_t> ToInt32Tokens(const std::vector<int64_t> &tokens) {
   return std::vector<int32_t>(tokens.begin(), tokens.end());
 }
 
-static std::vector<int32_t> GetQnnContext(const std::vector<int64_t> &tokens,
+inline std::vector<int32_t> GetQnnContext(const std::vector<int64_t> &tokens,
                                           int32_t context_size) {
   return GetQnnContext(ToInt32Tokens(tokens), context_size);
 }
 
-static OnlineRecognizerResult ConvertQnnResult(
+inline OnlineRecognizerResult ConvertQnnResult(
     OnlineTransducerDecoderResultNoOrt src, const SymbolTable &sym_table,
     float frame_shift_ms, int32_t subsampling_factor, int32_t segment,
     int32_t frames_since_start, int32_t context_size) {
@@ -367,7 +367,9 @@ class OnlineRecognizerZipformerTransducerQnnImpl
       if (config_.decoding_method == "modified_beam_search") {
         r.hyps = Hypotheses({Hypothesis(qnn_impl::ToInt64Tokens(r.tokens), 0)});
       }
-    } else if (config_.reset_encoder) {
+    }
+
+    if (config_.reset_encoder) {
       s->SetQnnStates(model_->GetEncoderInitStates());
     }
 

--- a/sherpa-onnx/csrc/qnn/online-zipformer-transducer-model-qnn.cc
+++ b/sherpa-onnx/csrc/qnn/online-zipformer-transducer-model-qnn.cc
@@ -1,0 +1,551 @@
+// sherpa-onnx/csrc/qnn/online-zipformer-transducer-model-qnn.cc
+//
+// Copyright (c)  2026  Xiaomi Corporation
+
+#include "sherpa-onnx/csrc/qnn/online-zipformer-transducer-model-qnn.h"
+
+#include <functional>
+#include <memory>
+#include <mutex>  // NOLINT
+#include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
+
+#if __ANDROID_API__ >= 9
+#include "android/asset_manager.h"
+#include "android/asset_manager_jni.h"
+#endif
+
+#if __OHOS__
+#include "rawfile/raw_file_manager.h"
+#endif
+
+#include "sherpa-onnx/csrc/file-utils.h"
+#include "sherpa-onnx/csrc/math.h"
+#include "sherpa-onnx/csrc/macros.h"
+#include "sherpa-onnx/csrc/qnn/macros.h"
+#include "sherpa-onnx/csrc/qnn/qnn-backend.h"
+#include "sherpa-onnx/csrc/qnn/qnn-model.h"
+#include "sherpa-onnx/csrc/text-utils.h"
+
+namespace sherpa_onnx {
+
+namespace {
+
+static bool IsQnnContextBinary(const std::string &filename) {
+  return EndsWith(filename, ".bin");
+}
+
+static bool NeedsCacheTranspose(const std::string &name) {
+  return name.rfind("cached_key_", 0) == 0 ||
+         name.rfind("cached_val_", 0) == 0 ||
+         name.rfind("cached_val2_", 0) == 0;
+}
+
+static std::vector<float> Transpose0123To0231(const float *x, int32_t d0,
+                                              int32_t d1, int32_t d2,
+                                              int32_t d3) {
+  std::vector<float> y(static_cast<size_t>(d0) * d1 * d2 * d3);
+
+  for (int32_t i0 = 0; i0 != d0; ++i0) {
+    for (int32_t i1 = 0; i1 != d1; ++i1) {
+      for (int32_t i2 = 0; i2 != d2; ++i2) {
+        for (int32_t i3 = 0; i3 != d3; ++i3) {
+          int32_t src = ((i0 * d1 + i1) * d2 + i2) * d3 + i3;
+          int32_t dst = ((i0 * d2 + i2) * d3 + i3) * d1 + i1;
+          y[dst] = x[src];
+        }
+      }
+    }
+  }
+
+  return y;
+}
+
+static int64_t NumElements(const std::vector<int64_t> &shape) {
+  return std::accumulate(shape.begin(), shape.end(), int64_t{1},
+                         std::multiplies<int64_t>());
+}
+
+}  // namespace
+
+class OnlineZipformerTransducerModelQnn::Impl {
+ public:
+  Impl(const OnlineModelConfig &config, int32_t feature_dim)
+      : config_(config), expected_feature_dim_(feature_dim) {
+    Init();
+  }
+
+  template <typename Manager>
+  Impl(Manager *mgr, const OnlineModelConfig &config, int32_t feature_dim)
+      : config_(config), expected_feature_dim_(feature_dim) {
+    SHERPA_ONNX_LOGE(
+        "Please copy all files from assets to SD card and set assetManager to "
+        "null");
+    SHERPA_ONNX_EXIT(-1);
+  }
+
+  std::vector<OnlineStreamStateTensor> GetEncoderInitStates() const {
+    std::vector<OnlineStreamStateTensor> ans;
+    ans.reserve(state_storage_shapes_.size());
+    for (size_t i = 0; i != state_storage_shapes_.size(); ++i) {
+      OnlineStreamStateTensor state;
+      int64_t n = NumElements(state_storage_shapes_[i]);
+      if (state_is_int32_[i]) {
+        state.int32_data.resize(n, 0);
+      } else {
+        state.float_data.resize(n, 0.f);
+      }
+      ans.push_back(std::move(state));
+    }
+
+    return ans;
+  }
+
+  std::vector<float> RunEncoder(std::vector<float> features, int32_t num_frames,
+                               std::vector<OnlineStreamStateTensor> *states) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    features = Transpose(features.data(), num_frames, feat_dim_);
+
+    encoder_->SetInputTensorData(encoder_input_name_, features.data(),
+                                features.size());
+
+    for (size_t i = 0; i != state_input_names_.size(); ++i) {
+      const auto &name = state_input_names_[i];
+      if (!(*states)[i].int32_data.empty()) {
+        const auto *p = (*states)[i].int32_data.data();
+        int32_t n = static_cast<int32_t>((*states)[i].int32_data.size());
+        encoder_->SetInputTensorData(name, p, n);
+      } else {
+        const auto *p = (*states)[i].float_data.data();
+        int32_t n = static_cast<int32_t>((*states)[i].float_data.size());
+        if (state_needs_transpose_[i]) {
+          const auto &shape = state_storage_shapes_[i];
+          auto transposed = Transpose0123To0231(
+              p, static_cast<int32_t>(shape[0]), static_cast<int32_t>(shape[1]),
+              static_cast<int32_t>(shape[2]), static_cast<int32_t>(shape[3]));
+          encoder_->SetInputTensorData(name, transposed.data(),
+                                       static_cast<int32_t>(transposed.size()));
+        } else {
+          encoder_->SetInputTensorData(name, p, n);
+        }
+      }
+    }
+
+    encoder_->Run();
+
+    std::vector<float> encoder_out =
+        encoder_->GetOutputTensorData("encoder_out");
+    for (size_t i = 0; i != state_output_names_.size(); ++i) {
+      const auto &name = state_output_names_[i];
+      if (state_is_int32_[i]) {
+        (*states)[i].int32_data = encoder_->GetOutputTensorDataInt32(name);
+      } else {
+        (*states)[i].float_data = encoder_->GetOutputTensorData(name);
+      }
+    }
+
+    return encoder_out;
+  }
+
+  std::vector<float> RunDecoder(const std::vector<int32_t> &tokens) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    decoder_->SetInputTensorData(decoder_input_name_, tokens.data(),
+                                 tokens.size());
+    decoder_->Run();
+
+    return decoder_->GetOutputTensorData(decoder_output_name_);
+  }
+
+  std::vector<float> RunJoiner(const float *encoder_out,
+                               const std::vector<float> &decoder_out) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    joiner_->SetInputTensorData(joiner_encoder_input_name_, encoder_out,
+                                encoder_out_dim_);
+    joiner_->SetInputTensorData(joiner_decoder_input_name_, decoder_out.data(),
+                                decoder_out_dim_);
+    joiner_->Run();
+
+    return joiner_->GetOutputTensorData(joiner_output_name_);
+  }
+
+  int32_t ContextSize() const { return context_size_; }
+  int32_t ChunkSize() const { return chunk_size_; }
+  int32_t ChunkShift() const { return chunk_shift_; }
+  int32_t VocabSize() const { return vocab_size_; }
+  int32_t FeatureDim() const { return feat_dim_; }
+  int32_t EncoderDim() const { return encoder_out_dim_; }
+
+ private:
+  void Init() {
+   ParseContextBinaries();
+   encoder_backend_ = std::make_unique<QnnBackend>(
+       config_.transducer.qnn_config.backend_lib, config_.debug);
+   decoder_backend_ = std::make_unique<QnnBackend>(
+        config_.transducer.qnn_config.backend_lib, config_.debug);
+    joiner_backend_ = std::make_unique<QnnBackend>(
+        config_.transducer.qnn_config.backend_lib, config_.debug);
+
+    InitEncoder();
+    InitDecoder();
+    InitJoiner();
+
+    CheckEncoder();
+    CheckDecoder();
+    CheckJoiner();
+  }
+
+  void ParseContextBinaries() {
+    SplitStringToVector(config_.transducer.qnn_config.context_binary, ",", true,
+                        &context_binaries_);
+    if (!context_binaries_.empty() && context_binaries_.size() != 3) {
+      SHERPA_ONNX_LOGE(
+          "There should be 3 files for online transducer context binary. "
+          "Actual: %d. '%s'",
+          static_cast<int32_t>(context_binaries_.size()),
+          config_.transducer.qnn_config.context_binary.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+  }
+
+  void CreateContextBinary(QnnModel *model,
+                           const std::string &context_binary) const {
+    if (config_.debug) {
+      SHERPA_ONNX_LOGE("Creating context binary '%s'.", context_binary.c_str());
+    }
+
+    bool ok = model->SaveBinaryContext(context_binary);
+
+    if (!ok) {
+      SHERPA_ONNX_LOGE("Failed to save context binary to '%s'",
+                       context_binary.c_str());
+    }
+
+    if (config_.debug && ok) {
+      SHERPA_ONNX_LOGE("Saved context binary to '%s'.", context_binary.c_str());
+      SHERPA_ONNX_LOGE("Remember to also provide libQnnSystem.so.");
+    }
+  }
+
+  void InitModelFromLib(const std::string &filename, QnnBackend *backend,
+                        std::unique_ptr<QnnModel> *model) const {
+    backend->InitContext();
+    *model = std::make_unique<QnnModel>(filename, backend, config_.debug);
+  }
+
+  void InitModelFromContextBinary(const std::string &filename,
+                                  QnnBackend *backend,
+                                  std::unique_ptr<QnnModel> *model) const {
+    if (config_.transducer.qnn_config.system_lib.empty()) {
+      SHERPA_ONNX_LOGE(
+          "You should provide --transducer.qnn-system-lib if you also provide "
+          "context binary");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    *model = std::make_unique<QnnModel>(
+        filename, config_.transducer.qnn_config.system_lib, backend,
+        BinaryContextTag{}, config_.debug);
+  }
+
+  void InitComponent(const std::string &lib_filename,
+                     const std::string &context_binary, const char *name,
+                     QnnBackend *backend,
+                     std::unique_ptr<QnnModel> *model) const {
+    if (context_binary.empty()) {
+      if (config_.debug) {
+        SHERPA_ONNX_LOGE(
+            "Init from %s model lib '%s' since context binary is not given.",
+            name, lib_filename.c_str());
+      }
+
+      InitModelFromLib(lib_filename, backend, model);
+      return;
+    }
+
+    if (!FileExists(context_binary)) {
+      if (config_.debug) {
+        SHERPA_ONNX_LOGE(
+            "Init %s from model lib '%s' since context binary '%s' does not "
+            "exist",
+            name, lib_filename.c_str(), context_binary.c_str());
+      }
+
+      InitModelFromLib(lib_filename, backend, model);
+      CreateContextBinary(model->get(), context_binary);
+    } else {
+      if (config_.debug) {
+        SHERPA_ONNX_LOGE("Init from %s context binary '%s'", name,
+                         context_binary.c_str());
+      }
+
+      InitModelFromContextBinary(context_binary, backend, model);
+    }
+  }
+
+  void InitEncoder() {
+    InitComponent(config_.transducer.encoder,
+                  context_binaries_.empty() ? "" : context_binaries_[0],
+                  "encoder", encoder_backend_.get(), &encoder_);
+  }
+
+  void InitDecoder() {
+    InitComponent(config_.transducer.decoder,
+                  context_binaries_.empty() ? "" : context_binaries_[1],
+                  "decoder", decoder_backend_.get(), &decoder_);
+  }
+
+  void InitJoiner() {
+    InitComponent(config_.transducer.joiner,
+                  context_binaries_.empty() ? "" : context_binaries_[2],
+                  "joiner", joiner_backend_.get(), &joiner_);
+  }
+
+  void CheckEncoder() {
+    if (!encoder_->HasTensor("encoder_out")) {
+      SHERPA_ONNX_LOGE("The encoder model does not have output 'encoder_out'");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    encoder_input_name_.clear();
+    for (const auto &name : encoder_->InputTensorNames()) {
+      if (name == "x") {
+        encoder_input_name_ = name;
+      } else if (name.rfind("cached_", 0) == 0) {
+        state_input_names_.push_back(name);
+      }
+    }
+
+    if (encoder_input_name_.empty()) {
+      SHERPA_ONNX_LOGE("The encoder model does not have input 'x'");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    if (state_input_names_.empty()) {
+      SHERPA_ONNX_LOGE("The encoder model does not contain streaming states");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    auto x_shape = encoder_->TensorShape(encoder_input_name_);
+    if (x_shape.size() != 3 || x_shape[0] != 1) {
+      SHERPA_ONNX_LOGE("The encoder input x should be of shape [1, ?, ?]");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    if (x_shape[1] != expected_feature_dim_) {
+      SHERPA_ONNX_LOGE(
+          "The encoder input x should be of shape [1, %d, T]. Given [1, %d, %d]",
+          expected_feature_dim_, static_cast<int32_t>(x_shape[1]),
+          static_cast<int32_t>(x_shape[2]));
+      SHERPA_ONNX_EXIT(-1);
+    }
+    feat_dim_ = x_shape[1];
+    chunk_size_ = x_shape[2];
+
+    auto out_shape = encoder_->TensorShape("encoder_out");
+    if (out_shape.size() != 3 || out_shape[0] != 1) {
+      SHERPA_ONNX_LOGE("The encoder output should be of shape [1, ?, ?]");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    encoder_out_dim_ = out_shape[2];
+    chunk_shift_ = out_shape[1] * 4;
+
+    for (const auto &name : state_input_names_) {
+      std::string new_name = "new_" + name;
+      if (!encoder_->HasTensor(new_name)) {
+        SHERPA_ONNX_LOGE("The encoder model does not have output '%s'",
+                         new_name.c_str());
+        SHERPA_ONNX_EXIT(-1);
+      }
+
+      state_output_names_.push_back(new_name);
+
+      auto output_shape = encoder_->TensorShape(new_name);
+      state_storage_shapes_.emplace_back(output_shape.begin(),
+                                         output_shape.end());
+      state_is_int32_.push_back(name.rfind("cached_len_", 0) == 0);
+      state_needs_transpose_.push_back(NeedsCacheTranspose(name));
+    }
+  }
+
+  void CheckDecoder() {
+    const auto &input_names = decoder_->InputTensorNames();
+    if (input_names.size() != 1) {
+      SHERPA_ONNX_LOGE("Expected one decoder input. Given %d",
+                       static_cast<int32_t>(input_names.size()));
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    decoder_input_name_ = input_names[0];
+    auto in_shape = decoder_->TensorShape(decoder_input_name_);
+    if (in_shape.size() != 2 || in_shape[0] != 1) {
+      SHERPA_ONNX_LOGE("Expected decoder input shape [1, context_size]");
+      SHERPA_ONNX_EXIT(-1);
+    }
+    context_size_ = in_shape[1];
+
+    const auto &output_names = decoder_->OutputTensorNames();
+    if (output_names.size() != 1) {
+      SHERPA_ONNX_LOGE("Expected one decoder output. Given %d",
+                       static_cast<int32_t>(output_names.size()));
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    decoder_output_name_ = output_names[0];
+    auto out_shape = decoder_->TensorShape(decoder_output_name_);
+    if (out_shape.size() != 2 || out_shape[0] != 1) {
+      SHERPA_ONNX_LOGE("Expected decoder output shape [1, decoder_dim]");
+      SHERPA_ONNX_EXIT(-1);
+    }
+    decoder_out_dim_ = out_shape[1];
+  }
+
+  void CheckJoiner() {
+    if (!joiner_->HasTensor("logit")) {
+      SHERPA_ONNX_LOGE("The joiner model does not have output 'logit'");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    for (const auto &name : joiner_->InputTensorNames()) {
+      auto shape = joiner_->TensorShape(name);
+      if (shape.size() != 2 || shape[0] != 1) {
+        continue;
+      }
+
+      if (shape[1] == encoder_out_dim_ && joiner_encoder_input_name_.empty()) {
+        joiner_encoder_input_name_ = name;
+      } else if (shape[1] == decoder_out_dim_ &&
+                 joiner_decoder_input_name_.empty()) {
+        joiner_decoder_input_name_ = name;
+      }
+    }
+
+    if (joiner_encoder_input_name_.empty() ||
+        joiner_decoder_input_name_.empty()) {
+      SHERPA_ONNX_LOGE("Failed to identify joiner inputs");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    auto out_shape = joiner_->TensorShape("logit");
+    if (out_shape.size() != 2 || out_shape[0] != 1) {
+      SHERPA_ONNX_LOGE("The joiner output should be of shape [1, vocab_size]");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    joiner_output_name_ = "logit";
+    vocab_size_ = out_shape[1];
+  }
+
+ private:
+ mutable std::mutex mutex_;
+
+ OnlineModelConfig config_;
+  int32_t expected_feature_dim_ = 80;
+
+  std::unique_ptr<QnnBackend> encoder_backend_;
+  std::unique_ptr<QnnBackend> decoder_backend_;
+  std::unique_ptr<QnnBackend> joiner_backend_;
+
+  std::unique_ptr<QnnModel> encoder_;
+  std::unique_ptr<QnnModel> decoder_;
+  std::unique_ptr<QnnModel> joiner_;
+  std::vector<std::string> context_binaries_;
+
+  std::string encoder_input_name_;
+  std::vector<std::string> state_input_names_;
+  std::vector<std::string> state_output_names_;
+
+  std::string decoder_input_name_;
+  std::string decoder_output_name_;
+
+  std::string joiner_encoder_input_name_;
+  std::string joiner_decoder_input_name_;
+  std::string joiner_output_name_;
+
+  std::vector<std::vector<int64_t>> state_storage_shapes_;
+  std::vector<bool> state_is_int32_;
+  std::vector<bool> state_needs_transpose_;
+
+  int32_t chunk_size_ = 0;
+  int32_t chunk_shift_ = 0;
+  int32_t feat_dim_ = 0;
+  int32_t encoder_out_dim_ = 0;
+  int32_t decoder_out_dim_ = 0;
+  int32_t context_size_ = 0;
+  int32_t vocab_size_ = 0;
+};
+
+OnlineZipformerTransducerModelQnn::OnlineZipformerTransducerModelQnn(
+    const OnlineModelConfig &config, int32_t feature_dim)
+    : impl_(std::make_unique<Impl>(config, feature_dim)) {}
+
+template <typename Manager>
+OnlineZipformerTransducerModelQnn::OnlineZipformerTransducerModelQnn(
+    Manager *mgr, const OnlineModelConfig &config, int32_t feature_dim)
+    : impl_(std::make_unique<Impl>(mgr, config, feature_dim)) {}
+
+OnlineZipformerTransducerModelQnn::~OnlineZipformerTransducerModelQnn() =
+    default;
+
+std::vector<OnlineStreamStateTensor>
+OnlineZipformerTransducerModelQnn::GetEncoderInitStates() const {
+  return impl_->GetEncoderInitStates();
+}
+
+std::vector<float> OnlineZipformerTransducerModelQnn::RunEncoder(
+    std::vector<float> features, int32_t num_frames,
+    std::vector<OnlineStreamStateTensor> *states) const {
+  return impl_->RunEncoder(std::move(features), num_frames, states);
+}
+
+std::vector<float> OnlineZipformerTransducerModelQnn::RunDecoder(
+    const std::vector<int32_t> &tokens) const {
+  return impl_->RunDecoder(tokens);
+}
+
+std::vector<float> OnlineZipformerTransducerModelQnn::RunJoiner(
+    const float *encoder_out, const std::vector<float> &decoder_out) const {
+  return impl_->RunJoiner(encoder_out, decoder_out);
+}
+
+int32_t OnlineZipformerTransducerModelQnn::ContextSize() const {
+  return impl_->ContextSize();
+}
+
+int32_t OnlineZipformerTransducerModelQnn::ChunkSize() const {
+  return impl_->ChunkSize();
+}
+
+int32_t OnlineZipformerTransducerModelQnn::ChunkShift() const {
+  return impl_->ChunkShift();
+}
+
+int32_t OnlineZipformerTransducerModelQnn::VocabSize() const {
+  return impl_->VocabSize();
+}
+
+int32_t OnlineZipformerTransducerModelQnn::FeatureDim() const {
+  return impl_->FeatureDim();
+}
+
+int32_t OnlineZipformerTransducerModelQnn::EncoderDim() const {
+  return impl_->EncoderDim();
+}
+
+#if __ANDROID_API__ >= 9
+template OnlineZipformerTransducerModelQnn::OnlineZipformerTransducerModelQnn(
+    AAssetManager *mgr, const OnlineModelConfig &config, int32_t feature_dim);
+#endif
+
+#if __OHOS__
+template OnlineZipformerTransducerModelQnn::OnlineZipformerTransducerModelQnn(
+    NativeResourceManager *mgr, const OnlineModelConfig &config,
+    int32_t feature_dim);
+#endif
+
+}  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/qnn/online-zipformer-transducer-model-qnn.cc
+++ b/sherpa-onnx/csrc/qnn/online-zipformer-transducer-model-qnn.cc
@@ -33,27 +33,23 @@ namespace sherpa_onnx {
 
 namespace {
 
-static bool IsQnnContextBinary(const std::string &filename) {
-  return EndsWith(filename, ".bin");
-}
-
 static bool NeedsCacheTranspose(const std::string &name) {
   return name.rfind("cached_key_", 0) == 0 ||
          name.rfind("cached_val_", 0) == 0 ||
          name.rfind("cached_val2_", 0) == 0;
 }
 
-static std::vector<float> Transpose0123To0231(const float *x, int32_t d0,
-                                              int32_t d1, int32_t d2,
-                                              int32_t d3) {
+static std::vector<float> Transpose0123To0231(const float *x, int64_t d0,
+                                              int64_t d1, int64_t d2,
+                                              int64_t d3) {
   std::vector<float> y(static_cast<size_t>(d0) * d1 * d2 * d3);
 
-  for (int32_t i0 = 0; i0 != d0; ++i0) {
-    for (int32_t i1 = 0; i1 != d1; ++i1) {
-      for (int32_t i2 = 0; i2 != d2; ++i2) {
-        for (int32_t i3 = 0; i3 != d3; ++i3) {
-          int32_t src = ((i0 * d1 + i1) * d2 + i2) * d3 + i3;
-          int32_t dst = ((i0 * d2 + i2) * d3 + i3) * d1 + i1;
+  for (int64_t i0 = 0; i0 != d0; ++i0) {
+    for (int64_t i1 = 0; i1 != d1; ++i1) {
+      for (int64_t i2 = 0; i2 != d2; ++i2) {
+        for (int64_t i3 = 0; i3 != d3; ++i3) {
+          int64_t src = ((i0 * d1 + i1) * d2 + i2) * d3 + i3;
+          int64_t dst = ((i0 * d2 + i2) * d3 + i3) * d1 + i1;
           y[dst] = x[src];
         }
       }
@@ -105,6 +101,11 @@ class OnlineZipformerTransducerModelQnn::Impl {
 
   std::vector<float> RunEncoder(std::vector<float> features, int32_t num_frames,
                                std::vector<OnlineStreamStateTensor> *states) const {
+    if (!states) {
+      SHERPA_ONNX_LOGE("states pointer is null");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
     std::lock_guard<std::mutex> lock(mutex_);
 
     features = Transpose(features.data(), num_frames, feat_dim_);
@@ -123,9 +124,8 @@ class OnlineZipformerTransducerModelQnn::Impl {
         int32_t n = static_cast<int32_t>((*states)[i].float_data.size());
         if (state_needs_transpose_[i]) {
           const auto &shape = state_storage_shapes_[i];
-          auto transposed = Transpose0123To0231(
-              p, static_cast<int32_t>(shape[0]), static_cast<int32_t>(shape[1]),
-              static_cast<int32_t>(shape[2]), static_cast<int32_t>(shape[3]));
+          auto transposed =
+              Transpose0123To0231(p, shape[0], shape[1], shape[2], shape[3]);
           encoder_->SetInputTensorData(name, transposed.data(),
                                        static_cast<int32_t>(transposed.size()));
         } else {
@@ -186,9 +186,9 @@ class OnlineZipformerTransducerModelQnn::Impl {
    encoder_backend_ = std::make_unique<QnnBackend>(
        config_.transducer.qnn_config.backend_lib, config_.debug);
    decoder_backend_ = std::make_unique<QnnBackend>(
-        config_.transducer.qnn_config.backend_lib, config_.debug);
-    joiner_backend_ = std::make_unique<QnnBackend>(
-        config_.transducer.qnn_config.backend_lib, config_.debug);
+       config_.transducer.qnn_config.backend_lib, config_.debug);
+   joiner_backend_ = std::make_unique<QnnBackend>(
+       config_.transducer.qnn_config.backend_lib, config_.debug);
 
     InitEncoder();
     InitDecoder();
@@ -389,17 +389,24 @@ class OnlineZipformerTransducerModelQnn::Impl {
     }
     context_size_ = in_shape[1];
 
-    const auto &output_names = decoder_->OutputTensorNames();
-    if (output_names.size() != 1) {
-      SHERPA_ONNX_LOGE("Expected one decoder output. Given %d",
-                       static_cast<int32_t>(output_names.size()));
+    if (!decoder_->HasTensor("decoder_out")) {
+      SHERPA_ONNX_LOGE("The decoder model does not have output 'decoder_out'");
       SHERPA_ONNX_EXIT(-1);
     }
 
-    decoder_output_name_ = output_names[0];
+    decoder_output_name_ = "decoder_out";
     auto out_shape = decoder_->TensorShape(decoder_output_name_);
     if (out_shape.size() != 2 || out_shape[0] != 1) {
-      SHERPA_ONNX_LOGE("Expected decoder output shape [1, decoder_dim]");
+      SHERPA_ONNX_LOGE(
+          "The decoder output should be of shape [1, decoder_dim]");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    const auto &output_names = decoder_->OutputTensorNames();
+    if (output_names.size() != 1 || output_names[0] != decoder_output_name_) {
+      SHERPA_ONNX_LOGE(
+          "Expected one decoder output named 'decoder_out'. Given %d outputs",
+          static_cast<int32_t>(output_names.size()));
       SHERPA_ONNX_EXIT(-1);
     }
     decoder_out_dim_ = out_shape[1];
@@ -411,23 +418,36 @@ class OnlineZipformerTransducerModelQnn::Impl {
       SHERPA_ONNX_EXIT(-1);
     }
 
-    for (const auto &name : joiner_->InputTensorNames()) {
-      auto shape = joiner_->TensorShape(name);
-      if (shape.size() != 2 || shape[0] != 1) {
-        continue;
-      }
+    joiner_encoder_input_name_ = "encoder_out";
+    joiner_decoder_input_name_ = "decoder_out";
 
-      if (shape[1] == encoder_out_dim_ && joiner_encoder_input_name_.empty()) {
-        joiner_encoder_input_name_ = name;
-      } else if (shape[1] == decoder_out_dim_ &&
-                 joiner_decoder_input_name_.empty()) {
-        joiner_decoder_input_name_ = name;
-      }
+    if (!joiner_->HasTensor(joiner_encoder_input_name_)) {
+      SHERPA_ONNX_LOGE("The joiner model does not have input '%s'",
+                       joiner_encoder_input_name_.c_str());
+      SHERPA_ONNX_EXIT(-1);
     }
 
-    if (joiner_encoder_input_name_.empty() ||
-        joiner_decoder_input_name_.empty()) {
-      SHERPA_ONNX_LOGE("Failed to identify joiner inputs");
+    if (!joiner_->HasTensor(joiner_decoder_input_name_)) {
+      SHERPA_ONNX_LOGE("The joiner model does not have input '%s'",
+                       joiner_decoder_input_name_.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    auto encoder_in_shape = joiner_->TensorShape(joiner_encoder_input_name_);
+    if (encoder_in_shape.size() != 2 || encoder_in_shape[0] != 1 ||
+        encoder_in_shape[1] != encoder_out_dim_) {
+      SHERPA_ONNX_LOGE(
+          "The joiner input '%s' should be of shape [1, %d]",
+          joiner_encoder_input_name_.c_str(), encoder_out_dim_);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    auto decoder_in_shape = joiner_->TensorShape(joiner_decoder_input_name_);
+    if (decoder_in_shape.size() != 2 || decoder_in_shape[0] != 1 ||
+        decoder_in_shape[1] != decoder_out_dim_) {
+      SHERPA_ONNX_LOGE(
+          "The joiner input '%s' should be of shape [1, %d]",
+          joiner_decoder_input_name_.c_str(), decoder_out_dim_);
       SHERPA_ONNX_EXIT(-1);
     }
 
@@ -445,7 +465,7 @@ class OnlineZipformerTransducerModelQnn::Impl {
  mutable std::mutex mutex_;
 
  OnlineModelConfig config_;
-  int32_t expected_feature_dim_ = 80;
+ int32_t expected_feature_dim_ = 80;
 
   std::unique_ptr<QnnBackend> encoder_backend_;
   std::unique_ptr<QnnBackend> decoder_backend_;

--- a/sherpa-onnx/csrc/qnn/online-zipformer-transducer-model-qnn.h
+++ b/sherpa-onnx/csrc/qnn/online-zipformer-transducer-model-qnn.h
@@ -1,0 +1,52 @@
+// sherpa-onnx/csrc/qnn/online-zipformer-transducer-model-qnn.h
+//
+// Copyright (c)  2026  Xiaomi Corporation
+
+#ifndef SHERPA_ONNX_CSRC_QNN_ONLINE_ZIPFORMER_TRANSDUCER_MODEL_QNN_H_
+#define SHERPA_ONNX_CSRC_QNN_ONLINE_ZIPFORMER_TRANSDUCER_MODEL_QNN_H_
+
+#include <memory>
+#include <vector>
+
+#include "sherpa-onnx/csrc/online-model-config.h"
+#include "sherpa-onnx/csrc/online-stream-state.h"
+
+namespace sherpa_onnx {
+
+class OnlineZipformerTransducerModelQnn {
+ public:
+  ~OnlineZipformerTransducerModelQnn();
+
+  OnlineZipformerTransducerModelQnn(const OnlineModelConfig &config,
+                                    int32_t feature_dim);
+
+  template <typename Manager>
+  OnlineZipformerTransducerModelQnn(Manager *mgr,
+                                    const OnlineModelConfig &config,
+                                    int32_t feature_dim);
+
+  std::vector<OnlineStreamStateTensor> GetEncoderInitStates() const;
+
+  std::vector<float> RunEncoder(std::vector<float> features, int32_t num_frames,
+                               std::vector<OnlineStreamStateTensor> *states) const;
+
+  std::vector<float> RunDecoder(const std::vector<int32_t> &tokens) const;
+
+  std::vector<float> RunJoiner(const float *encoder_out,
+                               const std::vector<float> &decoder_out) const;
+
+  int32_t ContextSize() const;
+  int32_t ChunkSize() const;
+  int32_t ChunkShift() const;
+  int32_t VocabSize() const;
+  int32_t FeatureDim() const;
+  int32_t EncoderDim() const;
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace sherpa_onnx
+
+#endif  // SHERPA_ONNX_CSRC_QNN_ONLINE_ZIPFORMER_TRANSDUCER_MODEL_QNN_H_

--- a/sherpa-onnx/csrc/qnn/qnn-model.cc
+++ b/sherpa-onnx/csrc/qnn/qnn-model.cc
@@ -308,6 +308,19 @@ class QnnModel::Impl {
     }
 
     auto t = name2tensor_.at(name);
+    if (t->v1.dataType == QNN_DATATYPE_FLOAT_32) {
+      if (n * sizeof(float) != t->v1.clientBuf.dataSize) {
+        SHERPA_ONNX_LOGE("tensor '%s' expects %d bytes, but you provide %d bytes",
+                         name.c_str(),
+                         static_cast<int32_t>(t->v1.clientBuf.dataSize),
+                         static_cast<int32_t>(n * sizeof(float)));
+        return false;
+      }
+
+      FillDataNonQuant(t, p, n);
+      return true;
+    }
+
     if (t->v1.dataType != QNN_DATATYPE_UFIXED_POINT_16) {
       SHERPA_ONNX_LOGE(
           "tensor '%s' should be of type "
@@ -377,6 +390,13 @@ class QnnModel::Impl {
     }
 
     auto t = name2tensor_.at(name);
+    if (t->v1.dataType == QNN_DATATYPE_FLOAT_32) {
+      int32_t n = t->v1.clientBuf.dataSize / sizeof(float);
+      std::vector<float> ans(n);
+      GetDataNonQuant(t, ans.data(), n);
+      return ans;
+    }
+
     if (t->v1.dataType != QNN_DATATYPE_UFIXED_POINT_16) {
       SHERPA_ONNX_LOGE(
           "tensor '%s' should be of type "
@@ -400,6 +420,28 @@ class QnnModel::Impl {
     int32_t n = t->v1.clientBuf.dataSize / sizeof(uint16_t);
     std::vector<float> ans(n);
 
+    GetData(t, ans.data(), n);
+
+    return ans;
+  }
+
+  std::vector<int32_t> GetOutputTensorDataInt32(const std::string &name) {
+    if (!HasTensor(name)) {
+      SHERPA_ONNX_LOGE("No such tensor '%s'", name.c_str());
+      return {};
+    }
+
+    auto t = name2tensor_.at(name);
+    if (t->v1.dataType != QNN_DATATYPE_INT_32) {
+      SHERPA_ONNX_LOGE(
+          "tensor '%s' should be of type "
+          "QNN_DATATYPE_INT_32, but it is %s",
+          name.c_str(), TensorDataTypeToString(t->v1.dataType).c_str());
+      return {};
+    }
+
+    int32_t n = t->v1.clientBuf.dataSize / sizeof(int32_t);
+    std::vector<int32_t> ans(n);
     GetData(t, ans.data(), n);
 
     return ans;
@@ -674,6 +716,11 @@ bool QnnModel::SetInputTensorData(const std::string &name, const int32_t *p,
 std::vector<float> QnnModel::GetOutputTensorData(
     const std::string &name) const {
   return impl_->GetOutputTensorData(name);
+}
+
+std::vector<int32_t> QnnModel::GetOutputTensorDataInt32(
+    const std::string &name) const {
+  return impl_->GetOutputTensorDataInt32(name);
 }
 
 bool QnnModel::Run() const { return impl_->Run(); }

--- a/sherpa-onnx/csrc/qnn/qnn-model.h
+++ b/sherpa-onnx/csrc/qnn/qnn-model.h
@@ -41,6 +41,8 @@ class QnnModel {
                           int32_t n) const;
 
   std::vector<float> GetOutputTensorData(const std::string &name) const;
+  std::vector<int32_t> GetOutputTensorDataInt32(
+      const std::string &name) const;
 
   bool Run() const;
   bool IsInitialized() const;

--- a/sherpa-onnx/csrc/qnn/utils.cc
+++ b/sherpa-onnx/csrc/qnn/utils.cc
@@ -93,6 +93,11 @@ std::string TensorMemTypeToString(Qnn_TensorMemType_t t) {
 
 #undef SHERPA_ONNX_TO_STRING
 
+void FillDataNonQuant(Qnn_Tensor_t *t, const float *data, int32_t n) {
+  float *out = reinterpret_cast<float *>(t->v1.clientBuf.data);
+  std::copy(data, data + n, out);
+}
+
 // quantized = float / scale - offset;
 void FillData(Qnn_Tensor_t *t, const float *data, int32_t n) {
   float scale = t->v1.quantizeParams.scaleOffsetEncoding.scale;
@@ -124,6 +129,11 @@ void FillData(Qnn_Tensor_t *t, const int32_t *data, int32_t n) {
   std::copy(data, data + n, out);
 }
 
+void GetDataNonQuant(const Qnn_Tensor_t *t, float *data, int32_t n) {
+  const float *p = reinterpret_cast<const float *>(t->v1.clientBuf.data);
+  std::copy(p, p + n, data);
+}
+
 void GetData(const Qnn_Tensor_t *t, float *data, int32_t n) {
   double scale = t->v1.quantizeParams.scaleOffsetEncoding.scale;
   double offset = t->v1.quantizeParams.scaleOffsetEncoding.offset;
@@ -133,6 +143,11 @@ void GetData(const Qnn_Tensor_t *t, float *data, int32_t n) {
     double quantizedValue = static_cast<double>(p[i]);
     data[i] = (quantizedValue + offset) * scale;
   }
+}
+
+void GetData(const Qnn_Tensor_t *t, int32_t *data, int32_t n) {
+  const int32_t *p = reinterpret_cast<const int32_t *>(t->v1.clientBuf.data);
+  std::copy(p, p + n, data);
 }
 
 static void FreeTensorV1(Qnn_Tensor_t *t) {

--- a/sherpa-onnx/csrc/qnn/utils.h
+++ b/sherpa-onnx/csrc/qnn/utils.h
@@ -35,6 +35,9 @@ std::vector<T> ReadFile(const std::string &filename) {
 
 void PrintTensor(Qnn_TensorV2_t t);
 
+// float -> float
+void FillDataNonQuant(Qnn_Tensor_t *t, const float *data, int32_t n);
+
 // float -> uint16_t
 void FillData(Qnn_Tensor_t *t, const float *data, int32_t n);
 
@@ -43,6 +46,12 @@ void FillData(Qnn_Tensor_t *t, const int32_t *data, int32_t n);
 
 // uint16_t -> float
 void GetData(const Qnn_Tensor_t *t, float *data, int32_t n);
+
+// int32_t -> int32_t
+void GetData(const Qnn_Tensor_t *t, int32_t *data, int32_t n);
+
+// float -> float
+void GetDataNonQuant(const Qnn_Tensor_t *t, float *data, int32_t n);
 
 void FreeTensor(Qnn_Tensor_t *t);
 


### PR DESCRIPTION
## TODOs
- [ ] Add CI to export streaming zipformer transducer models to QNN
- [ ] Add an Android demo


See also #3632  

cc @ZhangWei125521

----

Screenshot:

<img width="2892" height="1572" alt="Screenshot 2026-05-29 at 18 26 13" src="https://github.com/user-attachments/assets/28369f61-2c81-4f83-a620-5ad0dbd02fba" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * QNN backend added for online Zipformer Transducer recognition.
  * Public APIs extended to expose QNN streaming state and transducer results.
  * Model runtime now supports FP32 and INT32 tensor inputs/outputs.

* **Bug Fixes / Validation**
  * Stricter provider- and model-file validation to prevent incompatible configurations.

* **Documentation**
  * Provider help text and QNN option docs clarified (multiple context binaries supported).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/k2-fsa/sherpa-onnx/pull/3645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->