### PR TITLE
feat: add macOS Swift Package Manager support

### DIFF
--- a/flutter/sherpa_onnx_ios/ios/Package.swift
+++ b/flutter/sherpa_onnx_ios/ios/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "sherpa_onnx_ios",
+    platforms: [.iOS(.v13)],
+    products: [
+        .library(name: "sherpa_onnx_ios", targets: ["sherpa_onnx_ios"]),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "sherpa_onnx_ios",
+            path: "sherpa_onnx.xcframework"
+        ),
+    ]
+)

--- a/flutter/sherpa_onnx_ios/ios/Package.swift
+++ b/flutter/sherpa_onnx_ios/ios/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "sherpa_onnx_ios",
-            path: "sherpa_onnx.xcframework"
+            path: "sherpa-onnx.xcframework"
         ),
     ]
 )

--- a/flutter/sherpa_onnx_macos/macos/Package.swift
+++ b/flutter/sherpa_onnx_macos/macos/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "sherpa_onnx_macos",
+    platforms: [.macOS(.v10_11)],
+    products: [
+        .library(name: "sherpa_onnx_macos", targets: ["sherpa_onnx_macos"]),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "sherpa_onnx_macos",
+            path: "sherpa_onnx.xcframework"
+        ),
+    ]
+)

--- a/flutter/sherpa_onnx_macos/macos/Package.swift
+++ b/flutter/sherpa_onnx_macos/macos/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "sherpa_onnx_macos",
-            path: "sherpa_onnx.xcframework"
+            path: "sherpa-onnx.xcframework"
         ),
     ]
 )

--- a/flutter/sherpa_onnx_macos/macos/Package.swift
+++ b/flutter/sherpa_onnx_macos/macos/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "sherpa_onnx_macos",
-    platforms: [.macOS(.v10_11)],
+    platforms: [.macOS(.v10_13)],
     products: [
         .library(name: "sherpa_onnx_macos", targets: ["sherpa_onnx_macos"]),
     ],

--- a/flutter/sherpa_onnx_macos/macos/README.md
+++ b/flutter/sherpa_onnx_macos/macos/README.md
@@ -1,5 +1,5 @@
 # Introduction
 
-`*.dylib` files are generated dynamically using GitHub actions during a new release.
+`sherpa-onnx.xcframework` is generated dynamically using GitHub actions during a new release.
 
 We don't check-in pre-built library files into git.

--- a/flutter/sherpa_onnx_macos/macos/README.md
+++ b/flutter/sherpa_onnx_macos/macos/README.md
@@ -1,5 +1,5 @@
 # Introduction
 
-`sherpa-onnx.xcframework` is generated dynamically using GitHub actions during a new release.
+`sherpa_onnx.xcframework` is generated dynamically using GitHub actions during a new release.
 
 We don't check-in pre-built library files into git.

--- a/flutter/sherpa_onnx_macos/macos/sherpa_onnx_macos.podspec
+++ b/flutter/sherpa_onnx_macos/macos/sherpa_onnx_macos.podspec
@@ -19,7 +19,8 @@ sherpa-onnx Flutter FFI plugin project.
   # `../src/*` so that the C sources can be shared among all target platforms.
   s.source           = { :path => '.' }
   s.dependency 'FlutterMacOS'
-  s.vendored_libraries = '*.dylib'
+  s.preserve_paths = 'sherpa_onnx.xcframework/**/*'
+  s.vendored_frameworks = 'sherpa_onnx.xcframework'
 
   s.platform = :osx, '10.11'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }

--- a/flutter/sherpa_onnx_macos/macos/sherpa_onnx_macos.podspec
+++ b/flutter/sherpa_onnx_macos/macos/sherpa_onnx_macos.podspec
@@ -19,8 +19,8 @@ sherpa-onnx Flutter FFI plugin project.
   # `../src/*` so that the C sources can be shared among all target platforms.
   s.source           = { :path => '.' }
   s.dependency 'FlutterMacOS'
-  s.preserve_paths = 'sherpa_onnx.xcframework/**/*'
-  s.vendored_frameworks = 'sherpa_onnx.xcframework'
+  s.preserve_paths = 'sherpa-onnx.xcframework/**/*'
+  s.vendored_frameworks = 'sherpa-onnx.xcframework'
 
   s.platform = :osx, '10.11'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }


### PR DESCRIPTION
## Summary

为 macOS Flutter 插件添加 Swift Package Manager (SPM) 支持，与 #3428 和已合并的 iOS SPM 支持（740c435e）保持一致。

Resolves #3428（macOS 部分）

## Changes

- **新增** `flutter/sherpa_onnx_macos/macos/Package.swift` — SPM 包描述文件，引用 `sherpa_onnx.xcframework` 作为 binary target
- **修改** `flutter/sherpa_onnx_macos/macos/sherpa_onnx_macos.podspec` — 从 `vendored_libraries (*.dylib)` 切换为 `vendored_frameworks (sherpa_onnx.xcframework)`
- **修改** `flutter/sherpa_onnx_macos/macos/README.md` — 更新说明，反映使用 xcframework 而非 dylib

## Files Changed

| 文件 | 变更类型 |
|------|----------|
| `flutter/sherpa_onnx_macos/macos/Package.swift` | 新增 |
| `flutter/sherpa_onnx_macos/macos/README.md` | 修改 |
| `flutter/sherpa_onnx_macos/macos/sherpa_onnx_macos.podspec` | 修改 |

## Testing

- 需要通过 CI 验证 xcframework 正确生成和集成
- 需要验证 SPM 集成和 CocoaPods 集成均正常工作

## Related Issues

Resolves #3428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated iOS and macOS distribution to ship `sherpa_onnx` as prebuilt XCFrameworks via SwiftPM.
  * Adjusted podspec packaging to correctly treat `sherpa-onnx.xcframework` as a vendored framework (and preserve its bundled contents).
* **Documentation**
  * Updated the macOS README to clarify that `sherpa-onnx.xcframework` is generated during releases and that prebuilt binaries are not committed to git.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->