### PR TITLE
Export streaming zipformer transducer to QNN

### DIFF
--- a/.github/scripts/export-qnn/generate_streaming_zipformer_transducer.py
+++ b/.github/scripts/export-qnn/generate_streaming_zipformer_transducer.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright    2026  Xiaomi Corp.        (authors: Fangjun Kuang)
+
+import json
+
+from device_info import soc_info_dict
+from dataclasses import asdict, dataclass
+import itertools
+
+
+@dataclass
+class Config:
+    soc: str  # SM8850
+    soc_id: int  # 87
+    arch: str  # v81
+    chunk_size: int
+    model_name: str
+
+
+def main():
+
+    model_name_list = ["20230220"]
+    chunk_size_list = [32]
+
+    configs = []
+
+    for name, soc in soc_info_dict.items():
+        if soc.model.name == "SM8350":
+            # SM8350 does not support fp16
+            continue
+        for chunk_size, model_name in itertools.product(
+            chunk_size_list, model_name_list
+        ):
+            configs.append(
+                Config(
+                    soc=name,
+                    soc_id=soc.model.value,
+                    arch=soc.info.arch.name,
+                    model_name=model_name,
+                    chunk_size=chunk_size,
+                )
+            )
+
+    ans = [asdict(c) for c in configs]
+
+    print(json.dumps({"include": ans}))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/export-streaming-zipformer-transducer-to-qnn.yaml
+++ b/.github/workflows/export-streaming-zipformer-transducer-to-qnn.yaml
@@ -1,0 +1,434 @@
+name: export-streaming-zipformer-transducer-to-qnn
+
+on:
+  push:
+    branches:
+      - export-streaming-zipformer-qnn
+  workflow_dispatch:
+
+concurrency:
+  group: export-streaming-zipformer-transducer-to-qnn-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate_build_matrix:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
+    # see https://github.com/pytorch/pytorch/pull/50633
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generating build matrix
+        id: set-matrix
+        run: |
+          # outputting for debugging purposes
+          python3 .github/scripts/export-qnn/generate_streaming_zipformer_transducer.py
+          MATRIX=$(python3 .github/scripts/export-qnn/generate_streaming_zipformer_transducer.py)
+
+          # deprecated
+          # echo "::set-output name=matrix::${MATRIX}"
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+
+  export-streaming-zipformer-transducer-to-qnn:
+    needs: generate_build_matrix
+    if: github.repository_owner == 'k2-fsa' || github.repository_owner == 'csukuangfj'
+    name: ${{ matrix.model_name }} ${{ matrix.soc }} ${{ matrix.chunk_size }}
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ${{ fromJson(needs.generate_build_matrix.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone icefall
+        shell: bash
+        run: |
+          git clone https://github.com/k2-fsa/icefall
+
+      - name: Export onnx models
+        uses: addnab/docker-run-action@v3
+        with:
+            image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py3.10-torch2.6.0-v20250630
+            options: |
+              --volume ${{ github.workspace }}/icefall:/icefall
+              --volume ${{ github.workspace }}/:/sherpa-onnx
+            shell: bash
+            run: |
+              export PYTHONPATH=/icefall:$PYTHONPATH
+              cd /icefall
+              git config --global --add safe.directory /icefall
+
+              python3 -m torch.utils.collect_env
+              python3 -m k2.version
+
+              export model_name=${{ matrix.model_name }}
+              export chunk_size=${{ matrix.chunk_size }}
+
+              if [[ x$model_name == x"20230220" ]]; then
+                /sherpa-onnx/scripts/zipformer-transducer/streaming_v1/qnn/run-2023-02-20.sh $chunk_size
+              else
+              echo "Supported model names are: 20230220"
+                exit 1
+              fi
+
+      - name: Show model files
+        shell: bash
+        run: |
+          export chunk_size=${{ matrix.chunk_size }}
+          ls -lh model-files/$chunk_size
+
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Create directories
+        shell: bash
+        run: |
+          mkdir so binary
+
+      - name: Display NDK HOME
+        shell: bash
+        run: |
+          echo "ANDROID_NDK_LATEST_HOME: ${ANDROID_NDK_LATEST_HOME}"
+          ls -lh ${ANDROID_NDK_LATEST_HOME}
+
+      - name: Create Python virtual environment
+        shell: bash
+        run: |
+          python3 -m venv py310
+          which python3
+          source py310/bin/activate
+          which python3
+
+      - name: Show ndk-build help
+        shell: bash
+        run: |
+          export PATH=${ANDROID_NDK_LATEST_HOME}:$PATH
+          ndk-build --help
+
+      - name: Download toolkit
+        shell: bash
+        run: |
+          curl -SL -O https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.40.0.251030.zip
+          ls -lh v2.40.0.251030.zip
+
+      - name: Unzip toolkit
+        shell: bash
+        run: |
+          unzip v2.40.0.251030.zip
+
+      - name: Show
+        shell: bash
+        run: |
+          ls -lh
+
+          echo "---ls -lh qairt---"
+
+          ls -lh qairt
+
+          echo "---"
+
+      - name: Install linux dependencies
+        shell: bash
+        run: |
+          ls -lh
+
+          echo "---"
+
+          ls -lh qairt
+
+          cd qairt/2.40.0.251030/bin
+          source envsetup.sh
+
+          yes | sudo ${QNN_SDK_ROOT}/bin/check-linux-dependency.sh || true
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          source py310/bin/activate
+
+          cd qairt/2.40.0.251030/bin
+          source envsetup.sh
+
+          python3 -m pip install \
+            mock \
+            numpy \
+            opencv-python \
+            optuna \
+            packaging \
+            pandas \
+            paramiko \
+            pathlib2 \
+            pillow \
+            plotly \
+            protobuf \
+            psutil \
+            pydantic \
+            pytest \
+            pyyaml \
+            rich \
+            scikit-optimize \
+            scipy \
+            six \
+            tabulate \
+            typing-extensions \
+            xlsxwriter
+
+          python3 "${QNN_SDK_ROOT}/bin/check-python-dependency" || true
+
+          which python3
+
+      - name: Install onnx dependencies
+        shell: bash
+        run: |
+          source py310/bin/activate
+          python3 -m pip install --upgrade \
+            torch==2.0.0+cpu -f https://download.pytorch.org/whl/torch \
+            kaldi_native_fbank \
+            pip \
+            "numpy<2" \
+            onnx==1.17.0 \
+            onnxruntime==1.17.1 \
+            soundfile \
+            librosa \
+            onnxsim \
+            sentencepiece \
+            pyyaml
+
+          which python3
+
+      - name: Show qnn-onnx-converter help
+        shell: bash
+        run: |
+          source py310/bin/activate
+
+          pushd qairt/2.40.0.251030/bin
+          source envsetup.sh
+          popd
+
+          qnn-onnx-converter --help
+
+      - name: Show qnn-model-lib-generator help
+        shell: bash
+        run: |
+          source py310/bin/activate
+
+          pushd qairt/2.40.0.251030/bin
+          source envsetup.sh
+          popd
+
+          qnn-model-lib-generator --help
+
+      - name: Show qnn-net-run help
+        shell: bash
+        run: |
+          source py310/bin/activate
+
+          pushd qairt/2.40.0.251030/bin
+          source envsetup.sh
+          popd
+
+          qnn-net-run --help
+
+      - name: Run ${{ matrix.chunk_size }}
+        if: matrix.model_name == '20230220'
+        shell: bash
+        run: |
+          source py310/bin/activate
+
+          pushd qairt/2.40.0.251030/bin
+          source envsetup.sh
+          popd
+
+          export PATH=${ANDROID_NDK_LATEST_HOME}:$PATH
+
+          ndk-build --help
+
+
+          export LDFLAGS="-Wl,-z,max-page-size=16384"
+          dir=$PWD
+          chunk_size=${{ matrix.chunk_size }}
+          model_dir=$PWD/model-files/$chunk_size
+          soc=${{ matrix.soc }}
+
+          python3 ./scripts/pyannote/segmentation/show-onnx.py --filename $model_dir/encoder-epoch-99-avg-1.onnx
+          echo "---"
+          python3 ./scripts/pyannote/segmentation/show-onnx.py --filename $model_dir/decoder-epoch-99-avg-1.onnx
+          echo "---"
+          python3 ./scripts/pyannote/segmentation/show-onnx.py --filename $model_dir/joiner-epoch-99-avg-1.onnx
+
+          export PATH=${ANDROID_NDK_LATEST_HOME}:$PATH
+
+          echo "export to qnn"
+          echo "----------$chunk_size----------"
+
+          for m in encoder decoder joiner; do
+            echo "Processing $m"
+            qnn-onnx-converter \
+              --input_network $model_dir/$m-epoch-99-avg-1.onnx \
+              --output_path ./non_quant/$m.cpp \
+              --act_bitwidth 16 \
+              --bias_bitwidth 32 > ${m}-log-converter.t 2>&1
+
+            ls -lh non_quant
+
+
+            python3 ./scripts/qnn/generate_config.py  \
+                --soc $soc \
+                --graph-name $m \
+                --output-dir ./non_quant/my-config-$m \
+                --qnn-sdk-root $QNN_SDK_ROOT
+
+            ls -lh non_quant/my-config-$m
+
+            head -n100 ./non_quant/my-config-$m/*.json
+
+            python3 "${QNN_SDK_ROOT}/bin/x86_64-linux-clang/qnn-model-lib-generator" \
+                -c non_quant/$m.cpp \
+                -b non_quant/$m.bin \
+                -o non_quant/model_libs > ${m}-log-generator.txt 2>&1
+
+            ls -lh non_quant/model_libs
+            echo "---"
+            ls -lh non_quant/model_libs/x86_64-linux-clang
+            echo "---"
+            ls -lh non_quant/model_libs/aarch64-android
+
+
+            $QNN_SDK_ROOT/bin/x86_64-linux-clang/qnn-context-binary-generator \
+              --backend $QNN_SDK_ROOT/lib/x86_64-linux-clang/libQnnHtp.so \
+              --model ./non_quant/model_libs/x86_64-linux-clang/lib$m.so \
+              --output_dir ./non_quant/binary \
+              --binary_file $m \
+              --config_file ./non_quant/my-config-$m/htp_backend_extensions.json > ${m}-log-generator.txt 2>&1
+
+            ls -lh non_quant/binary/
+          done
+
+          readelf -lW non_quant/model_libs/*/lib*.so
+
+          echo "collect results"
+
+          d=sherpa-onnx-qnn-${{ matrix.soc}}-binary-streaming-zipformer-transducer-zh-en-2023-03-20-chunk-size-$chunk_size
+          mkdir -p $d
+          mkdir -p $d/test_wavs
+          cp -v non_quant/binary/*.bin $d/
+          cp -v $model_dir/tokens.txt $d
+
+          pushd $d/test_wavs
+
+          curl -SL -O https://huggingface.co/csukuangfj/sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20/resolve/main/test_wavs/0.wav
+          curl -SL -O https://huggingface.co/csukuangfj/sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20/resolve/main/test_wavs/1.wav
+          curl -SL -O https://huggingface.co/csukuangfj/sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20/resolve/main/test_wavs/2.wav
+          curl -SL -O https://huggingface.co/csukuangfj/sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20/resolve/main/test_wavs/3.wav
+          curl -SL -O https://huggingface.co/csukuangfj/sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20/resolve/main/test_wavs/8k.wav
+
+          popd
+
+          echo "chunk_size=$chunk_size" > $d/info.txt
+
+          ls -lh $d
+          tar cjfv $d.tar.bz2 $d
+          ls -lh *.tar.bz2
+          rm -rf $d
+
+          mkdir -p binary
+          mv *.tar.bz2 ./binary/
+
+          for p in x86_64-linux-clang aarch64-android; do
+            if [[ $p == x86_64-linux-clang ]]; then
+              d=sherpa-onnx-qnn-streaming-zipformer-transducer-zh-en-2023-03-20-chunk-size-$chunk_size-linux-x64
+            elif [[ $p == aarch64-android ]]; then
+              d=sherpa-onnx-qnn-streaming-zipformer-transducer-zh-en-2023-03-20-chunk-size-$chunk_size-android-aarch64
+            else
+              echo "Unknown $p"
+              exit -1
+            fi
+
+            mkdir -p $d
+            mkdir -p $d/test_wavs
+            pushd $d/test_wavs
+
+            curl -SL -O https://huggingface.co/csukuangfj/sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20/resolve/main/test_wavs/0.wav
+            curl -SL -O https://huggingface.co/csukuangfj/sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20/resolve/main/test_wavs/1.wav
+            curl -SL -O https://huggingface.co/csukuangfj/sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20/resolve/main/test_wavs/2.wav
+            curl -SL -O https://huggingface.co/csukuangfj/sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20/resolve/main/test_wavs/3.wav
+            curl -SL -O https://huggingface.co/csukuangfj/sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20/resolve/main/test_wavs/8k.wav
+
+            popd
+
+            cp -v non_quant/model_libs/$p/lib*.so $d/
+            cp -v $model_dir/tokens.txt $d
+
+            echo "chunk_size=$chunk_size" > $d/info.txt
+            echo "target=$p" >> $d/info.txt
+
+            ls -lh $d
+            tar cjfv $d.tar.bz2 $d
+            ls -lh *.tar.bz2
+            rm -rf $d
+          done
+
+          echo "----show---"
+          ls -lh *.tar.bz2
+
+          mkdir -p so
+
+          mv *.tar.bz2 ./so
+
+      - name: Setup tmate session
+        # if: true
+        if: failure()
+        uses: mxschmitt/action-tmate@v3
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.model_name }}-${{ matrix.soc }}-${{ matrix.chunk_size }}-json
+          path: ./non_quant/*.json
+
+      - name: Release
+        if: github.repository_owner == 'csukuangfj' && matrix.soc == 'SM8850'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./so/*.tar.bz2
+          overwrite: true
+          repo_name: k2-fsa/sherpa-onnx
+          repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
+          tag: asr-models-qnn
+
+      - name: Release
+        if: github.repository_owner == 'csukuangfj'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./binary/*.tar.bz2
+          overwrite: true
+          repo_name: k2-fsa/sherpa-onnx
+          repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
+          tag: asr-models-qnn-binary
+
+      - name: Release
+        if: github.repository_owner == 'k2-fsa' && matrix.soc == 'SM8850'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./so/*.tar.bz2
+          overwrite: true
+          tag: asr-models-qnn
+
+      - name: Release
+        if: github.repository_owner == 'k2-fsa'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./binary/*.tar.bz2
+          overwrite: true
+          tag: asr-models-qnn-binary

--- a/.github/workflows/export-zipformer-ctc-to-qnn-20250703.yaml
+++ b/.github/workflows/export-zipformer-ctc-to-qnn-20250703.yaml
@@ -3,7 +3,7 @@ name: export-zipformer-ctc-to-qnn-20250703
 on:
   push:
     branches:
-      - zipformer-qnn-model-2
+      - export-streaming-zipformer-qnn-2
   workflow_dispatch:
 
 concurrency:
@@ -79,13 +79,13 @@ jobs:
       - name: Download toolkit
         shell: bash
         run: |
-          curl -SL -O https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.33.0.250327.zip
-          ls -lh v2.33.0.250327.zip
+          curl -SL -O https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.40.0.251030.zip
+          ls -lh v2.40.0.251030.zip
 
       - name: Unzip toolkit
         shell: bash
         run: |
-          unzip v2.33.0.250327.zip
+          unzip v2.40.0.251030.zip
 
       - name: Show
         shell: bash
@@ -107,7 +107,7 @@ jobs:
 
           ls -lh qairt
 
-          cd qairt/2.33.0.250327/bin
+          cd qairt/2.40.0.251030/bin
           source envsetup.sh
 
           yes | sudo ${QNN_SDK_ROOT}/bin/check-linux-dependency.sh || true
@@ -117,7 +117,7 @@ jobs:
         run: |
           source py310/bin/activate
 
-          cd qairt/2.33.0.250327/bin
+          cd qairt/2.40.0.251030/bin
           source envsetup.sh
 
           python3 -m pip install \
@@ -172,7 +172,7 @@ jobs:
         run: |
           source py310/bin/activate
 
-          pushd qairt/2.33.0.250327/bin
+          pushd qairt/2.40.0.251030/bin
           source envsetup.sh
           popd
 
@@ -183,7 +183,7 @@ jobs:
         run: |
           source py310/bin/activate
 
-          pushd qairt/2.33.0.250327/bin
+          pushd qairt/2.40.0.251030/bin
           source envsetup.sh
           popd
 
@@ -194,7 +194,7 @@ jobs:
         run: |
           source py310/bin/activate
 
-          pushd qairt/2.33.0.250327/bin
+          pushd qairt/2.40.0.251030/bin
           source envsetup.sh
           popd
 
@@ -206,7 +206,7 @@ jobs:
         run: |
           source py310/bin/activate
 
-          pushd qairt/2.33.0.250327/bin
+          pushd qairt/2.40.0.251030/bin
           source envsetup.sh
           popd
 
@@ -346,7 +346,7 @@ jobs:
         run: |
           source py310/bin/activate
 
-          pushd qairt/2.33.0.250327/bin
+          pushd qairt/2.40.0.251030/bin
           source envsetup.sh
           popd
 

--- a/scripts/zipformer-transducer/streaming_v1/qnn/run-2023-02-20.sh
+++ b/scripts/zipformer-transducer/streaming_v1/qnn/run-2023-02-20.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+
+# We run this script inside a docker container using GitHub actions
+# sherpa-onnx repo is mounted at /sherpa-onnx
+# icefall repo is mounted at /icefall
+
+chunk_size=32
+
+if [ $# -ge 1 ]; then
+  chunk_size="$1"
+fi
+
+echo "chunk_size: $chunk_size"
+
+echo "download models"
+git clone https://huggingface.co/pfluo/k2fsa-zipformer-chinese-english-mixed
+pushd k2fsa-zipformer-chinese-english-mixed/exp
+git lfs pull
+rm *.onnx
+popd
+
+dir=$PWD/k2fsa-zipformer-chinese-english-mixed
+
+pushd /icefall/egs/librispeech/ASR/
+
+./pruned_transducer_stateless7_streaming/export-onnx-zh.py \
+  --exp-dir $dir/exp \
+  --tokens $dir/data/lang_char_bpe/tokens.txt \
+  --epoch 99 \
+  --avg 1 \
+  --use-averaged-model 0 \
+  \
+  --decode-chunk-len $chunk_size \
+  --num-encoder-layers "2,4,3,2,4" \
+  --feedforward-dims "1024,1024,1536,1536,1024" \
+  --nhead "8,8,8,8,8" \
+  --encoder-dims "384,384,384,384,384" \
+  --attention-dims "192,192,192,192,192" \
+  --encoder-unmasked-dims "256,256,256,256,256" \
+  --zipformer-downsampling-factors "1,2,4,8,2" \
+  --cnn-module-kernels "31,31,31,31,31" \
+  --decoder-dim 512 \
+  --joiner-dim 512 \
+  --dynamic-batch 0 \
+  --enable-int8-quantization 0 \
+  --use-int32-inputs 1
+
+ls -lh $dir/exp
+
+echo "copy onnx model files"
+
+src=/sherpa-onnx/model-files/$chunk_size
+mkdir -p $src
+
+mv -v $dir/exp/*.onnx $src/
+cp -v $dir/data/lang_char_bpe/tokens.txt $src
+rm -rf $dir

--- a/sherpa-onnx/csrc/online-recognizer-impl.cc
+++ b/sherpa-onnx/csrc/online-recognizer-impl.cc
@@ -44,6 +44,11 @@
 
 namespace sherpa_onnx {
 
+static bool HasQnnOnlineTransducerModel(const OnlineModelConfig &config) {
+  return !config.transducer.encoder.empty() ||
+         !config.transducer.qnn_config.context_binary.empty();
+}
+
 static bool IsNeMoParakeetUnifiedStreaming(const Ort::Session &decoder_sess) {
   Ort::AllocatorWithDefaultOptions allocator;
   Ort::ModelMetadata meta_data = decoder_sess.GetModelMetadata();
@@ -77,7 +82,7 @@ std::unique_ptr<OnlineRecognizerImpl> OnlineRecognizerImpl::Create(
 
   if (config.model_config.provider_config.provider == "qnn") {
 #ifdef SHERPA_ONNX_ENABLE_QNN
-    if (!config.model_config.transducer.encoder.empty()) {
+    if (HasQnnOnlineTransducerModel(config.model_config)) {
       return std::make_unique<OnlineRecognizerZipformerTransducerQnnImpl>(
           config);
     }
@@ -163,7 +168,7 @@ std::unique_ptr<OnlineRecognizerImpl> OnlineRecognizerImpl::Create(
 
   if (config.model_config.provider_config.provider == "qnn") {
 #ifdef SHERPA_ONNX_ENABLE_QNN
-    if (!config.model_config.transducer.encoder.empty()) {
+    if (HasQnnOnlineTransducerModel(config.model_config)) {
       return std::make_unique<OnlineRecognizerZipformerTransducerQnnImpl>(
           mgr, config);
     }


### PR DESCRIPTION
You can find the exported models at
- https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models-qnn
- https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models-qnn-binary

Please refer to
https://k2-fsa.github.io/sherpa/onnx/qnn/run-executables-on-your-phone-binary.html
for usages.

The following lists two examples.

## Use shared libs

```bash
./sherpa-onnx \
   --provider=qnn \
   --tokens=./sherpa-onnx-qnn-streaming-zipformer-transducer-zh-en-2023-03-20-chunk-size-32-android-aarch64/tokens.txt \
   --encoder=./sherpa-onnx-qnn-streaming-zipformer-transducer-zh-en-2023-03-20-chunk-size-32-android-aarch64/libencoder.so \
   --decoder=./sherpa-onnx-qnn-streaming-zipformer-transducer-zh-en-2023-03-20-chunk-size-32-android-aarch64/libdecoder.so \
   --joiner=./sherpa-onnx-qnn-streaming-zipformer-transducer-zh-en-2023-03-20-chunk-size-32-android-aarch64/libjoiner.so \
   --transducer.qnn-backend-lib=./libQnnHtp.so \
   --transducer.qnn-system-lib=./libQnnSystem.so \
   --transducer.qnn-context-binary=./sherpa-onnx-qnn-streaming-zipformer-transducer-zh-en-2023-03-20-chunk-size-32-android-aarch64/encoder.bin,./sherpa-onnx-qnn-streaming-zipformer-transducer-zh-en-2023-03-20-chunk-size-32-android-aarch64/decoder.bin,./sherpa-onnx-qnn-streaming-zipformer-transducer-zh-en-2023-03-20-chunk-size-32-android-aarch64/jooiner.bin \
   ./sherpa-onnx-qnn-streaming-zipformer-transducer-zh-en-2023-03-20-chunk-size-32-android-aarch64/test_wavs/0.wav
```

## Use context binary files

```bash

./sherpa-onnx \
   --provider=qnn \
   --tokens=./sherpa-onnx-qnn-SM8850-binary-streaming-zipformer-transducer-zh-en-2023-03-20-chunk-size-32/tokens.txt \
   --transducer.qnn-backend-lib=./libQnnHtp.so \
   --transducer.qnn-system-lib=./libQnnSystem.so \
   --transducer.qnn-context-binary=./sherpa-onnx-qnn-SM8850-binary-streaming-zipformer-transducer-zh-en-2023-03-20-chunk-size-32/encoder.bin,./sherpa-onnx-qnn-SM8850-binary-streaming-zipformer-transducer-zh-en-2023-03-20-chunk-size-32/decoder.bin,./sherpa-onnx-qnn-SM8850-binary-streaming-zipformer-transducer-zh-en-2023-03-20-chunk-size-32/joiner.bin \
   ./sherpa-onnx-qnn-SM8850-binary-streaming-zipformer-transducer-zh-en-2023-03-20-chunk-size-32/test_wavs/0.wav
```

Fixes #3632 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added workflow for exporting streaming Zipformer transducer models to QNN format with optimized build configurations.
  * Enhanced QNN online recognition support with improved transducer model handling.

* **Chores**
  * Updated QNN toolkit version to 2.40.0.251030 for improved performance.
  * Enhanced CI/CD automation for QNN model export and packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->