### PR TITLE
Support streaming zipformer transducer ASR for QNN.

### DIFF
--- a/python-api-examples/generate-subtitles.py
+++ b/python-api-examples/generate-subtitles.py
@@ -397,7 +397,7 @@ def get_args():
 
 
 def assert_file_exists(filename: str):
-    assert Path(filename).is_file(), (
+    assert Path(filename).exists(), (
         f"{filename} does not exist!\n"
         "Please refer to "
         "https://k2-fsa.github.io/sherpa/onnx/pretrained_models/index.html to download it"

--- a/sherpa-onnx/csrc/offline-recognizer-transducer-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-transducer-impl.h
@@ -31,28 +31,6 @@
 
 namespace sherpa_onnx {
 
-static std::string RemoveSpaceBetweenCjk(const std::string &text) {
-  std::u32string u32 = Utf8ToUtf32(text);
-  if (u32.size() < 3) {
-    return text;
-  }
-
-  std::u32string ans;
-  ans.reserve(u32.size());
-  ans.push_back(u32[0]);
-
-  for (size_t i = 1; i + 1 < u32.size(); ++i) {
-    if (u32[i] == U' ' && IsCJK(u32[i - 1]) && IsCJK(u32[i + 1])) {
-      continue;
-    }
-
-    ans.push_back(u32[i]);
-  }
-
-  ans.push_back(u32.back());
-  return Utf32ToUtf8(ans);
-}
-
 static OfflineRecognitionResult Convert(
     const OfflineTransducerDecoderResult &src, const SymbolTable &sym_table,
     int32_t frame_shift_ms, int32_t subsampling_factor) {

--- a/sherpa-onnx/csrc/offline-transducer-model.cc
+++ b/sherpa-onnx/csrc/offline-transducer-model.cc
@@ -31,9 +31,9 @@ namespace sherpa_onnx {
 
 namespace {
 
-static Ort::Value CastIntTensor(Ort::Value tensor,
-                                ONNXTensorElementDataType target_type,
-                                OrtAllocator *allocator) {
+Ort::Value CastIntTensor(Ort::Value tensor,
+                         ONNXTensorElementDataType target_type,
+                         OrtAllocator *allocator) {
   auto info = tensor.GetTensorTypeAndShapeInfo();
   auto source_type = info.GetElementType();
   auto shape = info.GetShape();
@@ -57,14 +57,9 @@ static Ort::Value CastIntTensor(Ort::Value tensor,
       Ort::Value ans =
           Ort::Value::CreateTensor<int32_t>(allocator, shape.data(), shape.size());
       int32_t *dst = ans.GetTensorMutableData<int32_t>();
-      if (source_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32) {
-        const int32_t *src = tensor.GetTensorData<int32_t>();
-        std::copy(src, src + n, dst);
-      } else {
-        const int64_t *src = tensor.GetTensorData<int64_t>();
-        for (size_t i = 0; i != n; ++i) {
-          dst[i] = static_cast<int32_t>(src[i]);
-        }
+      const int64_t *src = tensor.GetTensorData<int64_t>();
+      for (size_t i = 0; i != n; ++i) {
+        dst[i] = static_cast<int32_t>(src[i]);
       }
       return ans;
     }
@@ -72,14 +67,9 @@ static Ort::Value CastIntTensor(Ort::Value tensor,
       Ort::Value ans =
           Ort::Value::CreateTensor<int64_t>(allocator, shape.data(), shape.size());
       int64_t *dst = ans.GetTensorMutableData<int64_t>();
-      if (source_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) {
-        const int64_t *src = tensor.GetTensorData<int64_t>();
-        std::copy(src, src + n, dst);
-      } else {
-        const int32_t *src = tensor.GetTensorData<int32_t>();
-        for (size_t i = 0; i != n; ++i) {
-          dst[i] = src[i];
-        }
+      const int32_t *src = tensor.GetTensorData<int32_t>();
+      for (size_t i = 0; i != n; ++i) {
+        dst[i] = src[i];
       }
       return ans;
     }
@@ -87,12 +77,11 @@ static Ort::Value CastIntTensor(Ort::Value tensor,
       SHERPA_ONNX_LOGE("Expected int32 or int64 target tensor. Given %d",
                        static_cast<int32_t>(target_type));
       SHERPA_ONNX_EXIT(-1);
-      return Ort::Value{nullptr};
+      return Ort::Value{nullptr};  // unreachable
   }
 }
 
-static void ValidateIntTensorType(ONNXTensorElementDataType type,
-                                  const char *name) {
+void ValidateIntTensorType(ONNXTensorElementDataType type, const char *name) {
   if (type != ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32 &&
       type != ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) {
     SHERPA_ONNX_LOGE("%s should be int32 or int64. Given %d", name,

--- a/sherpa-onnx/csrc/qnn/online-recognizer-zipformer-transducer-qnn-impl.h
+++ b/sherpa-onnx/csrc/qnn/online-recognizer-zipformer-transducer-qnn-impl.h
@@ -22,6 +22,7 @@
 #include "sherpa-onnx/csrc/online-stream.h"
 #include "sherpa-onnx/csrc/qnn/online-zipformer-transducer-model-qnn.h"
 #include "sherpa-onnx/csrc/symbol-table.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 
 namespace sherpa_onnx {
 
@@ -82,6 +83,8 @@ inline OnlineRecognizerResult ConvertQnnResult(
   if (sym_table.IsByteBpe()) {
     text = sym_table.DecodeByteBpe(text);
   }
+
+  text = RemoveSpaceBetweenCjk(text);
 
   r.text = std::move(text);
 

--- a/sherpa-onnx/csrc/qnn/online-zipformer-transducer-model-qnn.cc
+++ b/sherpa-onnx/csrc/qnn/online-zipformer-transducer-model-qnn.cc
@@ -113,25 +113,10 @@ class OnlineZipformerTransducerModelQnn::Impl {
     encoder_->SetInputTensorData(encoder_input_name_, features.data(),
                                 features.size());
 
-    for (size_t i = 0; i != state_input_names_.size(); ++i) {
-      const auto &name = state_input_names_[i];
-      if (!(*states)[i].int32_data.empty()) {
-        const auto *p = (*states)[i].int32_data.data();
-        int32_t n = static_cast<int32_t>((*states)[i].int32_data.size());
-        encoder_->SetInputTensorData(name, p, n);
-      } else {
-        const auto *p = (*states)[i].float_data.data();
-        int32_t n = static_cast<int32_t>((*states)[i].float_data.size());
-        if (state_needs_transpose_[i]) {
-          const auto &shape = state_storage_shapes_[i];
-          auto transposed =
-              Transpose0123To0231(p, shape[0], shape[1], shape[2], shape[3]);
-          encoder_->SetInputTensorData(name, transposed.data(),
-                                       static_cast<int32_t>(transposed.size()));
-        } else {
-          encoder_->SetInputTensorData(name, p, n);
-        }
-      }
+    if (has_processed_lens_) {
+      RunEncoderV2(states);
+    } else {
+      RunEncoderV1(states);
     }
 
     encoder_->Run();
@@ -181,6 +166,46 @@ class OnlineZipformerTransducerModelQnn::Impl {
   int32_t EncoderDim() const { return encoder_out_dim_; }
 
  private:
+  // Set encoder state inputs for V1 model (cached_* states, some need transpose)
+  void RunEncoderV1(std::vector<OnlineStreamStateTensor> *states) const {
+    for (size_t i = 0; i != state_input_names_.size(); ++i) {
+      const auto &name = state_input_names_[i];
+      if (!(*states)[i].int32_data.empty()) {
+        const auto *p = (*states)[i].int32_data.data();
+        int32_t n = static_cast<int32_t>((*states)[i].int32_data.size());
+        encoder_->SetInputTensorData(name, p, n);
+      } else {
+        const auto *p = (*states)[i].float_data.data();
+        int32_t n = static_cast<int32_t>((*states)[i].float_data.size());
+        if (state_needs_transpose_[i]) {
+          const auto &shape = state_storage_shapes_[i];
+          auto transposed =
+              Transpose0123To0231(p, shape[0], shape[1], shape[2], shape[3]);
+          encoder_->SetInputTensorData(name, transposed.data(),
+                                       static_cast<int32_t>(transposed.size()));
+        } else {
+          encoder_->SetInputTensorData(name, p, n);
+        }
+      }
+    }
+  }
+
+  // Set encoder state inputs for V2 model (processed_lens, no transpose)
+  void RunEncoderV2(std::vector<OnlineStreamStateTensor> *states) const {
+    for (size_t i = 0; i != state_input_names_.size(); ++i) {
+      const auto &name = state_input_names_[i];
+      if (!(*states)[i].int32_data.empty()) {
+        const auto *p = (*states)[i].int32_data.data();
+        int32_t n = static_cast<int32_t>((*states)[i].int32_data.size());
+        encoder_->SetInputTensorData(name, p, n);
+      } else {
+        const auto *p = (*states)[i].float_data.data();
+        int32_t n = static_cast<int32_t>((*states)[i].float_data.size());
+        encoder_->SetInputTensorData(name, p, n);
+      }
+    }
+  }
+
   void Init() {
    ParseContextBinaries();
    encoder_backend_ = std::make_unique<QnnBackend>(
@@ -311,11 +336,17 @@ class OnlineZipformerTransducerModelQnn::Impl {
       SHERPA_ONNX_EXIT(-1);
     }
 
+    has_processed_lens_ = encoder_->HasTensor("processed_lens");
+
     encoder_input_name_.clear();
     for (const auto &name : encoder_->InputTensorNames()) {
       if (name == "x") {
         encoder_input_name_ = name;
+      } else if (has_processed_lens_) {
+        // V2: all non-"x" inputs are streaming states
+        state_input_names_.push_back(name);
       } else if (name.rfind("cached_", 0) == 0) {
+        // V1: only "cached_*" inputs are streaming states
         state_input_names_.push_back(name);
       }
     }
@@ -368,8 +399,14 @@ class OnlineZipformerTransducerModelQnn::Impl {
       auto output_shape = encoder_->TensorShape(new_name);
       state_storage_shapes_.emplace_back(output_shape.begin(),
                                          output_shape.end());
-      state_is_int32_.push_back(name.rfind("cached_len_", 0) == 0);
-      state_needs_transpose_.push_back(NeedsCacheTranspose(name));
+
+      if (has_processed_lens_) {
+        state_is_int32_.push_back(name == "processed_lens");
+        state_needs_transpose_.push_back(false);
+      } else {
+        state_is_int32_.push_back(name.rfind("cached_len_", 0) == 0);
+        state_needs_transpose_.push_back(NeedsCacheTranspose(name));
+      }
     }
   }
 
@@ -490,6 +527,8 @@ class OnlineZipformerTransducerModelQnn::Impl {
   std::vector<std::vector<int64_t>> state_storage_shapes_;
   std::vector<bool> state_is_int32_;
   std::vector<bool> state_needs_transpose_;
+
+  bool has_processed_lens_ = false;
 
   int32_t chunk_size_ = 0;
   int32_t chunk_shift_ = 0;

--- a/sherpa-onnx/csrc/text-utils.cc
+++ b/sherpa-onnx/csrc/text-utils.cc
@@ -1057,6 +1057,28 @@ bool ContainsCJK(const std::u32string &text) {
   return false;
 }
 
+std::string RemoveSpaceBetweenCjk(const std::string &text) {
+  std::u32string u32 = Utf8ToUtf32(text);
+  if (u32.size() < 3) {
+    return text;
+  }
+
+  std::u32string ans;
+  ans.reserve(u32.size());
+  ans.push_back(u32[0]);
+
+  for (size_t i = 1; i + 1 < u32.size(); ++i) {
+    if (u32[i] == U' ' && IsCJK(u32[i - 1]) && IsCJK(u32[i + 1])) {
+      continue;
+    }
+
+    ans.push_back(u32[i]);
+  }
+
+  ans.push_back(u32.back());
+  return Utf32ToUtf8(ans);
+}
+
 std::string GetWord(const std::vector<std::string> &words, int32_t start,
                     int32_t end) {
   std::string ans;

--- a/sherpa-onnx/csrc/text-utils.h
+++ b/sherpa-onnx/csrc/text-utils.h
@@ -188,6 +188,8 @@ bool ContainsCJK(const std::string &text);
 
 bool ContainsCJK(const std::u32string &text);
 
+std::string RemoveSpaceBetweenCjk(const std::string &text);
+
 bool StringToBool(const std::string &s);
 
 // end is inclusive


### PR DESCRIPTION
Now both
[pruned_transducer_stateless7_streaming](https://github.com/k2-fsa/icefall/tree/master/egs/librispeech/ASR/pruned_transducer_stateless7_streaming) (zipformer v1)
and
[zipformer](https://github.com/k2-fsa/icefall/tree/master/egs/librispeech/ASR/zipformer) (zipformer v2)
are supported on Qualcomm NPU with QNN.

## TODOs
- [ ] Add CI to upload converted QNN models
- [ ] Add Android demo

<img width="2892" height="1508" alt="Screenshot 2026-06-04 at 18 50 56" src="https://github.com/user-attachments/assets/9c12feca-27d5-4abf-bcec-9700647e5dee" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file validation to accept broader path types beyond files
  * Added CJK text processing to remove spaces between Chinese, Japanese, and Korean characters

* **New Features**
  * Enhanced encoder support to handle multiple model configurations with optimized state management

* **Refactor**
  * Reorganized text utility functions for improved code modularity
  * Streamlined tensor casting logic for better performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->