### PR TITLE
Add C++ runtime for Parakeet CTC with QNN.

### DIFF
--- a/sherpa-onnx/csrc/CMakeLists.txt
+++ b/sherpa-onnx/csrc/CMakeLists.txt
@@ -256,6 +256,7 @@ endif()
 
 if(SHERPA_ONNX_ENABLE_QNN)
   list(APPEND sources
+    ./qnn/offline-parakeet-ctc-model-qnn.cc
     ./qnn/offline-sense-voice-model-qnn.cc
     ./qnn/offline-paraformer-model-qnn.cc
     ./qnn/offline-zipformer-transducer-model-qnn.cc

--- a/sherpa-onnx/csrc/offline-nemo-enc-dec-ctc-model-config.cc
+++ b/sherpa-onnx/csrc/offline-nemo-enc-dec-ctc-model-config.cc
@@ -8,18 +8,46 @@
 
 #include "sherpa-onnx/csrc/file-utils.h"
 #include "sherpa-onnx/csrc/macros.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 
 namespace sherpa_onnx {
 
 void OfflineNemoEncDecCtcModelConfig::Register(ParseOptions *po) {
   po->Register("nemo-ctc-model", &model,
                "Path to model.onnx of Nemo EncDecCtcModel.");
+
+  std::string prefix = "nemo-ctc";
+  ParseOptions p(prefix, po);
+
+  qnn_config.Register(&p);
 }
 
 bool OfflineNemoEncDecCtcModelConfig::Validate() const {
-  if (!FileExists(model)) {
-    SHERPA_ONNX_LOGE("NeMo model: '%s' does not exist", model.c_str());
-    return false;
+  if (qnn_config.context_binary.empty()) {
+    if (model.empty()) {
+      SHERPA_ONNX_LOGE("Please provide a NeMo CTC model");
+      return false;
+    }
+
+    if (!FileExists(model)) {
+      SHERPA_ONNX_LOGE("NeMo model: '%s' does not exist", model.c_str());
+      return false;
+    }
+  }
+
+  if (model.empty() && !qnn_config.context_binary.empty()) {
+    // we require that the context_binary exists
+    if (!FileExists(qnn_config.context_binary)) {
+      SHERPA_ONNX_LOGE(
+          "Model is empty, but you provide a context binary that does not "
+          "exist");
+      return false;
+    }
+  }
+
+  if (EndsWith(model, ".so") || EndsWith(model, ".bin") ||
+      (model.empty() && !qnn_config.context_binary.empty())) {
+    return qnn_config.Validate();
   }
 
   return true;
@@ -29,7 +57,13 @@ std::string OfflineNemoEncDecCtcModelConfig::ToString() const {
   std::ostringstream os;
 
   os << "OfflineNemoEncDecCtcModelConfig(";
-  os << "model=\"" << model << "\")";
+  os << "model=\"" << model << "\"";
+
+  if (!qnn_config.backend_lib.empty()) {
+    os << ", qnn_config=" << qnn_config.ToString() << ", ";
+  }
+
+  os << ")";
 
   return os.str();
 }

--- a/sherpa-onnx/csrc/offline-nemo-enc-dec-ctc-model-config.cc
+++ b/sherpa-onnx/csrc/offline-nemo-enc-dec-ctc-model-config.cc
@@ -13,8 +13,10 @@
 namespace sherpa_onnx {
 
 void OfflineNemoEncDecCtcModelConfig::Register(ParseOptions *po) {
-  po->Register("nemo-ctc-model", &model,
-               "Path to model.onnx of Nemo EncDecCtcModel.");
+  po->Register(
+      "nemo-ctc-model", &model,
+      "Path to NeMo CTC model. For qnn, use compiled model library "
+      "(e.g. libmodel.so). For onnxruntime, use model.onnx.");
 
   std::string prefix = "nemo-ctc";
   ParseOptions p(prefix, po);

--- a/sherpa-onnx/csrc/offline-nemo-enc-dec-ctc-model-config.h
+++ b/sherpa-onnx/csrc/offline-nemo-enc-dec-ctc-model-config.h
@@ -7,11 +7,13 @@
 #include <string>
 
 #include "sherpa-onnx/csrc/parse-options.h"
+#include "sherpa-onnx/csrc/qnn-config.h"
 
 namespace sherpa_onnx {
 
 struct OfflineNemoEncDecCtcModelConfig {
   std::string model;
+  QnnConfig qnn_config;
 
   OfflineNemoEncDecCtcModelConfig() = default;
   explicit OfflineNemoEncDecCtcModelConfig(const std::string &model)

--- a/sherpa-onnx/csrc/offline-recognizer-impl.cc
+++ b/sherpa-onnx/csrc/offline-recognizer-impl.cc
@@ -67,6 +67,7 @@
 
 #if SHERPA_ONNX_ENABLE_QNN
 #include "sherpa-onnx/csrc/qnn/offline-paraformer-model-qnn.h"
+#include "sherpa-onnx/csrc/qnn/offline-recognizer-parakeet-ctc-qnn-impl.h"
 #include "sherpa-onnx/csrc/qnn/offline-recognizer-transducer-qnn-impl.h"
 #include "sherpa-onnx/csrc/qnn/offline-recognizer-zipformer-ctc-qnn-impl.h"
 #include "sherpa-onnx/csrc/qnn/offline-sense-voice-model-qnn.h"
@@ -201,10 +202,15 @@ std::unique_ptr<OfflineRecognizerImpl> OfflineRecognizerImpl::Create(
       return std::make_unique<
           OfflineRecognizerParaformerTplImpl<OfflineParaformerModelQnn>>(
           config);
+    } else if (!config.model_config.nemo_ctc.model.empty() ||
+               !config.model_config.nemo_ctc.qnn_config.context_binary
+                    .empty()) {
+      return std::make_unique<OfflineRecognizerParakeetCtcQnnImpl>(config);
     } else {
       SHERPA_ONNX_LOGE(
-          "Only SenseVoice, Paraformer, offline transducer, and Zipformer CTC "
-          "models are currently supported by QNN for non-streaming ASR.");
+          "Only SenseVoice, Paraformer, offline transducer, Zipformer CTC, "
+          "and NeMo CTC (Parakeet) models are currently supported by QNN "
+          "for non-streaming ASR.");
       SHERPA_ONNX_EXIT(-1);
       return nullptr;
     }
@@ -557,10 +563,15 @@ std::unique_ptr<OfflineRecognizerImpl> OfflineRecognizerImpl::Create(
       return std::make_unique<
           OfflineRecognizerParaformerTplImpl<OfflineParaformerModelQnn>>(
           mgr, config);
+    } else if (!config.model_config.nemo_ctc.model.empty() ||
+               !config.model_config.nemo_ctc.qnn_config.context_binary
+                    .empty()) {
+      return std::make_unique<OfflineRecognizerParakeetCtcQnnImpl>(mgr, config);
     } else {
       SHERPA_ONNX_LOGE(
-          "Only SenseVoice, Paraformer, offline transducer, and Zipformer CTC "
-          "models are currently supported by QNN for non-streaming ASR.");
+          "Only SenseVoice, Paraformer, offline transducer, Zipformer CTC, "
+          "and NeMo CTC (Parakeet) models are currently supported by QNN "
+          "for non-streaming ASR.");
       SHERPA_ONNX_EXIT(-1);
       return nullptr;
     }

--- a/sherpa-onnx/csrc/qnn/offline-parakeet-ctc-model-qnn.cc
+++ b/sherpa-onnx/csrc/qnn/offline-parakeet-ctc-model-qnn.cc
@@ -190,12 +190,31 @@ class OfflineParakeetCtcModelQnn::Impl {
     max_num_frames_ = x_shape[1];
     feat_dim_ = x_shape[2];
 
+    if (max_num_frames_ <= 0 || feat_dim_ <= 0) {
+      SHERPA_ONNX_LOGE(
+          "Invalid input shape: max_num_frames=%d, feat_dim=%d",
+          max_num_frames_, feat_dim_);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
     if (!model_->HasTensor("log_probs")) {
       SHERPA_ONNX_LOGE("Model does not have output node 'log_probs'");
       SHERPA_ONNX_EXIT(-1);
     }
 
     auto out_shape = model_->TensorShape("log_probs");
+    if (out_shape.size() != 3) {
+      SHERPA_ONNX_LOGE("The output log_probs should be 3-d, actual '%d'",
+                       static_cast<int32_t>(out_shape.size()));
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    if (out_shape[1] <= 0 || out_shape[2] <= 0) {
+      SHERPA_ONNX_LOGE("Invalid log_probs shape: [%d, %d, %d]", out_shape[0],
+                       out_shape[1], out_shape[2]);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
     vocab_size_ = out_shape[2];
 
     subsampling_factor_ = max_num_frames_ / out_shape[1];

--- a/sherpa-onnx/csrc/qnn/offline-parakeet-ctc-model-qnn.cc
+++ b/sherpa-onnx/csrc/qnn/offline-parakeet-ctc-model-qnn.cc
@@ -1,0 +1,262 @@
+// sherpa-onnx/csrc/qnn/offline-parakeet-ctc-model-qnn.cc
+//
+// Copyright (c)  2026  Xiaomi Corporation
+
+#include "sherpa-onnx/csrc/qnn/offline-parakeet-ctc-model-qnn.h"
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <mutex>  // NOLINT
+#include <string>
+#include <utility>
+#include <vector>
+
+#if __ANDROID_API__ >= 9
+#include "android/asset_manager.h"
+#include "android/asset_manager_jni.h"
+#endif
+
+#if __OHOS__
+#include "rawfile/raw_file_manager.h"
+#endif
+
+#include "sherpa-onnx/csrc/file-utils.h"
+#include "sherpa-onnx/csrc/qnn/macros.h"
+#include "sherpa-onnx/csrc/qnn/qnn-backend.h"
+#include "sherpa-onnx/csrc/qnn/qnn-model.h"
+
+namespace sherpa_onnx {
+
+class OfflineParakeetCtcModelQnn::Impl {
+ public:
+  explicit Impl(const OfflineModelConfig &config) : config_(config) {
+    backend_ = std::make_unique<QnnBackend>(
+        config.nemo_ctc.qnn_config.backend_lib, config_.debug);
+
+    const auto &context_binary =
+        config_.nemo_ctc.qnn_config.context_binary;
+
+    if (context_binary.empty()) {
+      if (config_.debug) {
+        SHERPA_ONNX_LOGE(
+            "Init from model lib since context binary is not given");
+      }
+
+      InitFromModelLib();
+
+      if (config_.debug) {
+        SHERPA_ONNX_LOGE(
+            "Skip generating context binary since you don't provide a path to "
+            "save it");
+      }
+    } else if (!FileExists(context_binary)) {
+      if (config_.debug) {
+        SHERPA_ONNX_LOGE(
+            "Init from model lib since context binary '%s' does not exist",
+            context_binary.c_str());
+      }
+
+      InitFromModelLib();
+
+      CreateContextBinary();
+    } else {
+      if (config_.debug) {
+        SHERPA_ONNX_LOGE("Init from context binary '%s'",
+                         context_binary.c_str());
+      }
+      InitFromContextBinary();
+    }
+
+    PostInit();
+  }
+
+  template <typename Manager>
+  Impl(Manager *mgr, const OfflineModelConfig &config) : config_(config) {
+    SHERPA_ONNX_LOGE(
+        "Please copy all files from assets to SD card and set assetManager to "
+        "null");
+    SHERPA_ONNX_EXIT(-1);
+  }
+
+  std::vector<float> Run(std::vector<float> features) {
+    int32_t num_frames = features.size() / feat_dim_;
+
+    if (num_frames != max_num_frames_) {
+      if (num_frames > max_num_frames_) {
+        SHERPA_ONNX_LOGE(
+            "Number of input frames %d is too large. Truncate it to %d frames.",
+            num_frames, max_num_frames_);
+
+        SHERPA_ONNX_LOGE(
+            "Recognition result may be truncated/incomplete. Please select a "
+            "model accepting longer audios.");
+      }
+
+      features.resize(max_num_frames_ * feat_dim_);
+
+      num_frames = max_num_frames_;
+    }
+
+    // Note: The QNN model expects input shape [1, max_num_frames, feat_dim],
+    // i.e., features in row-major order (num_frames, feat_dim), same layout
+    // as Zipformer CTC. No transpose is needed here.
+    //
+    // In contrast, the ONNX model for parakeet CTC expects input shape
+    // [1, feat_dim, max_num_frames], i.e., the features need to be
+    // transposed to (feat_dim, num_frames) before feeding to the ONNX model.
+
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    model_->SetInputTensorData("x", features.data(), features.size());
+
+    model_->Run();
+
+    return model_->GetOutputTensorData("log_probs");
+  }
+
+  int32_t VocabSize() const { return vocab_size_; }
+  int32_t SubsamplingFactor() const { return subsampling_factor_; }
+  int32_t FeatDim() const { return feat_dim_; }
+
+ private:
+  void InitFromModelLib() {
+    backend_->InitContext();
+
+    model_ = std::make_unique<QnnModel>(config_.nemo_ctc.model,
+                                        backend_.get(), config_.debug);
+  }
+
+  void InitFromContextBinary() {
+    model_ = std::make_unique<QnnModel>(
+        config_.nemo_ctc.qnn_config.context_binary,
+        config_.nemo_ctc.qnn_config.system_lib, backend_.get(),
+        BinaryContextTag{}, config_.debug);
+  }
+
+  void CreateContextBinary() {
+    const auto &context_binary =
+        config_.nemo_ctc.qnn_config.context_binary;
+
+    if (config_.debug) {
+      SHERPA_ONNX_LOGE("Creating context binary '%s'.", context_binary.c_str());
+    }
+
+    bool ok = model_->SaveBinaryContext(context_binary);
+
+    if (!ok) {
+      SHERPA_ONNX_LOGE("Failed to save context binary to '%s'",
+                       context_binary.c_str());
+    }
+
+    if (config_.debug && ok) {
+      SHERPA_ONNX_LOGE("Saved context binary to '%s'.", context_binary.c_str());
+      SHERPA_ONNX_LOGE(
+          "It should be super fast the next time you init the system.");
+      SHERPA_ONNX_LOGE("Remember to also provide libQnnSystem.so.");
+    }
+  }
+
+  void PostInit() { CheckModel(); }
+
+  void CheckModel() {
+    const auto &input_tensor_names = model_->InputTensorNames();
+    if (input_tensor_names.size() != 1) {
+      SHERPA_ONNX_LOGE("Expect 1 input tensor. Actual %d",
+                       static_cast<int32_t>(input_tensor_names.size()));
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    if (input_tensor_names[0] != "x") {
+      SHERPA_ONNX_LOGE("The 1st input should be x, actual '%s'",
+                       input_tensor_names[0].c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    std::vector<int32_t> x_shape = model_->TensorShape(input_tensor_names[0]);
+    if (x_shape.size() != 3) {
+      SHERPA_ONNX_LOGE("The 1st input should be 3-d, actual '%d'",
+                       static_cast<int32_t>(x_shape.size()));
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    if (x_shape[0] != 1) {
+      SHERPA_ONNX_LOGE("The x.shape[0] should be 1, actual '%d'", x_shape[0]);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    // QNN Parakeet CTC input shape: [1, max_num_frames, feat_dim=80]
+    // (Note: the ONNX model uses [1, feat_dim, max_num_frames] instead)
+    max_num_frames_ = x_shape[1];
+    feat_dim_ = x_shape[2];
+
+    if (!model_->HasTensor("log_probs")) {
+      SHERPA_ONNX_LOGE("Model does not have output node 'log_probs'");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    auto out_shape = model_->TensorShape("log_probs");
+    vocab_size_ = out_shape[2];
+
+    subsampling_factor_ = max_num_frames_ / out_shape[1];
+    if (config_.debug) {
+      SHERPA_ONNX_LOGE("max_num_frames: %d", max_num_frames_);
+      SHERPA_ONNX_LOGE("feat_dim: %d", feat_dim_);
+      SHERPA_ONNX_LOGE("vocab_size: %d", vocab_size_);
+      SHERPA_ONNX_LOGE("subsampling_factor: %d", subsampling_factor_);
+    }
+  }
+
+ private:
+  std::mutex mutex_;
+
+  OfflineModelConfig config_;
+
+  std::unique_ptr<QnnBackend> backend_;
+  std::unique_ptr<QnnModel> model_;
+
+  int32_t max_num_frames_ = 0;
+  int32_t feat_dim_ = 0;
+  int32_t vocab_size_ = 0;
+  int32_t subsampling_factor_ = 1;
+};
+
+OfflineParakeetCtcModelQnn::OfflineParakeetCtcModelQnn(
+    const OfflineModelConfig &config)
+    : impl_(std::make_unique<Impl>(config)) {}
+
+template <typename Manager>
+OfflineParakeetCtcModelQnn::OfflineParakeetCtcModelQnn(
+    Manager *mgr, const OfflineModelConfig &config)
+    : impl_(std::make_unique<Impl>(mgr, config)) {}
+
+OfflineParakeetCtcModelQnn::~OfflineParakeetCtcModelQnn() = default;
+
+std::vector<float> OfflineParakeetCtcModelQnn::Run(
+    std::vector<float> features) const {
+  return impl_->Run(std::move(features));
+}
+
+int32_t OfflineParakeetCtcModelQnn::VocabSize() const {
+  return impl_->VocabSize();
+}
+
+int32_t OfflineParakeetCtcModelQnn::SubsamplingFactor() const {
+  return impl_->SubsamplingFactor();
+}
+
+int32_t OfflineParakeetCtcModelQnn::FeatDim() const {
+  return impl_->FeatDim();
+}
+
+#if __ANDROID_API__ >= 9
+template OfflineParakeetCtcModelQnn::OfflineParakeetCtcModelQnn(
+    AAssetManager *mgr, const OfflineModelConfig &config);
+#endif
+
+#if __OHOS__
+template OfflineParakeetCtcModelQnn::OfflineParakeetCtcModelQnn(
+    NativeResourceManager *mgr, const OfflineModelConfig &config);
+#endif
+
+}  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/qnn/offline-parakeet-ctc-model-qnn.h
+++ b/sherpa-onnx/csrc/qnn/offline-parakeet-ctc-model-qnn.h
@@ -1,0 +1,41 @@
+// sherpa-onnx/csrc/qnn/offline-parakeet-ctc-model-qnn.h
+//
+// Copyright (c)  2026  Xiaomi Corporation
+#ifndef SHERPA_ONNX_CSRC_QNN_OFFLINE_PARAKEET_CTC_MODEL_QNN_H_
+#define SHERPA_ONNX_CSRC_QNN_OFFLINE_PARAKEET_CTC_MODEL_QNN_H_
+
+#include <memory>
+#include <vector>
+
+#include "sherpa-onnx/csrc/offline-model-config.h"
+
+namespace sherpa_onnx {
+
+class OfflineParakeetCtcModelQnn {
+ public:
+  ~OfflineParakeetCtcModelQnn();
+
+  explicit OfflineParakeetCtcModelQnn(const OfflineModelConfig &config);
+
+  template <typename Manager>
+  OfflineParakeetCtcModelQnn(Manager *mgr, const OfflineModelConfig &config);
+
+  /**
+   * @param features A tensor of shape (num_frames, feature_dim)
+   *                 with feature_dim=80, already mean-variance normalized.
+   * @returns Return a tensor of shape (num_output_frames, vocab_size)
+   */
+  std::vector<float> Run(std::vector<float> features) const;
+
+  int32_t VocabSize() const;
+  int32_t SubsamplingFactor() const;
+  int32_t FeatDim() const;
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace sherpa_onnx
+
+#endif  // SHERPA_ONNX_CSRC_QNN_OFFLINE_PARAKEET_CTC_MODEL_QNN_H_

--- a/sherpa-onnx/csrc/qnn/offline-recognizer-parakeet-ctc-qnn-impl.h
+++ b/sherpa-onnx/csrc/qnn/offline-recognizer-parakeet-ctc-qnn-impl.h
@@ -1,0 +1,142 @@
+// sherpa-onnx/csrc/qnn/offline-recognizer-parakeet-ctc-qnn-impl.h
+//
+// Copyright (c)  2026  Xiaomi Corporation
+
+#ifndef SHERPA_ONNX_CSRC_QNN_OFFLINE_RECOGNIZER_PARAKEET_CTC_QNN_IMPL_H_
+#define SHERPA_ONNX_CSRC_QNN_OFFLINE_RECOGNIZER_PARAKEET_CTC_QNN_IMPL_H_
+
+#include <ios>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "sherpa-onnx/csrc/macros.h"
+#include "sherpa-onnx/csrc/math.h"
+#include "sherpa-onnx/csrc/offline-model-config.h"
+#include "sherpa-onnx/csrc/offline-recognizer-impl.h"
+#include "sherpa-onnx/csrc/offline-recognizer.h"
+#include "sherpa-onnx/csrc/qnn/offline-parakeet-ctc-model-qnn.h"
+#include "sherpa-onnx/csrc/rknn/offline-ctc-greedy-search-decoder-rknn.h"
+#include "sherpa-onnx/csrc/symbol-table.h"
+
+namespace sherpa_onnx {
+
+// defined in ../offline-recognizer-ctc-impl.h
+OfflineRecognitionResult Convert(const OfflineCtcDecoderResult &src,
+                                 const SymbolTable &sym_table,
+                                 int32_t frame_shift_ms,
+                                 int32_t subsampling_factor);
+
+class OfflineRecognizerParakeetCtcQnnImpl : public OfflineRecognizerImpl {
+ public:
+  explicit OfflineRecognizerParakeetCtcQnnImpl(
+      const OfflineRecognizerConfig &config)
+      : OfflineRecognizerImpl(config),
+        config_(config),
+        symbol_table_(config_.model_config.tokens),
+        model_(std::make_unique<OfflineParakeetCtcModelQnn>(
+            config.model_config)) {
+    Init();
+  }
+
+  template <typename Manager>
+  OfflineRecognizerParakeetCtcQnnImpl(Manager *mgr,
+                                      const OfflineRecognizerConfig &config)
+      : OfflineRecognizerImpl(mgr, config),
+        config_(config),
+        symbol_table_(mgr, config_.model_config.tokens),
+        model_(std::make_unique<OfflineParakeetCtcModelQnn>(
+            mgr, config.model_config)) {
+    Init();
+  }
+
+  void Init() {
+    // Parakeet CTC uses the same librosa-compatible fbank features as
+    // NeMo CTC (non-GigaAM). See also scripts/nemo/qnn/parakeet-ctc/test_onnx.py
+    config_.feat_config.low_freq = 0;
+    config_.feat_config.high_freq = 0;
+    config_.feat_config.is_librosa = true;
+    config_.feat_config.remove_dc_offset = false;
+    config_.feat_config.window_type = "hann";
+    config_.feat_config.feature_dim = model_->FeatDim();
+
+    if (config_.decoding_method == "greedy_search") {
+      if (!symbol_table_.Contains("<blk>") &&
+          !symbol_table_.Contains("<eps>") &&
+          !symbol_table_.Contains("<blank>") &&
+          config_.model_config.omnilingual.model.empty()) {
+        // for omnilingual asr, its blank id is 0
+        SHERPA_ONNX_LOGE(
+            "We expect that tokens.txt contains "
+            "the symbol <blk> or <eps> or <blank> and its ID.");
+        SHERPA_ONNX_EXIT(-1);
+      }
+
+      int32_t blank_id = 0;
+      if (symbol_table_.Contains("<blk>")) {
+        blank_id = symbol_table_["<blk>"];
+      } else if (symbol_table_.Contains("<eps>")) {
+        // for tdnn models of the yesno recipe from icefall
+        blank_id = symbol_table_["<eps>"];
+      } else if (symbol_table_.Contains("<blank>")) {
+        // for Wenet CTC models
+        blank_id = symbol_table_["<blank>"];
+      }
+
+      decoder_ = std::make_unique<OfflineCtcGreedySearchDecoderRknn>(blank_id);
+    } else {
+      SHERPA_ONNX_LOGE("Only greedy_search is supported at present. Given %s",
+                       config_.decoding_method.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+  }
+
+  std::unique_ptr<OfflineStream> CreateStream() const override {
+    return std::make_unique<OfflineStream>(config_.feat_config);
+  }
+
+  void DecodeStreams(OfflineStream **ss, int32_t n) const override {
+    for (int32_t i = 0; i != n; ++i) {
+      DecodeStream(ss[i]);
+    }
+  }
+
+  OfflineRecognizerConfig GetConfig() const override { return config_; }
+
+ private:
+  // Decode a single stream.
+  void DecodeStream(OfflineStream *s) const {
+    std::vector<float> f = s->GetFrames();
+
+    int32_t feat_dim = config_.feat_config.feature_dim;
+    NemoNormalizePerFeature(f.data(), f.size() / feat_dim, feat_dim);
+
+    int32_t vocab_size = model_->VocabSize();
+
+    std::vector<float> log_probs = model_->Run(std::move(f));
+    int32_t num_out_frames = log_probs.size() / vocab_size;
+
+    auto result =
+        decoder_->Decode(log_probs.data(), num_out_frames, vocab_size);
+
+    int32_t frame_shift_ms = 10;
+
+    auto r = Convert(result, symbol_table_, frame_shift_ms,
+                     model_->SubsamplingFactor());
+    r.text = ApplyInverseTextNormalization(std::move(r.text));
+    r.text = ApplyHomophoneReplacer(std::move(r.text));
+    s->SetResult(r);
+  }
+
+ private:
+  OfflineRecognizerConfig config_;
+  SymbolTable symbol_table_;
+  std::unique_ptr<OfflineParakeetCtcModelQnn> model_;
+  std::unique_ptr<OfflineCtcGreedySearchDecoderRknn> decoder_;
+};
+
+}  // namespace sherpa_onnx
+
+#endif  // SHERPA_ONNX_CSRC_QNN_OFFLINE_RECOGNIZER_PARAKEET_CTC_QNN_IMPL_H_

--- a/sherpa-onnx/csrc/qnn/offline-recognizer-parakeet-ctc-qnn-impl.h
+++ b/sherpa-onnx/csrc/qnn/offline-recognizer-parakeet-ctc-qnn-impl.h
@@ -34,8 +34,7 @@ class OfflineRecognizerParakeetCtcQnnImpl : public OfflineRecognizerImpl {
   explicit OfflineRecognizerParakeetCtcQnnImpl(
       const OfflineRecognizerConfig &config)
       : OfflineRecognizerImpl(config),
-        config_(config),
-        symbol_table_(config_.model_config.tokens),
+        symbol_table_(config.model_config.tokens),
         model_(std::make_unique<OfflineParakeetCtcModelQnn>(
             config.model_config)) {
     Init();
@@ -45,8 +44,7 @@ class OfflineRecognizerParakeetCtcQnnImpl : public OfflineRecognizerImpl {
   OfflineRecognizerParakeetCtcQnnImpl(Manager *mgr,
                                       const OfflineRecognizerConfig &config)
       : OfflineRecognizerImpl(mgr, config),
-        config_(config),
-        symbol_table_(mgr, config_.model_config.tokens),
+        symbol_table_(mgr, config.model_config.tokens),
         model_(std::make_unique<OfflineParakeetCtcModelQnn>(
             mgr, config.model_config)) {
     Init();
@@ -103,7 +101,9 @@ class OfflineRecognizerParakeetCtcQnnImpl : public OfflineRecognizerImpl {
     }
   }
 
-  OfflineRecognizerConfig GetConfig() const override { return config_; }
+  OfflineRecognizerConfig GetConfig() const override {
+    return OfflineRecognizerImpl::config_;
+  }
 
  private:
   // Decode a single stream.
@@ -131,7 +131,6 @@ class OfflineRecognizerParakeetCtcQnnImpl : public OfflineRecognizerImpl {
   }
 
  private:
-  OfflineRecognizerConfig config_;
   SymbolTable symbol_table_;
   std::unique_ptr<OfflineParakeetCtcModelQnn> model_;
   std::unique_ptr<OfflineCtcGreedySearchDecoderRknn> decoder_;

--- a/sherpa-onnx/csrc/rknn/offline-ctc-greedy-search-decoder-rknn.cc
+++ b/sherpa-onnx/csrc/rknn/offline-ctc-greedy-search-decoder-rknn.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/macros.h"
+#include "sherpa-onnx/csrc/math.h"
 
 namespace sherpa_onnx {
 
@@ -19,10 +20,8 @@ OfflineCtcDecoderResult OfflineCtcGreedySearchDecoderRknn::Decode(
   int64_t prev_id = -1;
 
   for (int32_t t = 0; t != num_frames; ++t) {
-    auto y = static_cast<int64_t>(std::distance(
-        static_cast<const float *>(logits),
-        std::max_element(static_cast<const float *>(logits),
-                         static_cast<const float *>(logits) + vocab_size)));
+    int64_t y = MaxElementIndex(logits, vocab_size);
+
     logits += vocab_size;
 
     if (y != blank_id_ && y != prev_id) {


### PR DESCRIPTION
See https://k2-fsa.github.io/sherpa/onnx/qnn/run-executables-on-your-phone-binary.html
for how to run it.

Usage:
```
./sherpa-onnx-offline \
  --provider=qnn \
  --nemo-ctc-model=./libmodel.so \
  --nemo-ctc.qnn-backend-lib=./libQnnHtp.so \
  --nemo-ctc.qnn-context-binary=./model.bin \
  --nemo-ctc.qnn-system-lib=./libQnnSystem.so \
  --debug=1 \
  --tokens=./tokens.txt \
  ./0.wav
```

Logs:

```
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/parse-options.cc:Read:373 ./sherpa-onnx-offline --provider=qnn --nemo-ctc-model=./libmodel.so --nemo-ctc.qnn-backend-lib=.
/libQnnHtp.so --nemo-ctc.qnn-context-binary=./model.bin --nemo-ctc.qnn-system-lib=./libQnnSystem.so --debug=1 --tokens=./tokens.txt ./0.wav

OfflineRecognizerConfig(feat_config=FeatureExtractorConfig(sampling_rate=16000, feature_dim=80, low_freq=20, high_freq=-400, dither=0, normalize_samples=True, snip_edges=False),
model_config=OfflineModelConfig(transducer=OfflineTransducerModelConfig(encoder_filename="", decoder_filename="", joiner_filename=""), paraformer=OfflineParaformerModelConfig(mod
el=""), nemo_ctc=OfflineNemoEncDecCtcModelConfig(model="./libmodel.so", qnn_config=QnnConfig(backend_lib="./libQnnHtp.so", context_binary="./model.bin", system_lib="./libQnnSyste
m.so"), ), whisper=OfflineWhisperModelConfig(encoder="", decoder="", language="", task="transcribe", tail_paddings=-1, enable_token_timestamps=False, enable_segment_timestamps=Fa
lse), fire_red_asr=OfflineFireRedAsrModelConfig(encoder="", decoder=""), tdnn=OfflineTdnnModelConfig(model=""), zipformer_ctc=OfflineZipformerCtcModelConfig(model=""), wenet_ctc=
OfflineWenetCtcModelConfig(model=""), sense_voice=OfflineSenseVoiceModelConfig(model="", language="auto", use_itn=False), moonshine=OfflineMoonshineModelConfig(preprocessor="", e
ncoder="", uncached_decoder="", cached_decoder="", merged_decoder=""), dolphin=OfflineDolphinModelConfig(model=""), canary=OfflineCanaryModelConfig(encoder="", decoder="", src_la
ng="", tgt_lang="", use_pnc=True), cohere_transcribe=OfflineCohereTranscribeModelConfig(encoder="", decoder="", language="", use_punct=True, use_itn=True), omnilingual=OfflineOmn
ilingualAsrCtcModelConfig(model=""), funasr_nano=OfflineFunASRNanoModelConfig(encoder_adaptor="", llm="", embedding="", tokenizer="", system_prompt="You are a helpful assistant."
, user_prompt="语音转写：", max_new_tokens=512, temperature=1e-06, top_p=0.8, seed=42, language="", itn=True, hotwords=""), medasr=OfflineMedAsrCtcModelConfig(model=""), fire_red
_asr_ctc=OfflineFireRedAsrCtcModelConfig(model=""), qwen3_asr=OfflineQwen3ASRModelConfig(conv_frontend="", encoder="", decoder="", tokenizer="", hotwords="", max_total_len=512, m
ax_new_tokens=128, temperature=1e-06, top_p=0.8, seed=42), telespeech_ctc="", tokens="./tokens.txt", num_threads=2, debug=True, provider="qnn", model_type="", modeling_unit="cjkc
har", bpe_vocab=""), lm_config=OfflineLMConfig(model="", scale=0.5, lodr_scale=0.01, lodr_fst="", lodr_backoff_id=-1), ctc_fst_decoder_config=OfflineCtcFstDecoderConfig(graph="",
 max_active=3000), decoding_method="greedy_search", max_active_paths=4, hotwords_file="", hotwords_score=1.5, blank_penalty=0, rule_fsts="", rule_fars="", hr=HomophoneReplacerCon
fig(lexicon="", rule_fsts=""))
Creating recognizer ...
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/qnn-backend.cc:InitQnnInterface:100 loaded ./libQnnHtp.so
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/qnn-backend.cc:InitQnnInterface:114 Got QnnInterface_getProviders
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/qnn-backend.cc:InitQnnInterface:136 QNN_API_VERSION_MAJOR: 2
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/qnn-backend.cc:InitQnnInterface:137 QNN_API_VERSION_MINOR: 29
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/qnn-backend.cc:InitQnnInterface:138 QNN_API_VERSION_PATCH: 0
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/qnn-backend.cc:InitQnnInterface:161 ---0----
backendId: 6
coreApiVersion.major: 2
coreApiVersion.minor: 30
coreApiVersion.patch: 0
backendApiVersion.major: 5
backendApiVersion.minor: 40
backendApiVersion.patch: 0

/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/qnn-backend.cc:InitQnnInterface:179 backend build ID: v2.40.0.251030114326_189385
     0.0ms [WARN   ] QnnDsp <W> Initializing HtpProvider
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/offline-parakeet-ctc-model-qnn.cc:Impl:66 Init from context binary './model.bin'
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/qnn-model.cc:LoadSystemLib:65 loaded ./libQnnSystem.so
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/qnn-model.cc:LoadSystemLib:101 QNN_SYSTEM_API_VERSION_MAJOR: 1
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/qnn-model.cc:LoadSystemLib:103 QNN_SYSTEM_API_VERSION_MINOR: 5
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/qnn-model.cc:LoadSystemLib:107 systemApiVersion.major: 1
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/qnn-model.cc:LoadSystemLib:111 systemApiVersion.minor: 6
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/utils.cc:CopyGraphsInfo:481 version: 3
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/qnn-model.cc:InitInputTensors:570 input 0
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/utils.cc:PrintTensor:426   id: 1
  name: x
  type: QNN_TENSOR_TYPE_APP_WRITE
  data format: 0
  data type: QNN_DATATYPE_UFIXED_POINT_16
  quantize info:
    encodingDefinition: 0x1
    quantizationEncoding: QNN_QUANTIZATION_ENCODING_SCALE_OFFSET
     scale: 0.000124647
     offset: -31906
  rank: 3
  dimensions: 1, 1000, 80,
  memType: QNN_TENSORMEMTYPE_RAW
 memType raw data size: 160000
  isDynamicDimensions: False
  isProduced: 0

/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/qnn-model.cc:InitOutputTensors:591 output 2106
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/utils.cc:PrintTensor:426   id: 3757
  name: transpose_292
  type: QNN_TENSOR_TYPE_APP_READ
  data format: 0
  data type: QNN_DATATYPE_UFIXED_POINT_16
  quantize info:
    encodingDefinition: 0x1
    quantizationEncoding: QNN_QUANTIZATION_ENCODING_SCALE_OFFSET
     scale: 0.00219824
     offset: -3019
  rank: 3
  dimensions: 1, 125, 1025,
  memType: QNN_TENSORMEMTYPE_RAW
 memType raw data size: 256250
  isDynamicDimensions: False
  isProduced: 0

/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/qnn-model.cc:InitOutputTensors:591 output 2107
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/utils.cc:PrintTensor:426   id: 3758
  name: log_probs
  type: QNN_TENSOR_TYPE_APP_READ
  data format: 0
  data type: QNN_DATATYPE_UFIXED_POINT_16
  quantize info:
    encodingDefinition: 0x1
    quantizationEncoding: QNN_QUANTIZATION_ENCODING_SCALE_OFFSET
     scale: 0.00219739
     offset: -65535
  rank: 3
  dimensions: 1, 125, 1025,
  memType: QNN_TENSORMEMTYPE_RAW
 memType raw data size: 256250
  isDynamicDimensions: False
  isProduced: 0


/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/qnn-model.cc:AllocateBuffer:612 Allocate 817009250 bytes, or 779.161 MB
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/qnn-model.cc:SetupPointers:633 Setup pointers successfully.
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/offline-parakeet-ctc-model-qnn.cc:CheckModel:203 max_num_frames: 1000
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/offline-parakeet-ctc-model-qnn.cc:CheckModel:204 feat_dim: 80
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/offline-parakeet-ctc-model-qnn.cc:CheckModel:205 vocab_size: 1025
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/offline-parakeet-ctc-model-qnn.cc:CheckModel:206 subsampling_factor: 8
recognizer created in 4.852 s
Started
Done!

./0.wav
{"lang": "", "emotion": "", "event": "", "text": "well i don't wish to see it any more observed phoebe turning away her eyes it is certainly very like the old portrait it", "time
stamps": [0.48, 0.72, 0.88, 0.96, 1.04, 1.12, 1.20, 1.36, 1.44, 1.60, 1.76, 1.92, 2.16, 2.32, 2.40, 2.48, 2.64, 2.72, 2.88, 2.96, 3.36, 3.44, 3.60, 3.76, 4.00, 4.16, 4.24, 4.32,
5.04, 5.20, 5.44, 5.68, 5.84, 6.08, 6.32, 6.40, 6.64, 6.72, 6.80, 6.96, 7.60], "durations": [], "tokens":[" well", " i", " don", "'", "t", " w", "ish", " to", " see", " it", " an
y", " more", " ob", "s", "er", "ved", " ph", "o", "e", "be", " t", "ur", "ning", " away", " her", " e", "y", "es", " it", " is", " certain", "ly", " very", " like", " the", " old
", " p", "ort", "ra", "it", " it"], "ys_log_probs": [], "words": []}
----
num threads: 2
decoding method: greedy_search
Elapsed seconds: 0.518 s
Real time factor (RTF): 0.518 / 7.435 = 0.070
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added QNN-accelerated support for NeMo CTC (Parakeet) models in offline recognition.

* **Improvements**
  * Enhanced NeMo CTC model configuration to better handle QNN context binaries, including clearer validation and more informative config output.
  * Improved decoding robustness for per-frame selection during greedy CTC decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->