### PR TITLE
Build sdist in split-package mode so its metadata declares sherpa-onnx-core

### DIFF
--- a/.github/workflows/build-wheels-linux.yaml
+++ b/.github/workflows/build-wheels-linux.yaml
@@ -425,6 +425,12 @@ jobs:
       - name: Build sdist
         if: matrix.python-version == 'cp38' && matrix.manylinux == 'manylinux2014'
         shell: bash
+        env:
+          # Build the sdist in split-package mode so its metadata declares the
+          # sherpa-onnx-core dependency, matching the published wheels. Without
+          # this, the sdist's Requires-Dist omits sherpa-onnx-core, which breaks
+          # tools that resolve from sdist metadata (e.g. `uv lock`). See #3689.
+          SHERPA_ONNX_SPLIT_PYTHON_PACKAGE: ON
         run: |
           python3 setup.py sdist
           ls -l dist/*


### PR DESCRIPTION
## Problem

Fixes #3689.

The published wheels are built with `SHERPA_ONNX_SPLIT_PYTHON_PACKAGE=ON` (see all `build-wheels-*.yaml`), so their metadata correctly declares the runtime dependency on `sherpa-onnx-core`:

```python
>>> import importlib.metadata as md; md.requires("sherpa-onnx")
['sherpa-onnx-core==1.13.3']
```

But the **sdist** is built in `build-wheels-linux.yaml` *without* that variable:

```yaml
- name: Build sdist
  ...
  run: |
    python3 setup.py sdist
```

So `need_split_package()` returns `False`, `install_requires` becomes `None`, and the sdist's `PKG-INFO` omits `Requires-Dist: sherpa-onnx-core` entirely. Tools that resolve dependencies from **sdist** metadata (notably `uv lock`) then produce a lockfile without `sherpa-onnx-core`; after `uv sync` only `sherpa-onnx` is installed and `import sherpa_onnx` fails on a missing `libonnxruntime` dylib — even though a direct `uv pip install sherpa-onnx` (which uses the wheel) works.

## Fix

Set `SHERPA_ONNX_SPLIT_PYTHON_PACKAGE=ON` for the sdist build step so the sdist's metadata matches the published wheels. One env var, no other behavior change (`setup.py sdist` does not run the cmake build, so the variable only affects the declared `install_requires`).

## Verification

Built the sdist locally both ways and resolved it with `uv 0.11.13`:

| sdist build | `Requires-Dist` in `PKG-INFO` | `sherpa-onnx-core` in `uv.lock` |
|---|---|---|
| `setup.py sdist` (current) | *(absent)* | ❌ not present |
| `SHERPA_ONNX_SPLIT_PYTHON_PACKAGE=ON setup.py sdist` (this PR) | `sherpa-onnx-core==1.13.3` | ✅ `requires-dist = [{ name = "sherpa-onnx-core", specifier = "==1.13.3" }]` |

With the fix, `uv lock` against the local sdist resolves and locks `sherpa-onnx-core` as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Linux wheel build configuration to ensure proper dependency declarations in package distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->