### PR TITLE
Export Parakeet-TDT-CTC to QNN

### DIFF
--- a/.github/scripts/export-qnn/generate_parakeet_tdt_ctc.py
+++ b/.github/scripts/export-qnn/generate_parakeet_tdt_ctc.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright    2026  Xiaomi Corp.        (authors: Fangjun Kuang)
+
+import json
+
+from device_info import soc_info_dict
+from dataclasses import asdict, dataclass
+import itertools
+
+
+@dataclass
+class Config:
+    soc: str  # SM8850
+    soc_id: int  # 87
+    arch: str  # v81
+    num_seconds: int
+    model_name: str
+
+
+def main():
+
+    model_name_list = ["parakeet-tdt_ctc-110m"]
+    num_seconds_list = [3, 5, 8, 10, 13, 15, 18, 20, 23, 25, 28, 30]
+
+    configs = []
+
+    for name, soc in soc_info_dict.items():
+        for num_seconds, model_name in itertools.product(
+            num_seconds_list, model_name_list
+        ):
+            configs.append(
+                Config(
+                    soc=name,
+                    soc_id=soc.model.value,
+                    arch=soc.info.arch.name,
+                    model_name=model_name,
+                    num_seconds=num_seconds,
+                )
+            )
+
+    ans = [asdict(c) for c in configs]
+
+    print(json.dumps({"include": ans}))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/export-qnn/generate_parakeet_tdt_ctc.py
+++ b/.github/scripts/export-qnn/generate_parakeet_tdt_ctc.py
@@ -19,7 +19,7 @@ class Config:
 
 def main():
 
-    model_name_list = ["parakeet-tdt_ctc-110m"]
+    model_name_list = ["parakeet-tdt_ctc-110m", "parakeet-tdt_ctc-0.6b-ja"]
     num_seconds_list = [3, 5, 8, 10, 13, 15, 18, 20, 23, 25, 28, 30]
 
     configs = []

--- a/.github/workflows/export-paraformer-to-qnn.yaml
+++ b/.github/workflows/export-paraformer-to-qnn.yaml
@@ -79,7 +79,18 @@ jobs:
       - name: Download toolkit
         shell: bash
         run: |
-          curl -SL -O https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.40.0.251030.zip
+          url=https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.40.0.251030.zip
+          for i in $(seq 1 10); do
+            curl -SL -O $url
+            size=$(stat -c%s v2.40.0.251030.zip 2>/dev/null || stat -f%z v2.40.0.251030.zip 2>/dev/null)
+            if [ "$size" -gt 100000000 ]; then
+              echo "Download succeeded, size=$size"
+              break
+            fi
+            echo "Download failed (size=$size), retrying in 30s... ($i/10)"
+            rm -f v2.40.0.251030.zip
+            sleep 30
+          done
           ls -lh v2.40.0.251030.zip
 
       - name: Unzip toolkit

--- a/.github/workflows/export-parakeet-ctc-qnn.yaml
+++ b/.github/workflows/export-parakeet-ctc-qnn.yaml
@@ -198,7 +198,18 @@ jobs:
       - name: Download toolkit
         shell: bash
         run: |
-          curl -SL -O https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.40.0.251030.zip
+          url=https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.40.0.251030.zip
+          for i in $(seq 1 10); do
+            curl -SL -O $url
+            size=$(stat -c%s v2.40.0.251030.zip 2>/dev/null || stat -f%z v2.40.0.251030.zip 2>/dev/null)
+            if [ "$size" -gt 100000000 ]; then
+              echo "Download succeeded, size=$size"
+              break
+            fi
+            echo "Download failed (size=$size), retrying in 30s... ($i/10)"
+            rm -f v2.40.0.251030.zip
+            sleep 30
+          done
           ls -lh v2.40.0.251030.zip
 
       - name: Unzip toolkit

--- a/.github/workflows/export-parakeet-tdt-ctc-qnn.yaml
+++ b/.github/workflows/export-parakeet-tdt-ctc-qnn.yaml
@@ -3,7 +3,7 @@ name: export-parakeet-tdt-ctc-qnn
 on:
   push:
     branches:
-      - export-parakeet-tdt-ctc-qnn
+      - export-parakeet-tdt-ctc-qnn-2
   workflow_dispatch:
 
 concurrency:
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         num_seconds: [3, 5, 8, 10, 13, 15, 18, 20, 23, 25, 28, 30]
-        model_id: ["parakeet-tdt_ctc-110m"]
+        model_id: ["parakeet-tdt_ctc-110m", "parakeet-tdt_ctc-0.6b-ja"]
 
     steps:
       - uses: actions/checkout@v4
@@ -36,28 +36,52 @@ jobs:
           num_frames=$((num_seconds*100))
 
           # https://huggingface.co/nvidia/parakeet-tdt_ctc-110m
-          model_id=nvidia/${{ matrix.model_id }}
+          model_id=${{ matrix.model_id }}
 
           echo "num_frames: $num_frames"
           echo "model_id: $model_id"
 
           cd scripts/nemo/qnn/parakeet-tdt-ctc/
 
-          wget https://dldata-public.s3.us-east-2.amazonaws.com/2086-149220-0033.wav
-          mv 2086-149220-0033.wav 2.wav
+          if [[ $model_id == "parakeet-tdt_ctc-110m" ]]; then
+            wget https://dldata-public.s3.us-east-2.amazonaws.com/2086-149220-0033.wav
+            mv 2086-149220-0033.wav 2.wav
 
-          wget https://huggingface.co/csukuangfj/sherpa-onnx-whisper-tiny.en/resolve/main/test_wavs/0.wav
-          wget https://huggingface.co/csukuangfj/sherpa-onnx-whisper-tiny.en/resolve/main/test_wavs/1.wav
+            wget https://huggingface.co/csukuangfj/sherpa-onnx-whisper-tiny.en/resolve/main/test_wavs/0.wav
+            wget https://huggingface.co/csukuangfj/sherpa-onnx-whisper-tiny.en/resolve/main/test_wavs/1.wav
+          elif [[ $model_id == "parakeet-tdt_ctc-0.6b-ja" ]]; then
+            wget https://huggingface.co/csukuangfj/reazonspeech-k2-v2/resolve/main/test_wavs/1.wav
+            wget https://huggingface.co/csukuangfj/reazonspeech-k2-v2/resolve/main/test_wavs/2.wav
+            wget https://huggingface.co/csukuangfj/reazonspeech-k2-v2/resolve/main/test_wavs/3.wav
+            wget https://huggingface.co/csukuangfj/reazonspeech-k2-v2/resolve/main/test_wavs/4.wav
+            wget https://huggingface.co/csukuangfj/reazonspeech-k2-v2/resolve/main/test_wavs/5.wav
+          else
+            echo "Unsupported model id $model_id"
+            exit 1
+          fi
 
-          ./run.sh $num_frames $model_id
+          ./run.sh $num_frames nvidia/$model_id
 
           ls -lh model.*
 
-          python3 ./test_onnx.py --wav ./0.wav
-          python3 ./test_onnx.py --wav ./1.wav
-          python3 ./test_onnx.py --wav ./2.wav
+          if [[ $model_id == "parakeet-tdt_ctc-110m" ]]; then
+            python3 ./test_onnx.py --wav ./0.wav
+            python3 ./test_onnx.py --wav ./1.wav
+            python3 ./test_onnx.py --wav ./2.wav
 
-          printf "0.raw\n1.raw\n2.raw\n" > model.txt
+            printf "0.raw\n1.raw\n2.raw\n" > model.txt
+          elif [[ $model_id == "parakeet-tdt_ctc-0.6b-ja" ]]; then
+            python3 ./test_onnx.py --wav ./1.wav
+            python3 ./test_onnx.py --wav ./2.wav
+            python3 ./test_onnx.py --wav ./3.wav
+            python3 ./test_onnx.py --wav ./4.wav
+            python3 ./test_onnx.py --wav ./5.wav
+
+            printf "1.raw\n2.raw\n3.raw\n4.raw\n5.raw\n" > model.txt
+          else
+            echo "Unsupported model id $model_id"
+            exit 1
+          fi
 
           ls -lh model.*
           ls -lh *.raw
@@ -209,7 +233,18 @@ jobs:
       - name: Download toolkit
         shell: bash
         run: |
-          curl -SL -O https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.40.0.251030.zip
+          url=https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.40.0.251030.zip
+          for i in $(seq 1 10); do
+            curl -SL -O $url
+            size=$(stat -c%s v2.40.0.251030.zip 2>/dev/null || stat -f%z v2.40.0.251030.zip 2>/dev/null)
+            if [ "$size" -gt 100000000 ]; then
+              echo "Download succeeded, size=$size"
+              break
+            fi
+            echo "Download failed (size=$size), retrying in 30s... ($i/10)"
+            rm -f v2.40.0.251030.zip
+            sleep 30
+          done
           ls -lh v2.40.0.251030.zip
 
       - name: Unzip toolkit
@@ -500,7 +535,7 @@ jobs:
           overwrite: true
           repo_name: k2-fsa/sherpa-onnx
           repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
-          tag: asr-models-qnn
+          tag: asr-models-qnn-2
 
       - name: Release
         if: github.repository_owner == 'csukuangfj'
@@ -511,7 +546,7 @@ jobs:
           overwrite: true
           repo_name: k2-fsa/sherpa-onnx
           repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
-          tag: asr-models-qnn-binary
+          tag: asr-models-qnn-binary-2
 
       - name: Release
         if: github.repository_owner == 'k2-fsa' && matrix.soc == 'SM8850'
@@ -520,7 +555,7 @@ jobs:
           file_glob: true
           file: ./so/*.tar.bz2
           overwrite: true
-          tag: asr-models-qnn
+          tag: asr-models-qnn-2
 
       - name: Release
         if: github.repository_owner == 'k2-fsa'
@@ -529,4 +564,4 @@ jobs:
           file_glob: true
           file: ./binary/*.tar.bz2
           overwrite: true
-          tag: asr-models-qnn-binary
+          tag: asr-models-qnn-binary-2

--- a/.github/workflows/export-parakeet-tdt-ctc-qnn.yaml
+++ b/.github/workflows/export-parakeet-tdt-ctc-qnn.yaml
@@ -1,0 +1,532 @@
+name: export-parakeet-tdt-ctc-qnn
+
+on:
+  push:
+    branches:
+      - export-parakeet-tdt-ctc-qnn
+  workflow_dispatch:
+
+concurrency:
+  group: export-parakeet-tdt-ctc-qnn-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  onnx:
+    if: github.repository_owner == 'k2-fsa' || github.repository_owner == 'csukuangfj'
+    name: Export onnx
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        num_seconds: [3, 5, 8, 10, 13, 15, 18, 20, 23, 25, 28, 30]
+        model_id: ["parakeet-tdt_ctc-110m"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Export models
+        shell: bash
+        run: |
+          num_seconds=${{ matrix.num_seconds }}
+          num_frames=$((num_seconds*100))
+
+          # https://huggingface.co/nvidia/parakeet-tdt_ctc-110m
+          model_id=nvidia/${{ matrix.model_id }}
+
+          echo "num_frames: $num_frames"
+          echo "model_id: $model_id"
+
+          cd scripts/nemo/qnn/parakeet-tdt-ctc/
+
+          wget https://dldata-public.s3.us-east-2.amazonaws.com/2086-149220-0033.wav
+          mv 2086-149220-0033.wav 2.wav
+
+          wget https://huggingface.co/csukuangfj/sherpa-onnx-whisper-tiny.en/resolve/main/test_wavs/0.wav
+          wget https://huggingface.co/csukuangfj/sherpa-onnx-whisper-tiny.en/resolve/main/test_wavs/1.wav
+
+          ./run.sh $num_frames $model_id
+
+          ls -lh model.*
+
+          python3 ./test_onnx.py --wav ./0.wav
+          python3 ./test_onnx.py --wav ./1.wav
+          python3 ./test_onnx.py --wav ./2.wav
+
+          printf "0.raw\n1.raw\n2.raw\n" > model.txt
+
+          ls -lh model.*
+          ls -lh *.raw
+
+      - name: Collect models
+        shell: bash
+        run: |
+          num_seconds=${{ matrix.num_seconds }}
+
+          # https://huggingface.co/nvidia/parakeet-tdt_ctc-110m
+          model_id=${{ matrix.model_id }}
+
+          src=scripts/nemo/qnn/parakeet-tdt-ctc
+          dst=${model_id}-${num_seconds}
+
+          mkdir -p $dst
+
+          mv -v $src/model.* $dst
+          cp -v $src/tokens.txt $dst
+          cp -v $src/*.raw $dst
+          cp -v $src/*.wav $dst
+
+          ls -lh $dst/
+          tar cjvf $dst.tar.bz2 $dst
+          ls -lh *.tar.bz2
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.model_id }}-${{ matrix.num_seconds }}
+          path: ./*.tar.bz2
+
+  generate_build_matrix:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generating build matrix
+        id: set-matrix
+        run: |
+          # outputting for debugging purposes
+          python3 .github/scripts/export-qnn/generate_parakeet_tdt_ctc.py
+          MATRIX=$(python3 .github/scripts/export-qnn/generate_parakeet_tdt_ctc.py)
+
+          # deprecated
+          # echo "::set-output name=matrix::${MATRIX}"
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+
+  qnn:
+    needs: [generate_build_matrix, onnx]
+    if: github.repository_owner == 'k2-fsa' || github.repository_owner == 'csukuangfj'
+    name: ${{ matrix.model_name }} ${{ matrix.soc }} ${{ matrix.num_seconds }}
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ${{ fromJson(needs.generate_build_matrix.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Retrieve artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.model_name }}-${{ matrix.num_seconds }}
+          path: /tmp/
+
+      - name: Show space
+        shell: bash
+        run: |
+          df -h
+
+      - name: Show tmp
+        shell: bash
+        run: |
+          num_seconds=${{ matrix.num_seconds }}
+          model_id=${{ matrix.model_name }}
+
+          dir=$PWD
+          mkdir -p model-files/$num_seconds
+
+          ls -lh /tmp/
+
+          pushd /tmp
+          echo "num_seconds: $num_seconds"
+
+
+          src=${model_id}-${num_seconds}
+
+
+          ls -lh $src.tar.bz2
+
+          tar xvf $src.tar.bz2
+          rm $src.tar.bz2
+
+          echo "---"
+
+          ls -lh $src/*
+          popd
+
+          mv -v /tmp/$src/* $dir/model-files/$num_seconds/
+
+      - name: Show files
+        shell: bash
+        run: |
+          ls -lh model-files
+          echo "---"
+          ls -lh model-files/*
+
+      - name: Show space
+        shell: bash
+        run: |
+          df -h
+
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Create directories
+        shell: bash
+        run: |
+          mkdir so binary
+
+      - name: Display NDK HOME
+        shell: bash
+        run: |
+          echo "ANDROID_NDK_LATEST_HOME: ${ANDROID_NDK_LATEST_HOME}"
+          ls -lh ${ANDROID_NDK_LATEST_HOME}
+
+      - name: Create Python virtual environment
+        shell: bash
+        run: |
+          python3 -m venv py310
+          which python3
+          source py310/bin/activate
+          which python3
+
+      - name: Show ndk-build help
+        shell: bash
+        run: |
+          export PATH=${ANDROID_NDK_LATEST_HOME}:$PATH
+          ndk-build --help
+
+      - name: Download toolkit
+        shell: bash
+        run: |
+          curl -SL -O https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.40.0.251030.zip
+          ls -lh v2.40.0.251030.zip
+
+      - name: Unzip toolkit
+        shell: bash
+        run: |
+          unzip v2.40.0.251030.zip
+
+      - name: Show
+        shell: bash
+        run: |
+          ls -lh
+
+          echo "---ls -lh qairt---"
+
+          ls -lh qairt
+
+          echo "---"
+
+      - name: Install linux dependencies
+        shell: bash
+        run: |
+          ls -lh
+
+          echo "---"
+
+          ls -lh qairt
+
+          cd qairt/2.40.0.251030/bin
+          source envsetup.sh
+
+          yes | sudo ${QNN_SDK_ROOT}/bin/check-linux-dependency.sh || true
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          source py310/bin/activate
+
+          cd qairt/2.40.0.251030/bin
+          source envsetup.sh
+
+          python3 -m pip install \
+            mock \
+            numpy \
+            opencv-python \
+            optuna \
+            packaging \
+            pandas \
+            paramiko \
+            pathlib2 \
+            pillow \
+            plotly \
+            protobuf \
+            psutil \
+            pydantic \
+            pytest \
+            pyyaml \
+            rich \
+            scikit-optimize \
+            scipy \
+            six \
+            tabulate \
+            typing-extensions \
+            xlsxwriter
+
+          python3 "${QNN_SDK_ROOT}/bin/check-python-dependency" || true
+
+          which python3
+
+      - name: Install onnx dependencies
+        shell: bash
+        run: |
+          source py310/bin/activate
+          python3 -m pip install --upgrade \
+            torch==2.0.0+cpu -f https://download.pytorch.org/whl/torch \
+            kaldi_native_fbank \
+            pip \
+            "numpy<2" \
+            onnx==1.17.0 \
+            onnxruntime \
+            soundfile \
+            librosa \
+            onnxsim \
+            sentencepiece \
+            pyyaml
+
+          which python3
+
+      - name: Show qnn-onnx-converter help
+        shell: bash
+        run: |
+          source py310/bin/activate
+
+          pushd qairt/2.40.0.251030/bin
+          source envsetup.sh
+          popd
+
+          qnn-onnx-converter --help
+
+      - name: Show space
+        shell: bash
+        run: |
+          df -h
+
+      - name: Maximize Runner Swap Space
+        uses: pierotofy/set-swap-space@v1.0
+        with:
+          swap-size-gb: 12
+
+      - name: Show qnn-model-lib-generator help
+        shell: bash
+        run: |
+          source py310/bin/activate
+
+          pushd qairt/2.40.0.251030/bin
+          source envsetup.sh
+          popd
+
+          qnn-model-lib-generator --help
+
+      - name: Show qnn-net-run help
+        shell: bash
+        run: |
+          source py310/bin/activate
+
+          pushd qairt/2.40.0.251030/bin
+          source envsetup.sh
+          popd
+
+          qnn-net-run --help
+
+      - name: Run
+        shell: bash
+        run: |
+          source py310/bin/activate
+
+          pushd qairt/2.40.0.251030/bin
+          source envsetup.sh
+          popd
+
+          export PATH=${ANDROID_NDK_LATEST_HOME}:$PATH
+
+          ndk-build --help
+
+
+          export LDFLAGS="-Wl,-z,max-page-size=16384"
+          dir=$PWD
+          num_seconds=${{ matrix.num_seconds }}
+          model_dir=$PWD/model-files/$num_seconds
+          soc=${{ matrix.soc }}
+
+          python3 ./scripts/pyannote/segmentation/show-onnx.py --filename $model_dir/model.onnx
+
+          export PATH=${ANDROID_NDK_LATEST_HOME}:$PATH
+
+          echo "export to qnn"
+          echo "----------$num_seconds----------"
+
+          for m in model; do
+            echo "Processing $m"
+            mv -v $model_dir/${m}.* ./
+            mv -v $model_dir/*.raw ./
+            ls -lh $m.*
+            ls -lh *.raw
+
+            cat $m.txt
+
+            qnn-onnx-converter \
+              --input_network ./$m.onnx \
+              --output_path ./quant/$m.cpp \
+              --input_list $m.txt \
+              --use_native_input_files \
+              --act_bitwidth 16 \
+              --bias_bitwidth 32 > ${m}-log-converter.t 2>&1
+
+            ls -lh quant
+
+            python3 ./scripts/qnn/generate_config.py  \
+                --soc $soc \
+                --graph-name $m \
+                --output-dir ./quant/my-config-$m \
+                --qnn-sdk-root $QNN_SDK_ROOT
+
+            ls -lh quant/my-config-$m
+
+            head -n100 ./quant/my-config-$m/*.json
+
+            python3 "${QNN_SDK_ROOT}/bin/x86_64-linux-clang/qnn-model-lib-generator" \
+                -c quant/$m.cpp \
+                -b quant/$m.bin \
+                -o quant/model_libs > ${m}-log-generator.txt 2>&1
+
+            ls -lh quant/model_libs
+            echo "---"
+            ls -lh quant/model_libs/x86_64-linux-clang
+            echo "---"
+            ls -lh quant/model_libs/aarch64-android
+
+
+            $QNN_SDK_ROOT/bin/x86_64-linux-clang/qnn-context-binary-generator \
+              --backend $QNN_SDK_ROOT/lib/x86_64-linux-clang/libQnnHtp.so \
+              --model ./quant/model_libs/x86_64-linux-clang/lib$m.so \
+              --output_dir ./quant/binary \
+              --binary_file $m \
+              --config_file ./quant/my-config-$m/htp_backend_extensions.json > ${m}-log-generator.txt 2>&1
+
+            ls -lh quant/binary/
+          done
+
+          readelf -lW quant/model_libs/*/lib*.so
+
+          echo "collect results"
+
+          d=sherpa-onnx-qnn-${{ matrix.soc }}-binary-${{ matrix.model_name }}-${{ matrix.num_seconds }}s
+          mkdir -p $d
+          mkdir -p $d/test_wavs
+          cp -v quant/binary/*.bin $d/
+          cp -v $model_dir/tokens.txt $d
+          cp -v $model_dir/*.wav $d/test_wavs
+
+          echo "num_seconds=${num_seconds}s" > $d/info.txt
+
+          ls -lh $d
+          tar cjfv $d.tar.bz2 $d
+          ls -lh *.tar.bz2
+          rm -rf $d
+
+          mkdir -p binary
+          mv *.tar.bz2 ./binary/
+
+          for p in x86_64-linux-clang aarch64-android; do
+            if [[ $p == x86_64-linux-clang ]]; then
+              d=sherpa-onnx-qnn-${{ matrix.model_name }}-${{ matrix.num_seconds }}s-linux-x64
+            elif [[ $p == aarch64-android ]]; then
+              d=sherpa-onnx-qnn-${{ matrix.model_name }}-${{ matrix.num_seconds }}s-android-aarch64
+            else
+              echo "Unknown $p"
+              exit -1
+            fi
+
+            mkdir -p $d
+            mkdir -p $d/test_wavs
+
+            cp -v quant/model_libs/$p/lib*.so $d/
+            cp -v $model_dir/tokens.txt $d
+            cp -v $model_dir/*.wav $d/test_wavs
+
+            echo "num_seconds=${num_seconds}ms" > $d/info.txt
+            echo "target=$p" >> $d/info.txt
+
+            ls -lh $d
+            tar cjfv $d.tar.bz2 $d
+            ls -lh *.tar.bz2
+            rm -rf $d
+          done
+
+          echo "----show---"
+          ls -lh *.tar.bz2
+
+          mkdir -p so
+
+          mv *.tar.bz2 ./so
+
+      - name: Setup tmate session
+        if: false
+        # if: failure()
+        uses: mxschmitt/action-tmate@v3
+
+      - name: Show files
+        shell: bash
+        run: |
+          echo "---so---"
+          ls -lh so
+
+          echo "---binary---"
+          ls -lh binary
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.model_name }}-${{ matrix.soc }}-${{ matrix.num_seconds }}-json
+          path: ./quant/*.json
+
+      - name: Release
+        if: github.repository_owner == 'csukuangfj' && matrix.soc == 'SM8850'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./so/*.tar.bz2
+          overwrite: true
+          repo_name: k2-fsa/sherpa-onnx
+          repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
+          tag: asr-models-qnn
+
+      - name: Release
+        if: github.repository_owner == 'csukuangfj'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./binary/*.tar.bz2
+          overwrite: true
+          repo_name: k2-fsa/sherpa-onnx
+          repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
+          tag: asr-models-qnn-binary
+
+      - name: Release
+        if: github.repository_owner == 'k2-fsa' && matrix.soc == 'SM8850'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./so/*.tar.bz2
+          overwrite: true
+          tag: asr-models-qnn
+
+      - name: Release
+        if: github.repository_owner == 'k2-fsa'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./binary/*.tar.bz2
+          overwrite: true
+          tag: asr-models-qnn-binary

--- a/.github/workflows/export-sense-voice-to-qnn.yaml
+++ b/.github/workflows/export-sense-voice-to-qnn.yaml
@@ -79,7 +79,18 @@ jobs:
       - name: Download toolkit
         shell: bash
         run: |
-          curl -SL -O https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.40.0.251030.zip
+          url=https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.40.0.251030.zip
+          for i in $(seq 1 10); do
+            curl -SL -O $url
+            size=$(stat -c%s v2.40.0.251030.zip 2>/dev/null || stat -f%z v2.40.0.251030.zip 2>/dev/null)
+            if [ "$size" -gt 100000000 ]; then
+              echo "Download succeeded, size=$size"
+              break
+            fi
+            echo "Download failed (size=$size), retrying in 30s... ($i/10)"
+            rm -f v2.40.0.251030.zip
+            sleep 30
+          done
           ls -lh v2.40.0.251030.zip
 
       - name: Unzip toolkit

--- a/.github/workflows/export-streaming-zipformer-transducer-to-qnn.yaml
+++ b/.github/workflows/export-streaming-zipformer-transducer-to-qnn.yaml
@@ -116,7 +116,18 @@ jobs:
       - name: Download toolkit
         shell: bash
         run: |
-          curl -SL -O https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.40.0.251030.zip
+          url=https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.40.0.251030.zip
+          for i in $(seq 1 10); do
+            curl -SL -O $url
+            size=$(stat -c%s v2.40.0.251030.zip 2>/dev/null || stat -f%z v2.40.0.251030.zip 2>/dev/null)
+            if [ "$size" -gt 100000000 ]; then
+              echo "Download succeeded, size=$size"
+              break
+            fi
+            echo "Download failed (size=$size), retrying in 30s... ($i/10)"
+            rm -f v2.40.0.251030.zip
+            sleep 30
+          done
           ls -lh v2.40.0.251030.zip
 
       - name: Unzip toolkit

--- a/.github/workflows/export-x-asr-qnn.yaml
+++ b/.github/workflows/export-x-asr-qnn.yaml
@@ -187,7 +187,18 @@ jobs:
       - name: Download toolkit
         shell: bash
         run: |
-          curl -SL -O https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.40.0.251030.zip
+          url=https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.40.0.251030.zip
+          for i in $(seq 1 10); do
+            curl -SL -O $url
+            size=$(stat -c%s v2.40.0.251030.zip 2>/dev/null || stat -f%z v2.40.0.251030.zip 2>/dev/null)
+            if [ "$size" -gt 100000000 ]; then
+              echo "Download succeeded, size=$size"
+              break
+            fi
+            echo "Download failed (size=$size), retrying in 30s... ($i/10)"
+            rm -f v2.40.0.251030.zip
+            sleep 30
+          done
           ls -lh v2.40.0.251030.zip
 
       - name: Unzip toolkit

--- a/.github/workflows/export-zipformer-ctc-to-qnn-20250703.yaml
+++ b/.github/workflows/export-zipformer-ctc-to-qnn-20250703.yaml
@@ -79,7 +79,18 @@ jobs:
       - name: Download toolkit
         shell: bash
         run: |
-          curl -SL -O https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.40.0.251030.zip
+          url=https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.40.0.251030.zip
+          for i in $(seq 1 10); do
+            curl -SL -O $url
+            size=$(stat -c%s v2.40.0.251030.zip 2>/dev/null || stat -f%z v2.40.0.251030.zip 2>/dev/null)
+            if [ "$size" -gt 100000000 ]; then
+              echo "Download succeeded, size=$size"
+              break
+            fi
+            echo "Download failed (size=$size), retrying in 30s... ($i/10)"
+            rm -f v2.40.0.251030.zip
+            sleep 30
+          done
           ls -lh v2.40.0.251030.zip
 
       - name: Unzip toolkit

--- a/.github/workflows/export-zipformer-transducer-to-qnn.yaml
+++ b/.github/workflows/export-zipformer-transducer-to-qnn.yaml
@@ -170,7 +170,18 @@ jobs:
       - name: Download toolkit
         shell: bash
         run: |
-          curl -SL -O https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.40.0.251030.zip
+          url=https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.40.0.251030.zip
+          for i in $(seq 1 10); do
+            curl -SL -O $url
+            size=$(stat -c%s v2.40.0.251030.zip 2>/dev/null || stat -f%z v2.40.0.251030.zip 2>/dev/null)
+            if [ "$size" -gt 100000000 ]; then
+              echo "Download succeeded, size=$size"
+              break
+            fi
+            echo "Download failed (size=$size), retrying in 30s... ($i/10)"
+            rm -f v2.40.0.251030.zip
+            sleep 30
+          done
           ls -lh v2.40.0.251030.zip
 
       - name: Unzip toolkit

--- a/scripts/nemo/qnn/parakeet-ctc/test_onnx.py
+++ b/scripts/nemo/qnn/parakeet-ctc/test_onnx.py
@@ -54,14 +54,14 @@ class OnnxModel:
         return log_probs
 
 
-def create_fbank():
+def create_fbank(feat_dim):
     opts = knf.FbankOptions()
     opts.frame_opts.dither = 0
     opts.frame_opts.remove_dc_offset = False
     opts.frame_opts.window_type = "hann"
 
     opts.mel_opts.low_freq = 0
-    opts.mel_opts.num_bins = 80
+    opts.mel_opts.num_bins = feat_dim
 
     opts.mel_opts.is_librosa = True
 
@@ -111,10 +111,11 @@ def main():
     name = Path(args.wav).stem
 
     model = OnnxModel("./model.onnx")
+    feat_dim = model.encoder.get_inputs()[0].shape[1]
     max_len = model.encoder.get_inputs()[0].shape[2]
     print("max_len", max_len)
 
-    fbank = create_fbank()
+    fbank = create_fbank(feat_dim=feat_dim)
     audio, sample_rate = sf.read(args.wav, dtype="float32", always_2d=True)
     audio = audio[:, 0]  # only use the first channel
     if sample_rate != 16000:

--- a/scripts/nemo/qnn/parakeet-tdt-ctc/run.sh
+++ b/scripts/nemo/qnn/parakeet-tdt-ctc/run.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright      2026  Xiaomi Corp.        (authors: Fangjun Kuang)
+
+set -ex
+
+pip install \
+  nemo_toolkit['asr'] \
+  "numpy<2" \
+  ipython \
+  kaldi-native-fbank \
+  librosa \
+  onnx \
+  onnxruntime \
+  onnxscript \
+  soundfile
+
+num_frames=1000
+if [ $# -ge 1 ]; then
+  num_frames="$1"
+fi
+
+
+model_id=nvidia/parakeet-tdt_ctc-110m
+if [ $# -ge 2 ]; then
+  model_id="$2"
+fi
+
+python3 ./wrapper.py --max-len $num_frames --model-id $model_id

--- a/scripts/nemo/qnn/parakeet-tdt-ctc/test_onnx.py
+++ b/scripts/nemo/qnn/parakeet-tdt-ctc/test_onnx.py
@@ -1,0 +1,1 @@
+../parakeet-ctc/test_onnx.py

--- a/scripts/nemo/qnn/parakeet-tdt-ctc/wrapper.py
+++ b/scripts/nemo/qnn/parakeet-tdt-ctc/wrapper.py
@@ -21,7 +21,7 @@ def get_args():
     parser.add_argument(
         "--model-id",
         type=str,
-        help="e.g., nvidia/parakeet-ctc-0.6b",
+        help="e.g., nvidia/parakeet-tdt_ctc-110m",
         required=True,
     )
     return parser.parse_args()
@@ -40,7 +40,7 @@ class ModelWrapper(torch.nn.Module):
         encoder_output, encoder_out_lens = self.model.encoder(
             audio_signal=x, length=x_lens
         )
-        log_probs = self.model.decoder(encoder_output=encoder_output)
+        log_probs = self.model.ctc_decoder(encoder_output=encoder_output)
 
         return log_probs
 
@@ -53,19 +53,22 @@ def main():
     asr_model = nemo_asr.models.EncDecCTCModelBPE.from_pretrained(
         model_name=args.model_id
     )
+    asr_model = nemo_asr.models.ASRModel.from_pretrained(model_name=args.model_id)
+    asr_model.change_decoding_strategy(decoder_type="ctc")
+
     asr_model.eval()
     print(type(asr_model))
     print(asr_model)
     print(asr_model.cfg)
 
-    with open("tokens.txt", "w") as f:
-        for i, t in enumerate(asr_model.cfg["decoder"]["vocabulary"]):
-            f.write(f"{t} {i}\n")
-        f.write(f"<blk> {i+1}")
+    with open("./tokens.txt", "w", encoding="utf-8") as f:
+        for i, s in enumerate(asr_model.joint.vocabulary):
+            f.write(f"{s} {i}\n")
+        f.write(f"<blk> {i+1}\n")
 
     m = ModelWrapper(asr_model)
     m.eval()
-
+    feat_dim = asr_model.cfg["preprocessor"]["features"]
     print("feat_dim", feat_dim)
     x = torch.rand(1, feat_dim, args.max_len, dtype=torch.float32)
 


### PR DESCRIPTION
It adds two models
- https://huggingface.co/nvidia/parakeet-tdt_ctc-110m
- https://huggingface.co/nvidia/parakeet-tdt_ctc-0.6b-ja

Note that only the CTC branch is exported in this PR.  The transducer branch is handled in a separate PR.

https://huggingface.co/nvidia/parakeet-tdt_ctc-1.1b is not included since it throws OOM in GitHub Actions.

---

See
- https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models-qnn-2
- https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models-qnn-binary-2
for the exported models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for exporting Parakeet TDT CTC models to QNN format with dynamic build parameters across multiple configurations.

* **Chores**
  * Enhanced QNN toolkit download reliability with automatic retry mechanism across multiple export workflows.
  * Updated model export scripts to support configurable feature dimensions and dynamic model parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->