### PR TITLE
Remove leading spaces from ASR results

### DIFF
--- a/sherpa-onnx/csrc/offline-recognizer.cc
+++ b/sherpa-onnx/csrc/offline-recognizer.cc
@@ -172,6 +172,12 @@ std::unique_ptr<OfflineStream> OfflineRecognizer::CreateStream() const {
 
 void OfflineRecognizer::DecodeStreams(OfflineStream **ss, int32_t n) const {
   impl_->DecodeStreams(ss, n);
+
+  for (int32_t i = 0; i < n; ++i) {
+    auto r = ss[i]->GetResult();
+    r.text = RemoveLeadingSpaces(r.text);
+    ss[i]->SetResult(r);
+  }
 }
 
 void OfflineRecognizer::SetConfig(const OfflineRecognizerConfig &config) {

--- a/sherpa-onnx/csrc/online-recognizer.cc
+++ b/sherpa-onnx/csrc/online-recognizer.cc
@@ -252,7 +252,9 @@ void OnlineRecognizer::DecodeStreams(OnlineStream **ss, int32_t n) const {
 }
 
 OnlineRecognizerResult OnlineRecognizer::GetResult(OnlineStream *s) const {
-  return impl_->GetResult(s);
+  auto r = impl_->GetResult(s);
+  r.text = RemoveLeadingSpaces(r.text);
+  return r;
 }
 
 bool OnlineRecognizer::IsEndpoint(OnlineStream *s) const {

--- a/sherpa-onnx/csrc/text-utils.cc
+++ b/sherpa-onnx/csrc/text-utils.cc
@@ -1116,6 +1116,17 @@ std::string RemoveSpaceBetweenCjk(const std::string &text) {
   return Utf32ToUtf8(ans);
 }
 
+std::string RemoveLeadingSpaces(const std::string &text) {
+  size_t start = text.find_first_not_of(' ');
+  if (start == std::string::npos) {
+    return {};
+  }
+  if (start == 0) {
+    return text;
+  }
+  return text.substr(start);
+}
+
 std::string GetWord(const std::vector<std::string> &words, int32_t start,
                     int32_t end) {
   std::string ans;

--- a/sherpa-onnx/csrc/text-utils.h
+++ b/sherpa-onnx/csrc/text-utils.h
@@ -190,6 +190,8 @@ bool ContainsCJK(const std::u32string &text);
 
 std::string RemoveSpaceBetweenCjk(const std::string &text);
 
+std::string RemoveLeadingSpaces(const std::string &text);
+
 bool StringToBool(const std::string &s);
 
 // end is inclusive


### PR DESCRIPTION
See https://github.com/k2-fsa/sherpa-onnx/issues/3171#issuecomment-4841114709

cc @ljnhst



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recognition results now no longer include unwanted leading spaces in returned text for both offline and online speech decoding.
  * Output formatting is more consistent, making transcripts cleaner and easier to use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->