### PR TITLE
Export Parakeet TDT models to QNN

### DIFF
--- a/.github/scripts/export-qnn/generate_parakeet_tdt.py
+++ b/.github/scripts/export-qnn/generate_parakeet_tdt.py
@@ -19,8 +19,7 @@ class Config:
 
 def main():
 
-    #  model_name_list = ["parakeet-tdt-0.6b-v2", "parakeet-tdt-0.6b-v3"]
-    model_name_list = ["parakeet-tdt-0.6b-v3"]
+    model_name_list = ["parakeet-tdt-0.6b-v2", "parakeet-tdt-0.6b-v3"]
     num_seconds_list = [3, 5, 8, 10, 13, 15, 18, 20, 23, 25, 28, 30]
 
     configs = []

--- a/.github/scripts/export-qnn/generate_parakeet_tdt.py
+++ b/.github/scripts/export-qnn/generate_parakeet_tdt.py
@@ -26,11 +26,11 @@ def main():
     configs = []
 
     for name, soc in soc_info_dict.items():
+        if soc.model.name == "SM8350":
+            continue
         for num_seconds, model_name in itertools.product(
             num_seconds_list, model_name_list
         ):
-            if soc.model.name != "SM8850":
-                continue
             configs.append(
                 Config(
                     soc=name,

--- a/.github/scripts/export-qnn/generate_parakeet_tdt.py
+++ b/.github/scripts/export-qnn/generate_parakeet_tdt.py
@@ -21,8 +21,7 @@ def main():
 
     #  model_name_list = ["parakeet-tdt-0.6b-v2", "parakeet-tdt-0.6b-v3"]
     model_name_list = ["parakeet-tdt-0.6b-v2"]
-    #  num_seconds_list = [3, 5, 8, 10, 13, 15, 18, 20, 23, 25, 28, 30]
-    num_seconds_list = [10]
+    num_seconds_list = [3, 5, 8, 10, 13, 15, 18, 20, 23, 25, 28, 30]
 
     configs = []
 

--- a/.github/scripts/export-qnn/generate_parakeet_tdt.py
+++ b/.github/scripts/export-qnn/generate_parakeet_tdt.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright    2026  Xiaomi Corp.        (authors: Fangjun Kuang)
+
+import json
+
+from device_info import soc_info_dict
+from dataclasses import asdict, dataclass
+import itertools
+
+
+@dataclass
+class Config:
+    soc: str  # SM8850
+    soc_id: int  # 87
+    arch: str  # v81
+    num_seconds: int
+    model_name: str
+
+
+def main():
+
+    #  model_name_list = ["parakeet-tdt-0.6b-v2", "parakeet-tdt-0.6b-v3"]
+    model_name_list = ["parakeet-tdt-0.6b-v2"]
+    #  num_seconds_list = [3, 5, 8, 10, 13, 15, 18, 20, 23, 25, 28, 30]
+    num_seconds_list = [10]
+
+    configs = []
+
+    for name, soc in soc_info_dict.items():
+        for num_seconds, model_name in itertools.product(
+            num_seconds_list, model_name_list
+        ):
+            if soc.model.name != "SM8850":
+                continue
+            configs.append(
+                Config(
+                    soc=name,
+                    soc_id=soc.model.value,
+                    arch=soc.info.arch.name,
+                    model_name=model_name,
+                    num_seconds=num_seconds,
+                )
+            )
+
+    ans = [asdict(c) for c in configs]
+
+    print(json.dumps({"include": ans}))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/export-qnn/generate_parakeet_tdt.py
+++ b/.github/scripts/export-qnn/generate_parakeet_tdt.py
@@ -20,7 +20,7 @@ class Config:
 def main():
 
     #  model_name_list = ["parakeet-tdt-0.6b-v2", "parakeet-tdt-0.6b-v3"]
-    model_name_list = ["parakeet-tdt-0.6b-v2"]
+    model_name_list = ["parakeet-tdt-0.6b-v3"]
     num_seconds_list = [3, 5, 8, 10, 13, 15, 18, 20, 23, 25, 28, 30]
 
     configs = []

--- a/.github/workflows/export-parakeet-tdt-qnn.yaml
+++ b/.github/workflows/export-parakeet-tdt-qnn.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         num_seconds: [3, 5, 8, 10, 13, 15, 18, 20, 23, 25, 28, 30]
         # model_id: ["parakeet-tdt-0.6b-v2", "parakeet-tdt-0.6b-v3"]
-        model_id: ["parakeet-tdt-0.6b-v2"]
+        model_id: ["parakeet-tdt-0.6b-v3"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/export-parakeet-tdt-qnn.yaml
+++ b/.github/workflows/export-parakeet-tdt-qnn.yaml
@@ -6,9 +6,9 @@ on:
       - export-parakeet-tdt-qnn
   workflow_dispatch:
 
-concurrency:
-  group: export-parakeet-tdt-qnn-${{ github.ref }}
-  cancel-in-progress: true
+# concurrency:
+#   group: export-parakeet-tdt-qnn-${{ github.ref }}
+#   cancel-in-progress: true
 
 jobs:
   onnx:

--- a/.github/workflows/export-parakeet-tdt-qnn.yaml
+++ b/.github/workflows/export-parakeet-tdt-qnn.yaml
@@ -397,16 +397,16 @@ jobs:
               qnn-onnx-converter \
                 --input_network ./$m.onnx \
                 --output_path ./quant/$m.cpp \
-                --input_list $m.txt \
-                --use_native_input_files \
+                --float_bitwidth 16 \
                 --act_bitwidth 16 \
-                --bias_bitwidth 32 > ${m}-log-converter.t 2>&1
+                --bias_bitwidth 32 > ${m}-log-converter.txt 2>&1
             else
               qnn-onnx-converter \
                 --input_network ./$m.onnx \
                 --output_path ./quant/$m.cpp \
+                --float_bitwidth 16 \
                 --act_bitwidth 16 \
-                --bias_bitwidth 32 > ${m}-log-converter.t 2>&1
+                --bias_bitwidth 32 > ${m}-log-converter.txt 2>&1
             fi
 
             ls -lh quant

--- a/.github/workflows/export-parakeet-tdt-qnn.yaml
+++ b/.github/workflows/export-parakeet-tdt-qnn.yaml
@@ -60,9 +60,12 @@ jobs:
           python3 ./test_onnx.py --wav ./2.wav
 
           printf "0.raw\n1.raw\n2.raw\n" > encoder.txt
+          cat 0-decoder.txt 1-decoder.txt 2-decoder.txt > decoder.txt
+          cat 0-joiner.txt 1-joiner.txt 2-joiner.txt > joiner.txt
 
           ls -lh *.onnx*
           ls -lh *.raw
+          ls -lh *.txt
 
       - name: Collect models
         shell: bash
@@ -80,7 +83,7 @@ jobs:
           mv -v $src/encoder.* $dst
           mv -v $src/decoder.* $dst
           mv -v $src/joiner.* $dst
-          cp -v $src/tokens.txt $dst
+          cp -v $src/*.txt $dst
           cp -v $src/*.raw $dst
           cp -v $src/*.wav $dst
 
@@ -387,17 +390,21 @@ jobs:
             echo "Processing $m"
             mv -v $model_dir/${m}.* ./
             cp -v $model_dir/*.raw ./
+            cp -v $model_dir/*.txt ./
+
             ls -lh $m.*
             ls -lh *.raw
+            ls -lh *.txt
 
-            if [[ $m == 'encoder' ]]; then
+            if [[ $m == 'encoder' || $m == 'decoder' || $m == 'joiner' ]]; then
               # quantize only the encoder
               cat $m.txt
 
               qnn-onnx-converter \
                 --input_network ./$m.onnx \
                 --output_path ./quant/$m.cpp \
-                --float_bitwidth 16 \
+                --input_list $m.txt \
+                --use_native_input_files \
                 --act_bitwidth 16 \
                 --bias_bitwidth 32 > ${m}-log-converter.txt 2>&1
             else

--- a/.github/workflows/export-parakeet-tdt-qnn.yaml
+++ b/.github/workflows/export-parakeet-tdt-qnn.yaml
@@ -3,7 +3,7 @@ name: export-parakeet-tdt-qnn
 on:
   push:
     branches:
-      - export-parakeet-tdt-qnn
+      - export-parakeet-tdt-qnn-2
   workflow_dispatch:
 
 # concurrency:
@@ -19,8 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         num_seconds: [3, 5, 8, 10, 13, 15, 18, 20, 23, 25, 28, 30]
-        # model_id: ["parakeet-tdt-0.6b-v2", "parakeet-tdt-0.6b-v3"]
-        model_id: ["parakeet-tdt-0.6b-v3"]
+        model_id: ["parakeet-tdt-0.6b-v2", "parakeet-tdt-0.6b-v3"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/export-parakeet-tdt-qnn.yaml
+++ b/.github/workflows/export-parakeet-tdt-qnn.yaml
@@ -1,0 +1,556 @@
+name: export-parakeet-tdt-qnn
+
+on:
+  push:
+    branches:
+      - export-parakeet-tdt-qnn
+  workflow_dispatch:
+
+concurrency:
+  group: export-parakeet-tdt-qnn-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  onnx:
+    if: github.repository_owner == 'k2-fsa' || github.repository_owner == 'csukuangfj'
+    name: Export onnx
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # num_seconds: [3, 5, 8, 10, 13, 15, 18, 20, 23, 25, 28, 30]
+        num_seconds: [10]
+        # model_id: ["parakeet-tdt-0.6b-v2", "parakeet-tdt-0.6b-v3"]
+        model_id: ["parakeet-tdt-0.6b-v2"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Export models
+        shell: bash
+        run: |
+          num_seconds=${{ matrix.num_seconds }}
+          num_frames=$((num_seconds*100))
+
+          # https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2
+          model_id=${{ matrix.model_id }}
+
+          echo "num_frames: $num_frames"
+          echo "model_id: $model_id"
+
+          cd scripts/nemo/qnn/parakeet-tdt
+
+          wget https://dldata-public.s3.us-east-2.amazonaws.com/2086-149220-0033.wav
+          mv 2086-149220-0033.wav 2.wav
+
+          wget https://huggingface.co/csukuangfj/sherpa-onnx-whisper-tiny.en/resolve/main/test_wavs/0.wav
+          wget https://huggingface.co/csukuangfj/sherpa-onnx-whisper-tiny.en/resolve/main/test_wavs/1.wav
+
+          ./run.sh $num_frames nvidia/$model_id
+
+          ls -lh *.onnx*
+
+          python3 ./test_onnx.py --wav ./0.wav
+          python3 ./test_onnx.py --wav ./1.wav
+          python3 ./test_onnx.py --wav ./2.wav
+
+          printf "0.raw\n1.raw\n2.raw\n" > encoder.txt
+
+          ls -lh *.onnx*
+          ls -lh *.raw
+
+      - name: Collect models
+        shell: bash
+        run: |
+          num_seconds=${{ matrix.num_seconds }}
+
+          # https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2
+          model_id=${{ matrix.model_id }}
+
+          src=scripts/nemo/qnn/parakeet-tdt
+          dst=${model_id}-${num_seconds}
+
+          mkdir -p $dst
+
+          mv -v $src/encoder.* $dst
+          mv -v $src/decoder.* $dst
+          mv -v $src/joiner.* $dst
+          cp -v $src/tokens.txt $dst
+          cp -v $src/*.raw $dst
+          cp -v $src/*.wav $dst
+
+          ls -lh $dst/
+          tar cjvf $dst.tar.bz2 $dst
+          ls -lh *.tar.bz2
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.model_id }}-${{ matrix.num_seconds }}
+          path: ./*.tar.bz2
+
+  generate_build_matrix:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generating build matrix
+        id: set-matrix
+        run: |
+          # outputting for debugging purposes
+          python3 .github/scripts/export-qnn/generate_parakeet_tdt.py
+          MATRIX=$(python3 .github/scripts/export-qnn/generate_parakeet_tdt.py)
+
+          # deprecated
+          # echo "::set-output name=matrix::${MATRIX}"
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+
+  qnn:
+    needs: [generate_build_matrix, onnx]
+    if: github.repository_owner == 'k2-fsa' || github.repository_owner == 'csukuangfj'
+    name: ${{ matrix.model_name }} ${{ matrix.soc }} ${{ matrix.num_seconds }}
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ${{ fromJson(needs.generate_build_matrix.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Retrieve artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.model_name }}-${{ matrix.num_seconds }}
+          path: /tmp/
+
+      - name: Show space
+        shell: bash
+        run: |
+          df -h
+
+      - name: Show tmp
+        shell: bash
+        run: |
+          num_seconds=${{ matrix.num_seconds }}
+          model_id=${{ matrix.model_name }}
+
+          dir=$PWD
+          mkdir -p model-files/$num_seconds
+
+          ls -lh /tmp/
+
+          pushd /tmp
+          echo "num_seconds: $num_seconds"
+
+          src=${model_id}-${num_seconds}
+
+
+          ls -lh $src.tar.bz2
+
+          tar xvf $src.tar.bz2
+          rm $src.tar.bz2
+
+          echo "---"
+
+          ls -lh $src/*
+          popd
+
+          mv -v /tmp/$src/* $dir/model-files/$num_seconds/
+
+      - name: Show files
+        shell: bash
+        run: |
+          ls -lh model-files
+          echo "---"
+          ls -lh model-files/*
+
+      - name: Show space
+        shell: bash
+        run: |
+          df -h
+
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Create directories
+        shell: bash
+        run: |
+          mkdir so binary
+
+      - name: Display NDK HOME
+        shell: bash
+        run: |
+          echo "ANDROID_NDK_LATEST_HOME: ${ANDROID_NDK_LATEST_HOME}"
+          ls -lh ${ANDROID_NDK_LATEST_HOME}
+
+      - name: Create Python virtual environment
+        shell: bash
+        run: |
+          python3 -m venv py310
+          which python3
+          source py310/bin/activate
+          which python3
+
+      - name: Show ndk-build help
+        shell: bash
+        run: |
+          export PATH=${ANDROID_NDK_LATEST_HOME}:$PATH
+          ndk-build --help
+
+      - name: Download toolkit
+        shell: bash
+        run: |
+          url=https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v2.40.0.251030.zip
+          for i in $(seq 1 10); do
+            curl -SL -O $url
+            size=$(stat -c%s v2.40.0.251030.zip 2>/dev/null || stat -f%z v2.40.0.251030.zip 2>/dev/null)
+            if [ "$size" -gt 100000000 ]; then
+              echo "Download succeeded, size=$size"
+              break
+            fi
+            echo "Download failed (size=$size), retrying in 30s... ($i/10)"
+            rm -f v2.40.0.251030.zip
+            sleep 30
+          done
+          ls -lh v2.40.0.251030.zip
+
+      - name: Unzip toolkit
+        shell: bash
+        run: |
+          unzip v2.40.0.251030.zip
+
+      - name: Show
+        shell: bash
+        run: |
+          ls -lh
+
+          echo "---ls -lh qairt---"
+
+          ls -lh qairt
+
+          echo "---"
+
+      - name: Install linux dependencies
+        shell: bash
+        run: |
+          ls -lh
+
+          echo "---"
+
+          ls -lh qairt
+
+          cd qairt/2.40.0.251030/bin
+          source envsetup.sh
+
+          yes | sudo ${QNN_SDK_ROOT}/bin/check-linux-dependency.sh || true
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          source py310/bin/activate
+
+          cd qairt/2.40.0.251030/bin
+          source envsetup.sh
+
+          python3 -m pip install \
+            mock \
+            numpy \
+            opencv-python \
+            optuna \
+            packaging \
+            pandas \
+            paramiko \
+            pathlib2 \
+            pillow \
+            plotly \
+            protobuf \
+            psutil \
+            pydantic \
+            pytest \
+            pyyaml \
+            rich \
+            scikit-optimize \
+            scipy \
+            six \
+            tabulate \
+            typing-extensions \
+            xlsxwriter
+
+          python3 "${QNN_SDK_ROOT}/bin/check-python-dependency" || true
+
+          which python3
+
+      - name: Install onnx dependencies
+        shell: bash
+        run: |
+          source py310/bin/activate
+          python3 -m pip install --upgrade \
+            torch==2.0.0+cpu -f https://download.pytorch.org/whl/torch \
+            kaldi_native_fbank \
+            pip \
+            "numpy<2" \
+            onnx==1.17.0 \
+            onnxruntime \
+            soundfile \
+            librosa \
+            onnxsim \
+            sentencepiece \
+            pyyaml
+
+          which python3
+
+      - name: Show qnn-onnx-converter help
+        shell: bash
+        run: |
+          source py310/bin/activate
+
+          pushd qairt/2.40.0.251030/bin
+          source envsetup.sh
+          popd
+
+          qnn-onnx-converter --help
+
+      - name: Show space
+        shell: bash
+        run: |
+          df -h
+
+      - name: Maximize Runner Swap Space
+        uses: pierotofy/set-swap-space@v1.0
+        with:
+          swap-size-gb: 12
+
+      - name: Show qnn-model-lib-generator help
+        shell: bash
+        run: |
+          source py310/bin/activate
+
+          pushd qairt/2.40.0.251030/bin
+          source envsetup.sh
+          popd
+
+          qnn-model-lib-generator --help
+
+      - name: Show qnn-net-run help
+        shell: bash
+        run: |
+          source py310/bin/activate
+
+          pushd qairt/2.40.0.251030/bin
+          source envsetup.sh
+          popd
+
+          qnn-net-run --help
+
+      - name: Run ${{ matrix.model_type }}
+        shell: bash
+        run: |
+          source py310/bin/activate
+
+          pushd qairt/2.40.0.251030/bin
+          source envsetup.sh
+          popd
+
+          export PATH=${ANDROID_NDK_LATEST_HOME}:$PATH
+
+          ndk-build --help
+
+
+          export LDFLAGS="-Wl,-z,max-page-size=16384"
+          dir=$PWD
+          num_seconds=${{ matrix.num_seconds }}
+          model_dir=$PWD/model-files/$num_seconds
+          soc=${{ matrix.soc }}
+
+          python3 ./scripts/pyannote/segmentation/show-onnx.py --filename $model_dir/encoder.onnx
+          python3 ./scripts/pyannote/segmentation/show-onnx.py --filename $model_dir/decoder.onnx
+          python3 ./scripts/pyannote/segmentation/show-onnx.py --filename $model_dir/joiner.onnx
+
+          export PATH=${ANDROID_NDK_LATEST_HOME}:$PATH
+
+          echo "export to qnn"
+          echo "----------$num_seconds----------"
+
+          for m in encoder decoder joiner; do
+            echo "Processing $m"
+            mv -v $model_dir/${m}.* ./
+            cp -v $model_dir/*.raw ./
+            ls -lh $m.*
+            ls -lh *.raw
+
+            if [[ $m == 'encoder' ]]; then
+              # quantize only the encoder
+              cat $m.txt
+
+              qnn-onnx-converter \
+                --input_network ./$m.onnx \
+                --output_path ./quant/$m.cpp \
+                --input_list $m.txt \
+                --use_native_input_files \
+                --act_bitwidth 16 \
+                --bias_bitwidth 32 > ${m}-log-converter.t 2>&1
+            else
+              qnn-onnx-converter \
+                --input_network ./$m.onnx \
+                --output_path ./quant/$m.cpp \
+                --act_bitwidth 16 \
+                --bias_bitwidth 32 > ${m}-log-converter.t 2>&1
+            fi
+
+            ls -lh quant
+
+            python3 ./scripts/qnn/generate_config.py  \
+                --soc $soc \
+                --graph-name $m \
+                --output-dir ./quant/my-config-$m \
+                --qnn-sdk-root $QNN_SDK_ROOT
+
+            ls -lh quant/my-config-$m
+
+            head -n100 ./quant/my-config-$m/*.json
+
+            python3 "${QNN_SDK_ROOT}/bin/x86_64-linux-clang/qnn-model-lib-generator" \
+                -c quant/$m.cpp \
+                -b quant/$m.bin \
+                -o quant/model_libs > ${m}-log-generator.txt 2>&1
+
+            ls -lh quant/model_libs
+            echo "---"
+            ls -lh quant/model_libs/x86_64-linux-clang
+            echo "---"
+            ls -lh quant/model_libs/aarch64-android
+
+            $QNN_SDK_ROOT/bin/x86_64-linux-clang/qnn-context-binary-generator \
+              --backend $QNN_SDK_ROOT/lib/x86_64-linux-clang/libQnnHtp.so \
+              --model ./quant/model_libs/x86_64-linux-clang/lib$m.so \
+              --output_dir ./quant/binary \
+              --binary_file $m \
+              --config_file ./quant/my-config-$m/htp_backend_extensions.json > ${m}-log-generator.txt 2>&1
+
+            ls -lh quant/binary/
+          done
+
+          readelf -lW quant/model_libs/*/lib*.so
+
+          echo "collect results"
+
+          d=sherpa-onnx-qnn-${{ matrix.soc }}-binary-${{ matrix.model_name }}-${{ matrix.num_seconds }}s-transducer
+          mkdir -p $d
+          mkdir -p $d/test_wavs
+          cp -v quant/binary/*.bin $d/
+          cp -v $model_dir/tokens.txt $d
+          cp -v $model_dir/*.wav $d/test_wavs
+
+          echo "num_seconds=${num_seconds}s" > $d/info.txt
+
+          ls -lh $d
+          tar cjfv $d.tar.bz2 $d
+          ls -lh *.tar.bz2
+          rm -rf $d
+
+          mkdir -p binary
+          mv *.tar.bz2 ./binary/
+
+          for p in x86_64-linux-clang aarch64-android; do
+            if [[ $p == x86_64-linux-clang ]]; then
+              d=sherpa-onnx-qnn-${{ matrix.model_name }}-${{ matrix.num_seconds }}s-linux-x64
+            elif [[ $p == aarch64-android ]]; then
+              d=sherpa-onnx-qnn-${{ matrix.model_name }}-${{ matrix.num_seconds }}s-android-aarch64
+            else
+              echo "Unknown $p"
+              exit -1
+            fi
+
+            mkdir -p $d
+            mkdir -p $d/test_wavs
+
+            cp -v quant/model_libs/$p/lib*.so $d/
+            cp -v $model_dir/tokens.txt $d
+            cp -v $model_dir/*.wav $d/test_wavs
+
+            echo "num_seconds=${num_seconds}s" > $d/info.txt
+            echo "target=$p" >> $d/info.txt
+
+            ls -lh $d
+            tar cjfv $d.tar.bz2 $d
+            ls -lh *.tar.bz2
+            rm -rf $d
+          done
+
+          echo "----show---"
+          ls -lh *.tar.bz2
+
+          mkdir -p so
+
+          mv *.tar.bz2 ./so
+
+      - name: Setup tmate session
+        if: false
+        # if: failure()
+        uses: mxschmitt/action-tmate@v3
+
+      - name: Show files
+        shell: bash
+        run: |
+          echo "---so---"
+          ls -lh so
+
+          echo "---binary---"
+          ls -lh binary
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.model_name }}-${{ matrix.soc }}-${{ matrix.num_seconds }}-${{ matrix.model_type }}-json
+          path: ./quant/*.json
+
+      - name: Release
+        if: github.repository_owner == 'csukuangfj' && matrix.soc == 'SM8850'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./so/*.tar.bz2
+          overwrite: true
+          repo_name: k2-fsa/sherpa-onnx
+          repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
+          tag: asr-models-qnn-2
+
+      - name: Release
+        if: github.repository_owner == 'csukuangfj'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./binary/*.tar.bz2
+          overwrite: true
+          repo_name: k2-fsa/sherpa-onnx
+          repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
+          tag: asr-models-qnn-binary-2
+
+      - name: Release
+        if: github.repository_owner == 'k2-fsa' && matrix.soc == 'SM8850'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./so/*.tar.bz2
+          overwrite: true
+          tag: asr-models-qnn-2
+
+      - name: Release
+        if: github.repository_owner == 'k2-fsa'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./binary/*.tar.bz2
+          overwrite: true
+          tag: asr-models-qnn-binary-2

--- a/.github/workflows/export-parakeet-tdt-qnn.yaml
+++ b/.github/workflows/export-parakeet-tdt-qnn.yaml
@@ -18,8 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # num_seconds: [3, 5, 8, 10, 13, 15, 18, 20, 23, 25, 28, 30]
-        num_seconds: [10]
+        num_seconds: [3, 5, 8, 10, 13, 15, 18, 20, 23, 25, 28, 30]
         # model_id: ["parakeet-tdt-0.6b-v2", "parakeet-tdt-0.6b-v3"]
         model_id: ["parakeet-tdt-0.6b-v2"]
 
@@ -396,8 +395,8 @@ jobs:
             ls -lh *.raw
             ls -lh *.txt
 
-            if [[ $m == 'encoder' || $m == 'decoder' || $m == 'joiner' ]]; then
-              # quantize only the encoder
+            if [[ $m == 'encoder' || $m == 'joiner' ]]; then
+              # quantize only the encoder and joiner
               cat $m.txt
 
               qnn-onnx-converter \

--- a/scripts/nemo/qnn/parakeet-tdt-ctc/transducer/test_onnx.py
+++ b/scripts/nemo/qnn/parakeet-tdt-ctc/transducer/test_onnx.py
@@ -275,7 +275,7 @@ def main():
             decoder_input_list.append((ans[-1], h, c))
             decoder_out, h, c = model.run_decoder(ans[-1], h, c)
 
-    if False:
+    if True:
         # Don't quantize the decoder
         with open(f"{name}-decoder.txt", "w") as f:
             for i, (y, h, c) in enumerate(decoder_input_list):

--- a/scripts/nemo/qnn/parakeet-tdt-ctc/transducer/test_onnx.py
+++ b/scripts/nemo/qnn/parakeet-tdt-ctc/transducer/test_onnx.py
@@ -276,7 +276,6 @@ def main():
             decoder_out, h, c = model.run_decoder(ans[-1], h, c)
 
     if True:
-        # Don't quantize the decoder
         with open(f"{name}-decoder.txt", "w") as f:
             for i, (y, h, c) in enumerate(decoder_input_list):
                 y_name = f"{name}-{i}-y.raw"
@@ -289,7 +288,6 @@ def main():
                 c.tofile(c_name)
                 f.write(f"{y_name} {h_name} {c_name}\n")
 
-        # Don't quantize the joiner
         with open(f"{name}-joiner.txt", "w") as f:
             for i, (e, d) in enumerate(joiner_input_list):
                 e_name = f"{name}-{i}-joiner-e.raw"

--- a/scripts/nemo/qnn/parakeet-tdt/run.sh
+++ b/scripts/nemo/qnn/parakeet-tdt/run.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright      2026  Xiaomi Corp.        (authors: Fangjun Kuang)
+
+set -ex
+
+pip install \
+  nemo_toolkit['asr'] \
+  "numpy<2" \
+  ipython \
+  kaldi-native-fbank \
+  librosa \
+  onnx \
+  onnxruntime \
+  onnxscript \
+  soundfile
+
+num_frames=1000
+if [ $# -ge 1 ]; then
+  num_frames="$1"
+fi
+
+
+model_id=nvidia/parakeet-tdt-0.6b-v2
+if [ $# -ge 2 ]; then
+  model_id="$2"
+fi
+
+python3 ./wrapper.py --max-len $num_frames --model-id $model_id

--- a/scripts/nemo/qnn/parakeet-tdt/test_onnx.py
+++ b/scripts/nemo/qnn/parakeet-tdt/test_onnx.py
@@ -1,0 +1,1 @@
+../parakeet-tdt-ctc/transducer/test_onnx.py

--- a/scripts/nemo/qnn/parakeet-tdt/wrapper.py
+++ b/scripts/nemo/qnn/parakeet-tdt/wrapper.py
@@ -21,7 +21,7 @@ def get_args():
     parser.add_argument(
         "--model-id",
         type=str,
-        help="e.g., nvidia/parakeet-tdt_ctc-110m",
+        help="e.g., nvidia/parakeet-tdt-0.6b-v2",
         required=True,
     )
     return parser.parse_args()
@@ -138,7 +138,6 @@ def main():
     print(vars(args))
 
     asr_model = nemo_asr.models.ASRModel.from_pretrained(model_name=args.model_id)
-    asr_model.change_decoding_strategy(decoder_type="rnnt")
     asr_model.eval()
 
     asr_model.decoder._prepare_for_export()


### PR DESCRIPTION
Specifically, the following two models are supported:

- https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2
- https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3

Other models may also be converted to QNN using scripts in this PR.

C++ runtime will be added in a separate pull request.

Please see
- https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models-qnn-2
- https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models-qnn-binary-2
for exported QNN models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for exporting and packaging Parakeet-TDT model artifacts for multiple SoCs.
  * Added a new workflow to automate model export, conversion, and release preparation.
  * Added a new command-line entrypoint for running the Parakeet-TDT export flow.

* **Bug Fixes**
  * Enabled generation of additional intermediate export files needed for downstream conversion and validation.
  * Clarified input expectations for one model component to improve consistency during export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->