### PR TITLE
Add C++ runtime for Parakeet TDT models with QNN

### DIFF
--- a/sherpa-onnx/csrc/CMakeLists.txt
+++ b/sherpa-onnx/csrc/CMakeLists.txt
@@ -257,6 +257,7 @@ endif()
 if(SHERPA_ONNX_ENABLE_QNN)
   list(APPEND sources
     ./qnn/offline-parakeet-ctc-model-qnn.cc
+    ./qnn/offline-parakeet-tdt-model-qnn.cc
     ./qnn/offline-sense-voice-model-qnn.cc
     ./qnn/offline-paraformer-model-qnn.cc
     ./qnn/offline-whisper-model-qnn.cc

--- a/sherpa-onnx/csrc/offline-nemo-enc-dec-ctc-model.cc
+++ b/sherpa-onnx/csrc/offline-nemo-enc-dec-ctc-model.cc
@@ -3,12 +3,13 @@
 // Copyright (c)  2023-2024  Xiaomi Corporation
 
 #include "sherpa-onnx/csrc/offline-nemo-enc-dec-ctc-model.h"
-#include "sherpa-onnx/csrc/ort-env.h"
 
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
+
+#include "sherpa-onnx/csrc/ort-env.h"
 
 #if __ANDROID_API__ >= 9
 #include "android/asset_manager.h"
@@ -93,8 +94,8 @@ class OfflineNemoEncDecCtcModel::Impl {
  private:
   void Init(void *model_data, size_t model_data_length) {
     if (model_data) {
-      sess_ = std::make_unique<Ort::Session>(
-          env_, model_data, model_data_length, sess_opts_);
+      sess_ = std::make_unique<Ort::Session>(env_, model_data,
+                                             model_data_length, sess_opts_);
     } else if (!sess_) {
       SHERPA_ONNX_LOGE(
           "Please pass model data or initialize the session outside of "
@@ -124,6 +125,10 @@ class OfflineNemoEncDecCtcModel::Impl {
     SHERPA_ONNX_READ_META_DATA_STR_ALLOW_EMPTY(normalize_type_,
                                                "normalize_type");
     SHERPA_ONNX_READ_META_DATA_WITH_DEFAULT(is_giga_am_, "is_giga_am", 0);
+
+    if (normalize_type_ == "NA") {
+      normalize_type_ = "";
+    }
   }
 
  private:

--- a/sherpa-onnx/csrc/offline-recognizer-impl.cc
+++ b/sherpa-onnx/csrc/offline-recognizer-impl.cc
@@ -3,13 +3,14 @@
 // Copyright (c)  2023  Xiaomi Corporation
 
 #include "sherpa-onnx/csrc/offline-recognizer-impl.h"
-#include "sherpa-onnx/csrc/ort-env.h"
 
 #include <memory>
 #include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
+
+#include "sherpa-onnx/csrc/ort-env.h"
 
 #if __ANDROID_API__ >= 9
 
@@ -68,6 +69,7 @@
 #if SHERPA_ONNX_ENABLE_QNN
 #include "sherpa-onnx/csrc/qnn/offline-paraformer-model-qnn.h"
 #include "sherpa-onnx/csrc/qnn/offline-recognizer-parakeet-ctc-qnn-impl.h"
+#include "sherpa-onnx/csrc/qnn/offline-recognizer-parakeet-tdt-qnn-impl.h"
 #include "sherpa-onnx/csrc/qnn/offline-recognizer-transducer-qnn-impl.h"
 #include "sherpa-onnx/csrc/qnn/offline-recognizer-zipformer-ctc-qnn-impl.h"
 #include "sherpa-onnx/csrc/qnn/offline-sense-voice-model-qnn.h"
@@ -191,6 +193,9 @@ std::unique_ptr<OfflineRecognizerImpl> OfflineRecognizerImpl::Create(
       return std::make_unique<
           OfflineRecognizerSenseVoiceTplImpl<OfflineSenseVoiceModelQnn>>(
           config);
+    } else if (IsQnnTransducerArtifact(config.model_config.transducer) &&
+               config.model_config.model_type == "nemo_transducer") {
+      return std::make_unique<OfflineRecognizerParakeetTdtQnnImpl>(config);
     } else if (IsQnnTransducerArtifact(config.model_config.transducer)) {
       return std::make_unique<OfflineRecognizerTransducerQnnImpl>(config);
     } else if (!config.model_config.zipformer_ctc.model.empty() ||
@@ -208,15 +213,14 @@ std::unique_ptr<OfflineRecognizerImpl> OfflineRecognizerImpl::Create(
                     .empty()) {
       return std::make_unique<OfflineRecognizerParakeetCtcQnnImpl>(config);
     } else if (!config.model_config.whisper.encoder.empty() ||
-               !config.model_config.whisper.qnn_config.context_binary
-                    .empty()) {
+               !config.model_config.whisper.qnn_config.context_binary.empty()) {
       return std::make_unique<
           OfflineRecognizerWhisperTplImpl<OfflineWhisperModelQnn>>(config);
     } else {
       SHERPA_ONNX_LOGE(
-          "Only SenseVoice, Paraformer, offline transducer, Zipformer CTC, "
-          "NeMo CTC (Parakeet), and Whisper models are currently supported by "
-          "QNN for non-streaming ASR.");
+          "Only SenseVoice, Paraformer, Zipformer transducer, Zipformer CTC, "
+          "NeMo CTC (Parakeet), Parakeet TDT, and Whisper models are "
+          "currently supported by QNN for non-streaming ASR.");
       SHERPA_ONNX_EXIT(-1);
       return nullptr;
     }
@@ -554,8 +558,9 @@ std::unique_ptr<OfflineRecognizerImpl> OfflineRecognizerImpl::Create(
           mgr, config);
     } else if (IsQnnTransducerArtifact(config.model_config.transducer)) {
       SHERPA_ONNX_LOGE(
-          "QNN offline transducer does not support loading from asset manager. "
-          "Please copy model files to writable storage and use file paths.");
+          "QNN Zipformer transducer does not support loading from asset "
+          "manager. Please copy model files to writable storage and use file "
+          "paths.");
       SHERPA_ONNX_EXIT(-1);
       return nullptr;
     } else if (!config.model_config.zipformer_ctc.model.empty() ||
@@ -574,15 +579,14 @@ std::unique_ptr<OfflineRecognizerImpl> OfflineRecognizerImpl::Create(
                     .empty()) {
       return std::make_unique<OfflineRecognizerParakeetCtcQnnImpl>(mgr, config);
     } else if (!config.model_config.whisper.encoder.empty() ||
-               !config.model_config.whisper.qnn_config.context_binary
-                    .empty()) {
+               !config.model_config.whisper.qnn_config.context_binary.empty()) {
       return std::make_unique<
           OfflineRecognizerWhisperTplImpl<OfflineWhisperModelQnn>>(mgr, config);
     } else {
       SHERPA_ONNX_LOGE(
-          "Only SenseVoice, Paraformer, offline transducer, Zipformer CTC, "
-          "NeMo CTC (Parakeet), and Whisper models are currently supported by "
-          "QNN for non-streaming ASR.");
+          "Only SenseVoice, Paraformer, Zipformer transducer, Zipformer CTC, "
+          "NeMo CTC (Parakeet), Parakeet TDT, and Whisper models are "
+          "currently supported by QNN for non-streaming ASR.");
       SHERPA_ONNX_EXIT(-1);
       return nullptr;
     }

--- a/sherpa-onnx/csrc/qnn/offline-parakeet-tdt-model-qnn.cc
+++ b/sherpa-onnx/csrc/qnn/offline-parakeet-tdt-model-qnn.cc
@@ -1,0 +1,656 @@
+// sherpa-onnx/csrc/qnn/offline-parakeet-tdt-model-qnn.cc
+//
+// Copyright (c)  2026  Xiaomi Corporation
+
+#include "sherpa-onnx/csrc/qnn/offline-parakeet-tdt-model-qnn.h"
+
+#include <algorithm>
+#include <memory>
+#include <mutex>  // NOLINT
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#if __ANDROID_API__ >= 9
+#include "android/asset_manager.h"
+#include "android/asset_manager_jni.h"
+#endif
+
+#if __OHOS__
+#include "rawfile/raw_file_manager.h"
+#endif
+
+#include "sherpa-onnx/csrc/file-utils.h"
+#include "sherpa-onnx/csrc/macros.h"
+#include "sherpa-onnx/csrc/math.h"
+#include "sherpa-onnx/csrc/qnn/macros.h"
+#include "sherpa-onnx/csrc/qnn/qnn-backend.h"
+#include "sherpa-onnx/csrc/qnn/qnn-model.h"
+#include "sherpa-onnx/csrc/text-utils.h"
+
+namespace sherpa_onnx {
+
+class OfflineParakeetTdtModelQnn::Impl {
+ public:
+  explicit Impl(const OfflineModelConfig &config) : config_(config) { Init(); }
+
+  template <typename Manager>
+  Impl(Manager *mgr, const OfflineModelConfig &config) : config_(config) {
+    (void)mgr;
+    SHERPA_ONNX_LOGE(
+        "Please copy all files from assets to SD card and set assetManager to "
+        "null");
+    SHERPA_ONNX_EXIT(-1);
+  }
+
+  // Encoder:
+  //   Input  "x":           (1, max_num_frames, feat_dim)
+  //   Output "encoder_out": (1, num_encoder_frames, encoder_out_dim)
+  std::vector<float> RunEncoder(std::vector<float> features) const {
+    int32_t num_frames = static_cast<int32_t>(features.size()) / feat_dim_;
+    if (num_frames == 0) {
+      return {};
+    }
+
+    if (num_frames > max_num_frames_) {
+      SHERPA_ONNX_LOGE(
+          "Number of input frames %d is too large. Truncate it to %d frames.",
+          num_frames, max_num_frames_);
+      SHERPA_ONNX_LOGE(
+          "Recognition result may be truncated/incomplete. Please select a "
+          "model accepting longer audios.");
+      num_frames = max_num_frames_;
+      features.resize(static_cast<size_t>(num_frames) * feat_dim_);
+    }
+
+    // Pad to max_num_frames_
+    features.resize(static_cast<size_t>(max_num_frames_) * feat_dim_);
+
+    // Note: The QNN model expects input shape [1, max_num_frames, feat_dim].
+    // Features are already in (num_frames, feat_dim) row-major order.
+    // No transpose is needed here (unlike zipformer which needs transpose).
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    encoder_->SetInputTensorData(encoder_input_name_, features.data(),
+                                 static_cast<int32_t>(features.size()));
+    encoder_->Run();
+
+    std::vector<float> encoder_out =
+        encoder_->GetOutputTensorData(encoder_output_name_);
+    encoder_out.resize(static_cast<size_t>(NumEncoderFrames(num_frames)) *
+                       encoder_out_dim_);
+    return encoder_out;
+  }
+
+  // Decoder (LSTM-based):
+  //   Input  "y":            (1, 1)                           int32, a single
+  //                                                     token id
+  //   Input  "h":            (num_layers, hidden_dim, 1)      float, hidden
+  //                                                     state
+  //   Input  "c":            (num_layers, hidden_dim, 1)      float, cell
+  //                                                     state
+  //   Output "decoder_out":  (1, 1, decoder_out_dim)         float
+  //   Output "next_h":       (num_layers, 1, hidden_dim)     float, updated
+  //                                                     hidden state
+  //   Output "next_c":       (num_layers, 1, hidden_dim)     float, updated
+  //                                                     cell state
+  //
+  //   Note: h/c input shape is (num_layers, hidden_dim, 1) while
+  //         next_h/next_c output shape is (num_layers, 1, hidden_dim).
+  //         Since batch_size=1, no transpose is needed.
+  std::vector<std::vector<float>> GetDecoderInitStates() const {
+    return {std::vector<float>(h_size_, 0.0f),
+            std::vector<float>(c_size_, 0.0f)};
+  }
+
+  std::pair<std::vector<float>, std::vector<std::vector<float>>> RunDecoder(
+      int32_t token, std::vector<std::vector<float>> states) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    decoder_->SetInputTensorData(decoder_input_y_name_, &token, 1);
+    decoder_->SetInputTensorData(decoder_input_h_name_, states[0].data(),
+                                 static_cast<int32_t>(states[0].size()));
+    decoder_->SetInputTensorData(decoder_input_c_name_, states[1].data(),
+                                 static_cast<int32_t>(states[1].size()));
+    decoder_->Run();
+
+    std::vector<float> decoder_out =
+        decoder_->GetOutputTensorData(decoder_output_name_);
+    states[0] = decoder_->GetOutputTensorData(decoder_output_h_name_);
+    states[1] = decoder_->GetOutputTensorData(decoder_output_c_name_);
+
+    return {std::move(decoder_out), std::move(states)};
+  }
+
+  // Joiner:
+  //   Input  "encoder_out": (1, encoder_out_dim, 1) float
+  //   Input  "decoder_out": (1, decoder_out_dim, 1) float
+  //   Output "log_probs":   (1, 1, 1, vocab_size + num_durations) float
+  //     Despite the name "log_probs", the output contains raw logits
+  //     (log_softmax is NOT applied).
+  //     First vocab_size elements are token logits,
+  //     remaining num_durations elements are duration logits.
+  std::vector<float> RunJoiner(const float *encoder_out,
+                               const std::vector<float> &decoder_out) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    joiner_->SetInputTensorData(joiner_encoder_input_name_, encoder_out,
+                                encoder_out_dim_);
+    joiner_->SetInputTensorData(joiner_decoder_input_name_, decoder_out.data(),
+                                static_cast<int32_t>(decoder_out.size()));
+    joiner_->Run();
+    return joiner_->GetOutputTensorData(joiner_output_name_);
+  }
+
+  int32_t SubsamplingFactor() const { return subsampling_factor_; }
+  int32_t EncoderDim() const { return encoder_out_dim_; }
+  int32_t FeatDim() const { return feat_dim_; }
+
+  int32_t NumEncoderFrames(int32_t num_frames) const {
+    if (num_frames <= 0) {
+      return 0;
+    }
+
+    num_frames = std::min(num_frames, max_num_frames_);
+    int32_t ans = (num_frames + subsampling_factor_ - 1) / subsampling_factor_;
+    return std::min(ans, max_num_encoder_frames_);
+  }
+
+ private:
+  void Init() {
+    ParseContextBinaries();
+    encoder_backend_ = std::make_unique<QnnBackend>(
+        config_.transducer.qnn_config.backend_lib, config_.debug);
+    decoder_backend_ = std::make_unique<QnnBackend>(
+        config_.transducer.qnn_config.backend_lib, config_.debug);
+    joiner_backend_ = std::make_unique<QnnBackend>(
+        config_.transducer.qnn_config.backend_lib, config_.debug);
+
+    InitEncoder();
+    InitDecoder();
+    InitJoiner();
+
+    CheckEncoder();
+    CheckDecoder();
+    CheckJoiner();
+  }
+
+  void ParseContextBinaries() {
+    SplitStringToVector(config_.transducer.qnn_config.context_binary, ",", true,
+                        &context_binaries_);
+    if (!context_binaries_.empty() && context_binaries_.size() != 3) {
+      SHERPA_ONNX_LOGE(
+          "There should be 3 files for offline parakeet TDT context binary. "
+          "Actual: %d. '%s'",
+          static_cast<int32_t>(context_binaries_.size()),
+          config_.transducer.qnn_config.context_binary.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+  }
+
+  void CreateContextBinary(QnnModel *model,
+                           const std::string &context_binary) const {
+    if (config_.debug) {
+      SHERPA_ONNX_LOGE("Creating context binary '%s'.", context_binary.c_str());
+    }
+
+    bool ok = model->SaveBinaryContext(context_binary);
+    if (!ok) {
+      SHERPA_ONNX_LOGE("Failed to save context binary to '%s'",
+                       context_binary.c_str());
+    }
+
+    if (config_.debug && ok) {
+      SHERPA_ONNX_LOGE("Saved context binary to '%s'.", context_binary.c_str());
+      SHERPA_ONNX_LOGE("Remember to also provide libQnnSystem.so.");
+    }
+  }
+
+  void InitModelFromLib(const std::string &filename, QnnBackend *backend,
+                        std::unique_ptr<QnnModel> *model) const {
+    backend->InitContext();
+    *model = std::make_unique<QnnModel>(filename, backend, config_.debug);
+  }
+
+  void InitModelFromContextBinary(const std::string &filename,
+                                  QnnBackend *backend,
+                                  std::unique_ptr<QnnModel> *model) const {
+    if (config_.transducer.qnn_config.system_lib.empty()) {
+      SHERPA_ONNX_LOGE(
+          "You should provide --transducer.qnn-system-lib if you also provide "
+          "context binary");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    *model = std::make_unique<QnnModel>(
+        filename, config_.transducer.qnn_config.system_lib, backend,
+        BinaryContextTag{}, config_.debug);
+  }
+
+  void InitComponent(const std::string &lib_filename,
+                     const std::string &context_binary, const char *name,
+                     QnnBackend *backend,
+                     std::unique_ptr<QnnModel> *model) const {
+    if (context_binary.empty()) {
+      if (config_.debug) {
+        SHERPA_ONNX_LOGE(
+            "Init from %s model lib '%s' since context binary is not given.",
+            name, lib_filename.c_str());
+      }
+
+      InitModelFromLib(lib_filename, backend, model);
+      return;
+    }
+
+    if (!FileExists(context_binary)) {
+      if (config_.debug) {
+        SHERPA_ONNX_LOGE(
+            "Init %s from model lib '%s' since context binary '%s' does not "
+            "exist",
+            name, lib_filename.c_str(), context_binary.c_str());
+      }
+
+      InitModelFromLib(lib_filename, backend, model);
+      CreateContextBinary(model->get(), context_binary);
+    } else {
+      if (config_.debug) {
+        SHERPA_ONNX_LOGE("Init from %s context binary '%s'", name,
+                         context_binary.c_str());
+      }
+
+      InitModelFromContextBinary(context_binary, backend, model);
+    }
+  }
+
+  void InitEncoder() {
+    InitComponent(config_.transducer.encoder_filename,
+                  context_binaries_.empty() ? "" : context_binaries_[0],
+                  "encoder", encoder_backend_.get(), &encoder_);
+  }
+
+  void InitDecoder() {
+    InitComponent(config_.transducer.decoder_filename,
+                  context_binaries_.empty() ? "" : context_binaries_[1],
+                  "decoder", decoder_backend_.get(), &decoder_);
+  }
+
+  void InitJoiner() {
+    InitComponent(config_.transducer.joiner_filename,
+                  context_binaries_.empty() ? "" : context_binaries_[2],
+                  "joiner", joiner_backend_.get(), &joiner_);
+  }
+
+  void CheckEncoder() {
+    encoder_input_name_ = "x";
+    encoder_output_name_ = "encoder_out";
+
+    if (!encoder_->HasTensor(encoder_input_name_)) {
+      SHERPA_ONNX_LOGE("The encoder model does not have input '%s'",
+                       encoder_input_name_.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    if (!encoder_->HasTensor(encoder_output_name_)) {
+      SHERPA_ONNX_LOGE("The encoder model does not have output '%s'",
+                       encoder_output_name_.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    auto x_shape = encoder_->TensorShape(encoder_input_name_);
+    if (x_shape.size() != 3 || x_shape[0] != 1) {
+      SHERPA_ONNX_LOGE("The encoder input x should be of shape [1, ?, ?]");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    // QNN Parakeet TDT encoder input shape: [1, max_num_frames, feat_dim]
+    // (Note: the ONNX model uses [1, feat_dim, max_num_frames] instead)
+    max_num_frames_ = x_shape[1];
+    feat_dim_ = x_shape[2];
+
+    auto out_shape = encoder_->TensorShape(encoder_output_name_);
+    if (out_shape.size() != 3 || out_shape[0] != 1) {
+      SHERPA_ONNX_LOGE("The encoder output should be of shape [1, ?, ?]");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    max_num_encoder_frames_ = out_shape[1];
+    encoder_out_dim_ = out_shape[2];
+
+    if (feat_dim_ <= 0 || max_num_frames_ <= 0 || max_num_encoder_frames_ <= 0 ||
+        encoder_out_dim_ <= 0) {
+      SHERPA_ONNX_LOGE(
+          "Invalid encoder shapes. feat_dim: %d, max_num_frames: %d, "
+          "max_num_encoder_frames: %d, encoder_out_dim: %d",
+          feat_dim_, max_num_frames_, max_num_encoder_frames_,
+          encoder_out_dim_);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    subsampling_factor_ = max_num_frames_ / max_num_encoder_frames_;
+    if (subsampling_factor_ <= 0) {
+      SHERPA_ONNX_LOGE(
+          "Invalid parakeet TDT QNN encoder shapes. Input frames: %d, "
+          "output frames: %d",
+          max_num_frames_, max_num_encoder_frames_);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    if (config_.debug) {
+      SHERPA_ONNX_LOGE("encoder input '%s': [%d, %d, %d]",
+                       encoder_input_name_.c_str(), 1, max_num_frames_,
+                       feat_dim_);
+      SHERPA_ONNX_LOGE("encoder output '%s': [%d, %d, %d]",
+                       encoder_output_name_.c_str(), 1, max_num_encoder_frames_,
+                       encoder_out_dim_);
+      SHERPA_ONNX_LOGE("subsampling_factor: %d", subsampling_factor_);
+    }
+  }
+
+  void CheckDecoder() {
+    // Parakeet TDT decoder has 3 inputs: y (token), h (hidden state),
+    // c (cell state) and 3 outputs: decoder_out, next_h, next_c
+    decoder_input_y_name_ = "y";
+    decoder_input_h_name_ = "h";
+    decoder_input_c_name_ = "c";
+    decoder_output_name_ = "decoder_out";
+    decoder_output_h_name_ = "next_h";
+    decoder_output_c_name_ = "next_c";
+
+    if (!decoder_->HasTensor(decoder_input_y_name_)) {
+      SHERPA_ONNX_LOGE("The decoder model does not have input '%s'",
+                       decoder_input_y_name_.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    if (!decoder_->HasTensor(decoder_input_h_name_)) {
+      SHERPA_ONNX_LOGE("The decoder model does not have input '%s'",
+                       decoder_input_h_name_.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    if (!decoder_->HasTensor(decoder_input_c_name_)) {
+      SHERPA_ONNX_LOGE("The decoder model does not have input '%s'",
+                       decoder_input_c_name_.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    if (!decoder_->HasTensor(decoder_output_name_)) {
+      SHERPA_ONNX_LOGE("The decoder model does not have output '%s'",
+                       decoder_output_name_.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    if (!decoder_->HasTensor(decoder_output_h_name_)) {
+      SHERPA_ONNX_LOGE("The decoder model does not have output '%s'",
+                       decoder_output_h_name_.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    if (!decoder_->HasTensor(decoder_output_c_name_)) {
+      SHERPA_ONNX_LOGE("The decoder model does not have output '%s'",
+                       decoder_output_c_name_.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    auto y_shape = decoder_->TensorShape(decoder_input_y_name_);
+    if (y_shape.size() != 2 || y_shape[0] != 1 || y_shape[1] != 1) {
+      SHERPA_ONNX_LOGE(
+          "Expected decoder input 'y' shape [1, 1]. Actual: [%d, %d]",
+          y_shape[0], y_shape.size() > 1 ? y_shape[1] : 0);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    // h shape: (num_layers, hidden_dim, 1)
+    auto h_shape = decoder_->TensorShape(decoder_input_h_name_);
+    if (h_shape.size() != 3 || h_shape[2] != 1) {
+      SHERPA_ONNX_LOGE(
+          "Expected h shape (num_layers, hidden_dim, 1). Actual: [%d, %d, %d]",
+          h_shape.size() > 0 ? h_shape[0] : 0,
+          h_shape.size() > 1 ? h_shape[1] : 0,
+          h_shape.size() > 2 ? h_shape[2] : 0);
+      SHERPA_ONNX_EXIT(-1);
+    }
+    int32_t num_layers = h_shape[0];
+    int32_t hidden_dim = h_shape[1];
+    h_size_ = num_layers * hidden_dim * 1;
+
+    // c shape: (num_layers, hidden_dim, 1)
+    auto c_shape = decoder_->TensorShape(decoder_input_c_name_);
+    if (c_shape.size() != 3 || c_shape[0] != num_layers ||
+        c_shape[1] != hidden_dim || c_shape[2] != 1) {
+      SHERPA_ONNX_LOGE(
+          "Expected c shape (%d, %d, 1). Actual: [%d, %d, %d]", num_layers,
+          hidden_dim, c_shape.size() > 0 ? c_shape[0] : 0,
+          c_shape.size() > 1 ? c_shape[1] : 0,
+          c_shape.size() > 2 ? c_shape[2] : 0);
+      SHERPA_ONNX_EXIT(-1);
+    }
+    c_size_ = num_layers * hidden_dim * 1;
+
+    // next_h shape: (num_layers, 1, hidden_dim)
+    auto next_h_shape = decoder_->TensorShape(decoder_output_h_name_);
+    if (next_h_shape.size() != 3 || next_h_shape[0] != num_layers ||
+        next_h_shape[1] != 1 || next_h_shape[2] != hidden_dim) {
+      SHERPA_ONNX_LOGE(
+          "Expected next_h shape (%d, 1, %d). Actual: [%d, %d, %d]",
+          num_layers, hidden_dim,
+          next_h_shape.size() > 0 ? next_h_shape[0] : 0,
+          next_h_shape.size() > 1 ? next_h_shape[1] : 0,
+          next_h_shape.size() > 2 ? next_h_shape[2] : 0);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    // next_c shape: (num_layers, 1, hidden_dim)
+    auto next_c_shape = decoder_->TensorShape(decoder_output_c_name_);
+    if (next_c_shape.size() != 3 || next_c_shape[0] != num_layers ||
+        next_c_shape[1] != 1 || next_c_shape[2] != hidden_dim) {
+      SHERPA_ONNX_LOGE(
+          "Expected next_c shape (%d, 1, %d). Actual: [%d, %d, %d]",
+          num_layers, hidden_dim,
+          next_c_shape.size() > 0 ? next_c_shape[0] : 0,
+          next_c_shape.size() > 1 ? next_c_shape[1] : 0,
+          next_c_shape.size() > 2 ? next_c_shape[2] : 0);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    auto out_shape = decoder_->TensorShape(decoder_output_name_);
+    if (out_shape.size() != 3 || out_shape[0] != 1 || out_shape[1] != 1) {
+      SHERPA_ONNX_LOGE(
+          "The decoder output should be of shape [1, 1, decoder_dim]");
+      SHERPA_ONNX_EXIT(-1);
+    }
+    decoder_out_dim_ = out_shape[2];
+
+    if (decoder_out_dim_ <= 0 || h_size_ <= 0 || c_size_ <= 0) {
+      SHERPA_ONNX_LOGE(
+          "Invalid decoder shapes. decoder_out_dim: %d, h_size: %d, c_size: %d",
+          decoder_out_dim_, h_size_, c_size_);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    if (config_.debug) {
+      SHERPA_ONNX_LOGE("decoder input '%s': [%d, %d]",
+                       decoder_input_y_name_.c_str(), 1, 1);
+      SHERPA_ONNX_LOGE("decoder input '%s': [%d, %d, %d]",
+                       decoder_input_h_name_.c_str(), num_layers, hidden_dim,
+                       1);
+      SHERPA_ONNX_LOGE("decoder input '%s': [%d, %d, %d]",
+                       decoder_input_c_name_.c_str(), num_layers, hidden_dim,
+                       1);
+      SHERPA_ONNX_LOGE("decoder output '%s': [%d, %d, %d]",
+                       decoder_output_name_.c_str(), 1, 1, decoder_out_dim_);
+      SHERPA_ONNX_LOGE("decoder output '%s': [%d, %d, %d]",
+                       decoder_output_h_name_.c_str(), num_layers, 1,
+                       hidden_dim);
+      SHERPA_ONNX_LOGE("decoder output '%s': [%d, %d, %d]",
+                       decoder_output_c_name_.c_str(), num_layers, 1,
+                       hidden_dim);
+    }
+  }
+
+  void CheckJoiner() {
+    joiner_encoder_input_name_ = "encoder_out";
+    joiner_decoder_input_name_ = "decoder_out";
+    joiner_output_name_ = "log_probs";
+
+    if (!joiner_->HasTensor(joiner_encoder_input_name_)) {
+      SHERPA_ONNX_LOGE("The joiner model does not have input '%s'",
+                       joiner_encoder_input_name_.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    if (!joiner_->HasTensor(joiner_decoder_input_name_)) {
+      SHERPA_ONNX_LOGE("The joiner model does not have input '%s'",
+                       joiner_decoder_input_name_.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    if (!joiner_->HasTensor(joiner_output_name_)) {
+      SHERPA_ONNX_LOGE("The joiner model does not have output '%s'",
+                       joiner_output_name_.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    auto encoder_in_shape = joiner_->TensorShape(joiner_encoder_input_name_);
+    if (encoder_in_shape.size() != 3 || encoder_in_shape[0] != 1 ||
+        encoder_in_shape[1] != encoder_out_dim_ || encoder_in_shape[2] != 1) {
+      SHERPA_ONNX_LOGE(
+          "The joiner input '%s' should be of shape [1, %d, 1]",
+          joiner_encoder_input_name_.c_str(), encoder_out_dim_);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    auto decoder_in_shape = joiner_->TensorShape(joiner_decoder_input_name_);
+    if (decoder_in_shape.size() != 3 || decoder_in_shape[0] != 1 ||
+        decoder_in_shape[1] != decoder_out_dim_ || decoder_in_shape[2] != 1) {
+      SHERPA_ONNX_LOGE(
+          "The joiner input '%s' should be of shape [1, %d, 1]",
+          joiner_decoder_input_name_.c_str(), decoder_out_dim_);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    auto out_shape = joiner_->TensorShape(joiner_output_name_);
+    if (out_shape.size() != 4 || out_shape[0] != 1 || out_shape[1] != 1 ||
+        out_shape[2] != 1) {
+      SHERPA_ONNX_LOGE(
+          "The joiner output should be of shape [1, 1, 1, vocab_size + "
+          "num_durations]");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    // For TDT, the joiner output contains both token logits and duration logits
+    // vocab_size + num_durations
+    int32_t total_output = out_shape[3];
+    if (total_output <= 0) {
+      SHERPA_ONNX_LOGE("Invalid joiner output shape. total_output: %d",
+                       total_output);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    if (config_.debug) {
+      SHERPA_ONNX_LOGE("joiner input '%s': [%d, %d, %d]",
+                       joiner_encoder_input_name_.c_str(), 1, encoder_out_dim_,
+                       1);
+      SHERPA_ONNX_LOGE("joiner input '%s': [%d, %d, %d]",
+                       joiner_decoder_input_name_.c_str(), 1, decoder_out_dim_,
+                       1);
+      SHERPA_ONNX_LOGE("joiner output '%s': [%d, %d, %d, %d]",
+                       joiner_output_name_.c_str(), 1, 1, 1, total_output);
+    }
+  }
+
+ private:
+  mutable std::mutex mutex_;
+
+  OfflineModelConfig config_;
+
+  std::unique_ptr<QnnBackend> encoder_backend_;
+  std::unique_ptr<QnnBackend> decoder_backend_;
+  std::unique_ptr<QnnBackend> joiner_backend_;
+
+  std::unique_ptr<QnnModel> encoder_;
+  std::unique_ptr<QnnModel> decoder_;
+  std::unique_ptr<QnnModel> joiner_;
+  std::vector<std::string> context_binaries_;
+
+  std::string encoder_input_name_;
+  std::string encoder_output_name_;
+  std::string decoder_input_y_name_;
+  std::string decoder_input_h_name_;
+  std::string decoder_input_c_name_;
+  std::string decoder_output_name_;
+  std::string decoder_output_h_name_;
+  std::string decoder_output_c_name_;
+  std::string joiner_encoder_input_name_;
+  std::string joiner_decoder_input_name_;
+  std::string joiner_output_name_;
+
+  int32_t max_num_frames_ = 0;
+  int32_t feat_dim_ = 0;
+  int32_t max_num_encoder_frames_ = 0;
+  int32_t encoder_out_dim_ = 0;
+  int32_t decoder_out_dim_ = 0;
+  int32_t h_size_ = 0;
+  int32_t c_size_ = 0;
+  int32_t subsampling_factor_ = 0;
+};
+
+OfflineParakeetTdtModelQnn::OfflineParakeetTdtModelQnn(
+    const OfflineModelConfig &config)
+    : impl_(std::make_unique<Impl>(config)) {}
+
+template <typename Manager>
+OfflineParakeetTdtModelQnn::OfflineParakeetTdtModelQnn(
+    Manager *mgr, const OfflineModelConfig &config)
+    : impl_(std::make_unique<Impl>(mgr, config)) {}
+
+OfflineParakeetTdtModelQnn::~OfflineParakeetTdtModelQnn() = default;
+
+std::vector<float> OfflineParakeetTdtModelQnn::RunEncoder(
+    std::vector<float> features) const {
+  return impl_->RunEncoder(std::move(features));
+}
+
+std::vector<std::vector<float>>
+OfflineParakeetTdtModelQnn::GetDecoderInitStates() const {
+  return impl_->GetDecoderInitStates();
+}
+
+std::pair<std::vector<float>, std::vector<std::vector<float>>>
+OfflineParakeetTdtModelQnn::RunDecoder(
+    int32_t token, std::vector<std::vector<float>> states) const {
+  return impl_->RunDecoder(token, std::move(states));
+}
+
+std::vector<float> OfflineParakeetTdtModelQnn::RunJoiner(
+    const float *encoder_out, const std::vector<float> &decoder_out) const {
+  return impl_->RunJoiner(encoder_out, decoder_out);
+}
+
+int32_t OfflineParakeetTdtModelQnn::SubsamplingFactor() const {
+  return impl_->SubsamplingFactor();
+}
+
+int32_t OfflineParakeetTdtModelQnn::EncoderDim() const {
+  return impl_->EncoderDim();
+}
+
+int32_t OfflineParakeetTdtModelQnn::FeatDim() const {
+  return impl_->FeatDim();
+}
+
+int32_t OfflineParakeetTdtModelQnn::NumEncoderFrames(
+    int32_t num_frames) const {
+  return impl_->NumEncoderFrames(num_frames);
+}
+
+#if __ANDROID_API__ >= 9
+template OfflineParakeetTdtModelQnn::OfflineParakeetTdtModelQnn(
+    AAssetManager *mgr, const OfflineModelConfig &config);
+#endif
+
+#if __OHOS__
+template OfflineParakeetTdtModelQnn::OfflineParakeetTdtModelQnn(
+    NativeResourceManager *mgr, const OfflineModelConfig &config);
+#endif
+
+}  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/qnn/offline-parakeet-tdt-model-qnn.h
+++ b/sherpa-onnx/csrc/qnn/offline-parakeet-tdt-model-qnn.h
@@ -1,0 +1,71 @@
+// sherpa-onnx/csrc/qnn/offline-parakeet-tdt-model-qnn.h
+//
+// Copyright (c)  2026  Xiaomi Corporation
+#ifndef SHERPA_ONNX_CSRC_QNN_OFFLINE_PARAKEET_TDT_MODEL_QNN_H_
+#define SHERPA_ONNX_CSRC_QNN_OFFLINE_PARAKEET_TDT_MODEL_QNN_H_
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "sherpa-onnx/csrc/offline-model-config.h"
+
+namespace sherpa_onnx {
+
+class OfflineParakeetTdtModelQnn {
+ public:
+  ~OfflineParakeetTdtModelQnn();
+
+  explicit OfflineParakeetTdtModelQnn(const OfflineModelConfig &config);
+
+  template <typename Manager>
+  OfflineParakeetTdtModelQnn(Manager *mgr, const OfflineModelConfig &config);
+
+  /** Run the encoder.
+   *
+   * @param features A flat vector of shape (num_frames, feat_dim),
+   *                 already mean-variance normalized with per_feature.
+   *
+   * @return A flat vector of shape (num_encoder_frames, encoder_out_dim).
+   */
+  std::vector<float> RunEncoder(std::vector<float> features) const;
+
+  /** Get the initial decoder states (all zeros).
+   *
+   * @return A vector of state tensors. For LSTM, it contains [h, c].
+   */
+  std::vector<std::vector<float>> GetDecoderInitStates() const;
+
+  /** Run the decoder with states.
+   *
+   * @param token  A single token id.
+   * @param states  The decoder states (e.g. [h, c] for LSTM).
+   *
+   * @return A pair of (decoder_out, next_states).
+   */
+  std::pair<std::vector<float>, std::vector<std::vector<float>>> RunDecoder(
+      int32_t token, std::vector<std::vector<float>> states) const;
+
+  /** Run the joiner.
+   *
+   * @param encoder_out  Pointer to a single encoder output frame.
+   * @param decoder_out  The decoder output vector.
+   *
+   * @return A flat vector of shape (vocab_size + num_durations,).
+   */
+  std::vector<float> RunJoiner(const float *encoder_out,
+                               const std::vector<float> &decoder_out) const;
+
+  int32_t SubsamplingFactor() const;
+  int32_t EncoderDim() const;
+  int32_t FeatDim() const;
+  int32_t NumEncoderFrames(int32_t num_frames) const;
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace sherpa_onnx
+
+#endif  // SHERPA_ONNX_CSRC_QNN_OFFLINE_PARAKEET_TDT_MODEL_QNN_H_

--- a/sherpa-onnx/csrc/qnn/offline-recognizer-parakeet-tdt-qnn-impl.h
+++ b/sherpa-onnx/csrc/qnn/offline-recognizer-parakeet-tdt-qnn-impl.h
@@ -1,0 +1,264 @@
+// sherpa-onnx/csrc/qnn/offline-recognizer-parakeet-tdt-qnn-impl.h
+//
+// Copyright (c)  2026  Xiaomi Corporation
+
+#ifndef SHERPA_ONNX_CSRC_QNN_OFFLINE_RECOGNIZER_PARAKEET_TDT_QNN_IMPL_H_
+#define SHERPA_ONNX_CSRC_QNN_OFFLINE_RECOGNIZER_PARAKEET_TDT_QNN_IMPL_H_
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <ios>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "sherpa-onnx/csrc/macros.h"
+#include "sherpa-onnx/csrc/math.h"
+#include "sherpa-onnx/csrc/offline-recognizer-impl.h"
+#include "sherpa-onnx/csrc/offline-recognizer.h"
+#include "sherpa-onnx/csrc/qnn/offline-parakeet-tdt-model-qnn.h"
+#include "sherpa-onnx/csrc/symbol-table.h"
+#include "sherpa-onnx/csrc/text-utils.h"
+#include "sherpa-onnx/csrc/utils.h"
+
+namespace sherpa_onnx {
+
+namespace qnn_parakeet_tdt_impl {
+
+inline OfflineRecognitionResult Convert(
+    const OfflineTransducerDecoderResult &src, const SymbolTable &sym_table,
+    int32_t frame_shift_ms, int32_t subsampling_factor) {
+  OfflineRecognitionResult r;
+  r.tokens.reserve(src.tokens.size());
+  r.timestamps.reserve(src.timestamps.size());
+  r.durations.reserve(src.durations.size());
+
+  std::string text;
+  for (auto i : src.tokens) {
+    auto sym = sym_table[i];
+    text.append(sym);
+
+    if (sym.size() == 1 && (sym[0] < 0x20 || sym[0] > 0x7e)) {
+      std::ostringstream os;
+      os << "<0x" << std::hex << std::uppercase
+         << (static_cast<int32_t>(sym[0]) & 0xff) << ">";
+      sym = os.str();
+    }
+
+    r.tokens.push_back(std::move(sym));
+  }
+
+  if (sym_table.IsByteBpe()) {
+    text = sym_table.DecodeByteBpe(text);
+  }
+
+  text = RemoveSpaceBetweenCjk(text);
+
+  r.text = std::move(text);
+
+  float frame_shift_s = frame_shift_ms / 1000.f * subsampling_factor;
+  for (auto t : src.timestamps) {
+    r.timestamps.push_back(frame_shift_s * t);
+  }
+
+  for (auto d : src.durations) {
+    r.durations.push_back(d * frame_shift_s);
+  }
+
+  r.ys_log_probs = src.ys_log_probs;
+  return r;
+}
+
+}  // namespace qnn_parakeet_tdt_impl
+
+class OfflineRecognizerParakeetTdtQnnImpl : public OfflineRecognizerImpl {
+ public:
+  explicit OfflineRecognizerParakeetTdtQnnImpl(
+      const OfflineRecognizerConfig &config)
+      : OfflineRecognizerImpl(config),
+        config_(config),
+        symbol_table_(config_.model_config.tokens),
+        model_(std::make_unique<OfflineParakeetTdtModelQnn>(
+            config_.model_config)) {
+    Init();
+  }
+
+  template <typename Manager>
+  explicit OfflineRecognizerParakeetTdtQnnImpl(
+      Manager *mgr, const OfflineRecognizerConfig &config)
+      : OfflineRecognizerImpl(mgr, config),
+        config_(config),
+        symbol_table_(mgr, config_.model_config.tokens),
+        model_(std::make_unique<OfflineParakeetTdtModelQnn>(
+            mgr, config_.model_config)) {
+    Init();
+  }
+
+  std::unique_ptr<OfflineStream> CreateStream(
+      const std::string & /*hotwords*/) const override {
+    return std::make_unique<OfflineStream>(config_.feat_config);
+  }
+
+  std::unique_ptr<OfflineStream> CreateStream() const override {
+    return std::make_unique<OfflineStream>(config_.feat_config);
+  }
+
+  void DecodeStreams(OfflineStream **ss, int32_t n) const override {
+    int32_t frame_shift_ms = 10;
+    for (int32_t i = 0; i != n; ++i) {
+      auto result = DecodeStream(ss[i]);
+      auto r = qnn_parakeet_tdt_impl::Convert(
+          result, symbol_table_, frame_shift_ms, model_->SubsamplingFactor());
+
+      // Remove leading space from BPE tokenization
+      if (!r.text.empty() && r.text.front() == ' ') {
+        r.text.erase(0, 1);
+      }
+
+      r.text = ApplyInverseTextNormalization(std::move(r.text));
+      r.text = ApplyHomophoneReplacer(std::move(r.text));
+      ss[i]->SetResult(r);
+    }
+  }
+
+  OfflineRecognizerConfig GetConfig() const override { return config_; }
+
+ private:
+  void Init() {
+    if (!symbol_table_.Contains("<blk>")) {
+      SHERPA_ONNX_LOGE("tokens.txt does not include the blank token <blk>");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    int32_t blank_id = symbol_table_["<blk>"];
+    int32_t vocab_size = blank_id + 1;
+
+    if (symbol_table_.NumSymbols() != vocab_size) {
+      SHERPA_ONNX_LOGE("number of lines in tokens.txt %d != %d (vocab_size)",
+                       symbol_table_.NumSymbols(), vocab_size);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    if (config_.decoding_method != "greedy_search") {
+      SHERPA_ONNX_LOGE(
+          "Only greedy_search is supported for parakeet TDT QNN. "
+          "Given: %s",
+          config_.decoding_method.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    // Setup feat_config similar to offline-recognizer-transducer-nemo-impl.h
+    int32_t feat_dim = model_->FeatDim();
+    if (feat_dim > 0) {
+      config_.feat_config.feature_dim = feat_dim;
+    }
+
+    config_.feat_config.nemo_normalize_type = "per_feature";
+    config_.feat_config.low_freq = 0;
+    config_.feat_config.is_librosa = true;
+    config_.feat_config.remove_dc_offset = false;
+
+    if (config_.model_config.debug) {
+      SHERPA_ONNX_LOGE("blank_id: %d", blank_id);
+      SHERPA_ONNX_LOGE("vocab_size: %d", vocab_size);
+      SHERPA_ONNX_LOGE("subsampling_factor: %d", model_->SubsamplingFactor());
+      SHERPA_ONNX_LOGE("encoder_dim: %d", model_->EncoderDim());
+      SHERPA_ONNX_LOGE("feat_dim: %d", feat_dim);
+    }
+  }
+
+  OfflineTransducerDecoderResult DecodeStream(OfflineStream *s) const {
+    auto features = s->GetFrames();
+    auto encoder_out = model_->RunEncoder(std::move(features));
+    return GreedySearch(encoder_out);
+  }
+
+  OfflineTransducerDecoderResult GreedySearch(
+      const std::vector<float> &encoder_out) const {
+    OfflineTransducerDecoderResult ans;
+
+    int32_t blank_id = symbol_table_["<blk>"];
+    int32_t vocab_size = symbol_table_.NumSymbols();
+    int32_t encoder_dim = model_->EncoderDim();
+    int32_t num_encoder_frames =
+        static_cast<int32_t>(encoder_out.size()) / encoder_dim;
+
+    // Initialize decoder with blank token and zero states
+    auto states = model_->GetDecoderInitStates();
+    auto [decoder_out, next_states] =
+        model_->RunDecoder(blank_id, std::move(states));
+    states = std::move(next_states);
+
+    // TDT decoding loop
+    int32_t max_tokens_per_frame = 5;
+    int32_t tokens_this_frame = 0;
+    int32_t skip = 0;
+
+    for (int32_t t = 0; t < num_encoder_frames; t += skip) {
+      // The joiner output is named "log_probs" but actually contains raw
+      // logits (log_softmax is NOT applied by the joiner).
+      auto logits =
+          model_->RunJoiner(encoder_out.data() + t * encoder_dim, decoder_out);
+
+      // Split into token logits and duration logits
+      float *token_logits = logits.data();
+      int32_t output_size = static_cast<int32_t>(logits.size());
+      int32_t num_durations = output_size - vocab_size;
+      const float *duration_logits = logits.data() + vocab_size;
+
+      auto y = MaxElementIndex(token_logits, vocab_size);
+
+      // Duration prediction
+      if (num_durations > 0) {
+        skip = MaxElementIndex(duration_logits, num_durations);
+      } else {
+        skip = 0;
+      }
+
+      if (y != blank_id) {
+        LogSoftmax(token_logits, vocab_size);
+        float log_prob = token_logits[y];
+
+        ans.tokens.push_back(y);
+        ans.timestamps.push_back(t);
+        ans.durations.push_back(skip);
+        ans.ys_log_probs.push_back(log_prob);
+
+        auto [new_decoder_out, new_states] =
+            model_->RunDecoder(y, std::move(states));
+        decoder_out = std::move(new_decoder_out);
+        states = std::move(new_states);
+
+        tokens_this_frame += 1;
+      }
+
+      if (skip > 0) {
+        tokens_this_frame = 0;
+      }
+
+      if (tokens_this_frame >= max_tokens_per_frame) {
+        tokens_this_frame = 0;
+        skip = 1;
+      }
+
+      if (y == blank_id && skip == 0) {
+        tokens_this_frame = 0;
+        skip = 1;
+      }
+    }
+
+    return ans;
+  }
+
+ private:
+  OfflineRecognizerConfig config_;
+  SymbolTable symbol_table_;
+  std::unique_ptr<OfflineParakeetTdtModelQnn> model_;
+};
+
+}  // namespace sherpa_onnx
+
+#endif  // SHERPA_ONNX_CSRC_QNN_OFFLINE_RECOGNIZER_PARAKEET_TDT_QNN_IMPL_H_

--- a/sherpa-onnx/csrc/qnn/qnn-model.cc
+++ b/sherpa-onnx/csrc/qnn/qnn-model.cc
@@ -6,6 +6,7 @@
 
 #include <dlfcn.h>
 
+#include <cstdint>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -13,6 +14,7 @@
 #include <utility>
 #include <vector>
 
+#include "sherpa-onnx/csrc/file-utils.h"
 #include "sherpa-onnx/csrc/qnn/macros.h"
 #include "sherpa-onnx/csrc/qnn/qnn-backend.h"
 #include "sherpa-onnx/csrc/qnn/utils.h"
@@ -116,7 +118,8 @@ class QnnModel::Impl {
     }
 
     // read file into a buffer
-    std::vector<uint8_t> buffer = ReadFile<uint8_t>(binary_context_file);
+    auto char_buffer = ReadFile(binary_context_file);
+    std::vector<uint8_t> buffer(char_buffer.begin(), char_buffer.end());
 
     QnnSystemContext_Handle_t sys_ctx_handle = nullptr;
     if (qnn_system_interface_.systemContextCreate(&sys_ctx_handle) !=
@@ -321,6 +324,19 @@ class QnnModel::Impl {
       return true;
     }
 
+    if (t->v1.dataType == QNN_DATATYPE_FLOAT_16) {
+      if (n * sizeof(uint16_t) != t->v1.clientBuf.dataSize) {
+        SHERPA_ONNX_LOGE("tensor '%s' expects %d bytes, but you provide %d bytes",
+                         name.c_str(),
+                         static_cast<int32_t>(t->v1.clientBuf.dataSize),
+                         static_cast<int32_t>(n * sizeof(uint16_t)));
+        return false;
+      }
+
+      FillDataFloat16(t, p, n);
+      return true;
+    }
+
     if (t->v1.dataType != QNN_DATATYPE_UFIXED_POINT_16) {
       SHERPA_ONNX_LOGE(
           "tensor '%s' should be of type "
@@ -394,6 +410,13 @@ class QnnModel::Impl {
       int32_t n = t->v1.clientBuf.dataSize / sizeof(float);
       std::vector<float> ans(n);
       GetDataNonQuant(t, ans.data(), n);
+      return ans;
+    }
+
+    if (t->v1.dataType == QNN_DATATYPE_FLOAT_16) {
+      int32_t n = t->v1.clientBuf.dataSize / sizeof(uint16_t);
+      std::vector<float> ans(n);
+      GetDataFloat16(t, ans.data(), n);
       return ans;
     }
 

--- a/sherpa-onnx/csrc/qnn/utils.cc
+++ b/sherpa-onnx/csrc/qnn/utils.cc
@@ -5,6 +5,7 @@
 
 #include <math.h>
 #include <stdio.h>
+#include <cstring>
 
 #include <algorithm>
 #include <functional>
@@ -130,6 +131,36 @@ void FillData(Qnn_Tensor_t *t, const int32_t *data, int32_t n) {
   std::copy(data, data + n, out);
 }
 
+static uint16_t Float32ToFloat16(float f) {
+  uint32_t bits;
+  memcpy(&bits, &f, sizeof(bits));
+
+  uint32_t sign = (bits >> 16) & 0x8000;
+  int32_t exponent = ((bits >> 23) & 0xFF) - 127 + 15;
+  uint32_t mantissa = bits & 0x7FFFFF;
+
+  if (exponent <= 0) {
+    if (exponent < -10) {
+      return static_cast<uint16_t>(sign);
+    }
+    mantissa = (mantissa | 0x800000) >> (1 - exponent);
+    return static_cast<uint16_t>(sign | (mantissa >> 13));
+  }
+
+  if (exponent >= 31) {
+    return static_cast<uint16_t>(sign | 0x7C00);
+  }
+
+  return static_cast<uint16_t>(sign | (exponent << 10) | (mantissa >> 13));
+}
+
+void FillDataFloat16(Qnn_Tensor_t *t, const float *data, int32_t n) {
+  uint16_t *out = reinterpret_cast<uint16_t *>(t->v1.clientBuf.data);
+  for (int32_t i = 0; i < n; ++i) {
+    out[i] = Float32ToFloat16(data[i]);
+  }
+}
+
 void GetDataNonQuant(const Qnn_Tensor_t *t, float *data, int32_t n) {
   const float *p = reinterpret_cast<const float *>(t->v1.clientBuf.data);
   std::copy(p, p + n, data);
@@ -149,6 +180,42 @@ void GetData(const Qnn_Tensor_t *t, float *data, int32_t n) {
 void GetData(const Qnn_Tensor_t *t, int32_t *data, int32_t n) {
   const int32_t *p = reinterpret_cast<const int32_t *>(t->v1.clientBuf.data);
   std::copy(p, p + n, data);
+}
+
+static float Float16ToFloat32(uint16_t h) {
+  uint32_t sign = (h & 0x8000) << 16;
+  uint32_t exponent = (h >> 10) & 0x1F;
+  uint32_t mantissa = h & 0x3FF;
+
+  uint32_t bits;
+  if (exponent == 0) {
+    if (mantissa == 0) {
+      bits = sign;
+    } else {
+      exponent = 127 - 15 + 1;
+      while ((mantissa & 0x400) == 0) {
+        mantissa <<= 1;
+        exponent--;
+      }
+      mantissa &= 0x3FF;
+      bits = sign | (exponent << 23) | (mantissa << 13);
+    }
+  } else if (exponent == 31) {
+    bits = sign | 0x7F800000 | (mantissa << 13);
+  } else {
+    bits = sign | ((exponent - 15 + 127) << 23) | (mantissa << 13);
+  }
+
+  float result;
+  memcpy(&result, &bits, sizeof(result));
+  return result;
+}
+
+void GetDataFloat16(const Qnn_Tensor_t *t, float *data, int32_t n) {
+  const uint16_t *p = reinterpret_cast<const uint16_t *>(t->v1.clientBuf.data);
+  for (int32_t i = 0; i < n; ++i) {
+    data[i] = Float16ToFloat32(p[i]);
+  }
 }
 
 static void FreeTensorV1(Qnn_Tensor_t *t) {

--- a/sherpa-onnx/csrc/qnn/utils.h
+++ b/sherpa-onnx/csrc/qnn/utils.h
@@ -43,13 +43,16 @@ void PrintTensor(Qnn_TensorV2_t t);
 // float -> float
 void FillDataNonQuant(Qnn_Tensor_t *t, const float *data, int32_t n);
 
-// float -> uint16_t
+// float -> uint16_t (quantized)
 void FillData(Qnn_Tensor_t *t, const float *data, int32_t n);
 
 // int32_t -> int32_t
 void FillData(Qnn_Tensor_t *t, const int32_t *data, int32_t n);
 
-// uint16_t -> float
+// float -> float16 (IEEE 754 half-precision, stored as uint16_t)
+void FillDataFloat16(Qnn_Tensor_t *t, const float *data, int32_t n);
+
+// uint16_t (quantized) -> float
 void GetData(const Qnn_Tensor_t *t, float *data, int32_t n);
 
 // int32_t -> int32_t
@@ -57,6 +60,9 @@ void GetData(const Qnn_Tensor_t *t, int32_t *data, int32_t n);
 
 // float -> float
 void GetDataNonQuant(const Qnn_Tensor_t *t, float *data, int32_t n);
+
+// float16 (IEEE 754 half-precision, stored as uint16_t) -> float
+void GetDataFloat16(const Qnn_Tensor_t *t, float *data, int32_t n);
 
 void FreeTensor(Qnn_Tensor_t *t);
 


### PR DESCRIPTION
See also #3719 
# Usage

The following shows how to run parakeet-tdt-0.6b-v2 and parakeet-tdt-0.6b-v3 on my Xiaomi 17 Pro with Qualcomm NPU using sherpa-onnx

## https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2

Please download a QNN model for it from https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models-qnn-binary-2

The following is an example.

```
wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models-qnn-binary-2/sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v2-8s-transducer.tar.bz2

tar xvf sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v2-8s-transducer.tar.bz2
rm sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v2-8s-transducer.tar.bz2
```

```
ls -lh sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v2-8s-transducer
total 1246384
-rw-r--r--@ 1 fangjun  staff    14M  3 Jul 18:41 decoder.bin
-rw-r--r--@ 1 fangjun  staff   580M  3 Jul 18:41 encoder.bin
-rw-r--r--@ 1 fangjun  staff    15B  3 Jul 18:41 info.txt
-rw-r--r--@ 1 fangjun  staff   1.7M  3 Jul 18:41 joiner.bin
drwxr-xr-x@ 5 fangjun  staff   160B  3 Jul 18:41 test_wavs
-rw-r--r--@ 1 fangjun  staff   9.2K  3 Jul 18:41 tokens.txt
```

Now copy them to your device with Qualcomm NPU and follow
https://k2-fsa.github.io/sherpa/onnx/qnn/run-executables-on-your-phone-binary.html

The following is an example:
```
./sherpa-onnx-offline \
   --provider=qnn \
   --tokens=./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v2-8s-transducer/tokens.txt \
   --model-type=nemo_transducer \
   --transducer.qnn-backend-lib=./libQnnHtp.so \
   --transducer.qnn-system-lib=./libQnnSystem.so \
   --transducer.qnn-context-binary=./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v2-8s-transducer/encoder.bin,./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v2-8s-transducer/decoder.bin,./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v2-8s-transducer/joiner.bin \
   ./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v2-8s-transducer/test_wavs/2.wav
```

Output logs:
```
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/parse-options.cc:Read:374 ./sherpa-onnx-offline --provider=qnn --tokens=./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-
v2-8s-transducer/tokens.txt --model-type=nemo_transducer --transducer.qnn-backend-lib=./libQnnHtp.so --transducer.qnn-system-lib=./libQnnSystem.so --transducer.qnn-context-binary
=./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v2-8s-transducer/encoder.bin,./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v2-8s-transducer/decoder.bin,./sherpa-onnx-qnn-S
M8850-binary-parakeet-tdt-0.6b-v2-8s-transducer/joiner.bin ./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v2-8s-transducer/test_wavs/2.wav

OfflineRecognizerConfig(feat_config=FeatureExtractorConfig(sampling_rate=16000, feature_dim=80, low_freq=20, high_freq=-400, dither=0, normalize_samples=True, snip_edges=False),
model_config=OfflineModelConfig(transducer=OfflineTransducerModelConfig(encoder_filename="", decoder_filename="", joiner_filename="", qnn_config=QnnConfig(backend_lib="./libQnnHt
p.so", context_binary="./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v2-8s-transducer/encoder.bin,./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v2-8s-transducer/decoder.b
in,./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v2-8s-transducer/joiner.bin", system_lib="./libQnnSystem.so")), paraformer=OfflineParaformerModelConfig(model=""), nemo_ctc=O
fflineNemoEncDecCtcModelConfig(model=""), whisper=OfflineWhisperModelConfig(encoder="", decoder="", language="", task="transcribe", tail_paddings=-1, enable_token_timestamps=Fals
e, enable_segment_timestamps=False, ), fire_red_asr=OfflineFireRedAsrModelConfig(encoder="", decoder=""), tdnn=OfflineTdnnModelConfig(model=""), zipformer_ctc=OfflineZipformerCtc
ModelConfig(model=""), wenet_ctc=OfflineWenetCtcModelConfig(model=""), sense_voice=OfflineSenseVoiceModelConfig(model="", language="auto", use_itn=False), moonshine=OfflineMoonsh
ineModelConfig(preprocessor="", encoder="", uncached_decoder="", cached_decoder="", merged_decoder=""), dolphin=OfflineDolphinModelConfig(model=""), canary=OfflineCanaryModelConf
ig(encoder="", decoder="", src_lang="", tgt_lang="", use_pnc=True), cohere_transcribe=OfflineCohereTranscribeModelConfig(encoder="", decoder="", language="", use_punct=True, use_
itn=True), omnilingual=OfflineOmnilingualAsrCtcModelConfig(model=""), funasr_nano=OfflineFunASRNanoModelConfig(encoder_adaptor="", llm="", embedding="", tokenizer="", system_prom
pt="You are a helpful assistant.", user_prompt="语音转写：", max_new_tokens=512, temperature=1e-06, top_p=0.8, seed=42, language="", itn=True, hotwords=""), medasr=OfflineMedAsrC
tcModelConfig(model=""), fire_red_asr_ctc=OfflineFireRedAsrCtcModelConfig(model=""), qwen3_asr=OfflineQwen3ASRModelConfig(conv_frontend="", encoder="", decoder="", tokenizer="",
hotwords="", max_total_len=512, max_new_tokens=128, temperature=1e-06, top_p=0.8, seed=42), telespeech_ctc="", tokens="./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v2-8s-tra
nsducer/tokens.txt", num_threads=2, debug=False, provider="qnn", model_type="nemo_transducer", modeling_unit="cjkchar", bpe_vocab=""), lm_config=OfflineLMConfig(model="", scale=0
.5, lodr_scale=0.01, lodr_fst="", lodr_backoff_id=-1), ctc_fst_decoder_config=OfflineCtcFstDecoderConfig(graph="", max_active=3000), decoding_method="greedy_search", max_active_p
aths=4, hotwords_file="", hotwords_score=1.5, blank_penalty=0, rule_fsts="", rule_fars="", hr=HomophoneReplacerConfig(lexicon="", rule_fsts=""))
Creating recognizer ...
     0.0ms [WARN   ] QnnDsp <W> Initializing HtpProvider
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/utils.cc:CopyGraphsInfo:548 version: 3
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/utils.cc:CopyGraphsInfo:548 version: 3
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/utils.cc:CopyGraphsInfo:548 version: 3
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
recognizer created in 6.104 s
Started
Done!

./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v2-8s-transducer/test_wavs/2.wav
{"lang": "", "emotion": "", "event": "", "text": "Well, I don't wish to see it any more, observed Pebe, turning away her eyes. It is certainly very like the old portrait.", "timestamps": [0.40, 0.64, 0.72, 0.80, 0.96, 1.04, 1.04, 1.12, 1.28, 1.44, 1.60, 1.76, 1.92, 2.00, 2.24, 2.32, 2.40, 2.48, 2.56, 2.72, 2.88, 3.12, 3.36, 3.44, 3.52, 3.68, 3.76, 3.92, 4.16, 4.24, 4.40, 4.64, 4.96, 5.12, 5.28, 5.36, 5.52, 5.60, 5.76, 6.00, 6.24, 6.40, 6.48, 6.64, 6.72, 6.80, 6.96, 7.04], "durations": [0.24, 0.08, 0.08, 0.16, 0.08, 0.00, 0.08, 0.16, 0.16, 0.16, 0.16, 0.16, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.16, 0.00, 0.16, 0.24, 0.08, 0.08, 0.16, 0.08, 0.16, 0.24, 0.08, 0.16, 0.24, 0.16, 0.16, 0.16, 0.08, 0.16, 0.08, 0.16, 0.24, 0.24, 0.16, 0.08, 0.16, 0.08, 0.08, 0.16, 0.08, 0.24], "tokens":[" Well", ",", " I", " don", "'", "t", " w", "ish", " to", " see", " it", " any", " more", ",", " ob", "s", "er", "ved", " P", "e", "be", ",", " t", "ur", "ning", " a", "way", " her", " e", "y", "es", ".", " It", " is", " c", "ert", "ain", "ly", " very", " like", " the", " o", "ld", " p", "ort", "ra", "it", "."], "ys_log_probs": [-0.014221, -0.184570, -0.000099, -0.001823, -0.000221, 0.000000, -0.000099, 0.000000, -0.000107, -0.000038, -0.000069, -0.000198, -0.061008, -0.537109, -0.000023, -0.000008, 0.000000, -0.000259, -0.001572, -0.763535, -0.018227, -0.038132, -0.000038, -0.000107, 0.000000, -0.000145, -0.000053, -0.000046, -0.000046, -0.000008, -0.000130, -0.264198, -0.001572, -0.000175, -0.000542, 0.000000, 0.000000, -0.000023, -0.001030, -0.000656, -0.000221, -0.002243, 0.000000, -0.000839, -0.000061, 0.000000, 0.000000, -0.811222], "words": []}
----
num threads: 2
decoding method: greedy_search
Elapsed seconds: 0.439 s
Real time factor (RTF): 0.439 / 7.435 = 0.059
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
```

## https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3
Please download a QNN model for it from https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models-qnn-binary-2

The following is an example.

```
wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models-qnn-binary-2/sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v3-8s-transducer.tar.bz2

tar xvf sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v3-8s-transducer.tar.bz2
rm sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v3-8s-transducer.tar.bz2
```

```
ls -lh sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v3-8s-transducer
total 1273424
-rw-r--r--@ 1 fangjun  staff    23M  3 Jul 19:27 decoder.bin
-rw-r--r--@ 1 fangjun  staff   580M  3 Jul 19:27 encoder.bin
-rw-r--r--@ 1 fangjun  staff    15B  3 Jul 19:27 info.txt
-rw-r--r--@ 1 fangjun  staff   6.2M  3 Jul 19:27 joiner.bin
drwxr-xr-x@ 5 fangjun  staff   160B  3 Jul 19:27 test_wavs
-rw-r--r--@ 1 fangjun  staff    92K  3 Jul 19:27 tokens.txt
```

Now copy them to your device with Qualcomm NPU and follow
https://k2-fsa.github.io/sherpa/onnx/qnn/run-executables-on-your-phone-binary.html

The following is an example:

```
./sherpa-onnx-offline \
   --provider=qnn \
   --tokens=./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v3-8s-transducer/tokens.txt \
   --model-type=nemo_transducer \
   --transducer.qnn-backend-lib=./libQnnHtp.so \
   --transducer.qnn-system-lib=./libQnnSystem.so \
   --transducer.qnn-context-binary=./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v3-8s-transducer/encoder.bin,./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v3-8s-transducer/decoder.bin,./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v3-8s-transducer/joiner.bin \
   ./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v3-8s-transducer/test_wavs/2.wav
```

Output logs:
```
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/parse-options.cc:Read:374 ./sherpa-onnx-offline --provider=qnn --tokens=./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-
v3-8s-transducer/tokens.txt --model-type=nemo_transducer --transducer.qnn-backend-lib=./libQnnHtp.so --transducer.qnn-system-lib=./libQnnSystem.so --transducer.qnn-context-binary
=./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v3-8s-transducer/encoder.bin,./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v3-8s-transducer/decoder.bin,./sherpa-onnx-qnn-S
M8850-binary-parakeet-tdt-0.6b-v3-8s-transducer/joiner.bin ./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v3-8s-transducer/test_wavs/2.wav

OfflineRecognizerConfig(feat_config=FeatureExtractorConfig(sampling_rate=16000, feature_dim=80, low_freq=20, high_freq=-400, dither=0, normalize_samples=True, snip_edges=False),
model_config=OfflineModelConfig(transducer=OfflineTransducerModelConfig(encoder_filename="", decoder_filename="", joiner_filename="", qnn_config=QnnConfig(backend_lib="./libQnnHt
p.so", context_binary="./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v3-8s-transducer/encoder.bin,./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v3-8s-transducer/decoder.b
in,./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v3-8s-transducer/joiner.bin", system_lib="./libQnnSystem.so")), paraformer=OfflineParaformerModelConfig(model=""), nemo_ctc=O
fflineNemoEncDecCtcModelConfig(model=""), whisper=OfflineWhisperModelConfig(encoder="", decoder="", language="", task="transcribe", tail_paddings=-1, enable_token_timestamps=Fals
e, enable_segment_timestamps=False, ), fire_red_asr=OfflineFireRedAsrModelConfig(encoder="", decoder=""), tdnn=OfflineTdnnModelConfig(model=""), zipformer_ctc=OfflineZipformerCtc
ModelConfig(model=""), wenet_ctc=OfflineWenetCtcModelConfig(model=""), sense_voice=OfflineSenseVoiceModelConfig(model="", language="auto", use_itn=False), moonshine=OfflineMoonsh
ineModelConfig(preprocessor="", encoder="", uncached_decoder="", cached_decoder="", merged_decoder=""), dolphin=OfflineDolphinModelConfig(model=""), canary=OfflineCanaryModelConf
ig(encoder="", decoder="", src_lang="", tgt_lang="", use_pnc=True), cohere_transcribe=OfflineCohereTranscribeModelConfig(encoder="", decoder="", language="", use_punct=True, use_
itn=True), omnilingual=OfflineOmnilingualAsrCtcModelConfig(model=""), funasr_nano=OfflineFunASRNanoModelConfig(encoder_adaptor="", llm="", embedding="", tokenizer="", system_prom
pt="You are a helpful assistant.", user_prompt="语音转写：", max_new_tokens=512, temperature=1e-06, top_p=0.8, seed=42, language="", itn=True, hotwords=""), medasr=OfflineMedAsrC
tcModelConfig(model=""), fire_red_asr_ctc=OfflineFireRedAsrCtcModelConfig(model=""), qwen3_asr=OfflineQwen3ASRModelConfig(conv_frontend="", encoder="", decoder="", tokenizer="",
hotwords="", max_total_len=512, max_new_tokens=128, temperature=1e-06, top_p=0.8, seed=42), telespeech_ctc="", tokens="./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v3-8s-transducer/tokens.txt", num_threads=2, debug=False, provider="qnn", model_type="nemo_transducer", modeling_unit="cjkchar", bpe_vocab=""), lm_config=OfflineLMConfig(model="", scale=0.5, lodr_scale=0.01, lodr_fst="", lodr_backoff_id=-1), ctc_fst_decoder_config=OfflineCtcFstDecoderConfig(graph="", max_active=3000), decoding_method="greedy_search", max_active_paths=4, hotwords_file="", hotwords_score=1.5, blank_penalty=0, rule_fsts="", rule_fars="", hr=HomophoneReplacerConfig(lexicon="", rule_fsts=""))
Creating recognizer ...
     0.0ms [WARN   ] QnnDsp <W> Initializing HtpProvider
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/utils.cc:CopyGraphsInfo:548 version: 3
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/utils.cc:CopyGraphsInfo:548 version: 3
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/utils.cc:CopyGraphsInfo:548 version: 3
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
recognizer created in 5.019 s
Started
Done!

./sherpa-onnx-qnn-SM8850-binary-parakeet-tdt-0.6b-v3-8s-transducer/test_wavs/2.wav
{"lang": "", "emotion": "", "event": "", "text": "Well, I don't wish to see it any more, observed Phoebe, turning away her eyes. It is certainly very like the old portrait.", "timestamps": [0.32, 0.48, 0.56, 0.64, 0.80, 0.88, 0.96, 1.04, 1.12, 1.28, 1.36, 1.52, 1.68, 1.84, 2.00, 2.16, 2.40, 2.56, 2.64, 2.80, 2.96, 3.12, 3.28, 3.52, 3.68, 3.84, 4.00, 4.16, 4.32, 4.48, 4.64, 4.88, 5.12, 5.28, 5.44, 5.60, 5.76, 6.00, 6.16, 6.32, 6.40, 6.56, 6.80, 7.04], "durations": [0.16, 0.08, 0.08, 0.16, 0.08, 0.08, 0.08, 0.08, 0.16, 0.08, 0.16, 0.16, 0.08, 0.08, 0.16, 0.24, 0.16, 0.08, 0.16, 0.16, 0.16, 0.16, 0.24, 0.16, 0.16, 0.16, 0.16, 0.16, 0.16, 0.16, 0.24, 0.24, 0.16, 0.16, 0.16, 0.16, 0.24, 0.16, 0.16, 0.08, 0.16, 0.24, 0.24, 0.16], "tokens":[" W", "ell", ",", " I", " don", "'", "t", " w", "ish", " to", " see", " it", " any", " more", ",", " obser", "ved", " P", "ho", "eb", "e", ",", " tur", "ning", " a", "way", " her", " e", "y", "es", ".", " It", " is", " cer", "tain", "ly", " very", " like", " the", " ol", "d", " port", "rait", "."], "ys_log_probs": [-0.002341, -0.000556, -0.278612, -0.000648, -0.008892, -0.000010, -0.000004, -0.000451, -0.000259, -0.000718, -0.000634, -0.000882, -0.248227, -0.015185, -0.150477, -0.001028, -0.009532, -0.004053, -0.009192, -0.001387, -0.001984, -0.023924, -0.000038, -0.000028, -0.000731, -0.000018, -0.000318, -0.000094, -0.000341, -0.000010, -0.070848, -0.026106, -0.001763, -0.000675, -0.000000, -0.000006, -0.000806, -0.015650, -0.002750, -0.020044, -0.000553, -0.008260, -0.000844, -0.481244], "words": []}
----
num threads: 2
decoding method: greedy_search
Elapsed seconds: 0.417 s
Real time factor (RTF): 0.417 / 7.435 = 0.056
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Parakeet TDT QNN-based offline recognition, including encoder, decoder, and joiner processing.
  * Expanded QNN tensor handling to support float16 inputs and outputs.
* **Bug Fixes**
  * Improved recognition of certain metadata values so model settings are handled more consistently.
  * Updated QNN model selection so the correct Parakeet TDT path is used for supported artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->