### PR TITLE
Export nemotron-speech-streaming-en-0.6b to QNN

### DIFF
--- a/.github/scripts/export-qnn/generate_nemotron_speech_streaming.py
+++ b/.github/scripts/export-qnn/generate_nemotron_speech_streaming.py
@@ -20,16 +20,12 @@ class Config:
 def main():
 
     model_name_list = ["nemotron-speech-streaming-en-0.6b"]
-    #  chunk_size_ms_list = [80, 160, 560, 1120]
-    chunk_size_ms_list = [1120]
+    chunk_size_ms_list = [80, 160, 560, 1120]
 
     configs = []
 
     for name, soc in soc_info_dict.items():
         if soc.model.name == "SM8350":
-            continue
-
-        if soc.model.name != "SM8850":
             continue
         for chunk_size_ms, model_name in itertools.product(
             chunk_size_ms_list, model_name_list

--- a/.github/scripts/export-qnn/generate_nemotron_speech_streaming.py
+++ b/.github/scripts/export-qnn/generate_nemotron_speech_streaming.py
@@ -28,6 +28,9 @@ def main():
     for name, soc in soc_info_dict.items():
         if soc.model.name == "SM8350":
             continue
+
+        if soc.model.name != "SM8850":
+            continue
         for chunk_size_ms, model_name in itertools.product(
             chunk_size_ms_list, model_name_list
         ):

--- a/.github/scripts/export-qnn/generate_nemotron_speech_streaming.py
+++ b/.github/scripts/export-qnn/generate_nemotron_speech_streaming.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright    2026  Xiaomi Corp.        (authors: Fangjun Kuang)
+
+import json
+
+from device_info import soc_info_dict
+from dataclasses import asdict, dataclass
+import itertools
+
+
+@dataclass
+class Config:
+    soc: str  # SM8850
+    soc_id: int  # 87
+    arch: str  # v81
+    chunk_size_ms: int
+    model_name: str
+
+
+def main():
+
+    model_name_list = ["nemotron-speech-streaming-en-0.6b"]
+    #  chunk_size_ms_list = [80, 160, 560, 1120]
+    chunk_size_ms_list = [1120]
+
+    configs = []
+
+    for name, soc in soc_info_dict.items():
+        if soc.model.name == "SM8350":
+            continue
+        for chunk_size_ms, model_name in itertools.product(
+            chunk_size_ms_list, model_name_list
+        ):
+            configs.append(
+                Config(
+                    soc=name,
+                    soc_id=soc.model.value,
+                    arch=soc.info.arch.name,
+                    model_name=model_name,
+                    chunk_size_ms=chunk_size_ms,
+                )
+            )
+
+    ans = [asdict(c) for c in configs]
+
+    print(json.dumps({"include": ans}))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/export-nemotron-speech-streaming-en-0.6b-qnn.yaml
+++ b/.github/workflows/export-nemotron-speech-streaming-en-0.6b-qnn.yaml
@@ -18,8 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # chunk_size_ms: [80, 160, 560, 1120]
-        chunk_size_ms: [1120]
+        chunk_size_ms: [80, 160, 560, 1120]
         model_id: ["nemotron-speech-streaming-en-0.6b"]
 
     steps:

--- a/.github/workflows/export-nemotron-speech-streaming-en-0.6b-qnn.yaml
+++ b/.github/workflows/export-nemotron-speech-streaming-en-0.6b-qnn.yaml
@@ -392,15 +392,15 @@ jobs:
 
           for m in encoder decoder joiner; do
             echo "Processing $m"
-            mv -v $model_dir/${m}.* ./
-            cp -v $model_dir/*.raw ./
-            cp -v $model_dir/*.txt ./
+            mv  $model_dir/${m}.* ./
+            cp  $model_dir/*.raw ./
+            cp  $model_dir/*.txt ./
 
             ls -lh $m.*
             ls -lh *.raw
             ls -lh *.txt
 
-            if [[ $m == 'encoder2' || $m == 'joiner2' ]]; then
+            if [[ $m == 'encoder' || $m == 'joiner' ]]; then
               # quantize only the encoder and joiner
               cat $m.txt
 
@@ -508,8 +508,8 @@ jobs:
           mv *.tar.bz2 ./so
 
       - name: Setup tmate session
-        if: false
-        # if: failure()
+        # if: false
+        if: failure()
         uses: mxschmitt/action-tmate@v3
 
       - name: Show files

--- a/.github/workflows/export-nemotron-speech-streaming-en-0.6b-qnn.yaml
+++ b/.github/workflows/export-nemotron-speech-streaming-en-0.6b-qnn.yaml
@@ -1,14 +1,14 @@
-name: export-parakeet-tdt-qnn
+name: export-nemotron-speech-streaming-en-0.6b-qnn
 
 on:
   push:
     branches:
-      - export-parakeet-tdt-qnn-2
+      - export-nemotron-streaming-qnn
   workflow_dispatch:
 
-# concurrency:
-#   group: export-parakeet-tdt-qnn-${{ github.ref }}
-#   cancel-in-progress: true
+concurrency:
+  group: export-nemotron-streaming-qnn-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   onnx:
@@ -18,8 +18,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        num_seconds: [3, 5, 8, 10, 13, 15, 18, 20, 23, 25, 28, 30]
-        model_id: ["parakeet-tdt-0.6b-v2", "parakeet-tdt-0.6b-v3"]
+        # chunk_size_ms: [80, 160, 560, 1120]
+        chunk_size_ms: [1120]
+        model_id: ["nemotron-speech-streaming-en-0.6b"]
 
     steps:
       - uses: actions/checkout@v4
@@ -32,16 +33,15 @@ jobs:
       - name: Export models
         shell: bash
         run: |
-          num_seconds=${{ matrix.num_seconds }}
-          num_frames=$((num_seconds*100))
+          chunk_size_ms=${{ matrix.chunk_size_ms }}
 
-          # https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2
+          # https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b
           model_id=${{ matrix.model_id }}
 
-          echo "num_frames: $num_frames"
+          echo "chunk_size_ms: $chunk_size_ms"
           echo "model_id: $model_id"
 
-          cd scripts/nemo/qnn/parakeet-tdt
+          cd scripts/nemo/qnn/nemotron-speech-streaming-en-0.6b
 
           wget https://dldata-public.s3.us-east-2.amazonaws.com/2086-149220-0033.wav
           mv 2086-149220-0033.wav 2.wav
@@ -49,7 +49,9 @@ jobs:
           wget https://huggingface.co/csukuangfj/sherpa-onnx-whisper-tiny.en/resolve/main/test_wavs/0.wav
           wget https://huggingface.co/csukuangfj/sherpa-onnx-whisper-tiny.en/resolve/main/test_wavs/1.wav
 
-          ./run.sh $num_frames nvidia/$model_id
+          ./run.sh $chunk_size_ms nvidia/$model_id
+
+          rm -f  onnx__* layers* Constant* pre_encode*
 
           ls -lh *.onnx*
 
@@ -57,7 +59,7 @@ jobs:
           python3 ./test_onnx.py --wav ./1.wav
           python3 ./test_onnx.py --wav ./2.wav
 
-          printf "0.raw\n1.raw\n2.raw\n" > encoder.txt
+          cat 0-encoder.txt 1-encoder.txt 2-encoder.txt > encoder.txt
           cat 0-decoder.txt 1-decoder.txt 2-decoder.txt > decoder.txt
           cat 0-joiner.txt 1-joiner.txt 2-joiner.txt > joiner.txt
 
@@ -65,16 +67,20 @@ jobs:
           ls -lh *.raw
           ls -lh *.txt
 
+      - name: Setup tmate session
+        if: failure()
+        uses: mxschmitt/action-tmate@v3
+
       - name: Collect models
         shell: bash
         run: |
-          num_seconds=${{ matrix.num_seconds }}
+          chunk_size_ms=${{ matrix.chunk_size_ms }}
 
-          # https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2
+          # https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b
           model_id=${{ matrix.model_id }}
 
-          src=scripts/nemo/qnn/parakeet-tdt
-          dst=${model_id}-${num_seconds}
+          src=scripts/nemo/qnn/nemotron-speech-streaming-en-0.6b
+          dst=${model_id}-${chunk_size_ms}
 
           mkdir -p $dst
 
@@ -91,7 +97,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.model_id }}-${{ matrix.num_seconds }}
+          name: ${{ matrix.model_id }}-${{ matrix.chunk_size_ms }}
           path: ./*.tar.bz2
 
   generate_build_matrix:
@@ -108,8 +114,8 @@ jobs:
         id: set-matrix
         run: |
           # outputting for debugging purposes
-          python3 .github/scripts/export-qnn/generate_parakeet_tdt.py
-          MATRIX=$(python3 .github/scripts/export-qnn/generate_parakeet_tdt.py)
+          python3 .github/scripts/export-qnn/generate_nemotron_speech_streaming.py
+          MATRIX=$(python3 .github/scripts/export-qnn/generate_nemotron_speech_streaming.py)
 
           # deprecated
           # echo "::set-output name=matrix::${MATRIX}"
@@ -118,7 +124,7 @@ jobs:
   qnn:
     needs: [generate_build_matrix, onnx]
     if: github.repository_owner == 'k2-fsa' || github.repository_owner == 'csukuangfj'
-    name: ${{ matrix.model_name }} ${{ matrix.soc }} ${{ matrix.num_seconds }}
+    name: ${{ matrix.model_name }} ${{ matrix.soc }} ${{ matrix.chunk_size_ms }}
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -131,7 +137,7 @@ jobs:
       - name: Retrieve artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ matrix.model_name }}-${{ matrix.num_seconds }}
+          name: ${{ matrix.model_name }}-${{ matrix.chunk_size_ms }}
           path: /tmp/
 
       - name: Show space
@@ -142,18 +148,18 @@ jobs:
       - name: Show tmp
         shell: bash
         run: |
-          num_seconds=${{ matrix.num_seconds }}
+          chunk_size_ms=${{ matrix.chunk_size_ms }}
           model_id=${{ matrix.model_name }}
 
           dir=$PWD
-          mkdir -p model-files/$num_seconds
+          mkdir -p model-files/$chunk_size_ms
 
           ls -lh /tmp/
 
           pushd /tmp
-          echo "num_seconds: $num_seconds"
+          echo "chunk_size_ms: $chunk_size_ms"
 
-          src=${model_id}-${num_seconds}
+          src=${model_id}-${chunk_size_ms}
 
 
           ls -lh $src.tar.bz2
@@ -166,7 +172,7 @@ jobs:
           ls -lh $src/*
           popd
 
-          mv -v /tmp/$src/* $dir/model-files/$num_seconds/
+          mv -v /tmp/$src/* $dir/model-files/$chunk_size_ms/
 
       - name: Show files
         shell: bash
@@ -371,8 +377,8 @@ jobs:
 
           export LDFLAGS="-Wl,-z,max-page-size=16384"
           dir=$PWD
-          num_seconds=${{ matrix.num_seconds }}
-          model_dir=$PWD/model-files/$num_seconds
+          chunk_size_ms=${{ matrix.chunk_size_ms }}
+          model_dir=$PWD/model-files/$chunk_size_ms
           soc=${{ matrix.soc }}
 
           python3 ./scripts/pyannote/segmentation/show-onnx.py --filename $model_dir/encoder.onnx
@@ -382,7 +388,7 @@ jobs:
           export PATH=${ANDROID_NDK_LATEST_HOME}:$PATH
 
           echo "export to qnn"
-          echo "----------$num_seconds----------"
+          echo "----------$chunk_size_ms----------"
 
           for m in encoder decoder joiner; do
             echo "Processing $m"
@@ -394,7 +400,7 @@ jobs:
             ls -lh *.raw
             ls -lh *.txt
 
-            if [[ $m == 'encoder' || $m == 'joiner' ]]; then
+            if [[ $m == 'encoder2' || $m == 'joiner2' ]]; then
               # quantize only the encoder and joiner
               cat $m.txt
 
@@ -451,14 +457,14 @@ jobs:
 
           echo "collect results"
 
-          d=sherpa-onnx-qnn-${{ matrix.soc }}-binary-${{ matrix.model_name }}-${{ matrix.num_seconds }}s-transducer
+          d=sherpa-onnx-qnn-${{ matrix.soc }}-binary-${{ matrix.model_name }}-${{ matrix.chunk_size_ms }}ms
           mkdir -p $d
           mkdir -p $d/test_wavs
           cp -v quant/binary/*.bin $d/
           cp -v $model_dir/tokens.txt $d
           cp -v $model_dir/*.wav $d/test_wavs
 
-          echo "num_seconds=${num_seconds}s" > $d/info.txt
+          echo "chunk_size_ms=${chunk_size_ms}ms" > $d/info.txt
 
           ls -lh $d
           tar cjfv $d.tar.bz2 $d
@@ -470,9 +476,9 @@ jobs:
 
           for p in x86_64-linux-clang aarch64-android; do
             if [[ $p == x86_64-linux-clang ]]; then
-              d=sherpa-onnx-qnn-${{ matrix.model_name }}-${{ matrix.num_seconds }}s-transducer-linux-x64
+              d=sherpa-onnx-qnn-${{ matrix.model_name }}-${{ matrix.chunk_size_ms }}s-linux-x64
             elif [[ $p == aarch64-android ]]; then
-              d=sherpa-onnx-qnn-${{ matrix.model_name }}-${{ matrix.num_seconds }}s-transducer-android-aarch64
+              d=sherpa-onnx-qnn-${{ matrix.model_name }}-${{ matrix.chunk_size_ms }}s-android-aarch64
             else
               echo "Unknown $p"
               exit -1
@@ -485,7 +491,7 @@ jobs:
             cp -v $model_dir/tokens.txt $d
             cp -v $model_dir/*.wav $d/test_wavs
 
-            echo "num_seconds=${num_seconds}s" > $d/info.txt
+            echo "chunk_size_ms=${chunk_size_ms}ms" > $d/info.txt
             echo "target=$p" >> $d/info.txt
 
             ls -lh $d
@@ -517,7 +523,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.model_name }}-${{ matrix.soc }}-${{ matrix.num_seconds }}-${{ matrix.model_type }}-json
+          name: ${{ matrix.model_name }}-${{ matrix.soc }}-${{ matrix.chunk_size_ms }}-${{ matrix.model_type }}-json
           path: ./quant/*.json
 
       - name: Release

--- a/.github/workflows/export-parakeet-tdt-qnn.yaml
+++ b/.github/workflows/export-parakeet-tdt-qnn.yaml
@@ -470,9 +470,9 @@ jobs:
 
           for p in x86_64-linux-clang aarch64-android; do
             if [[ $p == x86_64-linux-clang ]]; then
-              d=sherpa-onnx-qnn-${{ matrix.model_name }}-${{ matrix.num_seconds }}s-transducer-linux-x64
+              d=sherpa-onnx-qnn-${{ matrix.model_name }}-${{ matrix.num_seconds }}s-linux-x64
             elif [[ $p == aarch64-android ]]; then
-              d=sherpa-onnx-qnn-${{ matrix.model_name }}-${{ matrix.num_seconds }}s-transducer-android-aarch64
+              d=sherpa-onnx-qnn-${{ matrix.model_name }}-${{ matrix.num_seconds }}s-android-aarch64
             else
               echo "Unknown $p"
               exit -1

--- a/scripts/nemo/qnn/nemotron-speech-streaming-en-0.6b/run.sh
+++ b/scripts/nemo/qnn/nemotron-speech-streaming-en-0.6b/run.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright      2026  Xiaomi Corp.        (authors: Fangjun Kuang)
+
+set -ex
+
+pip install \
+  nemo_toolkit['asr'] \
+  "numpy<2" \
+  ipython \
+  kaldi-native-fbank \
+  librosa \
+  onnx \
+  onnxruntime \
+  onnxscript \
+  soundfile
+
+# 80, 160, 560, 1120
+chunk_size_ms=1120
+if [ $# -ge 1 ]; then
+  chunk_size_ms="$1"
+fi
+
+
+model_id=nemotron-speech-streaming-en-0.6b
+if [ $# -ge 2 ]; then
+  model_id="$2"
+fi
+
+python3 ./wrapper.py --chunk-size-ms $chunk_size_ms --model-id $model_id

--- a/scripts/nemo/qnn/nemotron-speech-streaming-en-0.6b/test_onnx.py
+++ b/scripts/nemo/qnn/nemotron-speech-streaming-en-0.6b/test_onnx.py
@@ -13,15 +13,14 @@ import soundfile as sf
 """
 =========./encoder.onnx==========
 NodeArg(name='x_121_112', type='tensor(float)', shape=[1, 128, 121])
-NodeArg(name='cache_last_channel', type='tensor(float)', shape=[24, 1, 70, 1024])
-NodeArg(name='cache_last_time', type='tensor(float)', shape=[24, 1, 1024, 8])
+NodeArg(name='cache_last_channel', type='tensor(float)', shape=[1, 24, 70, 1024])
+NodeArg(name='cache_last_time', type='tensor(float)', shape=[1, 24, 1024, 8])
 NodeArg(name='cache_last_channel_len', type='tensor(int32)', shape=[1])
 -----
 NodeArg(name='encoder_out', type='tensor(float)', shape=[1, 1024, 14])
-NodeArg(name='next_cache_last_channel', type='tensor(float)', shape=[24, 1, 70, 1024])
-NodeArg(name='next_cache_last_time', type='tensor(float)', shape=[24, 1, 1024, 8])
+NodeArg(name='next_cache_last_channel', type='tensor(float)', shape=[1, 24, 70, 1024])
+NodeArg(name='next_cache_last_time', type='tensor(float)', shape=[1, 24, 1024, 8])
 NodeArg(name='next_cache_last_channel_len', type='tensor(int32)', shape=[1])
-
 =========./decoder.onnx==========
 NodeArg(name='y', type='tensor(int32)', shape=[1, 1])
 NodeArg(name='h', type='tensor(float)', shape=[2, 1, 640])
@@ -30,12 +29,11 @@ NodeArg(name='c', type='tensor(float)', shape=[2, 1, 640])
 NodeArg(name='decoder_out', type='tensor(float)', shape=[1, 1, 640])
 NodeArg(name='next_h', type='tensor(float)', shape=[2, 1, 640])
 NodeArg(name='next_c', type='tensor(float)', shape=[2, 1, 640])
-
 =========./joiner.onnx==========
 NodeArg(name='encoder_out', type='tensor(float)', shape=[1, 1, 1024])
 NodeArg(name='decoder_out', type='tensor(float)', shape=[1, 1, 640])
 -----
-NodeArg(name='logits', type='tensor(float)', shape=[1, 1, 1, 1025])
+NodeArg(name='log_probs', type='tensor(float)', shape=[1, 1, 1, 1025])
 """
 
 

--- a/scripts/nemo/qnn/nemotron-speech-streaming-en-0.6b/test_onnx.py
+++ b/scripts/nemo/qnn/nemotron-speech-streaming-en-0.6b/test_onnx.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+# Copyright      2026  Xiaomi Corp.        (authors: Fangjun Kuang)
+
+import argparse
+from pathlib import Path
+
+import kaldi_native_fbank as knf
+import librosa
+import numpy as np
+import onnxruntime as ort
+import soundfile as sf
+
+"""
+=========./encoder.onnx==========
+NodeArg(name='x_121_112', type='tensor(float)', shape=[1, 128, 121])
+NodeArg(name='cache_last_channel', type='tensor(float)', shape=[24, 1, 70, 1024])
+NodeArg(name='cache_last_time', type='tensor(float)', shape=[24, 1, 1024, 8])
+NodeArg(name='cache_last_channel_len', type='tensor(int32)', shape=[1])
+-----
+NodeArg(name='encoder_out', type='tensor(float)', shape=[1, 1024, 14])
+NodeArg(name='next_cache_last_channel', type='tensor(float)', shape=[24, 1, 70, 1024])
+NodeArg(name='next_cache_last_time', type='tensor(float)', shape=[24, 1, 1024, 8])
+NodeArg(name='next_cache_last_channel_len', type='tensor(int32)', shape=[1])
+
+=========./decoder.onnx==========
+NodeArg(name='y', type='tensor(int32)', shape=[1, 1])
+NodeArg(name='h', type='tensor(float)', shape=[2, 1, 640])
+NodeArg(name='c', type='tensor(float)', shape=[2, 1, 640])
+-----
+NodeArg(name='decoder_out', type='tensor(float)', shape=[1, 1, 640])
+NodeArg(name='next_h', type='tensor(float)', shape=[2, 1, 640])
+NodeArg(name='next_c', type='tensor(float)', shape=[2, 1, 640])
+
+=========./joiner.onnx==========
+NodeArg(name='encoder_out', type='tensor(float)', shape=[1, 1, 1024])
+NodeArg(name='decoder_out', type='tensor(float)', shape=[1, 1, 640])
+-----
+NodeArg(name='logits', type='tensor(float)', shape=[1, 1, 1, 1025])
+"""
+
+
+def get_args():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument(
+        "--wav",
+        type=str,
+        required=True,
+    )
+    return parser.parse_args()
+
+
+def create_fbank(feat_dim: int):
+    opts = knf.FbankOptions()
+    opts.frame_opts.dither = 0
+    opts.frame_opts.remove_dc_offset = False
+    opts.frame_opts.window_type = "hann"
+
+    opts.mel_opts.low_freq = 0
+    opts.mel_opts.num_bins = feat_dim
+
+    opts.mel_opts.is_librosa = True
+
+    fbank = knf.OnlineFbank(opts)
+    return fbank
+
+
+def compute_features(audio, fbank):
+    assert len(audio.shape) == 1, audio.shape
+    fbank.accept_waveform(16000, audio)
+    ans = []
+    processed = 0
+    while processed < fbank.num_frames_ready:
+        ans.append(np.array(fbank.get_frame(processed)))
+        processed += 1
+
+    features = np.stack(ans)
+    features = np.ascontiguousarray(features)
+    return features
+
+
+class OnnxModel:
+    def __init__(
+        self,
+        encoder: str,
+        decoder: str,
+        joiner: str,
+    ):
+        self.init_encoder(encoder)
+        self.init_decoder(decoder)
+        self.init_joiner(joiner)
+
+    def init_encoder(self, encoder):
+        session_opts = ort.SessionOptions()
+        session_opts.inter_op_num_threads = 1
+        session_opts.intra_op_num_threads = 1
+
+        self.encoder = ort.InferenceSession(
+            encoder,
+            sess_options=session_opts,
+            providers=["CPUExecutionProvider"],
+        )
+
+        x = self.encoder.get_inputs()[0].name
+        _, window_size, window_shift = x.split("_")
+
+        self.window_size = int(window_size)
+        self.window_shift = int(window_shift)
+
+    def init_decoder(self, decoder):
+        session_opts = ort.SessionOptions()
+        session_opts.inter_op_num_threads = 1
+        session_opts.intra_op_num_threads = 1
+
+        self.decoder = ort.InferenceSession(
+            decoder,
+            sess_options=session_opts,
+            providers=["CPUExecutionProvider"],
+        )
+
+    def init_joiner(self, joiner):
+        session_opts = ort.SessionOptions()
+        session_opts.inter_op_num_threads = 1
+        session_opts.intra_op_num_threads = 1
+
+        self.joiner = ort.InferenceSession(
+            joiner,
+            sess_options=session_opts,
+            providers=["CPUExecutionProvider"],
+        )
+
+    def get_encoder_state(self):
+        cache_last_channel_shape = self.encoder.get_inputs()[1].shape
+        cache_last_time_shape = self.encoder.get_inputs()[2].shape
+        cache_last_channel_len_shape = self.encoder.get_inputs()[3].shape
+
+        s0 = np.zeros(cache_last_channel_shape, dtype=np.float32)
+        s1 = np.zeros(cache_last_time_shape, dtype=np.float32)
+        s2 = np.zeros(cache_last_channel_len_shape, dtype=np.int32)
+
+        return s0, s1, s2
+
+    def get_decoder_state(self):
+        h_shape = self.decoder.get_inputs()[1].shape
+        c_shape = self.decoder.get_inputs()[2].shape
+
+        h = np.zeros(h_shape, dtype=np.float32)
+        c = np.zeros(c_shape, dtype=np.float32)
+        return h, c
+
+    def run_encoder(self, x: np.ndarray, states):
+        encoder_out, *next_states = self.encoder.run(
+            [
+                self.encoder.get_outputs()[0].name,
+                self.encoder.get_outputs()[1].name,
+                self.encoder.get_outputs()[2].name,
+                self.encoder.get_outputs()[3].name,
+            ],
+            {
+                self.encoder.get_inputs()[0].name: x,
+                self.encoder.get_inputs()[1].name: states[0],
+                self.encoder.get_inputs()[2].name: states[1],
+                self.encoder.get_inputs()[3].name: states[2],
+            },
+        )
+        return encoder_out, next_states
+
+    def run_decoder(
+        self,
+        token: int,
+        h: np.ndarray,
+        c: np.ndarray,
+    ):
+        y = np.array([[token]], dtype=np.int32)
+
+        (
+            decoder_out,
+            next_h,
+            next_c,
+        ) = self.decoder.run(
+            [
+                self.decoder.get_outputs()[0].name,
+                self.decoder.get_outputs()[1].name,
+                self.decoder.get_outputs()[2].name,
+            ],
+            {
+                self.decoder.get_inputs()[0].name: y,
+                self.decoder.get_inputs()[1].name: h,
+                self.decoder.get_inputs()[2].name: c,
+            },
+        )
+        return decoder_out, next_h, next_c
+
+    def run_joiner(
+        self,
+        encoder_out: np.ndarray,
+        decoder_out: np.ndarray,
+    ):
+        log_probs = self.joiner.run(
+            [
+                self.joiner.get_outputs()[0].name,
+            ],
+            {
+                self.joiner.get_inputs()[0].name: encoder_out,
+                self.joiner.get_inputs()[1].name: decoder_out,
+            },
+        )[0]
+        return log_probs
+
+
+def main():
+    args = get_args()
+    model = OnnxModel("encoder.onnx", "decoder.onnx", "joiner.onnx")
+
+    wav = args.wav
+    name = Path(wav).stem
+    window_size = model.encoder.get_inputs()[0].shape[2]
+    assert window_size == model.window_size, (window_size, model.window_size)
+
+    feat_dim = model.encoder.get_inputs()[0].shape[1]
+    window_shift = model.window_shift
+
+    assert feat_dim in (80, 128), feat_dim
+
+    id2token = dict()
+    with open("tokens.txt", encoding="utf-8") as f:
+        for line in f:
+            t, idx = line.split()
+            id2token[int(idx)] = t
+
+    fbank = create_fbank(feat_dim=feat_dim)
+    audio, sample_rate = sf.read(wav, dtype="float32", always_2d=True)
+    audio = audio[:, 0]  # only use the first channel
+    if sample_rate != 16000:
+        audio = librosa.resample(
+            audio,
+            orig_sr=sample_rate,
+            target_sr=16000,
+        )
+        sample_rate = 16000
+
+    tail_padding = np.zeros(sample_rate * 1)
+
+    audio = np.concatenate([audio, tail_padding])
+
+    blank = len(id2token) - 1
+    ans = [blank]
+
+    encoder_input_list = []
+    decoder_input_list = []
+    joiner_input_list = []
+
+    h, c = model.get_decoder_state()
+
+    decoder_input_list.append((ans[-1], h, c))
+    decoder_out, h, c = model.run_decoder(ans[-1], h, c)
+
+    features = compute_features(audio, fbank)
+    features.tofile(f"{name}-features.raw")
+
+    encoder_states = model.get_encoder_state()
+
+    max_symbols_per_frame = 10
+
+    for i in range(0, features.shape[0], window_shift):
+        f = features[i : i + window_size]
+        if f.shape[0] < window_size:
+            break
+
+        encoder_input_list.append([f, encoder_states])
+        encoder_out, encoder_states = model.run_encoder(
+            f[None].transpose(0, 2, 1), encoder_states
+        )
+        encoder_out = encoder_out.transpose(0, 2, 1)
+
+        num_symbols = 0
+        t = 0
+        while t < encoder_out.shape[1]:
+            encoder_out_t = encoder_out[:, t : t + 1]
+
+            joiner_input_list.append((encoder_out_t, decoder_out))
+            logits = model.run_joiner(encoder_out_t, decoder_out)
+
+            logits = logits.squeeze()
+            idx = np.argmax(logits).item()
+            if idx != blank:
+                ans.append(idx)
+
+                decoder_input_list.append((ans[-1], h, c))
+                decoder_out, h, c = model.run_decoder(ans[-1], h, c)
+
+                num_symbols += 1
+
+                if num_symbols > max_symbols_per_frame:
+                    num_symbols = 0
+                    t += 1
+            else:
+                t += 1
+                num_symbols = 0
+
+    if True:
+        with open(f"{name}-encoder.txt", "w") as f:
+            for i, (x, states) in enumerate(encoder_input_list):
+                x_name = f"{name}-{i}-x.raw"
+                x.tofile(x_name)
+
+                s0_name = f"{name}-{i}-s0.raw"
+                states[0].tofile(s0_name)
+
+                s1_name = f"{name}-{i}-s1.raw"
+                states[1].tofile(s1_name)
+
+                s2_name = f"{name}-{i}-s2.raw"
+                states[2].tofile(s2_name)
+
+                f.write(f"{x_name} {s0_name} {s1_name} {s2_name}\n")
+
+        with open(f"{name}-decoder.txt", "w") as f:
+            for i, (y, h, c) in enumerate(decoder_input_list):
+                y_name = f"{name}-{i}-y.raw"
+                np.array([y], dtype=np.int32).tofile(y_name)
+
+                h_name = f"{name}-{i}-h.raw"
+                h.tofile(h_name)
+
+                c_name = f"{name}-{i}-c.raw"
+                c.tofile(c_name)
+                f.write(f"{y_name} {h_name} {c_name}\n")
+
+        with open(f"{name}-joiner.txt", "w") as f:
+            for i, (e, d) in enumerate(joiner_input_list):
+                e_name = f"{name}-{i}-joiner-e.raw"
+                e.tofile(e_name)
+
+                d_name = f"{name}-{i}-joiner-d.raw"
+                d.tofile(d_name)
+
+                f.write(f"{e_name} {d_name}\n")
+
+    ans = ans[1:]  # remove the first blank
+    print(ans)
+    tokens = [id2token[i] for i in ans]
+    underline = "▁"
+    #  underline = b"\xe2\x96\x81".decode()
+    text = "".join(tokens).replace(underline, " ").strip()
+    print("result")
+    print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nemo/qnn/nemotron-speech-streaming-en-0.6b/wrapper.py
+++ b/scripts/nemo/qnn/nemotron-speech-streaming-en-0.6b/wrapper.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+# Copyright      2026  Xiaomi Corp.        (authors: Fangjun Kuang)
+
+import argparse
+
+import nemo.collections.asr as nemo_asr
+import torch
+
+
+def get_args():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument(
+        "--chunk-size-ms",
+        type=int,
+        choices=[80, 160, 560, 1120],
+        required=True,
+    )
+
+    parser.add_argument(
+        "--model-id",
+        type=str,
+        help="e.g., nvidia/nemotron-speech-streaming-en-0.6b",
+        required=True,
+    )
+    return parser.parse_args()
+
+
+class EncoderWrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def get_init_states(self):
+        cache_last_channel, cache_last_time, cache_last_channel_len = (
+            self.model.encoder.get_initial_cache_state()
+        )
+
+        print(cache_last_channel.shape)
+        print(cache_last_time.shape)
+        print(cache_last_channel_len.shape, cache_last_channel_len)
+
+        return (
+            cache_last_channel,
+            cache_last_time,
+            cache_last_channel_len.to(torch.int32),
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cache_last_channel: torch.Tensor,
+        cache_last_time: torch.Tensor,
+        cache_last_channel_len: torch.Tensor,
+    ):
+        """
+        Args:
+          x: feature tensor, (N, C, T)
+          cache_last_channel,
+          cache_last_time,
+          cache_last_channel_len,
+
+        Returns:
+          encoder_out: (N, C, T)
+        """
+        x_lens = torch.tensor([x.shape[2]], dtype=torch.int64)
+        encoder_out, encoder_out_len, *states = self.model.encoder(
+            audio_signal=x,
+            length=x_lens,
+            cache_last_channel=cache_last_channel,
+            cache_last_time=cache_last_time,
+            cache_last_channel_len=cache_last_channel_len,
+        )
+
+        return encoder_out, states
+
+
+class DecoderWrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def get_init_states(self):
+        h, c = self.model.decoder.initialize_state(
+            torch.tensor([[1.0]], dtype=torch.float)
+        )
+
+        return h, c
+
+    def forward(self, y: torch.Tensor, h: torch.Tensor, c: torch.Tensor):
+        """
+        y:  torch.int32, shape (1, 1)
+        """
+        transcript_len = torch.tensor([1], dtype=torch.int32)
+        decoder_out, target_lengths, states = self.model.decoder(
+            targets=y, target_length=transcript_len, states=[h, c]
+        )
+        decoder_out = decoder_out.permute(0, 2, 1)  # (N, C, 1) -> (N, 1, C)
+        return decoder_out, states[0], states[1]
+
+
+class JoinerWrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, encoder_out: torch.Tensor, decoder_out: torch.Tensor):
+        """
+        encoder_out: feature tensor, (1, 1, encoder_dim)
+        decoder_out: feature tensor, (1, 1, decoder_dim)
+        """
+        log_probs = self.model.joint.joint(encoder_out, decoder_out)
+
+        return log_probs
+
+
+def export_encoder(asr_model, window_size, window_shift):
+    m = EncoderWrapper(asr_model)
+    m.eval()
+
+    feat_dim = asr_model.cfg.preprocessor.features
+
+    states = m.get_init_states()
+    x = torch.rand(1, feat_dim, window_size, dtype=torch.float32)
+
+    print("x", x.shape)
+
+    torch.onnx.export(
+        m,
+        (x, *states),
+        "encoder.onnx",
+        opset_version=13,
+        input_names=[
+            f"x_{window_size}_{window_shift}",
+            "cache_last_channel",
+            "cache_last_time",
+            "cache_last_channel_len",
+        ],
+        output_names=[
+            "encoder_out",
+            "next_cache_last_channel",
+            "next_cache_last_time",
+            "next_cache_last_channel_len",
+        ],
+    )
+
+
+def export_decoder(asr_model):
+    m = DecoderWrapper(asr_model)
+    m.eval()
+
+    h, c = m.get_init_states()
+    y = torch.tensor([[1]], dtype=torch.int32)
+
+    torch.onnx.export(
+        m,
+        (y, h, c),
+        "decoder.onnx",
+        opset_version=13,
+        input_names=["y", "h", "c"],
+        output_names=["decoder_out", "next_h", "next_c"],
+    )
+
+
+def export_joiner(asr_model, encoder_dim, decoder_dim):
+    m = JoinerWrapper(asr_model)
+    m.eval()
+    encoder_out = torch.rand(1, 1, encoder_dim, dtype=torch.float32)
+    decoder_out = torch.rand(1, 1, decoder_dim, dtype=torch.float32)
+
+    torch.onnx.export(
+        m,
+        (encoder_out, decoder_out),
+        "joiner.onnx",
+        opset_version=13,
+        input_names=["encoder_out", "decoder_out"],
+        output_names=["log_probs"],
+    )
+
+
+@torch.no_grad()
+def main():
+    args = get_args()
+    print(vars(args))
+
+    asr_model = nemo_asr.models.ASRModel.from_pretrained(model_name=args.model_id)
+    asr_model.eval()
+
+    asr_model.set_export_config({"cache_support": True})
+
+    asr_model.decoder._prepare_for_export()
+    asr_model.joint._prepare_for_export()
+
+    chunk_size_ms = args.chunk_size_ms
+    chunk_size = chunk_size_ms // 80 - 1
+    print("chunk_size", chunk_size)
+    asr_model.encoder.set_default_att_context_size([70, chunk_size])
+    print("streaming_cfg", asr_model.encoder.streaming_cfg)
+
+    if isinstance(asr_model.encoder.streaming_cfg.pre_encode_cache_size, list):
+        pre_encode_cache_size = asr_model.encoder.streaming_cfg.pre_encode_cache_size[1]
+    else:
+        pre_encode_cache_size = asr_model.encoder.streaming_cfg.pre_encode_cache_size
+
+    if isinstance(asr_model.encoder.streaming_cfg.chunk_size, list):
+        chunk_size = asr_model.encoder.streaming_cfg.chunk_size[1]
+    else:
+        chunk_size = asr_model.encoder.streaming_cfg.chunk_size
+
+    window_size = chunk_size + pre_encode_cache_size
+
+    window_shift = chunk_size
+
+    print(window_size, window_shift)
+
+    print(type(asr_model))
+    print(asr_model)
+    print(asr_model.cfg)
+    print(asr_model.decoding)
+    print(asr_model.decoding.decoding)
+    print(asr_model.decoding.decoding._blank_index)
+    print(asr_model.decoding.decoding._SOS)
+
+    print("num layers", asr_model.decoder.pred_rnn_layers)
+
+    with open("./tokens.txt", "w", encoding="utf-8") as f:
+        for i, s in enumerate(asr_model.joint.vocabulary):
+            f.write(f"{s} {i}\n")
+        f.write(f"<blk> {i+1}\n")
+
+    feat_dim = asr_model.cfg["preprocessor"]["features"]
+    print("feat_dim", feat_dim)
+
+    export_encoder(asr_model, window_size=window_size, window_shift=window_shift)
+    export_decoder(asr_model)
+    export_joiner(
+        asr_model,
+        encoder_dim=asr_model.joint.enc.in_features,
+        decoder_dim=asr_model.joint.pred.in_features,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nemo/qnn/nemotron-speech-streaming-en-0.6b/wrapper.py
+++ b/scripts/nemo/qnn/nemotron-speech-streaming-en-0.6b/wrapper.py
@@ -6,6 +6,168 @@ import argparse
 import nemo.collections.asr as nemo_asr
 import nemo.collections.asr.modules.conformer_encoder as conformer_mod
 import torch
+import torch.nn as nn
+
+
+def patched_forward_internal(
+    self,
+    audio_signal,
+    length,
+    cache_last_channel=None,
+    cache_last_time=None,
+    cache_last_channel_len=None,
+    bypass_pre_encode=False,
+):
+    # Patched inference-only version of ConformerEncoder.forward_internal for QNN export.
+    #
+    # Based on the original at:
+    #   ../nemo/nemo/collections/asr/modules/conformer_encoder.py:636
+    #
+    # Three changes from the original NeMo implementation:
+    #
+    # 1. Replaced `torch.neg(cache_last_channel_len) + cache_len` with
+    #    `cache_len - cache_last_channel_len`. They are mathematically equivalent,
+    #    but the original produces a Neg op in the ONNX graph which the Qualcomm
+    #    QNN converter (qnn-onnx-converter) does not support, causing:
+    #      [ ERROR ] OpConfig validation failed for ElementWiseUnary
+    #      [ ERROR ] QnnModel::addNode() validating node node_neg failed.
+    #
+    # 2. Cast attention masks from bool to float before slicing, then back to
+    #    bool after slicing. QNN's StridedSlice does not support boolean tensors,
+    #    causing:
+    #      [ ERROR ] OpConfig validation failed for StridedSlice
+    #      [ ERROR ] QnnModel::addNode() validating node node_slice_3 failed.
+    #
+    # 3. Removed training-only code paths (stochastic depth, interctc loss capture,
+    #    random att_context_size selection) since this is only used during export
+    #    where the model is always in eval/inference mode.
+    if length is None:
+        length = audio_signal.new_full(
+            (audio_signal.size(0),), audio_signal.size(-1), dtype=torch.int64, device=audio_signal.device
+        )
+
+    cur_att_context_size = self.att_context_size
+
+    if not bypass_pre_encode:
+        audio_signal = torch.transpose(audio_signal, 1, 2)
+
+        if isinstance(self.pre_encode, nn.Linear):
+            audio_signal = self.pre_encode(audio_signal)
+        else:
+            audio_signal, length = self.pre_encode(x=audio_signal, lengths=length)
+            length = length.to(torch.int64)
+            if self.streaming_cfg.drop_extra_pre_encoded > 0 and cache_last_channel is not None:
+                audio_signal = audio_signal[:, self.streaming_cfg.drop_extra_pre_encoded :, :]
+                length = (length - self.streaming_cfg.drop_extra_pre_encoded).clamp(min=0)
+
+        if self.reduction_position is not None and cache_last_channel is not None:
+            raise ValueError("Caching with reduction feature is not supported yet!")
+
+    max_audio_length = audio_signal.size(1)
+    if cache_last_channel is not None:
+        cache_len = self.streaming_cfg.last_channel_cache_size
+        cache_keep_size = max_audio_length - self.streaming_cfg.cache_drop_size
+        max_audio_length = max_audio_length + cache_len
+        padding_length = length + cache_len
+        # Original: offset = torch.neg(cache_last_channel_len) + cache_len
+        # Changed to subtraction to avoid the Neg op that QNN rejects (see docstring).
+        offset = cache_len - cache_last_channel_len
+    else:
+        padding_length = length
+        cache_last_channel_next = None
+        cache_len = 0
+        offset = None
+
+    if self.self_attention_model == 'rope':
+        if self.xscale:
+            audio_signal = audio_signal * self.xscale
+        audio_signal = self.dropout_pre_encoder(audio_signal)
+        pos_emb = None
+    else:
+        audio_signal, pos_emb = self.pos_enc(x=audio_signal, cache_len=cache_len)
+
+    pad_mask, att_mask = self._create_masks(
+        att_context_size=cur_att_context_size,
+        padding_length=padding_length,
+        max_audio_length=max_audio_length,
+        offset=offset,
+        device=audio_signal.device,
+    )
+
+    # Cast masks from bool to float so that QNN StridedSlice can handle them.
+    # QNN does not support StridedSlice on boolean tensors.
+    # Cast back to bool before passing to layers below.
+    pad_mask = pad_mask.to(torch.float32)
+    if att_mask is not None:
+        att_mask = att_mask.to(torch.float32)
+
+    if cache_last_channel is not None:
+        pad_mask = pad_mask[:, cache_len:]
+        if att_mask is not None:
+            att_mask = att_mask[:, cache_len:]
+        cache_last_time_next = []
+        cache_last_channel_next = []
+
+    # Cast masks back to bool for the attention layers.
+    pad_mask = pad_mask.to(torch.bool)
+    if att_mask is not None:
+        att_mask = att_mask.to(torch.bool)
+
+    for lth, layer in enumerate(self.layers):
+        if cache_last_channel is not None:
+            cache_last_channel_cur = cache_last_channel[lth]
+            cache_last_time_cur = cache_last_time[lth]
+        else:
+            cache_last_channel_cur = None
+            cache_last_time_cur = None
+        audio_signal = layer(
+            x=audio_signal,
+            att_mask=att_mask,
+            pos_emb=pos_emb,
+            pad_mask=pad_mask,
+            cache_last_channel=cache_last_channel_cur,
+            cache_last_time=cache_last_time_cur,
+        )
+
+        if cache_last_channel_cur is not None:
+            (audio_signal, cache_last_channel_cur, cache_last_time_cur) = audio_signal
+            cache_last_channel_next.append(cache_last_channel_cur)
+            cache_last_time_next.append(cache_last_time_cur)
+
+        if self.reduction_position == lth:
+            audio_signal, length = self.reduction_subsampling(x=audio_signal, lengths=length)
+            max_audio_length = audio_signal.size(1)
+            if self.self_attention_model != 'rope':
+                _, pos_emb = self.pos_enc(x=audio_signal, cache_len=cache_len)
+            pad_mask, att_mask = self._create_masks(
+                att_context_size=cur_att_context_size,
+                padding_length=length,
+                max_audio_length=max_audio_length,
+                offset=offset,
+                device=audio_signal.device,
+            )
+
+    if self.out_proj is not None:
+        audio_signal = self.out_proj(audio_signal)
+
+    if self.reduction_position == -1:
+        audio_signal, length = self.reduction_subsampling(x=audio_signal, lengths=length)
+
+    audio_signal = torch.transpose(audio_signal, 1, 2)
+    length = length.to(dtype=torch.int64)
+
+    if cache_last_channel is not None:
+        cache_last_channel_next = torch.stack(cache_last_channel_next, dim=0)
+        cache_last_time_next = torch.stack(cache_last_time_next, dim=0)
+        return (
+            audio_signal,
+            length,
+            cache_last_channel_next,
+            cache_last_time_next,
+            torch.clamp(cache_last_channel_len + cache_keep_size, max=cache_len),
+        )
+    else:
+        return audio_signal, length
 
 
 def patched_streaming_post_process(self, rets, keep_all_outputs=True):
@@ -47,6 +209,11 @@ def patched_streaming_post_process(self, rets, keep_all_outputs=True):
     )
 
 
+# Monkey-patch NeMo's ConformerEncoder to produce an ONNX graph that
+# QNN can consume. forward_internal avoids unsupported Neg and
+# StridedSlice-on-bool ops; streaming_post_process simplifies the
+# cache/output handling.
+conformer_mod.ConformerEncoder.forward_internal = patched_forward_internal
 conformer_mod.ConformerEncoder.streaming_post_process = patched_streaming_post_process
 
 

--- a/scripts/nemo/qnn/nemotron-speech-streaming-en-0.6b/wrapper.py
+++ b/scripts/nemo/qnn/nemotron-speech-streaming-en-0.6b/wrapper.py
@@ -43,7 +43,10 @@ def patched_forward_internal(
     #    where the model is always in eval/inference mode.
     if length is None:
         length = audio_signal.new_full(
-            (audio_signal.size(0),), audio_signal.size(-1), dtype=torch.int64, device=audio_signal.device
+            (audio_signal.size(0),),
+            audio_signal.size(-1),
+            dtype=torch.int64,
+            device=audio_signal.device,
         )
 
     cur_att_context_size = self.att_context_size
@@ -56,9 +59,16 @@ def patched_forward_internal(
         else:
             audio_signal, length = self.pre_encode(x=audio_signal, lengths=length)
             length = length.to(torch.int64)
-            if self.streaming_cfg.drop_extra_pre_encoded > 0 and cache_last_channel is not None:
-                audio_signal = audio_signal[:, self.streaming_cfg.drop_extra_pre_encoded :, :]
-                length = (length - self.streaming_cfg.drop_extra_pre_encoded).clamp(min=0)
+            if (
+                self.streaming_cfg.drop_extra_pre_encoded > 0
+                and cache_last_channel is not None
+            ):
+                audio_signal = audio_signal[
+                    :, self.streaming_cfg.drop_extra_pre_encoded :, :
+                ]
+                length = (length - self.streaming_cfg.drop_extra_pre_encoded).clamp(
+                    min=0
+                )
 
         if self.reduction_position is not None and cache_last_channel is not None:
             raise ValueError("Caching with reduction feature is not supported yet!")
@@ -78,7 +88,7 @@ def patched_forward_internal(
         cache_len = 0
         offset = None
 
-    if self.self_attention_model == 'rope':
+    if self.self_attention_model == "rope":
         if self.xscale:
             audio_signal = audio_signal * self.xscale
         audio_signal = self.dropout_pre_encoder(audio_signal)
@@ -135,9 +145,11 @@ def patched_forward_internal(
             cache_last_time_next.append(cache_last_time_cur)
 
         if self.reduction_position == lth:
-            audio_signal, length = self.reduction_subsampling(x=audio_signal, lengths=length)
+            audio_signal, length = self.reduction_subsampling(
+                x=audio_signal, lengths=length
+            )
             max_audio_length = audio_signal.size(1)
-            if self.self_attention_model != 'rope':
+            if self.self_attention_model != "rope":
                 _, pos_emb = self.pos_enc(x=audio_signal, cache_len=cache_len)
             pad_mask, att_mask = self._create_masks(
                 att_context_size=cur_att_context_size,
@@ -151,7 +163,9 @@ def patched_forward_internal(
         audio_signal = self.out_proj(audio_signal)
 
     if self.reduction_position == -1:
-        audio_signal, length = self.reduction_subsampling(x=audio_signal, lengths=length)
+        audio_signal, length = self.reduction_subsampling(
+            x=audio_signal, lengths=length
+        )
 
     audio_signal = torch.transpose(audio_signal, 1, 2)
     length = length.to(dtype=torch.int64)
@@ -321,9 +335,9 @@ class JoinerWrapper(torch.nn.Module):
         encoder_out: feature tensor, (1, 1, encoder_dim)
         decoder_out: feature tensor, (1, 1, decoder_dim)
         """
-        log_probs = self.model.joint.joint(encoder_out, decoder_out)
+        logits = self.model.joint.joint(encoder_out, decoder_out)
 
-        return log_probs
+        return logits
 
 
 def export_encoder(asr_model, window_size, window_shift):
@@ -386,7 +400,7 @@ def export_joiner(asr_model, encoder_dim, decoder_dim):
         "joiner.onnx",
         opset_version=13,
         input_names=["encoder_out", "decoder_out"],
-        output_names=["log_probs"],
+        output_names=["logits"],
     )
 
 

--- a/scripts/nemo/qnn/nemotron-speech-streaming-en-0.6b/wrapper.py
+++ b/scripts/nemo/qnn/nemotron-speech-streaming-en-0.6b/wrapper.py
@@ -4,7 +4,50 @@
 import argparse
 
 import nemo.collections.asr as nemo_asr
+import nemo.collections.asr.modules.conformer_encoder as conformer_mod
 import torch
+
+
+def patched_streaming_post_process(self, rets, keep_all_outputs=True):
+    if len(rets) == 2:
+        return rets[0], rets[1], None, None, None
+
+    (
+        encoded,
+        encoded_len,
+        cache_last_channel_next,
+        cache_last_time_next,
+        cache_last_channel_next_len,
+    ) = rets
+
+    if (
+        cache_last_channel_next is not None
+        and self.streaming_cfg.last_channel_cache_size > 0
+    ):
+        cache_size = int(self.streaming_cfg.last_channel_cache_size)
+        total_size = cache_last_channel_next.shape[2]
+        start_idx = total_size - cache_size
+        cache_last_channel_next = cache_last_channel_next.narrow(
+            2, start_idx, cache_size
+        )
+
+    if self.streaming_cfg.valid_out_len > 0 and (
+        not keep_all_outputs or self.att_context_style == "regular"
+    ):
+        valid_len = int(self.streaming_cfg.valid_out_len)
+        encoded = encoded.narrow(2, 0, valid_len)
+        encoded_len = torch.clamp(encoded_len, max=valid_len)
+
+    return (
+        encoded,
+        encoded_len,
+        cache_last_channel_next,
+        cache_last_time_next,
+        cache_last_channel_next_len,
+    )
+
+
+conformer_mod.ConformerEncoder.streaming_post_process = patched_streaming_post_process
 
 
 def get_args():
@@ -43,8 +86,8 @@ class EncoderWrapper(torch.nn.Module):
         print(cache_last_channel_len.shape, cache_last_channel_len)
 
         return (
-            cache_last_channel,
-            cache_last_time,
+            cache_last_channel.transpose(0, 1),
+            cache_last_time.transpose(0, 1),
             cache_last_channel_len.to(torch.int32),
         )
 
@@ -66,7 +109,7 @@ class EncoderWrapper(torch.nn.Module):
           encoder_out: (N, C, T)
         """
         x_lens = torch.tensor([x.shape[2]], dtype=torch.int64)
-        encoder_out, encoder_out_len, *states = self.model.encoder(
+        encoder_out, encoder_out_len, *states = self.model.encoder.forward_for_export(
             audio_signal=x,
             length=x_lens,
             cache_last_channel=cache_last_channel,


### PR DESCRIPTION
C++ runtime will be added in a separate pull request.

You can find the exported models at
- https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models-qnn-binary-2
- https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models-qnn-2

(search for streaming in the above two pages)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for exporting a new streaming speech model to QNN artifacts.
  * Introduced automated workflows to generate model builds across multiple chunk sizes and target devices.
  * Added tooling to export ONNX components and run streaming inference checks for the model.

* **Bug Fixes**
  * Improved export compatibility for streaming model graphs and cached-state handling.
  * Added validation steps to help catch issues during model conversion and packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->