### PR TITLE
Add C++ runtime for nemotron-speech-streaming-en-0.6b with QNN

### DIFF
--- a/sherpa-onnx/csrc/CMakeLists.txt
+++ b/sherpa-onnx/csrc/CMakeLists.txt
@@ -263,6 +263,7 @@ if(SHERPA_ONNX_ENABLE_QNN)
     ./qnn/offline-whisper-model-qnn.cc
     ./qnn/offline-zipformer-transducer-model-qnn.cc
     ./qnn/offline-zipformer-ctc-model-qnn.cc
+    ./qnn/online-nemo-transducer-model-qnn.cc
     ./qnn/online-zipformer-transducer-model-qnn.cc
     ./qnn/qnn-backend.cc
     ./qnn/qnn-model.cc

--- a/sherpa-onnx/csrc/online-recognizer-impl.cc
+++ b/sherpa-onnx/csrc/online-recognizer-impl.cc
@@ -39,6 +39,7 @@
 #endif
 
 #ifdef SHERPA_ONNX_ENABLE_QNN
+#include "sherpa-onnx/csrc/qnn/online-recognizer-nemo-transducer-qnn-impl.h"
 #include "sherpa-onnx/csrc/qnn/online-recognizer-zipformer-transducer-qnn-impl.h"
 #endif
 
@@ -48,6 +49,7 @@ static bool HasQnnOnlineTransducerModel(const OnlineModelConfig &config) {
   return !config.transducer.encoder.empty() ||
          !config.transducer.qnn_config.context_binary.empty();
 }
+
 
 static bool IsNeMoParakeetUnifiedStreaming(const Ort::Session &decoder_sess) {
   Ort::AllocatorWithDefaultOptions allocator;
@@ -83,13 +85,16 @@ std::unique_ptr<OnlineRecognizerImpl> OnlineRecognizerImpl::Create(
   if (config.model_config.provider_config.provider == "qnn") {
 #ifdef SHERPA_ONNX_ENABLE_QNN
     if (HasQnnOnlineTransducerModel(config.model_config)) {
+      if (config.model_config.model_type == "nemo_transducer") {
+        return std::make_unique<OnlineRecognizerNemoTransducerQnnImpl>(config);
+      }
       return std::make_unique<OnlineRecognizerZipformerTransducerQnnImpl>(
           config);
     }
 
     SHERPA_ONNX_LOGE(
-        "Only Zipformer transducers are currently supported by qnn for "
-        "online recognition.");
+        "Only Zipformer transducers and nemo_transducer are currently "
+        "supported by qnn for online recognition.");
     SHERPA_ONNX_EXIT(-1);
 #else
     SHERPA_ONNX_LOGE(
@@ -169,13 +174,17 @@ std::unique_ptr<OnlineRecognizerImpl> OnlineRecognizerImpl::Create(
   if (config.model_config.provider_config.provider == "qnn") {
 #ifdef SHERPA_ONNX_ENABLE_QNN
     if (HasQnnOnlineTransducerModel(config.model_config)) {
+      if (config.model_config.model_type == "nemo_transducer") {
+        return std::make_unique<OnlineRecognizerNemoTransducerQnnImpl>(mgr,
+                                                                     config);
+      }
       return std::make_unique<OnlineRecognizerZipformerTransducerQnnImpl>(
           mgr, config);
     }
 
     SHERPA_ONNX_LOGE(
-        "Only Zipformer transducers are currently supported by qnn for "
-        "online recognition.");
+        "Only Zipformer transducers and nemo_transducer are currently "
+        "supported by qnn for online recognition.");
     SHERPA_ONNX_EXIT(-1);
 #else
     SHERPA_ONNX_LOGE(

--- a/sherpa-onnx/csrc/online-stream-state.h
+++ b/sherpa-onnx/csrc/online-stream-state.h
@@ -27,6 +27,10 @@ struct OnlineTransducerDecoderResultNoOrt {
   std::vector<float> context_scores;
   std::vector<float> decoder_out;
   Hypotheses hyps;
+
+  // Decoder states for models with LSTM decoders (e.g., nemo_transducer).
+  // Each element is a flat state tensor (h, c, etc.). Ignored by zipformer.
+  std::vector<std::vector<float>> states;
 };
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/qnn/offline-recognizer-transducer-qnn-impl.h
+++ b/sherpa-onnx/csrc/qnn/offline-recognizer-transducer-qnn-impl.h
@@ -224,8 +224,7 @@ class OfflineRecognizerTransducerQnnImpl : public OfflineRecognizerImpl {
       }
 
       LogSoftmax(logit.data(), vocab_size);
-      auto y = static_cast<int32_t>(std::distance(
-          logit.begin(), std::max_element(logit.begin(), logit.end())));
+      auto y = MaxElementIndex(logit.data(), logit.size());
       float log_prob = logit[y];
 
       if (y != 0 && y != unk_id_) {

--- a/sherpa-onnx/csrc/qnn/online-nemo-transducer-model-qnn.cc
+++ b/sherpa-onnx/csrc/qnn/online-nemo-transducer-model-qnn.cc
@@ -165,8 +165,8 @@ class OnlineNemoTransducerModelQnn::Impl {
         auto data = encoder_->GetOutputTensorData(name);
         if (state_needs_transpose_[i]) {
           const auto &out_shape = state_output_shapes_[i];
-          data = Transpose012To120(data.data(), out_shape[0], out_shape[1],
-                                      out_shape[2]);
+          data = Transpose012To120(data.data(), out_shape[1], out_shape[2],
+                                      out_shape[3]);
         }
         (*states)[i].float_data = std::move(data);
       }
@@ -523,8 +523,8 @@ class OnlineNemoTransducerModelQnn::Impl {
         // input [1, d1, d2, d0] -> output [1, d0, d1, d2]
         if (in_shape.size() != 4 || out_shape.size() != 4 ||
             in_shape[0] != 1 || out_shape[0] != 1 ||
-            in_shape[1] != out_shape[3] || in_shape[2] != out_shape[1] ||
-            in_shape[3] != out_shape[2]) {
+            in_shape[1] != out_shape[2] || in_shape[2] != out_shape[3] ||
+            in_shape[3] != out_shape[1]) {
           SHERPA_ONNX_LOGE(
               "Inconsistent cache shapes for '%s': input [%d,%d,%d,%d] "
               "output [%d,%d,%d,%d]",
@@ -536,15 +536,6 @@ class OnlineNemoTransducerModelQnn::Impl {
           SHERPA_ONNX_EXIT(-1);
         }
       }
-    }
-
-    if (config_.debug) {
-      SHERPA_ONNX_LOGE("encoder input '%s': [1, %d, %d]",
-                        encoder_input_name_.c_str(), window_size_, feat_dim_);
-      SHERPA_ONNX_LOGE("encoder output 'encoder_out': [1, %d, %d]",
-                        num_encoder_frames_, encoder_out_dim_);
-      SHERPA_ONNX_LOGE("window_size: %d, window_shift: %d, subsampling: %d",
-                        window_size_, window_shift_, subsampling_factor_);
     }
   }
 

--- a/sherpa-onnx/csrc/qnn/online-nemo-transducer-model-qnn.cc
+++ b/sherpa-onnx/csrc/qnn/online-nemo-transducer-model-qnn.cc
@@ -15,6 +15,7 @@
 #include "sherpa-onnx/csrc/qnn/online-nemo-transducer-model-qnn.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <functional>
 #include <memory>
 #include <mutex>  // NOLINT

--- a/sherpa-onnx/csrc/qnn/online-nemo-transducer-model-qnn.cc
+++ b/sherpa-onnx/csrc/qnn/online-nemo-transducer-model-qnn.cc
@@ -1,0 +1,829 @@
+// sherpa-onnx/csrc/qnn/online-nemo-transducer-model-qnn.cc
+//
+// Copyright (c)  2026  Xiaomi Corporation
+//
+// QNN layout differences from ONNX:
+//
+//   Encoder input x:  QNN uses [1, window_size, feat_dim]
+//                     (ONNX uses [1, feat_dim, window_size])
+//
+//   Encoder cache:    QNN input [1, d1, d2, d0], QNN output [1, d0, d1, d2]
+//                     (ONNX uses [1, d0, d1, d2])
+//                     Storage uses QNN input format. Transpose012To120 is
+//                     applied once on output; no transpose on input.
+
+#include "sherpa-onnx/csrc/qnn/online-nemo-transducer-model-qnn.h"
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <mutex>  // NOLINT
+#include <numeric>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#if __ANDROID_API__ >= 9
+#include "android/asset_manager.h"
+#include "android/asset_manager_jni.h"
+#endif
+
+#if __OHOS__
+#include "rawfile/raw_file_manager.h"
+#endif
+
+#include "sherpa-onnx/csrc/file-utils.h"
+#include "sherpa-onnx/csrc/macros.h"
+#include "sherpa-onnx/csrc/math.h"
+#include "sherpa-onnx/csrc/qnn/macros.h"
+#include "sherpa-onnx/csrc/qnn/qnn-backend.h"
+#include "sherpa-onnx/csrc/qnn/qnn-model.h"
+#include "sherpa-onnx/csrc/text-utils.h"
+
+namespace sherpa_onnx {
+
+namespace {
+
+// Transpose a 3D tensor from [d0, d1, d2] to [d1, d2, d0].
+// Used to convert QNN encoder cache outputs back to the storage layout
+// expected by the next encoder call.
+// Loop order: i1 (outer), i2 (middle), i0 (inner).
+// This makes writes to y sequential (consecutive i0 values are contiguous).
+static std::vector<float> Transpose012To120(const float *x, int64_t d0,
+                                            int64_t d1, int64_t d2) {
+  std::vector<float> y(static_cast<size_t>(d0) * d1 * d2);
+
+  for (int64_t i1 = 0; i1 != d1; ++i1) {
+    for (int64_t i2 = 0; i2 != d2; ++i2) {
+      const float *src = x + (i1 * d2 + i2);
+      float *dst = y.data() + (i1 * d2 + i2) * d0;
+      for (int64_t i0 = 0; i0 != d0; ++i0) {
+        dst[i0] = src[i0 * d1 * d2];
+      }
+    }
+  }
+
+  return y;
+}
+
+static int64_t NumElements(const std::vector<int64_t> &shape) {
+  return std::accumulate(shape.begin(), shape.end(), int64_t{1},
+                         std::multiplies<int64_t>());
+}
+
+}  // namespace
+
+class OnlineNemoTransducerModelQnn::Impl {
+ public:
+  explicit Impl(const OnlineModelConfig &config) : config_(config) { Init(); }
+
+  template <typename Manager>
+  Impl(Manager *mgr, const OnlineModelConfig &config) : config_(config) {
+    SHERPA_ONNX_LOGE(
+        "Please copy all files from assets to SD card and set assetManager to "
+        "null");
+    SHERPA_ONNX_EXIT(-1);
+  }
+
+  std::vector<OnlineStreamStateTensor> GetEncoderInitStates() const {
+    std::vector<OnlineStreamStateTensor> ans;
+    ans.reserve(state_storage_shapes_.size());
+    for (size_t i = 0; i != state_storage_shapes_.size(); ++i) {
+      OnlineStreamStateTensor state;
+      int64_t n = NumElements(state_storage_shapes_[i]);
+      if (state_is_int32_[i]) {
+        state.int32_data.resize(n, 0);
+      } else {
+        state.float_data.resize(n, 0.f);
+      }
+      ans.push_back(std::move(state));
+    }
+
+    return ans;
+  }
+
+  // QNN encoder tensor shapes:
+  //
+  //   Inputs:
+  //     x_{window_size}_{window_shift}[_norm]: (1, window_size, feat_dim) float
+  //     cache_last_channel:  (1, 70, 1024, 24) float  (QNN input layout)
+  //     cache_last_time:     (1, 1024, 8, 24) float    (QNN input layout)
+  //     cache_last_channel_len: (1,) int32
+  //
+  //   Outputs:
+  //     encoder_out:              (1, num_encoder_frames, encoder_out_dim) float
+  //     next_cache_last_channel:  (1, 24, 70, 1024) float
+  //     next_cache_last_time:     (1, 24, 1024, 8) float
+  //     next_cache_last_channel_len: (1,) int32
+  //
+  //   Cache layout: QNN output uses (d0, d1, d2), QNN input uses (d1, d2, d0).
+  //   We transpose once on output (Transpose012To120) and store in QNN input
+  //   format, so no transpose is needed on the next call.
+  std::vector<float> RunEncoder(std::vector<float> features, int32_t num_frames,
+                                std::vector<OnlineStreamStateTensor> *states) const {
+    if (!states) {
+      SHERPA_ONNX_LOGE("states pointer is null");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // Features come in as [num_frames, feat_dim] row-major, which matches
+    // the QNN encoder input layout [1, window_size, feat_dim] directly.
+    encoder_->SetInputTensorData(encoder_input_name_, features.data(),
+                                 static_cast<int32_t>(features.size()));
+
+    // Set encoder cache state inputs.
+    // Data is stored in QNN input format (transposed once on output),
+    // so feed directly without transpose.
+    for (size_t i = 0; i != state_input_names_.size(); ++i) {
+      const auto &name = state_input_names_[i];
+      if (!(*states)[i].int32_data.empty()) {
+        const auto *p = (*states)[i].int32_data.data();
+        int32_t n = static_cast<int32_t>((*states)[i].int32_data.size());
+        encoder_->SetInputTensorData(name, p, n);
+      } else {
+        const auto *p = (*states)[i].float_data.data();
+        int32_t n = static_cast<int32_t>((*states)[i].float_data.size());
+        encoder_->SetInputTensorData(name, p, n);
+      }
+    }
+
+    encoder_->Run();
+
+    std::vector<float> encoder_out =
+        encoder_->GetOutputTensorData("encoder_out");
+
+    // Read encoder cache outputs. Transpose once to QNN input format
+    // so it can be fed directly on the next call without transpose.
+    for (size_t i = 0; i != state_output_names_.size(); ++i) {
+      const auto &name = state_output_names_[i];
+      if (state_is_int32_[i]) {
+        (*states)[i].int32_data = encoder_->GetOutputTensorDataInt32(name);
+      } else {
+        auto data = encoder_->GetOutputTensorData(name);
+        if (state_needs_transpose_[i]) {
+          const auto &out_shape = state_output_shapes_[i];
+          data = Transpose012To120(data.data(), out_shape[0], out_shape[1],
+                                      out_shape[2]);
+        }
+        (*states)[i].float_data = std::move(data);
+      }
+    }
+
+    return encoder_out;
+  }
+
+  // QNN decoder tensor shapes:
+  //
+  //   Inputs:
+  //     y: (1, 1) int32
+  //     h: (num_layers, hidden_dim, 1) float
+  //     c: (num_layers, hidden_dim, 1) float
+  //
+  //   Outputs:
+  //     decoder_out: (1, 1, decoder_out_dim) float
+  //     next_h:      (num_layers, 1, hidden_dim) float
+  //     next_c:      (num_layers, 1, hidden_dim) float
+  //
+  //   Note: h/c input layout (d0, d1, 1) differs from next_h/next_c output
+  //   layout (d0, 1, d1), but since one dim is 1 the flat buffer is the same.
+  std::pair<std::vector<float>, std::vector<std::vector<float>>>
+  RunDecoder(int32_t token, std::vector<std::vector<float>> states) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // states[0] = h, states[1] = c
+    decoder_->SetInputTensorData("y", &token, 1);
+    decoder_->SetInputTensorData("h", states[0].data(),
+                                 static_cast<int32_t>(states[0].size()));
+    decoder_->SetInputTensorData("c", states[1].data(),
+                                 static_cast<int32_t>(states[1].size()));
+    decoder_->Run();
+
+    std::vector<float> decoder_out =
+        decoder_->GetOutputTensorData("decoder_out");
+    states[0] = decoder_->GetOutputTensorData("next_h");
+    states[1] = decoder_->GetOutputTensorData("next_c");
+
+    return {std::move(decoder_out), std::move(states)};
+  }
+
+  // QNN joiner tensor shapes:
+  //
+  //   Inputs:
+  //     encoder_out: (1, encoder_out_dim, 1) float
+  //     decoder_out: (1, decoder_out_dim, 1) float
+  //
+  //   Outputs:
+  //     logits: (1, 1, 1, vocab_size) float
+  std::vector<float> RunJoiner(const float *encoder_out,
+                               const std::vector<float> &decoder_out) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    joiner_->SetInputTensorData(joiner_encoder_input_name_, encoder_out,
+                                encoder_out_dim_);
+    joiner_->SetInputTensorData(joiner_decoder_input_name_, decoder_out.data(),
+                                static_cast<int32_t>(decoder_out.size()));
+    joiner_->Run();
+
+    return joiner_->GetOutputTensorData(joiner_output_name_);
+  }
+
+  int32_t WindowSize() const { return window_size_; }
+  int32_t WindowShift() const { return window_shift_; }
+  int32_t VocabSize() const { return vocab_size_; }
+  int32_t FeatureDim() const { return feat_dim_; }
+  int32_t EncoderDim() const { return encoder_out_dim_; }
+  int32_t DecoderDim() const { return decoder_out_dim_; }
+  int32_t SubsamplingFactor() const { return subsampling_factor_; }
+  const std::string &NormalizationType() const { return normalization_type_; }
+
+  std::vector<std::vector<float>> GetDecoderInitState() const {
+    return {std::vector<float>(h_size_, 0.f),
+            std::vector<float>(c_size_, 0.f)};
+  }
+
+ private:
+  void Init() {
+    ParseContextBinaries();
+    encoder_backend_ = std::make_unique<QnnBackend>(
+        config_.transducer.qnn_config.backend_lib, config_.debug);
+    decoder_backend_ = std::make_unique<QnnBackend>(
+        config_.transducer.qnn_config.backend_lib, config_.debug);
+    joiner_backend_ = std::make_unique<QnnBackend>(
+        config_.transducer.qnn_config.backend_lib, config_.debug);
+
+    InitEncoder();
+    InitDecoder();
+    InitJoiner();
+
+    CheckEncoder();
+    CheckDecoder();
+    CheckJoiner();
+  }
+
+  void ParseContextBinaries() {
+    SplitStringToVector(config_.transducer.qnn_config.context_binary, ",",
+                        true, &context_binaries_);
+    if (!context_binaries_.empty() && context_binaries_.size() != 3) {
+      SHERPA_ONNX_LOGE(
+          "There should be 3 files for online parakeet TDT context binary. "
+          "Actual: %d. '%s'",
+          static_cast<int32_t>(context_binaries_.size()),
+          config_.transducer.qnn_config.context_binary.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+  }
+
+  void CreateContextBinary(QnnModel *model,
+                           const std::string &context_binary) const {
+    if (config_.debug) {
+      SHERPA_ONNX_LOGE("Creating context binary '%s'.", context_binary.c_str());
+    }
+
+    bool ok = model->SaveBinaryContext(context_binary);
+    if (!ok) {
+      SHERPA_ONNX_LOGE("Failed to save context binary to '%s'",
+                       context_binary.c_str());
+    }
+
+    if (config_.debug && ok) {
+      SHERPA_ONNX_LOGE("Saved context binary to '%s'.",
+                        context_binary.c_str());
+      SHERPA_ONNX_LOGE("Remember to also provide libQnnSystem.so.");
+    }
+  }
+
+  void InitModelFromLib(const std::string &filename, QnnBackend *backend,
+                        std::unique_ptr<QnnModel> *model) const {
+    backend->InitContext();
+    *model = std::make_unique<QnnModel>(filename, backend, config_.debug);
+  }
+
+  void InitModelFromContextBinary(const std::string &filename,
+                                  QnnBackend *backend,
+                                  std::unique_ptr<QnnModel> *model) const {
+    if (config_.transducer.qnn_config.system_lib.empty()) {
+      SHERPA_ONNX_LOGE(
+          "You should provide --transducer.qnn-system-lib if you also provide "
+          "context binary");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    *model = std::make_unique<QnnModel>(
+        filename, config_.transducer.qnn_config.system_lib, backend,
+        BinaryContextTag{}, config_.debug);
+  }
+
+  void InitComponent(const std::string &lib_filename,
+                     const std::string &context_binary, const char *name,
+                     QnnBackend *backend,
+                     std::unique_ptr<QnnModel> *model) const {
+    if (context_binary.empty()) {
+      if (config_.debug) {
+        SHERPA_ONNX_LOGE(
+            "Init from %s model lib '%s' since context binary is not given.",
+            name, lib_filename.c_str());
+      }
+
+      InitModelFromLib(lib_filename, backend, model);
+      return;
+    }
+
+    if (!FileExists(context_binary)) {
+      if (config_.debug) {
+        SHERPA_ONNX_LOGE(
+            "Init %s from model lib '%s' since context binary '%s' does not "
+            "exist",
+            name, lib_filename.c_str(), context_binary.c_str());
+      }
+
+      InitModelFromLib(lib_filename, backend, model);
+      CreateContextBinary(model->get(), context_binary);
+    } else {
+      if (config_.debug) {
+        SHERPA_ONNX_LOGE("Init from %s context binary '%s'", name,
+                         context_binary.c_str());
+      }
+
+      InitModelFromContextBinary(context_binary, backend, model);
+    }
+  }
+
+  void InitEncoder() {
+    InitComponent(config_.transducer.encoder,
+                  context_binaries_.empty() ? "" : context_binaries_[0],
+                  "encoder", encoder_backend_.get(), &encoder_);
+  }
+
+  void InitDecoder() {
+    InitComponent(config_.transducer.decoder,
+                  context_binaries_.empty() ? "" : context_binaries_[1],
+                  "decoder", decoder_backend_.get(), &decoder_);
+  }
+
+  void InitJoiner() {
+    InitComponent(config_.transducer.joiner,
+                  context_binaries_.empty() ? "" : context_binaries_[2],
+                  "joiner", joiner_backend_.get(), &joiner_);
+  }
+
+  void CheckEncoder() {
+    if (!encoder_->HasTensor("encoder_out")) {
+      SHERPA_ONNX_LOGE("The encoder model does not have output 'encoder_out'");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    // The encoder input has a dynamic name: x_{window_size}_{window_shift}
+    // e.g., x_121_112
+    encoder_input_name_.clear();
+    for (const auto &name : encoder_->InputTensorNames()) {
+      if (name.size() > 2 && name[0] == 'x' && name[1] == '_') {
+        encoder_input_name_ = name;
+        std::vector<std::string> parts;
+        SplitStringToVector(name, "_", false, &parts);
+        // x name can be:
+        //   x_window-size_window-shift
+        //   x_window-size_window-shift_normalization-method
+        // where normalization-method is "NA" or "per-feature"
+        if (parts.size() != 3 && parts.size() != 4) {
+          SHERPA_ONNX_LOGE(
+              "Expected encoder input name "
+              "'x_window-size_window-shift[_normalization-method]'. "
+              "Given: '%s'",
+              name.c_str());
+          SHERPA_ONNX_EXIT(-1);
+        }
+
+        window_size_ = std::atoi(parts[1].c_str());
+        window_shift_ = std::atoi(parts[2].c_str());
+
+        if (window_size_ <= 0 || window_shift_ <= 0) {
+          SHERPA_ONNX_LOGE(
+              "Invalid window size/shift in encoder input name '%s'",
+              name.c_str());
+
+        normalization_type_.clear();
+        if (parts.size() == 4) {
+          if (parts[3] == "per-feature") {
+            normalization_type_ = "per_feature";
+          } else if (parts[3] != "NA") {
+            SHERPA_ONNX_LOGE(
+                "Unknown normalization method '%s' in encoder input name '%s'. "
+                "Expected 'NA' or 'per-feature'.",
+                parts[3].c_str(), name.c_str());
+            SHERPA_ONNX_EXIT(-1);
+          }
+        }
+          SHERPA_ONNX_EXIT(-1);
+        }
+
+        break;
+      }
+    }
+
+    if (encoder_input_name_.empty()) {
+      SHERPA_ONNX_LOGE(
+          "The encoder model does not have an input matching 'x_*_*'");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    // Identify cache state inputs (cache_last_channel, cache_last_time,
+    // cache_last_channel_len).
+    state_input_names_.clear();
+    for (const auto &name : encoder_->InputTensorNames()) {
+      if (name == encoder_input_name_) {
+        continue;
+      }
+      if (name == "cache_last_channel" || name == "cache_last_time" ||
+          name == "cache_last_channel_len") {
+        state_input_names_.push_back(name);
+      }
+    }
+
+    if (state_input_names_.size() != 3) {
+      SHERPA_ONNX_LOGE(
+          "Expected 3 encoder cache states (cache_last_channel, "
+          "cache_last_time, cache_last_channel_len). Found %d",
+          static_cast<int32_t>(state_input_names_.size()));
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    // The output cache names use "next_" prefix.
+    state_output_names_.clear();
+    for (const auto &name : state_input_names_) {
+      std::string out_name = "next_" + name;
+      if (!encoder_->HasTensor(out_name)) {
+        SHERPA_ONNX_LOGE("The encoder model does not have output '%s'",
+                         out_name.c_str());
+        SHERPA_ONNX_EXIT(-1);
+      }
+      state_output_names_.push_back(out_name);
+    }
+
+    // Validate input x shape: [1, window_size, feat_dim] (QNN layout).
+    // The ONNX model uses [1, feat_dim, window_size] but the QNN converter
+    // changes the layout to [1, window_size, feat_dim].
+    auto x_shape = encoder_->TensorShape(encoder_input_name_);
+    if (x_shape.size() != 3 || x_shape[0] != 1 ||
+        x_shape[1] != window_size_) {
+      SHERPA_ONNX_LOGE(
+          "The encoder input x should be of shape [1, %d, feat_dim]. "
+          "Actual: [1, %d, %d]",
+          window_size_, x_shape[1], x_shape[2]);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    feat_dim_ = x_shape[2];
+
+    auto out_shape = encoder_->TensorShape("encoder_out");
+    if (out_shape.size() != 3 || out_shape[0] != 1) {
+      SHERPA_ONNX_LOGE("The encoder output should be of shape [1, ?, ?]");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    encoder_out_dim_ = out_shape[2];
+    num_encoder_frames_ = out_shape[1];
+
+    // Each chunk of window_shift input frames produces num_encoder_frames_
+    // output frames, so the subsampling factor is window_shift /
+    // num_encoder_frames_.
+    subsampling_factor_ = window_shift_ / num_encoder_frames_;
+    if (subsampling_factor_ <= 0) {
+      SHERPA_ONNX_LOGE(
+          "Invalid subsampling factor: %d (window_shift=%d, "
+          "num_encoder_frames=%d)",
+          subsampling_factor_, window_shift_, num_encoder_frames_);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    // Validate and store cache shapes.
+    // cache_last_channel and cache_last_time are 4D and need 3D transpose.
+    // cache_last_channel_len is 1D int32, no transpose.
+    for (size_t i = 0; i != state_input_names_.size(); ++i) {
+      const auto &name = state_input_names_[i];
+      auto in_shape = encoder_->TensorShape(name);
+      auto out_shape = encoder_->TensorShape(state_output_names_[i]);
+
+      state_storage_shapes_.emplace_back(in_shape.begin(), in_shape.end());
+      state_output_shapes_.emplace_back(out_shape.begin(), out_shape.end());
+
+      bool is_int32 = (name == "cache_last_channel_len");
+      state_is_int32_.push_back(is_int32);
+
+      // cache_last_channel and cache_last_time need 3D transpose
+      // (model output [d0,d1,d2] <-> storage [d1,d2,d0])
+      bool needs_transpose =
+          (name == "cache_last_channel" || name == "cache_last_time");
+      state_needs_transpose_.push_back(needs_transpose);
+
+      if (needs_transpose) {
+        // Validate that the transpose is consistent:
+        // input [1, d1, d2, d0] -> output [1, d0, d1, d2]
+        if (in_shape.size() != 4 || out_shape.size() != 4 ||
+            in_shape[0] != 1 || out_shape[0] != 1 ||
+            in_shape[1] != out_shape[3] || in_shape[2] != out_shape[1] ||
+            in_shape[3] != out_shape[2]) {
+          SHERPA_ONNX_LOGE(
+              "Inconsistent cache shapes for '%s': input [%d,%d,%d,%d] "
+              "output [%d,%d,%d,%d]",
+              name.c_str(), in_shape[0], in_shape[1], in_shape[2],
+              in_shape[3], out_shape[0], out_shape[1], out_shape[2],
+              out_shape[3]);
+          SHERPA_ONNX_LOGE(
+              "Expected: input [1, d1, d2, d0] -> output [1, d0, d1, d2]");
+          SHERPA_ONNX_EXIT(-1);
+        }
+      }
+    }
+
+    if (config_.debug) {
+      SHERPA_ONNX_LOGE("encoder input '%s': [1, %d, %d]",
+                        encoder_input_name_.c_str(), window_size_, feat_dim_);
+      SHERPA_ONNX_LOGE("encoder output 'encoder_out': [1, %d, %d]",
+                        num_encoder_frames_, encoder_out_dim_);
+      SHERPA_ONNX_LOGE("window_size: %d, window_shift: %d, subsampling: %d",
+                        window_size_, window_shift_, subsampling_factor_);
+    }
+  }
+
+  void CheckDecoder() {
+    // Parakeet TDT decoder: 3 inputs (y, h, c), 3 outputs (decoder_out,
+    // next_h, next_c)
+    if (!decoder_->HasTensor("y")) {
+      SHERPA_ONNX_LOGE("The decoder model does not have input 'y'");
+      SHERPA_ONNX_EXIT(-1);
+    }
+    if (!decoder_->HasTensor("h")) {
+      SHERPA_ONNX_LOGE("The decoder model does not have input 'h'");
+      SHERPA_ONNX_EXIT(-1);
+    }
+    if (!decoder_->HasTensor("c")) {
+      SHERPA_ONNX_LOGE("The decoder model does not have input 'c'");
+      SHERPA_ONNX_EXIT(-1);
+    }
+    if (!decoder_->HasTensor("decoder_out")) {
+      SHERPA_ONNX_LOGE("The decoder model does not have output 'decoder_out'");
+      SHERPA_ONNX_EXIT(-1);
+    }
+    if (!decoder_->HasTensor("next_h")) {
+      SHERPA_ONNX_LOGE("The decoder model does not have output 'next_h'");
+      SHERPA_ONNX_EXIT(-1);
+    }
+    if (!decoder_->HasTensor("next_c")) {
+      SHERPA_ONNX_LOGE("The decoder model does not have output 'next_c'");
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    auto y_shape = decoder_->TensorShape("y");
+    if (y_shape.size() != 2 || y_shape[0] != 1 || y_shape[1] != 1) {
+      SHERPA_ONNX_LOGE(
+          "Expected decoder input 'y' shape [1, 1]. Actual: [%d, %d]",
+          y_shape[0], y_shape.size() > 1 ? y_shape[1] : 0);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    // QNN decoder h/c input:  (num_layers, hidden_dim, 1)
+    // QNN decoder next_h/next_c output: (num_layers, 1, hidden_dim)
+    auto h_shape = decoder_->TensorShape("h");
+    if (h_shape.size() != 3 || h_shape[2] != 1) {
+      SHERPA_ONNX_LOGE(
+          "Expected decoder input 'h' shape [num_layers, hidden_dim, 1]. "
+          "Actual: [%d, %d, %d]",
+          h_shape.size() > 0 ? h_shape[0] : 0,
+          h_shape.size() > 1 ? h_shape[1] : 0,
+          h_shape.size() > 2 ? h_shape[2] : 0);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    int32_t num_layers = h_shape[0];
+    int32_t hidden_dim = h_shape[1];
+    h_size_ = num_layers * hidden_dim;
+
+    auto c_shape = decoder_->TensorShape("c");
+    if (c_shape.size() != 3 || c_shape[0] != num_layers || c_shape[2] != 1) {
+      SHERPA_ONNX_LOGE(
+          "Expected decoder input 'c' shape [%d, ?, 1]. Actual: [%d, %d, %d]",
+          num_layers,
+          c_shape.size() > 0 ? c_shape[0] : 0,
+          c_shape.size() > 1 ? c_shape[1] : 0,
+          c_shape.size() > 2 ? c_shape[2] : 0);
+      SHERPA_ONNX_EXIT(-1);
+    }
+    c_size_ = c_shape[0] * c_shape[1];
+
+    auto out_shape = decoder_->TensorShape("decoder_out");
+    if (out_shape.size() != 3 || out_shape[0] != 1 || out_shape[1] != 1) {
+      SHERPA_ONNX_LOGE(
+          "Expected decoder output 'decoder_out' shape [1, 1, decoder_dim]. "
+          "Actual: [%d, %d, %d]",
+          out_shape.size() > 0 ? out_shape[0] : 0,
+          out_shape.size() > 1 ? out_shape[1] : 0,
+          out_shape.size() > 2 ? out_shape[2] : 0);
+      SHERPA_ONNX_EXIT(-1);
+    }
+    decoder_out_dim_ = out_shape[2];
+
+    if (config_.debug) {
+      SHERPA_ONNX_LOGE("decoder input 'y': [1, 1]");
+      SHERPA_ONNX_LOGE("decoder input 'h': [%d, 1, %d]", num_layers,
+                        hidden_dim);
+      SHERPA_ONNX_LOGE("decoder input 'c': [%d, 1, %d]", num_layers,
+                        hidden_dim);
+      SHERPA_ONNX_LOGE("decoder output 'decoder_out': [1, 1, %d]",
+                        decoder_out_dim_);
+    }
+  }
+
+  void CheckJoiner() {
+    joiner_encoder_input_name_ = "encoder_out";
+    joiner_decoder_input_name_ = "decoder_out";
+
+    joiner_output_name_ = "logits";
+
+    if (!joiner_->HasTensor(joiner_output_name_)) {
+      SHERPA_ONNX_LOGE("The joiner model does not have output '%s'",
+                       joiner_output_name_.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    if (!joiner_->HasTensor(joiner_encoder_input_name_)) {
+      SHERPA_ONNX_LOGE("The joiner model does not have input '%s'",
+                       joiner_encoder_input_name_.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    if (!joiner_->HasTensor(joiner_decoder_input_name_)) {
+      SHERPA_ONNX_LOGE("The joiner model does not have input '%s'",
+                       joiner_decoder_input_name_.c_str());
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    // QNN joiner input shapes: encoder_out = (1, encoder_out_dim, 1),
+    // decoder_out = (1, decoder_out_dim, 1)
+    auto encoder_in_shape = joiner_->TensorShape(joiner_encoder_input_name_);
+    if (encoder_in_shape.size() != 3 || encoder_in_shape[0] != 1 ||
+        encoder_in_shape[1] != encoder_out_dim_ || encoder_in_shape[2] != 1) {
+      SHERPA_ONNX_LOGE(
+          "The joiner input '%s' should be [1, %d, 1]. Actual: [%d, %d, %d]",
+          joiner_encoder_input_name_.c_str(), encoder_out_dim_,
+          encoder_in_shape[0], encoder_in_shape[1], encoder_in_shape[2]);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    auto decoder_in_shape = joiner_->TensorShape(joiner_decoder_input_name_);
+    if (decoder_in_shape.size() != 3 || decoder_in_shape[0] != 1 ||
+        decoder_in_shape[1] != decoder_out_dim_ || decoder_in_shape[2] != 1) {
+      SHERPA_ONNX_LOGE(
+          "The joiner input '%s' should be [1, %d, 1]. Actual: [%d, %d, %d]",
+          joiner_decoder_input_name_.c_str(), decoder_out_dim_,
+          decoder_in_shape[0], decoder_in_shape[1], decoder_in_shape[2]);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    auto out_shape = joiner_->TensorShape(joiner_output_name_);
+    // The joiner output can be 2D [1, vocab_size] or 4D [1, 1, 1, vocab_size]
+    // depending on the QNN converter. The last dimension is always vocab_size.
+    if (out_shape.size() < 2 || out_shape[0] != 1) {
+      SHERPA_ONNX_LOGE(
+          "The joiner output should have first dimension 1. Actual shape "
+          "rank: %d",
+          static_cast<int32_t>(out_shape.size()));
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    vocab_size_ = out_shape.back();
+
+    if (config_.debug) {
+      SHERPA_ONNX_LOGE("joiner input '%s': [1, %d]",
+                        joiner_encoder_input_name_.c_str(), encoder_out_dim_);
+      SHERPA_ONNX_LOGE("joiner input '%s': [1, %d]",
+                        joiner_decoder_input_name_.c_str(), decoder_out_dim_);
+      SHERPA_ONNX_LOGE("joiner output '%s': rank %d, vocab_size %d",
+                        joiner_output_name_.c_str(),
+                        static_cast<int32_t>(out_shape.size()), vocab_size_);
+    }
+  }
+
+ private:
+  mutable std::mutex mutex_;
+
+  OnlineModelConfig config_;
+
+  std::unique_ptr<QnnBackend> encoder_backend_;
+  std::unique_ptr<QnnBackend> decoder_backend_;
+  std::unique_ptr<QnnBackend> joiner_backend_;
+
+  std::unique_ptr<QnnModel> encoder_;
+  std::unique_ptr<QnnModel> decoder_;
+  std::unique_ptr<QnnModel> joiner_;
+  std::vector<std::string> context_binaries_;
+
+  std::string encoder_input_name_;
+  std::vector<std::string> state_input_names_;
+  std::vector<std::string> state_output_names_;
+
+  std::string joiner_encoder_input_name_;
+  std::string joiner_decoder_input_name_;
+  std::string joiner_output_name_;
+
+  std::vector<std::vector<int64_t>> state_storage_shapes_;
+  std::vector<std::vector<int64_t>> state_output_shapes_;
+  std::vector<bool> state_is_int32_;
+  std::vector<bool> state_needs_transpose_;
+
+  int32_t window_size_ = 0;
+  int32_t window_shift_ = 0;
+  int32_t num_encoder_frames_ = 0;
+  int32_t subsampling_factor_ = 0;
+  int32_t feat_dim_ = 0;
+  int32_t encoder_out_dim_ = 0;
+  int32_t decoder_out_dim_ = 0;
+  int32_t vocab_size_ = 0;
+  int32_t h_size_ = 0;
+  int32_t c_size_ = 0;
+  std::string normalization_type_;  // "" or "per_feature"
+};
+
+OnlineNemoTransducerModelQnn::OnlineNemoTransducerModelQnn(
+    const OnlineModelConfig &config)
+    : impl_(std::make_unique<Impl>(config)) {}
+
+template <typename Manager>
+OnlineNemoTransducerModelQnn::OnlineNemoTransducerModelQnn(
+    Manager *mgr, const OnlineModelConfig &config)
+    : impl_(std::make_unique<Impl>(mgr, config)) {}
+
+OnlineNemoTransducerModelQnn::~OnlineNemoTransducerModelQnn() = default;
+
+std::vector<OnlineStreamStateTensor>
+OnlineNemoTransducerModelQnn::GetEncoderInitStates() const {
+  return impl_->GetEncoderInitStates();
+}
+
+std::vector<float> OnlineNemoTransducerModelQnn::RunEncoder(
+    std::vector<float> features, int32_t num_frames,
+    std::vector<OnlineStreamStateTensor> *states) const {
+  return impl_->RunEncoder(std::move(features), num_frames, states);
+}
+
+std::pair<std::vector<float>, std::vector<std::vector<float>>>
+OnlineNemoTransducerModelQnn::RunDecoder(
+    int32_t token, std::vector<std::vector<float>> states) const {
+  return impl_->RunDecoder(token, std::move(states));
+}
+
+std::vector<float> OnlineNemoTransducerModelQnn::RunJoiner(
+    const float *encoder_out, const std::vector<float> &decoder_out) const {
+  return impl_->RunJoiner(encoder_out, decoder_out);
+}
+
+int32_t OnlineNemoTransducerModelQnn::WindowSize() const {
+  return impl_->WindowSize();
+}
+
+int32_t OnlineNemoTransducerModelQnn::WindowShift() const {
+  return impl_->WindowShift();
+}
+
+int32_t OnlineNemoTransducerModelQnn::VocabSize() const {
+  return impl_->VocabSize();
+}
+
+int32_t OnlineNemoTransducerModelQnn::FeatureDim() const {
+  return impl_->FeatureDim();
+}
+
+int32_t OnlineNemoTransducerModelQnn::EncoderDim() const {
+  return impl_->EncoderDim();
+}
+
+int32_t OnlineNemoTransducerModelQnn::DecoderDim() const {
+  return impl_->DecoderDim();
+}
+
+int32_t OnlineNemoTransducerModelQnn::SubsamplingFactor() const {
+  return impl_->SubsamplingFactor();
+}
+
+const std::string &OnlineNemoTransducerModelQnn::NormalizationType() const {
+  return impl_->NormalizationType();
+}
+
+std::vector<std::vector<float>>
+OnlineNemoTransducerModelQnn::GetDecoderInitState() const {
+  return impl_->GetDecoderInitState();
+}
+
+#if __ANDROID_API__ >= 9
+template OnlineNemoTransducerModelQnn::OnlineNemoTransducerModelQnn(
+    AAssetManager *mgr, const OnlineModelConfig &config);
+#endif
+
+#if __OHOS__
+template OnlineNemoTransducerModelQnn::OnlineNemoTransducerModelQnn(
+    NativeResourceManager *mgr, const OnlineModelConfig &config);
+#endif
+
+}  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/qnn/online-nemo-transducer-model-qnn.cc
+++ b/sherpa-onnx/csrc/qnn/online-nemo-transducer-model-qnn.cc
@@ -127,6 +127,13 @@ class OnlineNemoTransducerModelQnn::Impl {
       SHERPA_ONNX_EXIT(-1);
     }
 
+    if (states->size() < state_input_names_.size()) {
+      SHERPA_ONNX_LOGE("states size %d is less than expected %d",
+                        static_cast<int32_t>(states->size()),
+                        static_cast<int32_t>(state_input_names_.size()));
+      SHERPA_ONNX_EXIT(-1);
+    }
+
     std::lock_guard<std::mutex> lock(mutex_);
 
     // Features come in as [num_frames, feat_dim] row-major, which matches
@@ -192,6 +199,11 @@ class OnlineNemoTransducerModelQnn::Impl {
   std::pair<std::vector<float>, std::vector<std::vector<float>>>
   RunDecoder(int32_t token, std::vector<std::vector<float>> states) const {
     std::lock_guard<std::mutex> lock(mutex_);
+
+    if (states.size() < 2) {
+      SHERPA_ONNX_LOGE("states should have at least 2 elements (h and c)");
+      SHERPA_ONNX_EXIT(-1);
+    }
 
     // states[0] = h, states[1] = c
     decoder_->SetInputTensorData("y", &token, 1);
@@ -403,6 +415,8 @@ class OnlineNemoTransducerModelQnn::Impl {
           SHERPA_ONNX_LOGE(
               "Invalid window size/shift in encoder input name '%s'",
               name.c_str());
+          SHERPA_ONNX_EXIT(-1);
+        }
 
         normalization_type_.clear();
         if (parts.size() == 4) {
@@ -415,8 +429,6 @@ class OnlineNemoTransducerModelQnn::Impl {
                 parts[3].c_str(), name.c_str());
             SHERPA_ONNX_EXIT(-1);
           }
-        }
-          SHERPA_ONNX_EXIT(-1);
         }
 
         break;

--- a/sherpa-onnx/csrc/qnn/online-nemo-transducer-model-qnn.h
+++ b/sherpa-onnx/csrc/qnn/online-nemo-transducer-model-qnn.h
@@ -1,0 +1,63 @@
+// sherpa-onnx/csrc/qnn/online-nemo-transducer-model-qnn.h
+//
+// Copyright (c)  2026  Xiaomi Corporation
+
+#ifndef SHERPA_ONNX_CSRC_QNN_ONLINE_NEMO_TRANSDUCER_MODEL_QNN_H_
+#define SHERPA_ONNX_CSRC_QNN_ONLINE_NEMO_TRANSDUCER_MODEL_QNN_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "sherpa-onnx/csrc/online-model-config.h"
+#include "sherpa-onnx/csrc/online-stream-state.h"
+
+namespace sherpa_onnx {
+
+class OnlineNemoTransducerModelQnn {
+ public:
+  ~OnlineNemoTransducerModelQnn();
+
+  explicit OnlineNemoTransducerModelQnn(const OnlineModelConfig &config);
+
+  template <typename Manager>
+  OnlineNemoTransducerModelQnn(Manager *mgr, const OnlineModelConfig &config);
+
+  std::vector<OnlineStreamStateTensor> GetEncoderInitStates() const;
+
+  std::vector<float> RunEncoder(std::vector<float> features,
+                                int32_t num_frames,
+                                std::vector<OnlineStreamStateTensor> *states) const;
+
+  // Run the LSTM decoder.
+  //
+  // @param token  A single token id.
+  // @param states  Decoder states from previous call or GetDecoderInitState().
+  //
+  // @return (decoder_out, next_states)
+  std::pair<std::vector<float>, std::vector<std::vector<float>>> RunDecoder(
+      int32_t token, std::vector<std::vector<float>> states) const;
+
+  std::vector<float> RunJoiner(const float *encoder_out,
+                               const std::vector<float> &decoder_out) const;
+
+  int32_t WindowSize() const;
+  int32_t WindowShift() const;
+  int32_t VocabSize() const;
+  int32_t FeatureDim() const;
+  int32_t EncoderDim() const;
+  int32_t DecoderDim() const;
+  int32_t SubsamplingFactor() const;
+  const std::string &NormalizationType() const;
+
+  // Get the initial zero-filled decoder states (e.g., [h, c] for LSTM).
+  std::vector<std::vector<float>> GetDecoderInitState() const;
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace sherpa_onnx
+
+#endif  // SHERPA_ONNX_CSRC_QNN_ONLINE_NEMO_TRANSDUCER_MODEL_QNN_H_

--- a/sherpa-onnx/csrc/qnn/online-recognizer-nemo-transducer-qnn-impl.h
+++ b/sherpa-onnx/csrc/qnn/online-recognizer-nemo-transducer-qnn-impl.h
@@ -35,6 +35,12 @@ inline OnlineRecognizerResult ConvertResult(
     int32_t frames_since_start) {
   OnlineRecognizerResult r;
 
+  // The first token is the initial blank_id_ used to bootstrap the decoder.
+  // Remove it before processing.
+  if (!src.tokens.empty()) {
+    src.tokens.erase(src.tokens.begin());
+  }
+
   r.tokens.reserve(src.tokens.size());
   r.timestamps.reserve(src.timestamps.size());
   r.ys_probs = std::move(src.ys_probs);
@@ -186,6 +192,7 @@ class OnlineRecognizerNemoTransducerQnnImpl : public OnlineRecognizerImpl {
             ++t;
           }
         } else {
+          ++r.num_trailing_blanks;
           ++t;
           num_symbols = 0;
         }

--- a/sherpa-onnx/csrc/qnn/online-recognizer-nemo-transducer-qnn-impl.h
+++ b/sherpa-onnx/csrc/qnn/online-recognizer-nemo-transducer-qnn-impl.h
@@ -1,0 +1,306 @@
+// sherpa-onnx/csrc/qnn/online-recognizer-nemo-transducer-qnn-impl.h
+//
+// Copyright (c)  2026  Xiaomi Corporation
+
+#ifndef SHERPA_ONNX_CSRC_QNN_ONLINE_RECOGNIZER_NEMO_TRANSDUCER_QNN_IMPL_H_
+#define SHERPA_ONNX_CSRC_QNN_ONLINE_RECOGNIZER_NEMO_TRANSDUCER_QNN_IMPL_H_
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <numeric>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "sherpa-onnx/csrc/endpoint.h"
+#include "sherpa-onnx/csrc/hypothesis.h"
+#include "sherpa-onnx/csrc/log.h"
+#include "sherpa-onnx/csrc/math.h"
+#include "sherpa-onnx/csrc/online-recognizer-impl.h"
+#include "sherpa-onnx/csrc/online-recognizer.h"
+#include "sherpa-onnx/csrc/online-stream.h"
+#include "sherpa-onnx/csrc/qnn/online-nemo-transducer-model-qnn.h"
+#include "sherpa-onnx/csrc/symbol-table.h"
+#include "sherpa-onnx/csrc/text-utils.h"
+
+namespace sherpa_onnx {
+
+namespace nemo_transducer_qnn_impl {
+
+inline OnlineRecognizerResult ConvertResult(
+    OnlineTransducerDecoderResultNoOrt src, const SymbolTable &sym_table,
+    float frame_shift_ms, int32_t subsampling_factor, int32_t segment,
+    int32_t frames_since_start) {
+  OnlineRecognizerResult r;
+
+  r.tokens.reserve(src.tokens.size());
+  r.timestamps.reserve(src.timestamps.size());
+  r.ys_probs = std::move(src.ys_probs);
+
+  std::string text;
+  for (auto i : src.tokens) {
+    auto sym = sym_table[i];
+
+    text.append(sym);
+
+    if (sym.size() == 1 && (sym[0] < 0x20 || sym[0] > 0x7e)) {
+      std::ostringstream os;
+      os << "<0x" << std::hex << std::uppercase
+         << (static_cast<int32_t>(sym[0]) & 0xff) << ">";
+      sym = os.str();
+    }
+
+    r.tokens.push_back(std::move(sym));
+  }
+
+  if (sym_table.IsByteBpe()) {
+    text = sym_table.DecodeByteBpe(text);
+  }
+
+  text = RemoveSpaceBetweenCjk(text);
+
+  r.text = std::move(text);
+
+  float frame_shift_s = frame_shift_ms / 1000.f * subsampling_factor;
+  for (auto t : src.timestamps) {
+    r.timestamps.push_back(frame_shift_s * t);
+  }
+
+  r.segment = segment;
+  r.start_time = frames_since_start * frame_shift_ms / 1000.f;
+
+  return r;
+}
+
+}  // namespace nemo_transducer_qnn_impl
+
+class OnlineRecognizerNemoTransducerQnnImpl : public OnlineRecognizerImpl {
+ public:
+  explicit OnlineRecognizerNemoTransducerQnnImpl(
+      const OnlineRecognizerConfig &config)
+      : OnlineRecognizerImpl(config),
+        config_(config),
+        endpoint_(config.endpoint_config),
+        model_(std::make_unique<OnlineNemoTransducerModelQnn>(
+            config.model_config)),
+        blank_id_(model_->VocabSize() - 1) {
+    if (!config.model_config.tokens_buf.empty()) {
+      sym_ = SymbolTable(config.model_config.tokens_buf, false);
+    } else {
+      sym_ = SymbolTable(config.model_config.tokens, true);
+    }
+    ValidateBlankId();
+    SetupFeatConfig();
+    InitResultTemplate();
+  }
+
+  template <typename Manager>
+  OnlineRecognizerNemoTransducerQnnImpl(Manager *mgr,
+                                     const OnlineRecognizerConfig &config)
+      : OnlineRecognizerImpl(mgr, config),
+        config_(config),
+        endpoint_(config.endpoint_config),
+        model_(std::make_unique<OnlineNemoTransducerModelQnn>(
+            mgr, config.model_config)),
+        blank_id_(model_->VocabSize() - 1) {
+    if (!config.model_config.tokens_buf.empty()) {
+      sym_ = SymbolTable(config.model_config.tokens_buf, false);
+    } else {
+      sym_ = SymbolTable(mgr, config.model_config.tokens);
+    }
+    ValidateBlankId();
+    SetupFeatConfig();
+    InitResultTemplate();
+  }
+
+  std::unique_ptr<OnlineStream> CreateStream() const override {
+    auto s = std::make_unique<OnlineStream>(config_.feat_config);
+    s->SetQnnStates(model_->GetEncoderInitStates());
+    s->SetQnnResult(result_template_);
+    return s;
+  }
+
+  std::unique_ptr<OnlineStream> CreateStream(
+      const std::string &hotwords) const override {
+    if (!hotwords.empty()) {
+      SHERPA_ONNX_LOGE("hotwords are not supported with qnn nemo transducer");
+      SHERPA_ONNX_EXIT(-1);
+    }
+    return CreateStream();
+  }
+
+  bool IsReady(OnlineStream *s) const override {
+    return s->NumFramesReady() - s->GetNumProcessedFrames() >=
+           model_->WindowSize();
+  }
+
+  void DecodeStreams(OnlineStream **ss, int32_t n) const override {
+    for (int32_t i = 0; i != n; ++i) {
+      auto *s = ss[i];
+      std::vector<float> features =
+          s->GetFrames(s->GetNumProcessedFrames(), model_->WindowSize());
+
+      auto encoder_out = model_->RunEncoder(
+          std::move(features), model_->WindowSize(), &s->GetQnnStates());
+
+      int32_t num_processed = s->GetNumProcessedFrames();
+      // Each encoder output frame corresponds to subsampling_factor input
+      // frames. The frame_offset is in terms of encoder output frames.
+      int32_t frame_offset = num_processed / subsampling_factor_;
+
+      int32_t encoder_dim = model_->EncoderDim();
+      int32_t num_encoder_frames =
+          static_cast<int32_t>(encoder_out.size()) / encoder_dim;
+      const float *p = encoder_out.data();
+
+      // TDT-style greedy decoding loop.
+      // For each encoder output frame, try up to max_symbols_per_frame
+      // non-blank predictions before moving to the next frame.
+      int32_t max_symbols_per_frame = 10;
+      int32_t num_symbols = 0;
+
+      for (int32_t t = 0; t < num_encoder_frames;) {
+        auto &r = s->GetQnnResult();
+        int32_t frame_index = frame_offset + t;
+
+        auto logit =
+            model_->RunJoiner(p + t * encoder_dim, r.decoder_out);
+        auto y = MaxElementIndex(logit.data(), logit.size());
+
+        if (y != blank_id_) {
+          r.tokens.push_back(y);
+          r.timestamps.push_back(frame_index);
+          r.num_trailing_blanks = 0;
+
+          // Run decoder with the new token and current states.
+          auto [decoder_out, next_states] =
+              model_->RunDecoder(y, std::move(r.states));
+          r.decoder_out = std::move(decoder_out);
+          r.states = std::move(next_states);
+
+          ++num_symbols;
+          if (num_symbols > max_symbols_per_frame) {
+            num_symbols = 0;
+            ++t;
+          }
+        } else {
+          ++t;
+          num_symbols = 0;
+        }
+      }
+
+      s->GetNumProcessedFrames() += model_->WindowShift();
+    }
+  }
+
+  OnlineRecognizerResult GetResult(OnlineStream *s) const override {
+    int32_t frame_shift_ms = 10;
+    auto r = nemo_transducer_qnn_impl::ConvertResult(
+        s->GetQnnResult(), sym_, frame_shift_ms, subsampling_factor_,
+        s->GetCurrentSegment(), s->GetNumFramesSinceStart());
+    r.text = ApplyInverseTextNormalization(std::move(r.text));
+    r.text = ApplyHomophoneReplacer(std::move(r.text));
+    return r;
+  }
+
+  bool IsEndpoint(OnlineStream *s) const override {
+    if (!config_.enable_endpoint) {
+      return false;
+    }
+
+    int32_t num_processed_frames = s->GetNumProcessedFrames();
+    float frame_shift_in_seconds = 0.01f;
+    int32_t trailing_silence_frames =
+        s->GetQnnResult().num_trailing_blanks * subsampling_factor_;
+
+    return endpoint_.IsEndpoint(num_processed_frames, trailing_silence_frames,
+                                frame_shift_in_seconds);
+  }
+
+  void Reset(OnlineStream *s) const override {
+    const auto &last = s->GetQnnResult();
+    if (!last.tokens.empty() && last.tokens.back() != blank_id_ &&
+        static_cast<int32_t>(last.tokens.size()) > 1) {
+      s->GetCurrentSegment() += 1;
+    }
+
+    OnlineTransducerDecoderResultNoOrt r;
+    r.tokens.push_back(blank_id_);
+
+    // Carry over decoder states from the last result for warm-up.
+    if (!last.states.empty()) {
+      auto [decoder_out, next_states] =
+          model_->RunDecoder(blank_id_, last.states);
+      r.decoder_out = std::move(decoder_out);
+      r.states = std::move(next_states);
+    } else {
+      // First time: run decoder from zero states.
+      auto [decoder_out, next_states] =
+          model_->RunDecoder(blank_id_, model_->GetDecoderInitState());
+      r.decoder_out = std::move(decoder_out);
+      r.states = std::move(next_states);
+    }
+
+    if (config_.reset_encoder) {
+      s->SetQnnStates(model_->GetEncoderInitStates());
+    }
+
+    s->Reset();
+    s->SetQnnResult(r);
+  }
+
+ private:
+  void ValidateBlankId() const {
+    if (sym_.Contains(blank_id_)) {
+      auto sym = sym_[blank_id_];
+      if (sym != "<blk>") {
+        SHERPA_ONNX_LOGE(
+            "Expected blank token '<blk>' at id %d, but got '%s'",
+            blank_id_, sym.c_str());
+        SHERPA_ONNX_EXIT(-1);
+      }
+    }
+    if (blank_id_ != model_->VocabSize() - 1) {
+      SHERPA_ONNX_LOGE(
+          "blank_id %d should equal vocab_size - 1 (%d)", blank_id_,
+          model_->VocabSize() - 1);
+      SHERPA_ONNX_EXIT(-1);
+    }
+  }
+
+  void SetupFeatConfig() {
+    config_.feat_config.feature_dim = model_->FeatureDim();
+    config_.feat_config.nemo_normalize_type = model_->NormalizationType();
+    config_.feat_config.low_freq = 0;
+    config_.feat_config.is_librosa = true;
+    config_.feat_config.remove_dc_offset = false;
+  }
+
+  void InitResultTemplate() {
+    result_template_.tokens.push_back(blank_id_);
+
+    // Run decoder with blank to get the initial decoder_out and states.
+    auto [decoder_out, next_states] =
+        model_->RunDecoder(blank_id_, model_->GetDecoderInitState());
+    result_template_.decoder_out = std::move(decoder_out);
+    result_template_.states = std::move(next_states);
+
+    subsampling_factor_ = model_->SubsamplingFactor();
+  }
+
+ private:
+  OnlineRecognizerConfig config_;
+  Endpoint endpoint_;
+  std::unique_ptr<OnlineNemoTransducerModelQnn> model_;
+  SymbolTable sym_;
+
+  int32_t blank_id_ = 0;
+  int32_t subsampling_factor_ = 8;  // will be overwritten in InitResultTemplate
+  OnlineTransducerDecoderResultNoOrt result_template_;
+};
+
+}  // namespace sherpa_onnx
+
+#endif  // SHERPA_ONNX_CSRC_QNN_ONLINE_RECOGNIZER_NEMO_TRANSDUCER_QNN_IMPL_H_

--- a/sherpa-onnx/csrc/qnn/online-recognizer-zipformer-transducer-qnn-impl.h
+++ b/sherpa-onnx/csrc/qnn/online-recognizer-zipformer-transducer-qnn-impl.h
@@ -17,6 +17,7 @@
 #include "sherpa-onnx/csrc/endpoint.h"
 #include "sherpa-onnx/csrc/hypothesis.h"
 #include "sherpa-onnx/csrc/log.h"
+#include "sherpa-onnx/csrc/math.h"
 #include "sherpa-onnx/csrc/online-recognizer-impl.h"
 #include "sherpa-onnx/csrc/online-recognizer.h"
 #include "sherpa-onnx/csrc/online-stream.h"
@@ -115,8 +116,7 @@ class QnnGreedySearchDecoder {
               const OnlineZipformerTransducerModelQnn &model,
               OnlineTransducerDecoderResultNoOrt *r) const {
     auto logit = model.RunJoiner(encoder_out, r->decoder_out);
-    auto y = static_cast<int32_t>(
-        std::distance(logit.begin(), std::max_element(logit.begin(), logit.end())));
+    auto y = MaxElementIndex(logit.data(), logit.size());
 
     if (y != blank_id_) {
       r->tokens.push_back(y);
@@ -290,7 +290,6 @@ class OnlineRecognizerZipformerTransducerQnnImpl
   void DecodeStreams(OnlineStream **ss, int32_t n) const override {
     for (int32_t i = 0; i != n; ++i) {
       auto *s = ss[i];
-      EnsureInitialized(s);
 
       std::vector<float> features =
           s->GetFrames(s->GetNumProcessedFrames(), model_->ChunkSize());
@@ -323,7 +322,6 @@ class OnlineRecognizerZipformerTransducerQnnImpl
   }
 
   OnlineRecognizerResult GetResult(OnlineStream *s) const override {
-    EnsureInitialized(s);
     int32_t frame_shift_ms = 10;
     int32_t subsampling_factor = 4;
     auto r = qnn_impl::ConvertQnnResult(
@@ -336,8 +334,6 @@ class OnlineRecognizerZipformerTransducerQnnImpl
   }
 
   bool IsEndpoint(OnlineStream *s) const override {
-    EnsureInitialized(s);
-
     if (!config_.enable_endpoint) {
       return false;
     }
@@ -351,8 +347,6 @@ class OnlineRecognizerZipformerTransducerQnnImpl
   }
 
   void Reset(OnlineStream *s) const override {
-    EnsureInitialized(s);
-
     int32_t context_size = model_->ContextSize();
 
     const auto &last = s->GetQnnResult();
@@ -381,15 +375,6 @@ class OnlineRecognizerZipformerTransducerQnnImpl
   }
 
  private:
-  void EnsureInitialized(OnlineStream *s) const {
-    if (!s->GetQnnStates().empty()) {
-      return;
-    }
-
-    s->SetQnnStates(model_->GetEncoderInitStates());
-    s->SetQnnResult(result_template_);
-  }
-
   void InitResultTemplate() {
     result_template_ = GetEmptyResult();
   }

--- a/sherpa-onnx/csrc/qnn/online-zipformer-transducer-model-qnn.cc
+++ b/sherpa-onnx/csrc/qnn/online-zipformer-transducer-model-qnn.cc
@@ -339,6 +339,7 @@ class OnlineZipformerTransducerModelQnn::Impl {
     has_processed_lens_ = encoder_->HasTensor("processed_lens");
 
     encoder_input_name_.clear();
+    bool has_parakeet_pattern = false;
     for (const auto &name : encoder_->InputTensorNames()) {
       if (name == "x") {
         encoder_input_name_ = name;
@@ -349,10 +350,25 @@ class OnlineZipformerTransducerModelQnn::Impl {
         // V1: only "cached_*" inputs are streaming states
         state_input_names_.push_back(name);
       }
+
+      // Detect Parakeet TDT encoder patterns: x_window_shift or
+      // cache_last_channel
+      if (name.size() > 2 && name[0] == 'x' && name[1] == '_') {
+        has_parakeet_pattern = true;
+      }
+      if (name == "cache_last_channel") {
+        has_parakeet_pattern = true;
+      }
     }
 
     if (encoder_input_name_.empty()) {
-      SHERPA_ONNX_LOGE("The encoder model does not have input 'x'");
+      if (has_parakeet_pattern) {
+        SHERPA_ONNX_LOGE(
+            "This looks like a nemo_transducer model, "
+            "not a Zipformer transducer. Please set --model-type=nemo_transducer");
+      } else {
+        SHERPA_ONNX_LOGE("The encoder model does not have input 'x'");
+      }
       SHERPA_ONNX_EXIT(-1);
     }
 


### PR DESCRIPTION
# Usage

## Download a model
Please see 
https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models-qnn-binary-2

The following is an example for Xiaomi 17 Pro.
```
wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models-qnn-binary-2/sherpa-onnx-qnn-SM8850-binary-nemotron-speech-streaming-en-0.6b-1120ms.tar.bz2
tar xvf sherpa-onnx-qnn-SM8850-binary-nemotron-speech-streaming-en-0.6b-1120ms.tar.bz2
rm sherpa-onnx-qnn-SM8850-binary-nemotron-speech-streaming-en-0.6b-1120ms.tar.bz2
```

```
ls -lh sherpa-onnx-qnn-SM8850-binary-nemotron-speech-streaming-en-0.6b-1120ms/
total 1218608
-rw-r--r--@ 1 fangjun  staff    14M  7 Jul 12:44 decoder.bin
-rw-r--r--@ 1 fangjun  staff   579M  7 Jul 12:44 encoder.bin
-rw-r--r--@ 1 fangjun  staff    21B  7 Jul 12:44 info.txt
-rw-r--r--@ 1 fangjun  staff   1.7M  7 Jul 12:44 joiner.bin
drwxr-xr-x@ 5 fangjun  staff   160B  7 Jul 12:44 test_wavs
-rw-r--r--@ 1 fangjun  staff   8.7K  7 Jul 12:44 tokens.txt
```

## Run it

Please follow
https://k2-fsa.github.io/sherpa/onnx/qnn/run-executables-on-your-phone-binary.html

```
./sherpa-onnx \
   --model-type=nemo_transducer \
   --provider=qnn \
   --tokens=./sherpa-onnx-qnn-SM8850-binary-nemotron-speech-streaming-en-0.6b-1120ms/tokens.txt \
   --transducer.qnn-backend-lib=./libQnnHtp.so \
   --transducer.qnn-system-lib=./libQnnSystem.so \
   --transducer.qnn-context-binary=./sherpa-onnx-qnn-SM8850-binary-nemotron-speech-streaming-en-0.6b-1120ms/encoder.bin,./sherpa-onnx-qnn-SM8850-binary-nemotron-speech-streaming-en-0.6b-1120ms/decoder.bin,./sherpa-onnx-qnn-SM8850-binary-nemotron-speech-streaming-en-0.6b-1120ms/joiner.bin \
   ./sherpa-onnx-qnn-SM8850-binary-nemotron-speech-streaming-en-0.6b-1120ms/test_wavs/2.wav
```

Output logs:

```
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/parse-options.cc:Read:374 ./sherpa-onnx --model-type=nemo_transducer --provider=qnn --tokens=./sherpa-onnx-qnn-SM8850-binary-nemotron-speech-streaming-en-0.6b-1120ms/tokens.txt --transducer.qnn-backend-lib=./libQnnHtp.so --transducer.qnn-system-lib=./libQnnSystem.so --transducer.qnn-context-binary=./sherpa-onnx-qnn-SM8850-binary-nemotron-speech-streaming-en-0.6b-1120ms/encoder.bin,./sherpa-onnx-qnn-SM8850-binary-nemotron-speech-streaming-en-0.6b-1120ms/decoder.bin,./sherpa-onnx-qnn-SM8850-binary-nemotron-speech-streaming-en-0.6b-1120ms/joiner.bin ./sherpa-onnx-qnn-SM8850-binary-nemotron-speech-streaming-en-0.6b-1120ms/test_wavs/2.wav

OnlineRecognizerConfig(feat_config=FeatureExtractorConfig(sampling_rate=16000, feature_dim=80, low_freq=20, high_freq=-400, dither=0, normalize_samples=True, snip_edges=False), model_config=OnlineModelConfig(transducer=OnlineTransducerModelConfig(encoder="", decoder="", joiner="", qnn_config=QnnConfig(backend_lib="./libQnnHtp.so", context_binary="./sherpa-onnx-qnn-SM8850-binary-nemotron-speech-streaming-en-0.6b-1120ms/encoder.bin,./sherpa-onnx-qnn-SM8850-binary-nemotron-speech-streaming-en-0.6b-1120ms/decoder.bin,./sherpa-onnx-qnn-SM8850-binary-nemotron-speech-streaming-en-0.6b-1120ms/joiner.bin", system_lib="./libQnnSystem.so")), paraformer=OnlineParaformerModelConfig(encoder="", decoder=""), wenet_ctc=OnlineWenetCtcModelConfig(model="", chunk_size=16, num_left_chunks=4), zipformer2_ctc=OnlineZipformer2CtcModelConfig(model=""), nemo_ctc=OnlineNeMoCtcModelConfig(model=""), t_one_ctc=OnlineToneCtcModelConfig(model=""), provider_config=ProviderConfig(device=0, provider="qnn", cuda_config=CudaConfig(cudnn_conv_algo_search=1), trt_config=TensorrtConfig(trt_max_workspace_size=2147483647, trt_max_partition_iterations=10, trt_min_subgraph_size=5, trt_fp16_enable="True", trt_detailed_build_log="False", trt_engine_cache_enable="True", trt_engine_cache_path=".", trt_timing_cache_enable="True", trt_timing_cache_path=".",trt_dump_subgraphs="False" )), tokens="./sherpa-onnx-qnn-SM8850-binary-nemotron-speech-streaming-en-0.6b-1120ms/tokens.txt", num_threads=1, warm_up=0, debug=False, model_type="nemo_transducer", modeling_unit="cjkchar", bpe_vocab=""), lm_config=OnlineLMConfig(model="", scale=0.5, lodr_scale=0.01, lodr_fst="", lodr_backoff_id=-1, shallow_fusion=True), endpoint_config=EndpointConfig(rule1=EndpointRule(must_contain_nonsilence=False, min_trailing_silence=2.4, min_utterance_length=0), rule2=EndpointRule(must_contain_nonsilence=True, min_trailing_silence=1.2, min_utterance_length=0), rule3=EndpointRule(must_contain_nonsilence=False, min_trailing_silence=0, min_utterance_length=20)), ctc_fst_decoder_config=OnlineCtcFstDecoderConfig(graph="", max_active=3000), enable_endpoint=True, max_active_paths=4, hotwords_score=1.5, hotwords_file="", decoding_method="greedy_search", blank_penalty=0, temperature_scale=2, rule_fsts="", rule_fars="", reset_encoder=False, hr=HomophoneReplacerConfig(lexicon="", rule_fsts=""))
Start to create recognizer
     0.0ms [WARN   ] QnnDsp <W> Initializing HtpProvider
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/utils.cc:CopyGraphsInfo:548 version: 3
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/utils.cc:CopyGraphsInfo:548 version: 3
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/utils.cc:CopyGraphsInfo:548 version: 3
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
Recognizer created in 3.17978 s
./sherpa-onnx-qnn-SM8850-binary-nemotron-speech-streaming-en-0.6b-1120ms/test_wavs/2.wav
Number of threads: 1, Elapsed seconds: 2.1, Audio duration (s): 7.4, Real time factor (RTF) = 2.1/7.4 = 0.28
Well, I don't wish to see it any more, observed Phoebe, turning away her eyes. It is certainly very like the old portrait
{ "text": "Well, I don't wish to see it any more, observed Phoebe, turning away her eyes. It is certainly very like the old portrait", "tokens": [" We", "ll", ",", " I", " don", "'", "t", " w", "ish", " to", " see", " it", " any", " m", "ore", ",", " ob", "s", "er", "ved", " P", "h", "o", "e", "be", ",", " t", "ur", "ning", " a", "way", " her", " ey", "es", ".", " It", " is", " cer", "tain", "ly", " ", "very", " li", "ke", " the", " old", " p", "ort", "ra", "it"], "timestamps": [0.40, 0.40, 1.12, 1.12, 1.20, 1.20, 1.20, 1.28, 1.28, 1.44, 1.52, 1.68, 1.84, 2.16, 2.16, 2.32, 2.48, 2.48, 2.48, 2.64, 2.96, 2.96, 2.96, 2.96, 3.36, 3.52, 3.68, 3.68, 3.68, 3.84, 3.84, 4.00, 4.48, 4.48, 5.04, 5.20, 5.36, 5.68, 5.68, 5.76, 5.84, 5.84, 6.08, 6.08, 6.48, 6.72, 6.88, 6.88, 6.96, 6.96], "ys_probs": [], "lm_probs": [], "context_scores": [], "segment": 0, "words": [], "start_time": 0.00, "is_final": false, "is_eof": false}

     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added QNN-backed support for online NeMo/Parakeet transducer models.
  * Online recognition now selects the appropriate QNN implementation for NeMo vs. Zipformer transducer models.
* **Bug Fixes**
  * Improved transducer model validation and made error messaging clearer when model type or expected tensors don’t match.
  * Updated QNN greedy token selection for more robust joiner decoding.
* **Improvements**
  * Streaming recognition now carries decoder states more reliably for stateful (e.g., LSTM) transducer models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->