### PR TITLE
Re-export nemotron-3.5-asr-streaming-0.6b to ONNX

### DIFF
--- a/.github/workflows/export-nemotron-3.5-asr-streaming-0.6b.yaml
+++ b/.github/workflows/export-nemotron-3.5-asr-streaming-0.6b.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        python-version: ["3.10"]
+        python-version: ["3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -37,7 +37,8 @@ jobs:
           # instructs installing NeMo from main.
           BRANCH='main'
           pip install Cython packaging
-          pip install "nemo_toolkit[asr] @ git+https://github.com/NVIDIA/NeMo.git@$BRANCH"
+          # pip install "nemo_toolkit[asr] @ git+https://github.com/NVIDIA/NeMo.git@$BRANCH"
+          pip install "git+https://github.com/NVIDIA/NeMo.git@main#egg=nemo_toolkit[asr]"
           pip install onnxruntime ipython sentencepiece
           pip install kaldi-native-fbank
           pip install soundfile librosa
@@ -112,10 +113,12 @@ jobs:
           models=(
             sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-80ms-int8-2026-06-11
             sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-160ms-int8-2026-06-11
+            sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-320ms-int8-2026-06-11
             sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11
             sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-1120ms-int8-2026-06-11
             sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-80ms-2026-06-11
             sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-160ms-2026-06-11
+            sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-320ms-2026-06-11
             sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-2026-06-11
             sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-1120ms-2026-06-11
           )
@@ -127,6 +130,7 @@ jobs:
           ls -lh *.tar.bz2
 
       - name: Release
+        if: github.repository_owner == 'csukuangfj'
         uses: svenstaro/upload-release-action@v2
         with:
           file_glob: true
@@ -134,6 +138,15 @@ jobs:
           overwrite: true
           repo_name: k2-fsa/sherpa-onnx
           repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
+          tag: asr-models
+
+      - name: Release
+        if: github.repository_owner == 'k2-fsa'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-*-int8-2026-06-11.tar.bz2
+          overwrite: true
           tag: asr-models
 
       - name: Publish to huggingface
@@ -151,10 +164,12 @@ jobs:
             models=(
               sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-80ms-int8-2026-06-11
               sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-160ms-int8-2026-06-11
+              sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-320ms-int8-2026-06-11
               sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11
               sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-1120ms-int8-2026-06-11
               sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-80ms-2026-06-11
               sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-160ms-2026-06-11
+              sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-320ms-2026-06-11
               sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-2026-06-11
               sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-1120ms-2026-06-11
             )

--- a/.github/workflows/export-nemotron-3.5-asr-streaming-0.6b.yaml
+++ b/.github/workflows/export-nemotron-3.5-asr-streaming-0.6b.yaml
@@ -37,8 +37,7 @@ jobs:
           # instructs installing NeMo from main.
           BRANCH='main'
           pip install Cython packaging
-          # pip install "nemo_toolkit[asr] @ git+https://github.com/NVIDIA/NeMo.git@$BRANCH"
-          pip install "git+https://github.com/NVIDIA/NeMo.git@main#egg=nemo_toolkit[asr]"
+          pip install "nemo_toolkit[asr] @ git+https://github.com/NVIDIA/NeMo.git@$BRANCH"
           pip install onnxruntime ipython sentencepiece
           pip install kaldi-native-fbank
           pip install soundfile librosa

--- a/scripts/nemo/nemotron-3.5-asr-streaming-0.6b/README.md
+++ b/scripts/nemo/nemotron-3.5-asr-streaming-0.6b/README.md
@@ -33,7 +33,7 @@ pip install soundfile librosa
 python3 ./export_onnx.py
 ```
 
-The script exports 80ms, 160ms, 560ms, and 1120ms chunk sizes.
+The script exports 80ms, 160ms, 320ms, 560ms, and 1120ms chunk sizes.
 
 ## Decode
 

--- a/scripts/nemo/nemotron-3.5-asr-streaming-0.6b/export_onnx.py
+++ b/scripts/nemo/nemotron-3.5-asr-streaming-0.6b/export_onnx.py
@@ -137,8 +137,7 @@ def get_prompt_dictionary(asr_model) -> Dict[str, int]:
     for language in ["en", "ja"]:
         if not any(k == language or k.startswith(f"{language}-") for k in ans):
             raise RuntimeError(
-                "cfg.model_defaults.prompt_dictionary is missing "
-                f"'{language}'"
+                "cfg.model_defaults.prompt_dictionary is missing " f"'{language}'"
             )
 
     return ans
@@ -218,8 +217,7 @@ class PromptedStreamingEncoder(torch.nn.Module):
         for attr in ["encoder", "prompt_kernel", "num_prompts"]:
             if not hasattr(asr_model, attr):
                 raise RuntimeError(
-                    "Expected a prompt-conditioned NeMo model with "
-                    f"'{attr}'"
+                    "Expected a prompt-conditioned NeMo model with " f"'{attr}'"
                 )
 
         self.encoder = asr_model.encoder
@@ -266,9 +264,7 @@ class PromptedStreamingEncoder(torch.nn.Module):
             1.0,
         )
 
-        encoded = self.prompt_kernel(torch.cat([encoded, prompt], dim=-1)).to(
-            out_dtype
-        )
+        encoded = self.prompt_kernel(torch.cat([encoded, prompt], dim=-1)).to(out_dtype)
         encoded = encoded.transpose(1, 2)  # (B, T, D) -> (B, D, T)
 
         return encoded, encoded_len, channel_next, time_next, channel_len_next
@@ -326,9 +322,7 @@ def export_prompted_encoder(
 ):
     device, dtype = _module_device_and_dtype(asr_model.encoder)
 
-    audio_signal = torch.zeros(
-        1, 128, window_size, dtype=dtype, device=device
-    )
+    audio_signal = torch.zeros(1, 128, window_size, dtype=dtype, device=device)
     length = torch.full((1,), window_size, dtype=torch.int64, device=device)
     cache_last_channel = torch.zeros(
         1,
@@ -430,7 +424,7 @@ def main():
     for ms in chunk_size_ms_list:
         chunk_size = ms // 80 - 1
         print("chunk_size", chunk_size)
-        asr_model.encoder.set_default_att_context_size([70, chunk_size])
+        asr_model.encoder.set_default_att_context_size([56, chunk_size])
 
         print("streaming_cfg", asr_model.encoder.streaming_cfg)
         print("att_context_size", asr_model.encoder.att_context_size)

--- a/scripts/nemo/nemotron-3.5-asr-streaming-0.6b/export_onnx.py
+++ b/scripts/nemo/nemotron-3.5-asr-streaming-0.6b/export_onnx.py
@@ -426,7 +426,7 @@ def main():
     print("streaming_cfg", asr_model.encoder.streaming_cfg)
     print("prompt_dictionary", prompt_dictionary)
 
-    chunk_size_ms_list = [80, 160, 560, 1120]
+    chunk_size_ms_list = [80, 160, 320, 560, 1120]
     for ms in chunk_size_ms_list:
         chunk_size = ms // 80 - 1
         print("chunk_size", chunk_size)


### PR DESCRIPTION
1. Add the variant 320ms. It was ignored.
2. Change encoder.att_context_size from 70 to 56. nemotron-speech-streaming-en-0.6b uses 70 by default, whereas nemotron-3.5-asr-streaming-0.6b uses 56

See also #3671 

cc @JulianPscheid

Please re-download the models.

---

https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b

<img width="1718" height="960" alt="Screenshot 2026-07-08 at 14 14 09" src="https://github.com/user-attachments/assets/f0018781-80e0-45f4-808a-38d83e5b6298" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for exporting and publishing an additional **320ms** streaming model variant, including both int8 and non-int8 builds.
  * Expanded release packaging to include the new 320ms artifacts alongside existing chunk sizes.
* **Documentation**
  * Updated export instructions to list the new **320ms** option.
* **Chores**
  * Updated the export workflow to use a newer Python runtime on macOS and support releases for multiple repository owners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->