### PR TITLE
Export nemotron-3.5-asr-streaming-0.6b to QNN

### DIFF
--- a/.github/scripts/export-qnn/Dockerfile-2.40
+++ b/.github/scripts/export-qnn/Dockerfile-2.40
@@ -1,12 +1,15 @@
+# https://docs.qualcomm.com/bundle/publicresource/topics/80-63442-10/linux_setup.html
 FROM ubuntu:22.04
 
 ARG QNN_SDK_VERSION=2.40.0.251030
 ARG QNN_TOOLKIT_URL=https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v${QNN_SDK_VERSION}.zip
 
-LABEL org.opencontainers.image.title="QNN SDK ${QNN_SDK_VERSION}" \
-      org.opencontainers.image.description="Pre-built development environment for Qualcomm AI Engine Direct (QNN) SDK ${QNN_SDK_VERSION}, used by sherpa-onnx to convert and run ASR/TTS models on Qualcomm Snapdragon chipsets (e.g. SM8850). Includes: Android NDK r29 (${ANDROID_NDK_VERSION}) for cross-compiling to aarch64-android; Python 3.10 virtualenv with PyTorch, ONNX, onnxruntime, and QNN Python dependencies; QNN CLI tools (qnn-onnx-converter, qnn-model-lib-generator, qnn-context-binary-generator, qnn-net-run) for quantizing ONNX models to QNN context binaries targeting HTP/DSP backends. Typical workflow: mount model files, source envsetup.sh, run qnn-onnx-converter to quantize, then qnn-context-binary-generator to produce .bin files deployable on-device." \
-      org.opencontainers.image.source="https://github.com/k2-fsa/sherpa-onnx" \
-      org.opencontainers.image.licenses="Apache-2.0"
+# See https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images
+
+LABEL org.opencontainers.image.title="QNN SDK ${QNN_SDK_VERSION}"
+LABEL org.opencontainers.image.description="Pre-built development environment for Qualcomm AI Engine Direct (QNN) SDK ${QNN_SDK_VERSION}, used by sherpa-onnx to convert and run ASR/TTS models on Qualcomm Snapdragon chipsets (e.g. SM8850). Includes: Android NDK r29 (${ANDROID_NDK_VERSION}) for cross-compiling to aarch64-android; Python 3.10 virtualenv with PyTorch, ONNX, onnxruntime, and QNN Python dependencies; QNN CLI tools (qnn-onnx-converter, qnn-model-lib-generator, qnn-context-binary-generator, qnn-net-run) for quantizing ONNX models to QNN context binaries targeting HTP/DSP backends. Typical workflow: mount model files, source envsetup.sh, run qnn-onnx-converter to quantize, then qnn-context-binary-generator to produce .bin files deployable on-device."
+LABEL org.opencontainers.image.source="https://github.com/k2-fsa/sherpa-onnx"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -15,6 +18,13 @@ SHELL ["/bin/bash", "-c"]
 
 # Install basic system dependencies (Ubuntu 22.04 ships Python 3.10 natively)
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    bzip2 \
+    file \
+    gcc \
+    g++ \
+    less \
+    make \
+    vim \
     ca-certificates \
     curl \
     unzip \

--- a/.github/scripts/export-qnn/Dockerfile-2.40
+++ b/.github/scripts/export-qnn/Dockerfile-2.40
@@ -3,6 +3,7 @@ FROM ubuntu:22.04
 
 ARG QNN_SDK_VERSION=2.40.0.251030
 ARG QNN_TOOLKIT_URL=https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v${QNN_SDK_VERSION}.zip
+ARG ANDROID_NDK_VERSION=29.0.14206865
 
 # See https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images
 
@@ -43,7 +44,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Android NDK r29 (placed early so failures surface quickly)
-ARG ANDROID_NDK_VERSION=29.0.14206865
 ARG ANDROID_NDK_REVISION=r29
 RUN curl -SL -o /tmp/ndk.zip https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_REVISION}-linux.zip \
     && unzip -q /tmp/ndk.zip -d /opt \

--- a/.github/scripts/export-qnn/Dockerfile-2.40
+++ b/.github/scripts/export-qnn/Dockerfile-2.40
@@ -3,6 +3,11 @@ FROM ubuntu:22.04
 ARG QNN_SDK_VERSION=2.40.0.251030
 ARG QNN_TOOLKIT_URL=https://huggingface.co/csukuangfj/qnn-toolkit/resolve/main/v${QNN_SDK_VERSION}.zip
 
+LABEL org.opencontainers.image.title="QNN SDK ${QNN_SDK_VERSION}" \
+      org.opencontainers.image.description="Pre-built development environment for Qualcomm AI Engine Direct (QNN) SDK ${QNN_SDK_VERSION}, used by sherpa-onnx to convert and run ASR/TTS models on Qualcomm Snapdragon chipsets (e.g. SM8850). Includes: Android NDK r29 (${ANDROID_NDK_VERSION}) for cross-compiling to aarch64-android; Python 3.10 virtualenv with PyTorch, ONNX, onnxruntime, and QNN Python dependencies; QNN CLI tools (qnn-onnx-converter, qnn-model-lib-generator, qnn-context-binary-generator, qnn-net-run) for quantizing ONNX models to QNN context binaries targeting HTP/DSP backends. Typical workflow: mount model files, source envsetup.sh, run qnn-onnx-converter to quantize, then qnn-context-binary-generator to produce .bin files deployable on-device." \
+      org.opencontainers.image.source="https://github.com/k2-fsa/sherpa-onnx" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Use bash as default shell (envsetup.sh requires bash syntax)
@@ -51,8 +56,10 @@ ENV PATH=${QNN_SDK_ROOT}/bin/x86_64-linux-clang:${QNN_SDK_ROOT}/bin:${PATH}
 ENV LD_LIBRARY_PATH=${QNN_SDK_ROOT}/lib/x86_64-linux-clang:${LD_LIBRARY_PATH}
 
 # Install linux dependencies required by QNN SDK (source envsetup.sh first, matching workflow)
-RUN cd ${QNN_SDK_ROOT}/bin && . envsetup.sh \
-    && yes | ${QNN_SDK_ROOT}/bin/check-linux-dependency.sh || true \
+# apt-get update is needed because check-linux-dependency.sh runs apt-get install
+RUN apt-get update \
+    && cd ${QNN_SDK_ROOT}/bin && . envsetup.sh \
+    && { yes | ${QNN_SDK_ROOT}/bin/check-linux-dependency.sh || true; } \
     && rm -rf /var/lib/apt/lists/*
 
 # Create and activate a Python 3.10 virtual environment
@@ -66,7 +73,7 @@ RUN . /opt/py310/bin/activate && \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir \
     mock \
-    numpy \
+    "numpy<2" \
     opencv-python \
     optuna \
     packaging \
@@ -87,19 +94,17 @@ RUN . /opt/py310/bin/activate && \
     tabulate \
     typing-extensions \
     xlsxwriter \
-    && python3 "${QNN_SDK_ROOT}/bin/check-python-dependency" || true \
+    && { python3 "${QNN_SDK_ROOT}/bin/check-python-dependency" || true; } \
     && pip install --no-cache-dir \
     torch==2.0.0+cpu -f https://download.pytorch.org/whl/torch \
     kaldi_native_fbank \
-    "numpy<2" \
     onnx==1.17.0 \
     onnxruntime \
     soundfile \
     librosa \
     onnxsim \
     sentencepiece \
-    pyyaml \
-    && pip cache purge 2>/dev/null || true
+    && { pip cache purge 2>/dev/null || true; }
 
 # Verify QNN tools are accessible (source envsetup.sh first, matching workflow)
 RUN cd ${QNN_SDK_ROOT}/bin && . envsetup.sh \

--- a/.github/scripts/export-qnn/generate_nemotron_35_asr_streaming.py
+++ b/.github/scripts/export-qnn/generate_nemotron_35_asr_streaming.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright    2026  Xiaomi Corp.        (authors: Fangjun Kuang)
+
+import json
+
+from device_info import soc_info_dict
+from dataclasses import asdict, dataclass
+import itertools
+
+
+@dataclass
+class Config:
+    soc: str  # SM8850
+    soc_id: int  # 87
+    arch: str  # v81
+    chunk_size_ms: int
+    model_name: str
+
+
+def main():
+
+    model_name_list = ["nemotron-3.5-asr-streaming-0.6b"]
+    chunk_size_ms_list = [80, 160, 320, 560, 1120]
+    chunk_size_ms_list = [1120]
+
+    configs = []
+
+    for name, soc in soc_info_dict.items():
+        if soc.model.name == "SM8350":
+            continue
+
+        if soc.model.name != "SM8850":
+            continue
+        for chunk_size_ms, model_name in itertools.product(
+            chunk_size_ms_list, model_name_list
+        ):
+            configs.append(
+                Config(
+                    soc=name,
+                    soc_id=soc.model.value,
+                    arch=soc.info.arch.name,
+                    model_name=model_name,
+                    chunk_size_ms=chunk_size_ms,
+                )
+            )
+
+    ans = [asdict(c) for c in configs]
+
+    print(json.dumps({"include": ans}))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/export-qnn/generate_nemotron_35_asr_streaming.py
+++ b/.github/scripts/export-qnn/generate_nemotron_35_asr_streaming.py
@@ -21,15 +21,11 @@ def main():
 
     model_name_list = ["nemotron-3.5-asr-streaming-0.6b"]
     chunk_size_ms_list = [80, 160, 320, 560, 1120]
-    chunk_size_ms_list = [1120]
 
     configs = []
 
     for name, soc in soc_info_dict.items():
         if soc.model.name == "SM8350":
-            continue
-
-        if soc.model.name != "SM8850":
             continue
         for chunk_size_ms, model_name in itertools.product(
             chunk_size_ms_list, model_name_list

--- a/.github/workflows/export-nemotron-3.5-asr-streaming-0.6b-qnn.yaml
+++ b/.github/workflows/export-nemotron-3.5-asr-streaming-0.6b-qnn.yaml
@@ -3,7 +3,7 @@ name: export-nemotron-3.5-asr-streaming-0.6b-qnn
 on:
   push:
     branches:
-      - nemotron-3.5-qnn
+      - nemotron-3.5-qnn-2
   workflow_dispatch:
 
 concurrency:
@@ -18,8 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # chunk_size_ms: [80, 160, 320, 560, 1120]
-        chunk_size_ms: [1120]
+        chunk_size_ms: [80, 160, 320, 560, 1120]
         model_id: ["nemotron-3.5-asr-streaming-0.6b"]
 
     steps:
@@ -59,7 +58,7 @@ jobs:
 
           ls -lh *.onnx*
 
-          for lang in ar de es fr ja ko uk vi zh; do
+          for lang in ar de en es fr ja ko uk vi zh; do
             wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/$lang.wav
             python3 ./test_onnx.py --wav ./$lang.wav
           done
@@ -71,9 +70,9 @@ jobs:
 
           ls -l encoder* decoder* joiner*
 
-          # ls -lh *.onnx*
-          # ls -lh *.txt
-          # ls -lh *.raw | head
+          ls -lh *.onnx*
+          ls -lh *.txt
+          ls -lh *.raw || head
 
       - name: Setup tmate session
         if: failure() && steps.cache-onnx.outputs.cache-hit != 'true'

--- a/.github/workflows/export-nemotron-3.5-asr-streaming-0.6b-qnn.yaml
+++ b/.github/workflows/export-nemotron-3.5-asr-streaming-0.6b-qnn.yaml
@@ -1,0 +1,414 @@
+name: export-nemotron-3.5-asr-streaming-0.6b-qnn
+
+on:
+  push:
+    branches:
+      - nemotron-3.5-qnn
+  workflow_dispatch:
+
+concurrency:
+  group: export-nemotron-3.5-asr-streaming-qnn-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  onnx:
+    if: github.repository_owner == 'k2-fsa' || github.repository_owner == 'csukuangfj'
+    name: Export onnx
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # chunk_size_ms: [80, 160, 320, 560, 1120]
+        chunk_size_ms: [1120]
+        model_id: ["nemotron-3.5-asr-streaming-0.6b"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Export models
+        shell: bash
+        run: |
+          chunk_size_ms=${{ matrix.chunk_size_ms }}
+
+          # https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b
+          model_id=${{ matrix.model_id }}
+
+          echo "chunk_size_ms: $chunk_size_ms"
+          echo "model_id: $model_id"
+
+          cd scripts/nemo/qnn/nemotron-3.5-asr-streaming-0.6b
+
+
+          ./run.sh $chunk_size_ms nvidia/$model_id
+
+          rm -f  onnx__* layers* Constant* pre_encode*
+
+          ls -lh *.onnx*
+
+          for lang in ar de es fr ja ko uk vi zh; do
+            wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/$lang.wav
+            python3 ./test_onnx.py --wav ./$lang.wav
+          done
+          ls -lh *.wav
+
+          cat *-encoder.txt > encoder.txt
+          cat *-decoder.txt > decoder.txt
+          cat *-joiner.txt  > joiner.txt
+
+          ls -l encoder* decoder* joiner*
+
+          # ls -lh *.onnx*
+          # ls -lh *.txt
+          # ls -lh *.raw | head
+
+      - name: Setup tmate session
+        if: failure()
+        # if: false
+        uses: mxschmitt/action-tmate@v3
+
+      - name: Collect models
+        shell: bash
+        run: |
+          chunk_size_ms=${{ matrix.chunk_size_ms }}
+
+          # https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b
+          model_id=${{ matrix.model_id }}
+
+          src=scripts/nemo/qnn/nemotron-3.5-asr-streaming-0.6b
+          dst=${model_id}-${chunk_size_ms}
+
+          mkdir -p $dst
+
+          mv -v $src/encoder.* $dst
+          mv -v $src/decoder.* $dst
+          mv -v $src/joiner.* $dst
+          cp -v $src/*.txt $dst
+          cp $src/*.raw $dst
+          cp -v $src/*.wav $dst
+
+          ls -lh $dst/
+          tar cjvf $dst.tar.bz2 $dst
+          ls -lh *.tar.bz2
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.model_id }}-${{ matrix.chunk_size_ms }}
+          path: ./*.tar.bz2
+
+  generate_build_matrix:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generating build matrix
+        id: set-matrix
+        run: |
+          # outputting for debugging purposes
+          python3 .github/scripts/export-qnn/generate_nemotron_35_asr_streaming.py
+          MATRIX=$(python3 .github/scripts/export-qnn/generate_nemotron_35_asr_streaming.py)
+
+          # deprecated
+          # echo "::set-output name=matrix::${MATRIX}"
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+
+  qnn:
+    needs: [generate_build_matrix, onnx]
+    if: github.repository_owner == 'k2-fsa' || github.repository_owner == 'csukuangfj'
+    name: ${{ matrix.model_name }} ${{ matrix.soc }} ${{ matrix.chunk_size_ms }}
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/qnn-sdk:2.40
+    strategy:
+      fail-fast: false
+      matrix:
+        ${{ fromJson(needs.generate_build_matrix.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Retrieve artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.model_name }}-${{ matrix.chunk_size_ms }}
+          path: /tmp/
+
+      - name: Show space
+        shell: bash
+        run: |
+          df -h
+
+      - name: Show tmp
+        shell: bash
+        run: |
+          chunk_size_ms=${{ matrix.chunk_size_ms }}
+          model_id=${{ matrix.model_name }}
+
+          dir=$PWD
+          mkdir -p model-files/$chunk_size_ms
+
+          ls -lh /tmp/
+
+          pushd /tmp
+          echo "chunk_size_ms: $chunk_size_ms"
+
+          src=${model_id}-${chunk_size_ms}
+
+
+          ls -lh $src.tar.bz2
+
+          tar xvf $src.tar.bz2
+          rm $src.tar.bz2
+
+          echo "---"
+
+          ls -lh $src/*
+          popd
+
+          mv -v /tmp/$src/* $dir/model-files/$chunk_size_ms/
+
+      - name: Show files
+        shell: bash
+        run: |
+          ls -lh model-files
+          echo "---"
+          ls -lh model-files/*
+
+      - name: Show space
+        shell: bash
+        run: |
+          df -h
+
+      - name: Create directories
+        shell: bash
+        run: |
+          mkdir so binary
+
+      - name: Display NDK HOME
+        shell: bash
+        run: |
+          echo "ANDROID_NDK_LATEST_HOME: ${ANDROID_NDK_LATEST_HOME}"
+          ls -lh ${ANDROID_NDK_LATEST_HOME}
+
+      - name: Show ndk-build help
+        shell: bash
+        run: |
+          export PATH=${ANDROID_NDK_LATEST_HOME}:$PATH
+          ndk-build --help
+
+      - name: Show space
+        shell: bash
+        run: |
+          df -h
+
+      - name: Maximize Runner Swap Space
+        uses: pierotofy/set-swap-space@v1.0
+        with:
+          swap-size-gb: 12
+
+      - name: Run ${{ matrix.model_type }}
+        shell: bash
+        run: |
+          pushd $QNN_SDK_ROOT/bin
+          source envsetup.sh
+          popd
+
+          export LDFLAGS="-Wl,-z,max-page-size=16384"
+          dir=$PWD
+          chunk_size_ms=${{ matrix.chunk_size_ms }}
+          model_dir=$PWD/model-files/$chunk_size_ms
+          soc=${{ matrix.soc }}
+
+          python3 ./scripts/pyannote/segmentation/show-onnx.py --filename $model_dir/encoder.onnx
+          python3 ./scripts/pyannote/segmentation/show-onnx.py --filename $model_dir/decoder.onnx
+          python3 ./scripts/pyannote/segmentation/show-onnx.py --filename $model_dir/joiner.onnx
+
+          export PATH=${ANDROID_NDK_LATEST_HOME}:$PATH
+
+          echo "export to qnn"
+          echo "----------$chunk_size_ms----------"
+
+          for m in encoder decoder joiner; do
+            echo "Processing $m"
+            mv  $model_dir/${m}.* ./
+            cp  $model_dir/*.raw ./
+            cp  $model_dir/*.txt ./
+
+            ls -lh $m.*
+            ls -lh *.raw || head
+            ls -lh *.txt
+
+            if [[ $m == 'encoder' || $m == 'joiner' ]]; then
+              # quantize only the encoder and joiner
+              cat $m.txt
+
+              qnn-onnx-converter \
+                --input_network ./$m.onnx \
+                --output_path ./quant/$m.cpp \
+                --input_list $m.txt \
+                --use_native_input_files \
+                --act_bitwidth 16 \
+                --bias_bitwidth 32 > ${m}-log-converter.txt 2>&1
+            else
+              qnn-onnx-converter \
+                --input_network ./$m.onnx \
+                --output_path ./quant/$m.cpp \
+                --float_bitwidth 16 \
+                --act_bitwidth 16 \
+                --bias_bitwidth 32 > ${m}-log-converter.txt 2>&1
+            fi
+
+            ls -lh quant
+
+            python3 ./scripts/qnn/generate_config.py  \
+                --soc $soc \
+                --graph-name $m \
+                --output-dir ./quant/my-config-$m \
+                --qnn-sdk-root $QNN_SDK_ROOT
+
+            ls -lh quant/my-config-$m
+
+            head -n100 ./quant/my-config-$m/*.json
+
+            python3 "${QNN_SDK_ROOT}/bin/x86_64-linux-clang/qnn-model-lib-generator" \
+                -c quant/$m.cpp \
+                -b quant/$m.bin \
+                -o quant/model_libs > ${m}-log-generator.txt 2>&1
+
+            ls -lh quant/model_libs
+            echo "---"
+            ls -lh quant/model_libs/x86_64-linux-clang
+            echo "---"
+            ls -lh quant/model_libs/aarch64-android
+
+            $QNN_SDK_ROOT/bin/x86_64-linux-clang/qnn-context-binary-generator \
+              --backend $QNN_SDK_ROOT/lib/x86_64-linux-clang/libQnnHtp.so \
+              --model ./quant/model_libs/x86_64-linux-clang/lib$m.so \
+              --output_dir ./quant/binary \
+              --binary_file $m \
+              --config_file ./quant/my-config-$m/htp_backend_extensions.json > ${m}-log-generator.txt 2>&1
+
+            ls -lh quant/binary/
+          done
+
+          readelf -lW quant/model_libs/*/lib*.so
+
+          echo "collect results"
+
+          d=sherpa-onnx-qnn-${{ matrix.soc }}-binary-${{ matrix.model_name }}-${{ matrix.chunk_size_ms }}ms
+          mkdir -p $d
+          mkdir -p $d/test_wavs
+          cp -v quant/binary/*.bin $d/
+          cp -v $model_dir/tokens.txt $d
+          cp -v $model_dir/*.wav $d/test_wavs
+
+          echo "chunk_size_ms=${chunk_size_ms}ms" > $d/info.txt
+
+          ls -lh $d
+          tar cjfv $d.tar.bz2 $d
+          ls -lh *.tar.bz2
+          rm -rf $d
+
+          mkdir -p binary
+          mv *.tar.bz2 ./binary/
+
+          for p in x86_64-linux-clang aarch64-android; do
+            if [[ $p == x86_64-linux-clang ]]; then
+              d=sherpa-onnx-qnn-${{ matrix.model_name }}-${{ matrix.chunk_size_ms }}s-linux-x64
+            elif [[ $p == aarch64-android ]]; then
+              d=sherpa-onnx-qnn-${{ matrix.model_name }}-${{ matrix.chunk_size_ms }}s-android-aarch64
+            else
+              echo "Unknown $p"
+              exit -1
+            fi
+
+            mkdir -p $d
+            mkdir -p $d/test_wavs
+
+            cp -v quant/model_libs/$p/lib*.so $d/
+            cp -v $model_dir/tokens.txt $d
+            cp -v $model_dir/*.wav $d/test_wavs
+
+            echo "chunk_size_ms=${chunk_size_ms}ms" > $d/info.txt
+            echo "target=$p" >> $d/info.txt
+
+            ls -lh $d
+            tar cjfv $d.tar.bz2 $d
+            ls -lh *.tar.bz2
+            rm -rf $d
+          done
+
+          echo "----show---"
+          ls -lh *.tar.bz2
+
+          mkdir -p so
+
+          mv *.tar.bz2 ./so
+
+      - name: Setup tmate session
+        # if: false
+        if: failure()
+        uses: mxschmitt/action-tmate@v3
+
+      - name: Show files
+        shell: bash
+        run: |
+          echo "---so---"
+          ls -lh so
+
+          echo "---binary---"
+          ls -lh binary
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.model_name }}-${{ matrix.soc }}-${{ matrix.chunk_size_ms }}-${{ matrix.model_type }}-json
+          path: ./quant/*.json
+
+      - name: Release
+        if: github.repository_owner == 'csukuangfj' && matrix.soc == 'SM8850'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./so/*.tar.bz2
+          overwrite: true
+          repo_name: k2-fsa/sherpa-onnx
+          repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
+          tag: asr-models-qnn-3
+
+      - name: Release
+        if: github.repository_owner == 'csukuangfj'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./binary/*.tar.bz2
+          overwrite: true
+          repo_name: k2-fsa/sherpa-onnx
+          repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
+          tag: asr-models-qnn-binary-3
+
+      - name: Release
+        if: github.repository_owner == 'k2-fsa' && matrix.soc == 'SM8850'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./so/*.tar.bz2
+          overwrite: true
+          tag: asr-models-qnn-3
+
+      - name: Release
+        if: github.repository_owner == 'k2-fsa'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          file: ./binary/*.tar.bz2
+          overwrite: true
+          tag: asr-models-qnn-binary-3

--- a/.github/workflows/export-nemotron-3.5-asr-streaming-0.6b-qnn.yaml
+++ b/.github/workflows/export-nemotron-3.5-asr-streaming-0.6b-qnn.yaml
@@ -25,12 +25,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Cache ONNX models
+        id: cache-onnx
+        uses: actions/cache@v4
+        with:
+          path: ./*.tar.bz2
+          key: onnx-${{ matrix.model_id }}-${{ matrix.chunk_size_ms }}
+
       - name: Setup Python
+        if: steps.cache-onnx.outputs.cache-hit != 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
       - name: Export models
+        if: steps.cache-onnx.outputs.cache-hit != 'true'
         shell: bash
         run: |
           chunk_size_ms=${{ matrix.chunk_size_ms }}
@@ -67,11 +76,12 @@ jobs:
           # ls -lh *.raw | head
 
       - name: Setup tmate session
-        if: failure()
+        if: failure() && steps.cache-onnx.outputs.cache-hit != 'true'
         # if: false
         uses: mxschmitt/action-tmate@v3
 
       - name: Collect models
+        if: steps.cache-onnx.outputs.cache-hit != 'true'
         shell: bash
         run: |
           chunk_size_ms=${{ matrix.chunk_size_ms }}
@@ -95,7 +105,8 @@ jobs:
           tar cjvf $dst.tar.bz2 $dst
           ls -lh *.tar.bz2
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.model_id }}-${{ matrix.chunk_size_ms }}
           path: ./*.tar.bz2
@@ -209,11 +220,6 @@ jobs:
         shell: bash
         run: |
           df -h
-
-      - name: Maximize Runner Swap Space
-        uses: pierotofy/set-swap-space@v1.0
-        with:
-          swap-size-gb: 12
 
       - name: Run ${{ matrix.model_type }}
         shell: bash

--- a/.github/workflows/export-nemotron-3.5-asr-streaming-0.6b.yaml
+++ b/.github/workflows/export-nemotron-3.5-asr-streaming-0.6b.yaml
@@ -3,7 +3,7 @@ name: export-nemotron-3-5-asr-streaming-06b
 on:
   push:
     branches:
-      - export-nemotron-3-5-asr-streaming
+      - nemotron-3.5-qnn-2
   workflow_dispatch:
 
 concurrency:
@@ -11,23 +11,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  export-nemotron-3-5-asr-streaming-0-6b-to-onnx:
+  onnx:
     if: github.repository_owner == 'k2-fsa' || github.repository_owner == 'csukuangfj'
-    name: nemotron-3-5-asr-streaming-0-6b-to-onnx
-    runs-on: ${{ matrix.os }}
+    name: Export onnx ${{ matrix.chunk_size_ms }}ms
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
-        python-version: ["3.12"]
+        chunk_size_ms: [80, 160, 320, 560, 1120]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Python ${{ matrix.python-version }}
+      - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
 
       - name: Install NeMo
         shell: bash
@@ -50,14 +49,14 @@ jobs:
 
           sherpa-onnx-version
 
-      - name: Run
+      - name: Export ${{ matrix.chunk_size_ms }}ms
         shell: bash
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           cd scripts/nemo/nemotron-3.5-asr-streaming-0.6b
 
-          python3 ./export_onnx.py
+          python3 ./export_onnx.py --chunk-size-ms ${{ matrix.chunk_size_ms }}
 
           ls -lh
           echo "---"
@@ -66,7 +65,7 @@ jobs:
 
           echo "---"
 
-      - name: Test onnx models
+      - name: Test ${{ matrix.chunk_size_ms }}ms onnx models
         shell: bash
         run: |
           pip install sherpa-onnx-bin
@@ -75,70 +74,69 @@ jobs:
           wget https://dldata-public.s3.us-east-2.amazonaws.com/2086-149220-0033.wav
 
           src=scripts/nemo/nemotron-3.5-asr-streaming-0.6b
+          chunk=${{ matrix.chunk_size_ms }}
 
-          for chunk in 80 160 560 1120; do
-            echo "test $chunk int8"
+          echo "test $chunk int8"
 
-            sherpa-onnx \
-              --encoder=$src/$chunk/encoder.int8.onnx \
-              --decoder=$src/$chunk/decoder.int8.onnx \
-              --joiner=$src/$chunk/joiner.int8.onnx \
-              --tokens=$src/tokens.txt \
-              ./2086-149220-0033.wav
+          sherpa-onnx \
+            --encoder=$src/$chunk/encoder.int8.onnx \
+            --decoder=$src/$chunk/decoder.int8.onnx \
+            --joiner=$src/$chunk/joiner.int8.onnx \
+            --tokens=$src/tokens.txt \
+            ./2086-149220-0033.wav
 
-            echo "test $chunk float32"
+          echo "test $chunk float32"
 
-            sherpa-onnx \
-              --encoder=$src/$chunk/encoder.onnx \
-              --decoder=$src/$chunk/decoder.onnx \
-              --joiner=$src/$chunk/joiner.onnx \
-              --tokens=$src/tokens.txt \
-              ./2086-149220-0033.wav
-          done
+          sherpa-onnx \
+            --encoder=$src/$chunk/encoder.onnx \
+            --decoder=$src/$chunk/decoder.onnx \
+            --joiner=$src/$chunk/joiner.onnx \
+            --tokens=$src/tokens.txt \
+            ./2086-149220-0033.wav
 
-      - name: Collect results
+      - name: Collect ${{ matrix.chunk_size_ms }}ms results
         shell: bash
         run: |
           src=scripts/nemo/nemotron-3.5-asr-streaming-0.6b
+          chunk=${{ matrix.chunk_size_ms }}
 
-          for chunk in 80 160 320 560 1120; do
-            d=sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-${chunk}ms-2026-06-11
-            mkdir -p $d
+          d=sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-${chunk}ms-2026-06-11
+          mkdir -p $d
 
-            cp -av $src/$chunk/encoder.onnx $d/
-            cp -av $src/$chunk/encoder.data $d/
-            cp -av $src/$chunk/decoder.onnx $d/
-            cp -av $src/$chunk/joiner.onnx $d/
-            cp -av $src/tokens.txt $d/
-            cat >$d/README.md <<EOF
-            # Introduction
-            This model is from https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b
+          cp -av $src/$chunk/encoder.onnx $d/
+          cp -av $src/$chunk/encoder.data $d/
+          cp -av $src/$chunk/decoder.onnx $d/
+          cp -av $src/$chunk/joiner.onnx $d/
+          cp -av $src/tokens.txt $d/
 
-            The chunk size is ${chunk}ms for the exported ONNX model.
+          cat >$d/README.md <<EOF
+          # Introduction
+          This model is from https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b
 
-            Use per-stream language strings such as "en", "ja", or "auto".
+          The chunk size is ${chunk}ms for the exported ONNX model.
+
+          Use per-stream language strings such as "en", "ja", or "auto".
           EOF
 
-            ls -lh $d
+          ls -lh $d
 
-            d=sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-${chunk}ms-int8-2026-06-11
-            mkdir -p $d
+          d=sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-${chunk}ms-int8-2026-06-11
+          mkdir -p $d
 
-            cp -av $src/${chunk}/encoder.int8.onnx $d/
-            cp -av $src/${chunk}/decoder.int8.onnx $d/
-            cp -av $src/${chunk}/joiner.int8.onnx $d/
-            cp -av $src/tokens.txt $d/
-            cat >$d/README.md <<EOF
-            # Introduction
-            This model is from https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b
+          cp -av $src/${chunk}/encoder.int8.onnx $d/
+          cp -av $src/${chunk}/decoder.int8.onnx $d/
+          cp -av $src/${chunk}/joiner.int8.onnx $d/
+          cp -av $src/tokens.txt $d/
+          cat >$d/README.md <<EOF
+          # Introduction
+          This model is from https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b
 
-            The chunk size is ${chunk}ms for the exported ONNX model.
+          The chunk size is ${chunk}ms for the exported ONNX model.
 
-            Use per-stream language strings such as "en", "ja", or "auto".
+          Use per-stream language strings such as "en", "ja", or "auto".
           EOF
 
-            ls -lh $d
-          done
+          ls -lh $d
 
       - name: Download test waves
         shell: bash
@@ -152,17 +150,10 @@ jobs:
 
           popd
 
+          chunk=${{ matrix.chunk_size_ms }}
           models=(
-            sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-80ms-int8-2026-06-11
-            sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-160ms-int8-2026-06-11
-            sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-320ms-int8-2026-06-11
-            sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11
-            sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-1120ms-int8-2026-06-11
-            sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-80ms-2026-06-11
-            sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-160ms-2026-06-11
-            sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-320ms-2026-06-11
-            sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-2026-06-11
-            sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-1120ms-2026-06-11
+            sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-${chunk}ms-int8-2026-06-11
+            sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-${chunk}ms-2026-06-11
           )
           for m in ${models[@]}; do
             cp -av test_wavs $m
@@ -203,17 +194,10 @@ jobs:
             git config --global user.email "csukuangfj@gmail.com"
             git config --global user.name "Fangjun Kuang"
 
+            chunk=${{ matrix.chunk_size_ms }}
             models=(
-              sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-80ms-int8-2026-06-11
-              sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-160ms-int8-2026-06-11
-              sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-320ms-int8-2026-06-11
-              sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11
-              sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-1120ms-int8-2026-06-11
-              sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-80ms-2026-06-11
-              sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-160ms-2026-06-11
-              sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-320ms-2026-06-11
-              sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-2026-06-11
-              sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-1120ms-2026-06-11
+              sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-${chunk}ms-int8-2026-06-11
+              sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-${chunk}ms-2026-06-11
             )
 
             for m in ${models[@]}; do

--- a/.github/workflows/export-nemotron-3.5-asr-streaming-0.6b.yaml
+++ b/.github/workflows/export-nemotron-3.5-asr-streaming-0.6b.yaml
@@ -101,7 +101,7 @@ jobs:
         run: |
           src=scripts/nemo/nemotron-3.5-asr-streaming-0.6b
 
-          for chunk in 80 160 560 1120; do
+          for chunk in 80 160 320 560 1120; do
             d=sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-${chunk}ms-2026-06-11
             mkdir -p $d
 
@@ -145,8 +145,11 @@ jobs:
         run: |
           mkdir test_wavs
           pushd test_wavs
-          curl -SL -O https://hf-mirror.com/csukuangfj/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17/resolve/main/test_wavs/en.wav
-          curl -SL -O https://hf-mirror.com/csukuangfj/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17/resolve/main/test_wavs/ja.wav
+
+          for lang in ar de es fr ja ko uk vi zh; do
+            wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/$lang.wav
+          done
+
           popd
 
           models=(

--- a/.github/workflows/qnn-sdk-docker-build.yaml
+++ b/.github/workflows/qnn-sdk-docker-build.yaml
@@ -3,7 +3,7 @@ name: Build docker image for qnn SDK
 on:
   push:
     branches:
-      - docker-qnn-2
+      - docker-qnn
   workflow_dispatch:
 
 jobs:

--- a/scripts/nemo/nemotron-3.5-asr-streaming-0.6b/export_onnx.py
+++ b/scripts/nemo/nemotron-3.5-asr-streaming-0.6b/export_onnx.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright      2026  Julian Pscheid
+import argparse
 import inspect
 import json
 import os
@@ -259,6 +260,18 @@ def export_prompted_encoder(
 
 @torch.no_grad()
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--chunk-size-ms",
+        type=int,
+        required=True,
+        choices=[80, 160, 320, 560, 1120],
+        help="Chunk size in milliseconds",
+    )
+    args = parser.parse_args()
+
+    ms = args.chunk_size_ms
+
     model_name = "nvidia/nemotron-3.5-asr-streaming-0.6b"
 
     asr_model = nemo_asr.models.ASRModel.from_pretrained(model_name=model_name)
@@ -274,118 +287,116 @@ def main():
     print("streaming_cfg", asr_model.encoder.streaming_cfg)
     print("prompt_dictionary", prompt_dictionary)
 
-    chunk_size_ms_list = [80, 160, 320, 560, 1120]
-    for ms in chunk_size_ms_list:
-        chunk_size = ms // 80 - 1
-        print("chunk_size", chunk_size)
-        asr_model.encoder.set_default_att_context_size([56, chunk_size])
+    chunk_size = ms // 80 - 1
+    print("chunk_size", chunk_size)
+    asr_model.encoder.set_default_att_context_size([56, chunk_size])
 
-        print("streaming_cfg", asr_model.encoder.streaming_cfg)
-        print("att_context_size", asr_model.encoder.att_context_size)
-        print(
-            "pre_encode_cache_size",
-            asr_model.encoder.streaming_cfg.pre_encode_cache_size,
+    print("streaming_cfg", asr_model.encoder.streaming_cfg)
+    print("att_context_size", asr_model.encoder.att_context_size)
+    print(
+        "pre_encode_cache_size",
+        asr_model.encoder.streaming_cfg.pre_encode_cache_size,
+    )
+
+    if isinstance(asr_model.encoder.streaming_cfg.pre_encode_cache_size, list):
+        pre_encode_cache_size = (
+            asr_model.encoder.streaming_cfg.pre_encode_cache_size[1]
+        )
+    else:
+        pre_encode_cache_size = (
+            asr_model.encoder.streaming_cfg.pre_encode_cache_size
         )
 
-        if isinstance(asr_model.encoder.streaming_cfg.pre_encode_cache_size, list):
-            pre_encode_cache_size = (
-                asr_model.encoder.streaming_cfg.pre_encode_cache_size[1]
-            )
-        else:
-            pre_encode_cache_size = (
-                asr_model.encoder.streaming_cfg.pre_encode_cache_size
-            )
+    if isinstance(asr_model.encoder.streaming_cfg.chunk_size, list):
+        chunk_size = asr_model.encoder.streaming_cfg.chunk_size[1]
+    else:
+        chunk_size = asr_model.encoder.streaming_cfg.chunk_size
 
-        if isinstance(asr_model.encoder.streaming_cfg.chunk_size, list):
-            chunk_size = asr_model.encoder.streaming_cfg.chunk_size[1]
-        else:
-            chunk_size = asr_model.encoder.streaming_cfg.chunk_size
+    window_size = chunk_size + pre_encode_cache_size
 
-        window_size = chunk_size + pre_encode_cache_size
+    print("chunk_size", chunk_size)
+    print("pre_encode_cache_size", pre_encode_cache_size)
+    print("window_size", window_size)
 
-        print("chunk_size", chunk_size)
-        print("pre_encode_cache_size", pre_encode_cache_size)
-        print("window_size", window_size)
+    chunk_shift = chunk_size
 
-        chunk_shift = chunk_size
+    # cache_last_channel: (batch_size, dim1, dim2, dim3)
+    cache_last_channel_dim1 = len(asr_model.encoder.layers)
+    cache_last_channel_dim2 = (
+        asr_model.encoder.streaming_cfg.last_channel_cache_size
+    )
+    cache_last_channel_dim3 = asr_model.encoder.d_model
 
-        # cache_last_channel: (batch_size, dim1, dim2, dim3)
-        cache_last_channel_dim1 = len(asr_model.encoder.layers)
-        cache_last_channel_dim2 = (
-            asr_model.encoder.streaming_cfg.last_channel_cache_size
+    # cache_last_time: (batch_size, dim1, dim2, dim3)
+    cache_last_time_dim1 = len(asr_model.encoder.layers)
+    cache_last_time_dim2 = asr_model.encoder.d_model
+    cache_last_time_dim3 = asr_model.encoder.conv_context_size[0]
+
+    asr_model.set_export_config({"cache_support": True})
+
+    export_prompted_encoder(
+        asr_model=asr_model,
+        window_size=window_size,
+        cache_last_channel_dim1=cache_last_channel_dim1,
+        cache_last_channel_dim2=cache_last_channel_dim2,
+        cache_last_channel_dim3=cache_last_channel_dim3,
+        cache_last_time_dim1=cache_last_time_dim1,
+        cache_last_time_dim2=cache_last_time_dim2,
+        cache_last_time_dim3=cache_last_time_dim3,
+        auto_prompt_id=auto_prompt_id,
+    )
+    asr_model.decoder.export("decoder.onnx")
+    asr_model.joint.export("joiner.onnx")
+
+    normalize_type = asr_model.cfg.preprocessor.normalize
+    if normalize_type == "NA":
+        normalize_type = ""
+
+    meta_data = {
+        "vocab_size": asr_model.decoder.vocab_size,
+        "window_size": window_size,
+        "chunk_size_ms": ms,
+        "chunk_shift": chunk_shift,
+        "normalize_type": normalize_type,
+        "cache_last_channel_dim1": cache_last_channel_dim1,
+        "cache_last_channel_dim2": cache_last_channel_dim2,
+        "cache_last_channel_dim3": cache_last_channel_dim3,
+        "cache_last_time_dim1": cache_last_time_dim1,
+        "cache_last_time_dim2": cache_last_time_dim2,
+        "cache_last_time_dim3": cache_last_time_dim3,
+        "pred_rnn_layers": asr_model.decoder.pred_rnn_layers,
+        "pred_hidden": asr_model.decoder.pred_hidden,
+        "subsampling_factor": 8,
+        "feat_dim": 128,
+        "model_type": type(asr_model).__name__,
+        "version": "1",
+        "model_author": "NeMo",
+        "url": f"https://huggingface.co/{model_name}",
+        "comment": "Only the transducer branch is exported",
+        "prompt_dictionary": json.dumps(
+            _normalize_prompt_dictionary(prompt_dictionary), sort_keys=True
+        ),
+        "auto_prompt_id": auto_prompt_id,
+    }
+    print("meta_data", meta_data)
+    add_meta_data("encoder.onnx", meta_data)
+
+    for m in ["encoder", "decoder", "joiner"]:
+        quantize_dynamic(
+            model_input=f"{m}.onnx",
+            model_output=f"{m}.int8.onnx",
+            weight_type=QuantType.QUInt8,
         )
-        cache_last_channel_dim3 = asr_model.encoder.d_model
 
-        # cache_last_time: (batch_size, dim1, dim2, dim3)
-        cache_last_time_dim1 = len(asr_model.encoder.layers)
-        cache_last_time_dim2 = asr_model.encoder.d_model
-        cache_last_time_dim3 = asr_model.encoder.conv_context_size[0]
+    Path(str(ms)).mkdir(exist_ok=True)
+    for suffix in ["onnx", "data"]:
+        for p in Path(".").glob(f"*.{suffix}"):
+            p.rename(Path(str(ms)) / p.name)
 
-        asr_model.set_export_config({"cache_support": True})
-
-        export_prompted_encoder(
-            asr_model=asr_model,
-            window_size=window_size,
-            cache_last_channel_dim1=cache_last_channel_dim1,
-            cache_last_channel_dim2=cache_last_channel_dim2,
-            cache_last_channel_dim3=cache_last_channel_dim3,
-            cache_last_time_dim1=cache_last_time_dim1,
-            cache_last_time_dim2=cache_last_time_dim2,
-            cache_last_time_dim3=cache_last_time_dim3,
-            auto_prompt_id=auto_prompt_id,
-        )
-        asr_model.decoder.export("decoder.onnx")
-        asr_model.joint.export("joiner.onnx")
-
-        normalize_type = asr_model.cfg.preprocessor.normalize
-        if normalize_type == "NA":
-            normalize_type = ""
-
-        meta_data = {
-            "vocab_size": asr_model.decoder.vocab_size,
-            "window_size": window_size,
-            "chunk_size_ms": ms,
-            "chunk_shift": chunk_shift,
-            "normalize_type": normalize_type,
-            "cache_last_channel_dim1": cache_last_channel_dim1,
-            "cache_last_channel_dim2": cache_last_channel_dim2,
-            "cache_last_channel_dim3": cache_last_channel_dim3,
-            "cache_last_time_dim1": cache_last_time_dim1,
-            "cache_last_time_dim2": cache_last_time_dim2,
-            "cache_last_time_dim3": cache_last_time_dim3,
-            "pred_rnn_layers": asr_model.decoder.pred_rnn_layers,
-            "pred_hidden": asr_model.decoder.pred_hidden,
-            "subsampling_factor": 8,
-            "feat_dim": 128,
-            "model_type": type(asr_model).__name__,
-            "version": "1",
-            "model_author": "NeMo",
-            "url": f"https://huggingface.co/{model_name}",
-            "comment": "Only the transducer branch is exported",
-            "prompt_dictionary": json.dumps(
-                _normalize_prompt_dictionary(prompt_dictionary), sort_keys=True
-            ),
-            "auto_prompt_id": auto_prompt_id,
-        }
-        print("meta_data", meta_data)
-        add_meta_data("encoder.onnx", meta_data)
-
-        for m in ["encoder", "decoder", "joiner"]:
-            quantize_dynamic(
-                model_input=f"{m}.onnx",
-                model_output=f"{m}.int8.onnx",
-                weight_type=QuantType.QUInt8,
-            )
-
-        Path(str(ms)).mkdir(exist_ok=True)
-        for suffix in ["onnx", "data"]:
-            for p in Path(".").glob(f"*.{suffix}"):
-                p.rename(Path(str(ms)) / p.name)
-
-        print(meta_data)
-        print(f"Saved exported models to {ms}")
-        remove_export_scratch_files()
-        os.system(f"ls -lh {ms}")
+    print(meta_data)
+    print(f"Saved exported models to {ms}")
+    remove_export_scratch_files()
+    os.system(f"ls -lh {ms}")
 
 
 if __name__ == "__main__":

--- a/scripts/nemo/qnn/nemotron-3.5-asr-streaming-0.6b/run.sh
+++ b/scripts/nemo/qnn/nemotron-3.5-asr-streaming-0.6b/run.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright      2026  Xiaomi Corp.        (authors: Fangjun Kuang)
+
+set -ex
+
+pip install \
+  "nemo_toolkit[asr] @ git+https://github.com/NVIDIA/NeMo.git@main" \
+  "numpy<2" \
+  ipython \
+  kaldi-native-fbank \
+  librosa \
+  onnx \
+  onnxruntime \
+  onnxscript \
+  soundfile
+
+# 80, 160, 320, 560, 1120
+chunk_size_ms=1120
+if [ $# -ge 1 ]; then
+  chunk_size_ms="$1"
+fi
+
+
+model_id=nemotron-3.5-asr-streaming-0.6b
+if [ $# -ge 2 ]; then
+  model_id="$2"
+fi
+
+python3 ./wrapper.py --chunk-size-ms $chunk_size_ms --model-id $model_id

--- a/scripts/nemo/qnn/nemotron-3.5-asr-streaming-0.6b/test_onnx.py
+++ b/scripts/nemo/qnn/nemotron-3.5-asr-streaming-0.6b/test_onnx.py
@@ -148,7 +148,7 @@ class OnnxModel:
         c = np.zeros(c_shape, dtype=np.float32)
         return h, c
 
-    def run_encoder(self, x: np.ndarray, states):
+    def run_encoder(self, x: np.ndarray, states, prompt_index):
         encoder_out, *next_states = self.encoder.run(
             [
                 self.encoder.get_outputs()[0].name,
@@ -161,6 +161,7 @@ class OnnxModel:
                 self.encoder.get_inputs()[1].name: states[0],
                 self.encoder.get_inputs()[2].name: states[1],
                 self.encoder.get_inputs()[3].name: states[2],
+                self.encoder.get_inputs()[4].name: prompt_index,
             },
         )
         return encoder_out, next_states
@@ -259,6 +260,7 @@ def main():
     features.tofile(f"{name}-features.raw")
 
     encoder_states = model.get_encoder_state()
+    prompt_index = np.array([101], dtype=np.int32)
 
     max_symbols_per_frame = 10
 
@@ -267,9 +269,9 @@ def main():
         if f.shape[0] < window_size:
             break
 
-        encoder_input_list.append([f, encoder_states])
+        encoder_input_list.append([f, encoder_states, prompt_index])
         encoder_out, encoder_states = model.run_encoder(
-            f[None].transpose(0, 2, 1), encoder_states
+            f[None].transpose(0, 2, 1), encoder_states, prompt_index
         )
         encoder_out = encoder_out.transpose(0, 2, 1)
 
@@ -300,7 +302,7 @@ def main():
 
     if True:
         with open(f"{name}-encoder.txt", "w") as f:
-            for i, (x, states) in enumerate(encoder_input_list):
+            for i, (x, states, prompt_index) in enumerate(encoder_input_list):
                 x_name = f"{name}-{i}-x.raw"
                 x.tofile(x_name)
 
@@ -313,7 +315,10 @@ def main():
                 s2_name = f"{name}-{i}-s2.raw"
                 states[2].tofile(s2_name)
 
-                f.write(f"{x_name} {s0_name} {s1_name} {s2_name}\n")
+                prompt_name = f"{name}-{i}-prompt.raw"
+                prompt_index.tofile(prompt_name)
+
+                f.write(f"{x_name} {s0_name} {s1_name} {s2_name} {prompt_name}\n")
 
         with open(f"{name}-decoder.txt", "w") as f:
             for i, (y, h, c) in enumerate(decoder_input_list):

--- a/scripts/nemo/qnn/nemotron-3.5-asr-streaming-0.6b/wrapper.py
+++ b/scripts/nemo/qnn/nemotron-3.5-asr-streaming-0.6b/wrapper.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+# Copyright      2026  Xiaomi Corp.        (authors: Fangjun Kuang)
+
+import argparse
+
+import nemo.collections.asr as nemo_asr
+import nemo.collections.asr.modules.conformer_encoder as conformer_mod
+import torch
+import torch.nn as nn
+
+
+def patched_forward_internal(
+    self,
+    audio_signal,
+    length,
+    cache_last_channel=None,
+    cache_last_time=None,
+    cache_last_channel_len=None,
+    bypass_pre_encode=False,
+):
+    # Patched inference-only version of ConformerEncoder.forward_internal for QNN export.
+    #
+    # Based on the original at:
+    #   ../nemo/nemo/collections/asr/modules/conformer_encoder.py:636
+    #
+    # Three changes from the original NeMo implementation:
+    #
+    # 1. Replaced `torch.neg(cache_last_channel_len) + cache_len` with
+    #    `cache_len - cache_last_channel_len`. They are mathematically equivalent,
+    #    but the original produces a Neg op in the ONNX graph which the Qualcomm
+    #    QNN converter (qnn-onnx-converter) does not support, causing:
+    #      [ ERROR ] OpConfig validation failed for ElementWiseUnary
+    #      [ ERROR ] QnnModel::addNode() validating node node_neg failed.
+    #
+    # 2. Cast attention masks from bool to float before slicing, then back to
+    #    bool after slicing. QNN's StridedSlice does not support boolean tensors,
+    #    causing:
+    #      [ ERROR ] OpConfig validation failed for StridedSlice
+    #      [ ERROR ] QnnModel::addNode() validating node node_slice_3 failed.
+    #
+    # 3. Removed training-only code paths (stochastic depth, interctc loss capture,
+    #    random att_context_size selection) since this is only used during export
+    #    where the model is always in eval/inference mode.
+    if length is None:
+        length = audio_signal.new_full(
+            (audio_signal.size(0),),
+            audio_signal.size(-1),
+            dtype=torch.int64,
+            device=audio_signal.device,
+        )
+
+    cur_att_context_size = self.att_context_size
+
+    if not bypass_pre_encode:
+        audio_signal = torch.transpose(audio_signal, 1, 2)
+
+        if isinstance(self.pre_encode, nn.Linear):
+            audio_signal = self.pre_encode(audio_signal)
+        else:
+            audio_signal, length = self.pre_encode(x=audio_signal, lengths=length)
+            length = length.to(torch.int64)
+            if (
+                self.streaming_cfg.drop_extra_pre_encoded > 0
+                and cache_last_channel is not None
+            ):
+                audio_signal = audio_signal[
+                    :, self.streaming_cfg.drop_extra_pre_encoded :, :
+                ]
+                length = (length - self.streaming_cfg.drop_extra_pre_encoded).clamp(
+                    min=0
+                )
+
+        if self.reduction_position is not None and cache_last_channel is not None:
+            raise ValueError("Caching with reduction feature is not supported yet!")
+
+    max_audio_length = audio_signal.size(1)
+    if cache_last_channel is not None:
+        cache_len = self.streaming_cfg.last_channel_cache_size
+        cache_keep_size = max_audio_length - self.streaming_cfg.cache_drop_size
+        max_audio_length = max_audio_length + cache_len
+        padding_length = length + cache_len
+        # Original: offset = torch.neg(cache_last_channel_len) + cache_len
+        # Changed to subtraction to avoid the Neg op that QNN rejects (see docstring).
+        offset = cache_len - cache_last_channel_len
+    else:
+        padding_length = length
+        cache_last_channel_next = None
+        cache_len = 0
+        offset = None
+
+    if self.self_attention_model == "rope":
+        if self.xscale:
+            audio_signal = audio_signal * self.xscale
+        audio_signal = self.dropout_pre_encoder(audio_signal)
+        pos_emb = None
+    else:
+        audio_signal, pos_emb = self.pos_enc(x=audio_signal, cache_len=cache_len)
+
+    pad_mask, att_mask = self._create_masks(
+        att_context_size=cur_att_context_size,
+        padding_length=padding_length,
+        max_audio_length=max_audio_length,
+        offset=offset,
+        device=audio_signal.device,
+    )
+
+    # Cast masks from bool to float so that QNN StridedSlice can handle them.
+    # QNN does not support StridedSlice on boolean tensors.
+    # Cast back to bool before passing to layers below.
+    pad_mask = pad_mask.to(torch.float32)
+    if att_mask is not None:
+        att_mask = att_mask.to(torch.float32)
+
+    if cache_last_channel is not None:
+        pad_mask = pad_mask[:, cache_len:]
+        if att_mask is not None:
+            att_mask = att_mask[:, cache_len:]
+        cache_last_time_next = []
+        cache_last_channel_next = []
+
+    # Cast masks back to bool for the attention layers.
+    pad_mask = pad_mask.to(torch.bool)
+    if att_mask is not None:
+        att_mask = att_mask.to(torch.bool)
+
+    for lth, layer in enumerate(self.layers):
+        if cache_last_channel is not None:
+            cache_last_channel_cur = cache_last_channel[lth]
+            cache_last_time_cur = cache_last_time[lth]
+        else:
+            cache_last_channel_cur = None
+            cache_last_time_cur = None
+        audio_signal = layer(
+            x=audio_signal,
+            att_mask=att_mask,
+            pos_emb=pos_emb,
+            pad_mask=pad_mask,
+            cache_last_channel=cache_last_channel_cur,
+            cache_last_time=cache_last_time_cur,
+        )
+
+        if cache_last_channel_cur is not None:
+            (audio_signal, cache_last_channel_cur, cache_last_time_cur) = audio_signal
+            cache_last_channel_next.append(cache_last_channel_cur)
+            cache_last_time_next.append(cache_last_time_cur)
+
+        if self.reduction_position == lth:
+            audio_signal, length = self.reduction_subsampling(
+                x=audio_signal, lengths=length
+            )
+            max_audio_length = audio_signal.size(1)
+            if self.self_attention_model != "rope":
+                _, pos_emb = self.pos_enc(x=audio_signal, cache_len=cache_len)
+            pad_mask, att_mask = self._create_masks(
+                att_context_size=cur_att_context_size,
+                padding_length=length,
+                max_audio_length=max_audio_length,
+                offset=offset,
+                device=audio_signal.device,
+            )
+
+    if self.out_proj is not None:
+        audio_signal = self.out_proj(audio_signal)
+
+    if self.reduction_position == -1:
+        audio_signal, length = self.reduction_subsampling(
+            x=audio_signal, lengths=length
+        )
+
+    audio_signal = torch.transpose(audio_signal, 1, 2)
+    length = length.to(dtype=torch.int64)
+
+    if cache_last_channel is not None:
+        cache_last_channel_next = torch.stack(cache_last_channel_next, dim=0)
+        cache_last_time_next = torch.stack(cache_last_time_next, dim=0)
+        return (
+            audio_signal,
+            length,
+            cache_last_channel_next,
+            cache_last_time_next,
+            torch.clamp(cache_last_channel_len + cache_keep_size, max=cache_len),
+        )
+    else:
+        return audio_signal, length
+
+
+def patched_streaming_post_process(self, rets, keep_all_outputs=True):
+    if len(rets) == 2:
+        return rets[0], rets[1], None, None, None
+
+    (
+        encoded,
+        encoded_len,
+        cache_last_channel_next,
+        cache_last_time_next,
+        cache_last_channel_next_len,
+    ) = rets
+
+    if (
+        cache_last_channel_next is not None
+        and self.streaming_cfg.last_channel_cache_size > 0
+    ):
+        cache_size = int(self.streaming_cfg.last_channel_cache_size)
+        total_size = cache_last_channel_next.shape[2]
+        start_idx = total_size - cache_size
+        cache_last_channel_next = cache_last_channel_next.narrow(
+            2, start_idx, cache_size
+        )
+
+    if self.streaming_cfg.valid_out_len > 0 and (
+        not keep_all_outputs or self.att_context_style == "regular"
+    ):
+        valid_len = int(self.streaming_cfg.valid_out_len)
+        encoded = encoded.narrow(2, 0, valid_len)
+        encoded_len = torch.clamp(encoded_len, max=valid_len)
+
+    return (
+        encoded,
+        encoded_len,
+        cache_last_channel_next,
+        cache_last_time_next,
+        cache_last_channel_next_len,
+    )
+
+
+# Monkey-patch NeMo's ConformerEncoder to produce an ONNX graph that
+# QNN can consume. forward_internal avoids unsupported Neg and
+# StridedSlice-on-bool ops; streaming_post_process simplifies the
+# cache/output handling.
+conformer_mod.ConformerEncoder.forward_internal = patched_forward_internal
+conformer_mod.ConformerEncoder.streaming_post_process = patched_streaming_post_process
+
+
+def get_args():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument(
+        "--chunk-size-ms",
+        type=int,
+        choices=[80, 160, 320, 560, 1120],
+        required=True,
+    )
+
+    parser.add_argument(
+        "--model-id",
+        type=str,
+        help="e.g., nvidia/nemotron-speech-streaming-en-0.6b",
+        required=True,
+    )
+    return parser.parse_args()
+
+
+class EncoderWrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def get_init_states(self):
+        cache_last_channel, cache_last_time, cache_last_channel_len = (
+            self.model.encoder.get_initial_cache_state()
+        )
+
+        print(cache_last_channel.shape)
+        print(cache_last_time.shape)
+        print(cache_last_channel_len.shape, cache_last_channel_len)
+
+        return (
+            cache_last_channel.transpose(0, 1),
+            cache_last_time.transpose(0, 1),
+            cache_last_channel_len.to(torch.int32),
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cache_last_channel: torch.Tensor,
+        cache_last_time: torch.Tensor,
+        cache_last_channel_len: torch.Tensor,
+        prompt_index: torch.Tensor,
+    ):
+        """
+        Args:
+          x: feature tensor, (N, C, T)
+          cache_last_channel,
+          cache_last_time,
+          cache_last_channel_len,
+          prompt_index: (N,) torch.int32
+
+        Returns:
+          encoder_out: (N, C, T)
+        """
+        x_lens = torch.tensor([x.shape[2]], dtype=torch.int64)
+        encoder_out, encoder_out_len, *states = self.model.encoder.forward_for_export(
+            audio_signal=x,
+            length=x_lens,
+            cache_last_channel=cache_last_channel,
+            cache_last_time=cache_last_time,
+            cache_last_channel_len=cache_last_channel_len,
+        )
+
+        encoder_out = encoder_out.transpose(1, 2)  # (B, D, T) -> (B, T, D)
+        batch_size, time_steps, _ = encoder_out.shape
+
+        prompt = torch.zeros(
+            batch_size,
+            time_steps,
+            self.model.num_prompts,
+            dtype=encoder_out.dtype,
+            device=encoder_out.device,
+        )
+        prompt.scatter_(
+            2,
+            prompt_index.view(batch_size, 1, 1).expand(-1, time_steps, -1),
+            1.0,
+        )
+
+        encoder_out = self.model.prompt_kernel(
+            torch.cat([encoder_out, prompt], dim=-1)
+        ).to(encoder_out.dtype)
+        encoder_out = encoder_out.transpose(1, 2)  # (B, T, D) -> (B, D, T)
+
+        return encoder_out, states
+
+
+class DecoderWrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def get_init_states(self):
+        h, c = self.model.decoder.initialize_state(
+            torch.tensor([[1.0]], dtype=torch.float)
+        )
+
+        return h, c
+
+    def forward(self, y: torch.Tensor, h: torch.Tensor, c: torch.Tensor):
+        """
+        y:  torch.int32, shape (1, 1)
+        """
+        transcript_len = torch.tensor([1], dtype=torch.int32)
+        decoder_out, target_lengths, states = self.model.decoder(
+            targets=y, target_length=transcript_len, states=[h, c]
+        )
+        decoder_out = decoder_out.permute(0, 2, 1)  # (N, C, 1) -> (N, 1, C)
+        return decoder_out, states[0], states[1]
+
+
+class JoinerWrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, encoder_out: torch.Tensor, decoder_out: torch.Tensor):
+        """
+        encoder_out: feature tensor, (1, 1, encoder_dim)
+        decoder_out: feature tensor, (1, 1, decoder_dim)
+        """
+        logits = self.model.joint.joint(encoder_out, decoder_out)
+
+        return logits
+
+
+def export_encoder(asr_model, window_size, window_shift):
+    m = EncoderWrapper(asr_model)
+    m.eval()
+
+    feat_dim = asr_model.cfg.preprocessor.features
+
+    prompt_id = asr_model.cfg.model_defaults.prompt_dictionary["auto"]
+    prompt_index = torch.tensor([prompt_id], dtype=torch.int32)
+
+    states = m.get_init_states()
+    x = torch.rand(1, feat_dim, window_size, dtype=torch.float32)
+
+    print("x", x.shape)
+
+    torch.onnx.export(
+        m,
+        (x, *states, prompt_index),
+        "encoder.onnx",
+        opset_version=13,
+        input_names=[
+            f"x_{window_size}_{window_shift}",
+            "cache_last_channel",
+            "cache_last_time",
+            "cache_last_channel_len",
+            "prompt_index",
+        ],
+        output_names=[
+            "encoder_out",
+            "next_cache_last_channel",
+            "next_cache_last_time",
+            "next_cache_last_channel_len",
+        ],
+    )
+
+
+def export_decoder(asr_model):
+    m = DecoderWrapper(asr_model)
+    m.eval()
+
+    h, c = m.get_init_states()
+    y = torch.tensor([[1]], dtype=torch.int32)
+
+    torch.onnx.export(
+        m,
+        (y, h, c),
+        "decoder.onnx",
+        opset_version=13,
+        input_names=["y", "h", "c"],
+        output_names=["decoder_out", "next_h", "next_c"],
+    )
+
+
+def export_joiner(asr_model, encoder_dim, decoder_dim):
+    m = JoinerWrapper(asr_model)
+    m.eval()
+    encoder_out = torch.rand(1, 1, encoder_dim, dtype=torch.float32)
+    decoder_out = torch.rand(1, 1, decoder_dim, dtype=torch.float32)
+
+    torch.onnx.export(
+        m,
+        (encoder_out, decoder_out),
+        "joiner.onnx",
+        opset_version=13,
+        input_names=["encoder_out", "decoder_out"],
+        output_names=["logits"],
+    )
+
+
+@torch.no_grad()
+def main():
+    args = get_args()
+    print(vars(args))
+
+    asr_model = nemo_asr.models.ASRModel.from_pretrained(model_name=args.model_id)
+    asr_model.eval()
+
+    asr_model.set_export_config({"cache_support": True})
+
+    asr_model.decoder._prepare_for_export()
+    asr_model.joint._prepare_for_export()
+
+    chunk_size_ms = args.chunk_size_ms
+    chunk_size = chunk_size_ms // 80 - 1
+    print("chunk_size", chunk_size)
+    asr_model.encoder.set_default_att_context_size([56, chunk_size])
+    print("streaming_cfg", asr_model.encoder.streaming_cfg)
+
+    if isinstance(asr_model.encoder.streaming_cfg.pre_encode_cache_size, list):
+        pre_encode_cache_size = asr_model.encoder.streaming_cfg.pre_encode_cache_size[1]
+    else:
+        pre_encode_cache_size = asr_model.encoder.streaming_cfg.pre_encode_cache_size
+
+    if isinstance(asr_model.encoder.streaming_cfg.chunk_size, list):
+        chunk_size = asr_model.encoder.streaming_cfg.chunk_size[1]
+    else:
+        chunk_size = asr_model.encoder.streaming_cfg.chunk_size
+
+    window_size = chunk_size + pre_encode_cache_size
+
+    window_shift = chunk_size
+
+    print(window_size, window_shift)
+
+    print(type(asr_model))
+    print(asr_model)
+    print(asr_model.cfg)
+    print(asr_model.decoding)
+    print(asr_model.decoding.decoding)
+    print(asr_model.decoding.decoding._blank_index)
+    print(asr_model.decoding.decoding._SOS)
+
+    print("num layers", asr_model.decoder.pred_rnn_layers)
+
+    with open("./tokens.txt", "w", encoding="utf-8") as f:
+        for i, s in enumerate(asr_model.joint.vocabulary):
+            f.write(f"{s} {i}\n")
+        f.write(f"<blk> {i+1}\n")
+
+    feat_dim = asr_model.cfg["preprocessor"]["features"]
+    print("feat_dim", feat_dim)
+
+    export_encoder(asr_model, window_size=window_size, window_shift=window_shift)
+    export_decoder(asr_model)
+    export_joiner(
+        asr_model,
+        encoder_dim=asr_model.joint.enc.in_features,
+        decoder_dim=asr_model.joint.pred.in_features,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/sherpa-onnx/csrc/online-stream.cc
+++ b/sherpa-onnx/csrc/online-stream.cc
@@ -349,8 +349,7 @@ std::vector<float> &OnlineStream::GetParaformerAlphaCache() {
   return impl_->GetParaformerAlphaCache();
 }
 
-void OnlineStream::SetOption(const std::string &key,
-                             const std::string &value) {
+void OnlineStream::SetOption(const std::string &key, const std::string &value) {
   impl_->SetOption(key, value);
 }
 

--- a/sherpa-onnx/csrc/qnn/online-nemo-transducer-model-qnn.cc
+++ b/sherpa-onnx/csrc/qnn/online-nemo-transducer-model-qnn.cc
@@ -22,6 +22,7 @@
 #include <numeric>
 #include <string>
 #include <tuple>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -73,6 +74,48 @@ static int64_t NumElements(const std::vector<int64_t> &shape) {
                          std::multiplies<int64_t>());
 }
 
+// clang-format off
+// Hardcoded prompt dictionary for Nemotron 3.5 ASR.
+// Maps language codes to prompt IDs used by the encoder's prompt_index input.
+// From the model config: default is 'auto' -> 101.
+static const std::unordered_map<std::string, int32_t> &GetPromptDictionary() {
+  static const std::unordered_map<std::string, int32_t> dict = {
+      {"en-US", 0},   {"en", 0},       {"en-GB", 1},    {"enGB", 1},
+      {"es-ES", 2},   {"esES", 2},     {"es-US", 3},    {"es", 3},
+      {"zh-CN", 4},   {"zh-ZH", 4},   {"zh-TW", 5},    {"hi-IN", 6},
+      {"hi", 6},      {"hi-HI", 6},    {"ar-AR", 7},    {"ar", 7},
+      {"fr-FR", 8},   {"fr", 8},       {"de-DE", 9},    {"de", 9},
+      {"ja-JP", 10},  {"ja-JA", 10},   {"ru-RU", 11},   {"ru", 11},
+      {"pt-BR", 12},  {"pt-PT", 13},   {"pt", 13},      {"ko-KR", 14},
+      {"ko", 14},     {"ko-KO", 14},   {"it-IT", 15},   {"it", 15},
+      {"nl-NL", 16},  {"nl", 16},      {"pl-PL", 17},   {"pl", 17},
+      {"tr-TR", 18},  {"tr", 18},      {"uk-UA", 19},   {"uk", 19},
+      {"ro-RO", 20},  {"ro", 20},      {"el-GR", 21},   {"el", 21},
+      {"cs-CZ", 22},  {"cs", 22},      {"hu-HU", 23},   {"hu", 23},
+      {"sv-SE", 24},  {"sv", 24},      {"da-DK", 25},   {"da", 25},
+      {"fi-FI", 26},  {"fi", 26},      {"no-NO", 27},   {"no", 27},
+      {"nb-NO", 103}, {"nb", 103},     {"nn-NO", 104},  {"nn", 104},
+      {"sk-SK", 28},  {"sk", 28},      {"hr-HR", 29},   {"hr", 29},
+      {"bg-BG", 30},  {"bg", 30},      {"lt-LT", 31},   {"lt", 31},
+      {"et-EE", 60},  {"et", 60},      {"lv-LV", 61},   {"lv", 61},
+      {"sl-SI", 62},  {"sl", 62},      {"th-TH", 32},   {"vi-VN", 33},
+      {"id-ID", 34},  {"ms-MY", 35},   {"bn-IN", 36},   {"ur-PK", 37},
+      {"fa-IR", 38},  {"ta-IN", 39},   {"te-IN", 40},   {"mr-IN", 41},
+      {"gu-IN", 42},  {"kn-IN", 43},   {"ml-IN", 44},   {"si-LK", 45},
+      {"ne-NP", 46},  {"km-KH", 47},   {"sw-KE", 48},   {"am-ET", 49},
+      {"ha-NG", 50},  {"zu-ZA", 51},   {"yo-NG", 52},   {"ig-NG", 53},
+      {"af-ZA", 54},  {"rw-RW", 55},   {"so-SO", 56},   {"ny-MW", 57},
+      {"ln-CD", 58},  {"or-KE", 59},   {"he-IL", 64},   {"ku-TR", 65},
+      {"az-AZ", 66},  {"ka-GE", 67},   {"hy-AM", 68},   {"uz-UZ", 69},
+      {"tg-TJ", 70},  {"ky-KG", 71},   {"qu-PE", 80},   {"ay-BO", 81},
+      {"gn-PY", 82},  {"nah-MX", 83},  {"mi-NZ", 96},   {"haw-US", 97},
+      {"sm-WS", 98},  {"to-TO", 99},   {"fr-CA", 100},  {"mt-MT", 102},
+      {"auto", 101},
+  };
+  return dict;
+}
+// clang-format on
+
 }  // namespace
 
 class OnlineNemoTransducerModelQnn::Impl {
@@ -113,8 +156,8 @@ class OnlineNemoTransducerModelQnn::Impl {
   //     cache_last_channel_len: (1,) int32
   //
   //   Outputs:
-  //     encoder_out:              (1, num_encoder_frames, encoder_out_dim) float
-  //     next_cache_last_channel:  (1, 24, 70, 1024) float
+  //     encoder_out:              (1, num_encoder_frames, encoder_out_dim)
+  //     float next_cache_last_channel:  (1, 24, 70, 1024) float
   //     next_cache_last_time:     (1, 24, 1024, 8) float
   //     next_cache_last_channel_len: (1,) int32
   //
@@ -122,7 +165,8 @@ class OnlineNemoTransducerModelQnn::Impl {
   //   We transpose once on output (Transpose012To120) and store in QNN input
   //   format, so no transpose is needed on the next call.
   std::vector<float> RunEncoder(std::vector<float> features, int32_t num_frames,
-                                std::vector<OnlineStreamStateTensor> *states) const {
+                                std::vector<OnlineStreamStateTensor> *states,
+                                int32_t prompt_index) const {
     if (!states) {
       SHERPA_ONNX_LOGE("states pointer is null");
       SHERPA_ONNX_EXIT(-1);
@@ -130,8 +174,8 @@ class OnlineNemoTransducerModelQnn::Impl {
 
     if (states->size() < state_input_names_.size()) {
       SHERPA_ONNX_LOGE("states size %d is less than expected %d",
-                        static_cast<int32_t>(states->size()),
-                        static_cast<int32_t>(state_input_names_.size()));
+                       static_cast<int32_t>(states->size()),
+                       static_cast<int32_t>(state_input_names_.size()));
       SHERPA_ONNX_EXIT(-1);
     }
 
@@ -158,6 +202,11 @@ class OnlineNemoTransducerModelQnn::Impl {
       }
     }
 
+    // Set prompt_index for Nemotron 3.5 ASR models.
+    if (has_prompt_index_ && prompt_index >= 0) {
+      encoder_->SetInputTensorData("prompt_index", &prompt_index, 1);
+    }
+
     encoder_->Run();
 
     std::vector<float> encoder_out =
@@ -174,10 +223,18 @@ class OnlineNemoTransducerModelQnn::Impl {
         if (state_needs_transpose_[i]) {
           const auto &out_shape = state_output_shapes_[i];
           data = Transpose012To120(data.data(), out_shape[1], out_shape[2],
-                                      out_shape[3]);
+                                   out_shape[3]);
         }
         (*states)[i].float_data = std::move(data);
       }
+    }
+
+    // If encoder_out is [1, encoder_out_dim, num_frames], transpose to
+    // [1, num_frames, encoder_out_dim] so that frame t is at
+    // p + t * encoder_out_dim.
+    if (encoder_out_needs_transpose_) {
+      encoder_out = Transpose(encoder_out.data(), encoder_out_dim_,
+                              num_encoder_frames_);
     }
 
     return encoder_out;
@@ -197,8 +254,8 @@ class OnlineNemoTransducerModelQnn::Impl {
   //
   //   Note: h/c input layout (d0, d1, 1) differs from next_h/next_c output
   //   layout (d0, 1, d1), but since one dim is 1 the flat buffer is the same.
-  std::pair<std::vector<float>, std::vector<std::vector<float>>>
-  RunDecoder(int32_t token, std::vector<std::vector<float>> states) const {
+  std::pair<std::vector<float>, std::vector<std::vector<float>>> RunDecoder(
+      int32_t token, std::vector<std::vector<float>> states) const {
     std::lock_guard<std::mutex> lock(mutex_);
 
     if (states.size() < 2) {
@@ -252,9 +309,30 @@ class OnlineNemoTransducerModelQnn::Impl {
   int32_t SubsamplingFactor() const { return subsampling_factor_; }
   const std::string &NormalizationType() const { return normalization_type_; }
 
+  int32_t GetLanguagePromptId(const std::string &language) const {
+    const auto &dict = GetPromptDictionary();
+    if (language.empty()) {
+      return dict.at("auto");
+    }
+    auto it = dict.find(language);
+    if (it != dict.end()) {
+      return it->second;
+    }
+    SHERPA_ONNX_LOGE("Unknown language '%s' for Nemotron 3.5 ASR.",
+                     language.c_str());
+    std::string available;
+    for (const auto &p : dict) {
+      if (!available.empty()) {
+        available += ", ";
+      }
+      available += p.first;
+    }
+    SHERPA_ONNX_LOGE("Available languages: %s", available.c_str());
+    return dict.at("auto");
+  }
+
   std::vector<std::vector<float>> GetDecoderInitState() const {
-    return {std::vector<float>(h_size_, 0.f),
-            std::vector<float>(c_size_, 0.f)};
+    return {std::vector<float>(h_size_, 0.f), std::vector<float>(c_size_, 0.f)};
   }
 
  private:
@@ -277,8 +355,8 @@ class OnlineNemoTransducerModelQnn::Impl {
   }
 
   void ParseContextBinaries() {
-    SplitStringToVector(config_.transducer.qnn_config.context_binary, ",",
-                        true, &context_binaries_);
+    SplitStringToVector(config_.transducer.qnn_config.context_binary, ",", true,
+                        &context_binaries_);
     if (!context_binaries_.empty() && context_binaries_.size() != 3) {
       SHERPA_ONNX_LOGE(
           "There should be 3 files for online parakeet TDT context binary. "
@@ -302,8 +380,7 @@ class OnlineNemoTransducerModelQnn::Impl {
     }
 
     if (config_.debug && ok) {
-      SHERPA_ONNX_LOGE("Saved context binary to '%s'.",
-                        context_binary.c_str());
+      SHERPA_ONNX_LOGE("Saved context binary to '%s'.", context_binary.c_str());
       SHERPA_ONNX_LOGE("Remember to also provide libQnnSystem.so.");
     }
   }
@@ -443,8 +520,9 @@ class OnlineNemoTransducerModelQnn::Impl {
     }
 
     // Identify cache state inputs (cache_last_channel, cache_last_time,
-    // cache_last_channel_len).
+    // cache_last_channel_len) and optional prompt_index.
     state_input_names_.clear();
+    has_prompt_index_ = false;
     for (const auto &name : encoder_->InputTensorNames()) {
       if (name == encoder_input_name_) {
         continue;
@@ -452,6 +530,8 @@ class OnlineNemoTransducerModelQnn::Impl {
       if (name == "cache_last_channel" || name == "cache_last_time" ||
           name == "cache_last_channel_len") {
         state_input_names_.push_back(name);
+      } else if (name == "prompt_index") {
+        has_prompt_index_ = true;
       }
     }
 
@@ -479,8 +559,7 @@ class OnlineNemoTransducerModelQnn::Impl {
     // The ONNX model uses [1, feat_dim, window_size] but the QNN converter
     // changes the layout to [1, window_size, feat_dim].
     auto x_shape = encoder_->TensorShape(encoder_input_name_);
-    if (x_shape.size() != 3 || x_shape[0] != 1 ||
-        x_shape[1] != window_size_) {
+    if (x_shape.size() != 3 || x_shape[0] != 1 || x_shape[1] != window_size_) {
       SHERPA_ONNX_LOGE(
           "The encoder input x should be of shape [1, %d, feat_dim]. "
           "Actual: [1, %d, %d]",
@@ -493,21 +572,6 @@ class OnlineNemoTransducerModelQnn::Impl {
     auto out_shape = encoder_->TensorShape("encoder_out");
     if (out_shape.size() != 3 || out_shape[0] != 1) {
       SHERPA_ONNX_LOGE("The encoder output should be of shape [1, ?, ?]");
-      SHERPA_ONNX_EXIT(-1);
-    }
-
-    encoder_out_dim_ = out_shape[2];
-    num_encoder_frames_ = out_shape[1];
-
-    // Each chunk of window_shift input frames produces num_encoder_frames_
-    // output frames, so the subsampling factor is window_shift /
-    // num_encoder_frames_.
-    subsampling_factor_ = window_shift_ / num_encoder_frames_;
-    if (subsampling_factor_ <= 0) {
-      SHERPA_ONNX_LOGE(
-          "Invalid subsampling factor: %d (window_shift=%d, "
-          "num_encoder_frames=%d)",
-          subsampling_factor_, window_shift_, num_encoder_frames_);
       SHERPA_ONNX_EXIT(-1);
     }
 
@@ -534,16 +598,14 @@ class OnlineNemoTransducerModelQnn::Impl {
       if (needs_transpose) {
         // Validate that the transpose is consistent:
         // input [1, d1, d2, d0] -> output [1, d0, d1, d2]
-        if (in_shape.size() != 4 || out_shape.size() != 4 ||
-            in_shape[0] != 1 || out_shape[0] != 1 ||
-            in_shape[1] != out_shape[2] || in_shape[2] != out_shape[3] ||
-            in_shape[3] != out_shape[1]) {
+        if (in_shape.size() != 4 || out_shape.size() != 4 || in_shape[0] != 1 ||
+            out_shape[0] != 1 || in_shape[1] != out_shape[2] ||
+            in_shape[2] != out_shape[3] || in_shape[3] != out_shape[1]) {
           SHERPA_ONNX_LOGE(
               "Inconsistent cache shapes for '%s': input [%d,%d,%d,%d] "
               "output [%d,%d,%d,%d]",
-              name.c_str(), in_shape[0], in_shape[1], in_shape[2],
-              in_shape[3], out_shape[0], out_shape[1], out_shape[2],
-              out_shape[3]);
+              name.c_str(), in_shape[0], in_shape[1], in_shape[2], in_shape[3],
+              out_shape[0], out_shape[1], out_shape[2], out_shape[3]);
           SHERPA_ONNX_LOGE(
               "Expected: input [1, d1, d2, d0] -> output [1, d0, d1, d2]");
           SHERPA_ONNX_EXIT(-1);
@@ -609,8 +671,7 @@ class OnlineNemoTransducerModelQnn::Impl {
     if (c_shape.size() != 3 || c_shape[0] != num_layers || c_shape[2] != 1) {
       SHERPA_ONNX_LOGE(
           "Expected decoder input 'c' shape [%d, ?, 1]. Actual: [%d, %d, %d]",
-          num_layers,
-          c_shape.size() > 0 ? c_shape[0] : 0,
+          num_layers, c_shape.size() > 0 ? c_shape[0] : 0,
           c_shape.size() > 1 ? c_shape[1] : 0,
           c_shape.size() > 2 ? c_shape[2] : 0);
       SHERPA_ONNX_EXIT(-1);
@@ -632,11 +693,11 @@ class OnlineNemoTransducerModelQnn::Impl {
     if (config_.debug) {
       SHERPA_ONNX_LOGE("decoder input 'y': [1, 1]");
       SHERPA_ONNX_LOGE("decoder input 'h': [%d, 1, %d]", num_layers,
-                        hidden_dim);
+                       hidden_dim);
       SHERPA_ONNX_LOGE("decoder input 'c': [%d, 1, %d]", num_layers,
-                        hidden_dim);
+                       hidden_dim);
       SHERPA_ONNX_LOGE("decoder output 'decoder_out': [1, 1, %d]",
-                        decoder_out_dim_);
+                       decoder_out_dim_);
     }
   }
 
@@ -666,25 +727,55 @@ class OnlineNemoTransducerModelQnn::Impl {
 
     // QNN joiner input shapes: encoder_out = (1, encoder_out_dim, 1),
     // decoder_out = (1, decoder_out_dim, 1)
+    //
+    // Read encoder_out_dim from the joiner input (not from the encoder output)
+    // because the encoder_out shape layout differs between models
     auto encoder_in_shape = joiner_->TensorShape(joiner_encoder_input_name_);
     if (encoder_in_shape.size() != 3 || encoder_in_shape[0] != 1 ||
-        encoder_in_shape[1] != encoder_out_dim_ || encoder_in_shape[2] != 1) {
+        encoder_in_shape[2] != 1) {
       SHERPA_ONNX_LOGE(
-          "The joiner input '%s' should be [1, %d, 1]. Actual: [%d, %d, %d]",
-          joiner_encoder_input_name_.c_str(), encoder_out_dim_,
-          encoder_in_shape[0], encoder_in_shape[1], encoder_in_shape[2]);
+          "The joiner input '%s' should be [1, ?, 1]. Actual: [%d, %d, %d]",
+          joiner_encoder_input_name_.c_str(), encoder_in_shape[0],
+          encoder_in_shape[1], encoder_in_shape[2]);
+      SHERPA_ONNX_EXIT(-1);
+    }
+    encoder_out_dim_ = encoder_in_shape[1];
+
+    // Compute num_encoder_frames from the encoder output shape and
+    // encoder_out_dim (read from the joiner input above).
+    // encoder_out shape differs between models:
+    //   nemotron-speech-streaming-en-0.6b: [1, num_frames, encoder_out_dim]
+    //   nemotron-3.5-asr-streaming-0.6b:  [1, encoder_out_dim, num_frames]
+    // We use encoder_out_dim to determine which dimension is num_frames
+    // and whether the encoder output needs to be transposed.
+    auto enc_out_shape = encoder_->TensorShape("encoder_out");
+    int64_t total = enc_out_shape[1] * enc_out_shape[2];
+    num_encoder_frames_ = static_cast<int32_t>(total / encoder_out_dim_);
+
+    // If encoder_out is [1, encoder_out_dim, num_frames], we need to
+    // transpose it to [1, num_frames, encoder_out_dim] before returning.
+    // If it is [1, num_frames, encoder_out_dim], no transpose needed.
+    encoder_out_needs_transpose_ = (enc_out_shape[1] == encoder_out_dim_);
+
+    subsampling_factor_ = window_shift_ / num_encoder_frames_;
+    if (subsampling_factor_ <= 0) {
+      SHERPA_ONNX_LOGE(
+          "Invalid subsampling factor: %d (window_shift=%d, "
+          "num_encoder_frames=%d)",
+          subsampling_factor_, window_shift_, num_encoder_frames_);
       SHERPA_ONNX_EXIT(-1);
     }
 
     auto decoder_in_shape = joiner_->TensorShape(joiner_decoder_input_name_);
     if (decoder_in_shape.size() != 3 || decoder_in_shape[0] != 1 ||
-        decoder_in_shape[1] != decoder_out_dim_ || decoder_in_shape[2] != 1) {
+        decoder_in_shape[2] != 1) {
       SHERPA_ONNX_LOGE(
-          "The joiner input '%s' should be [1, %d, 1]. Actual: [%d, %d, %d]",
-          joiner_decoder_input_name_.c_str(), decoder_out_dim_,
-          decoder_in_shape[0], decoder_in_shape[1], decoder_in_shape[2]);
+          "The joiner input '%s' should be [1, ?, 1]. Actual: [%d, %d, %d]",
+          joiner_decoder_input_name_.c_str(), decoder_in_shape[0],
+          decoder_in_shape[1], decoder_in_shape[2]);
       SHERPA_ONNX_EXIT(-1);
     }
+    decoder_out_dim_ = decoder_in_shape[1];
 
     auto out_shape = joiner_->TensorShape(joiner_output_name_);
     // The joiner output can be 2D [1, vocab_size] or 4D [1, 1, 1, vocab_size]
@@ -700,13 +791,20 @@ class OnlineNemoTransducerModelQnn::Impl {
     vocab_size_ = out_shape.back();
 
     if (config_.debug) {
-      SHERPA_ONNX_LOGE("joiner input '%s': [1, %d]",
-                        joiner_encoder_input_name_.c_str(), encoder_out_dim_);
-      SHERPA_ONNX_LOGE("joiner input '%s': [1, %d]",
-                        joiner_decoder_input_name_.c_str(), decoder_out_dim_);
+      SHERPA_ONNX_LOGE("encoder_out shape: [%d, %d, %d]", enc_out_shape[0],
+                       enc_out_shape[1], enc_out_shape[2]);
+      SHERPA_ONNX_LOGE("encoder_out_dim: %d, num_encoder_frames: %d, "
+                       "needs_transpose: %d",
+                       encoder_out_dim_, num_encoder_frames_,
+                       encoder_out_needs_transpose_);
+      SHERPA_ONNX_LOGE("subsampling_factor: %d", subsampling_factor_);
+      SHERPA_ONNX_LOGE("joiner input '%s': [1, %d, 1]",
+                       joiner_encoder_input_name_.c_str(), encoder_out_dim_);
+      SHERPA_ONNX_LOGE("joiner input '%s': [1, %d, 1]",
+                       joiner_decoder_input_name_.c_str(), decoder_out_dim_);
       SHERPA_ONNX_LOGE("joiner output '%s': rank %d, vocab_size %d",
-                        joiner_output_name_.c_str(),
-                        static_cast<int32_t>(out_shape.size()), vocab_size_);
+                       joiner_output_name_.c_str(),
+                       static_cast<int32_t>(out_shape.size()), vocab_size_);
     }
   }
 
@@ -740,6 +838,7 @@ class OnlineNemoTransducerModelQnn::Impl {
   int32_t window_size_ = 0;
   int32_t window_shift_ = 0;
   int32_t num_encoder_frames_ = 0;
+  bool encoder_out_needs_transpose_ = false;
   int32_t subsampling_factor_ = 0;
   int32_t feat_dim_ = 0;
   int32_t encoder_out_dim_ = 0;
@@ -748,6 +847,7 @@ class OnlineNemoTransducerModelQnn::Impl {
   int32_t h_size_ = 0;
   int32_t c_size_ = 0;
   std::string normalization_type_;  // "" or "per_feature"
+  bool has_prompt_index_ = false;
 };
 
 OnlineNemoTransducerModelQnn::OnlineNemoTransducerModelQnn(
@@ -768,8 +868,9 @@ OnlineNemoTransducerModelQnn::GetEncoderInitStates() const {
 
 std::vector<float> OnlineNemoTransducerModelQnn::RunEncoder(
     std::vector<float> features, int32_t num_frames,
-    std::vector<OnlineStreamStateTensor> *states) const {
-  return impl_->RunEncoder(std::move(features), num_frames, states);
+    std::vector<OnlineStreamStateTensor> *states, int32_t prompt_index) const {
+  return impl_->RunEncoder(std::move(features), num_frames, states,
+                           prompt_index);
 }
 
 std::pair<std::vector<float>, std::vector<std::vector<float>>>
@@ -813,6 +914,11 @@ int32_t OnlineNemoTransducerModelQnn::SubsamplingFactor() const {
 
 const std::string &OnlineNemoTransducerModelQnn::NormalizationType() const {
   return impl_->NormalizationType();
+}
+
+int32_t OnlineNemoTransducerModelQnn::GetLanguagePromptId(
+    const std::string &language) const {
+  return impl_->GetLanguagePromptId(language);
 }
 
 std::vector<std::vector<float>>

--- a/sherpa-onnx/csrc/qnn/online-nemo-transducer-model-qnn.h
+++ b/sherpa-onnx/csrc/qnn/online-nemo-transducer-model-qnn.h
@@ -27,7 +27,8 @@ class OnlineNemoTransducerModelQnn {
 
   std::vector<float> RunEncoder(std::vector<float> features,
                                 int32_t num_frames,
-                                std::vector<OnlineStreamStateTensor> *states) const;
+                                std::vector<OnlineStreamStateTensor> *states,
+                                int32_t prompt_index = -1) const;
 
   // Run the LSTM decoder.
   //
@@ -49,6 +50,11 @@ class OnlineNemoTransducerModelQnn {
   int32_t DecoderDim() const;
   int32_t SubsamplingFactor() const;
   const std::string &NormalizationType() const;
+
+  // Get the prompt ID for a given language (e.g., "en-US", "zh-CN").
+  // Returns the prompt ID for "auto" for empty or unknown language
+  // (logs warning for unknown).
+  int32_t GetLanguagePromptId(const std::string &language) const;
 
   // Get the initial zero-filled decoder states (e.g., [h, c] for LSTM).
   std::vector<std::vector<float>> GetDecoderInitState() const;

--- a/sherpa-onnx/csrc/qnn/online-recognizer-nemo-transducer-qnn-impl.h
+++ b/sherpa-onnx/csrc/qnn/online-recognizer-nemo-transducer-qnn-impl.h
@@ -6,11 +6,13 @@
 #define SHERPA_ONNX_CSRC_QNN_ONLINE_RECOGNIZER_NEMO_TRANSDUCER_QNN_IMPL_H_
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <memory>
 #include <numeric>
 #include <sstream>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -34,16 +36,8 @@ inline OnlineRecognizerResult ConvertResult(
     float frame_shift_ms, int32_t subsampling_factor, int32_t segment,
     int32_t frames_since_start) {
   OnlineRecognizerResult r;
-
-  // The first token is the initial blank_id_ used to bootstrap the decoder.
-  // Remove it before processing.
-  if (!src.tokens.empty()) {
-    src.tokens.erase(src.tokens.begin());
-  }
-
   r.tokens.reserve(src.tokens.size());
   r.timestamps.reserve(src.timestamps.size());
-  r.ys_probs = std::move(src.ys_probs);
 
   std::string text;
   for (auto i : src.tokens) {
@@ -98,6 +92,7 @@ class OnlineRecognizerNemoTransducerQnnImpl : public OnlineRecognizerImpl {
       sym_ = SymbolTable(config.model_config.tokens, true);
     }
     ValidateBlankId();
+    InitLanguageTagTokenIds();
     SetupFeatConfig();
     InitResultTemplate();
   }
@@ -117,6 +112,7 @@ class OnlineRecognizerNemoTransducerQnnImpl : public OnlineRecognizerImpl {
       sym_ = SymbolTable(mgr, config.model_config.tokens);
     }
     ValidateBlankId();
+    InitLanguageTagTokenIds();
     SetupFeatConfig();
     InitResultTemplate();
   }
@@ -145,11 +141,17 @@ class OnlineRecognizerNemoTransducerQnnImpl : public OnlineRecognizerImpl {
   void DecodeStreams(OnlineStream **ss, int32_t n) const override {
     for (int32_t i = 0; i != n; ++i) {
       auto *s = ss[i];
+
+      // Get prompt index for Nemotron 3.5 ASR.
+      int32_t prompt_index =
+          model_->GetLanguagePromptId(s->GetOption("language"));
+
       std::vector<float> features =
           s->GetFrames(s->GetNumProcessedFrames(), model_->WindowSize());
 
       auto encoder_out = model_->RunEncoder(
-          std::move(features), model_->WindowSize(), &s->GetQnnStates());
+          std::move(features), model_->WindowSize(), &s->GetQnnStates(),
+          prompt_index);
 
       int32_t num_processed = s->GetNumProcessedFrames();
       // Each encoder output frame corresponds to subsampling_factor input
@@ -204,9 +206,18 @@ class OnlineRecognizerNemoTransducerQnnImpl : public OnlineRecognizerImpl {
 
   OnlineRecognizerResult GetResult(OnlineStream *s) const override {
     int32_t frame_shift_ms = 10;
-    auto r = nemo_transducer_qnn_impl::ConvertResult(
-        s->GetQnnResult(), sym_, frame_shift_ms, subsampling_factor_,
-        s->GetCurrentSegment(), s->GetNumFramesSinceStart());
+    const auto &decoder_result = s->GetQnnResult();
+    bool has_language_tag = !language_tag_token_ids_.empty() &&
+                            ContainsLanguageTag(decoder_result);
+    auto r = has_language_tag
+                 ? nemo_transducer_qnn_impl::ConvertResult(
+                       FilterLanguageTags(decoder_result), sym_, frame_shift_ms,
+                       subsampling_factor_, s->GetCurrentSegment(),
+                       s->GetNumFramesSinceStart())
+                 : nemo_transducer_qnn_impl::ConvertResult(
+                       decoder_result, sym_, frame_shift_ms,
+                       subsampling_factor_, s->GetCurrentSegment(),
+                       s->GetNumFramesSinceStart());
     r.text = ApplyInverseTextNormalization(std::move(r.text));
     r.text = ApplyHomophoneReplacer(std::move(r.text));
     return r;
@@ -228,13 +239,11 @@ class OnlineRecognizerNemoTransducerQnnImpl : public OnlineRecognizerImpl {
 
   void Reset(OnlineStream *s) const override {
     const auto &last = s->GetQnnResult();
-    if (!last.tokens.empty() && last.tokens.back() != blank_id_ &&
-        static_cast<int32_t>(last.tokens.size()) > 1) {
+    if (!last.tokens.empty()) {
       s->GetCurrentSegment() += 1;
     }
 
     OnlineTransducerDecoderResultNoOrt r;
-    r.tokens.push_back(blank_id_);
 
     // Carry over decoder states from the last result for warm-up.
     if (!last.states.empty()) {
@@ -286,9 +295,9 @@ class OnlineRecognizerNemoTransducerQnnImpl : public OnlineRecognizerImpl {
   }
 
   void InitResultTemplate() {
-    result_template_.tokens.push_back(blank_id_);
-
     // Run decoder with blank to get the initial decoder_out and states.
+    // Do NOT add blank to tokens — follow the ONNX impl pattern where
+    // r.tokens only contains non-blank tokens.
     auto [decoder_out, next_states] =
         model_->RunDecoder(blank_id_, model_->GetDecoderInitState());
     result_template_.decoder_out = std::move(decoder_out);
@@ -298,6 +307,72 @@ class OnlineRecognizerNemoTransducerQnnImpl : public OnlineRecognizerImpl {
   }
 
  private:
+  static bool IsLanguageTagToken(const std::string &sym) {
+    if (sym.size() < 4 || sym.front() != '<' || sym.back() != '>') {
+      return false;
+    }
+
+    size_t i = 1;
+    int32_t num_lowercase = 0;
+    while (i + 1 < sym.size() && num_lowercase != 3 &&
+           std::islower(static_cast<unsigned char>(sym[i]))) {
+      ++i;
+      ++num_lowercase;
+    }
+
+    if (num_lowercase < 2) {
+      return false;
+    }
+
+    if (i == sym.size() - 1) {
+      return true;
+    }
+
+    if (sym[i] != '-' || i + 3 != sym.size() - 1) {
+      return false;
+    }
+
+    return std::isupper(static_cast<unsigned char>(sym[i + 1])) &&
+           std::isupper(static_cast<unsigned char>(sym[i + 2]));
+  }
+
+  bool ContainsLanguageTag(
+      const OnlineTransducerDecoderResultNoOrt &src) const {
+    for (auto token : src.tokens) {
+      if (language_tag_token_ids_.count(token)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void InitLanguageTagTokenIds() {
+    for (int32_t i = 0; i != sym_.NumSymbols(); ++i) {
+      if (sym_.Contains(i) && IsLanguageTagToken(sym_[i])) {
+        language_tag_token_ids_.insert(i);
+      }
+    }
+  }
+
+  OnlineTransducerDecoderResultNoOrt FilterLanguageTags(
+      const OnlineTransducerDecoderResultNoOrt &src) const {
+    OnlineTransducerDecoderResultNoOrt ans;
+    ans.frame_offset = src.frame_offset;
+    ans.num_trailing_blanks = src.num_trailing_blanks;
+
+    for (size_t i = 0; i != src.tokens.size(); ++i) {
+      if (language_tag_token_ids_.count(src.tokens[i])) {
+        continue;
+      }
+      ans.tokens.push_back(src.tokens[i]);
+      if (i < src.timestamps.size()) {
+        ans.timestamps.push_back(src.timestamps[i]);
+      }
+    }
+
+    return ans;
+  }
+
   OnlineRecognizerConfig config_;
   Endpoint endpoint_;
   std::unique_ptr<OnlineNemoTransducerModelQnn> model_;
@@ -306,6 +381,7 @@ class OnlineRecognizerNemoTransducerQnnImpl : public OnlineRecognizerImpl {
   int32_t blank_id_ = 0;
   int32_t subsampling_factor_ = 8;  // will be overwritten in InitResultTemplate
   OnlineTransducerDecoderResultNoOrt result_template_;
+  std::unordered_set<int64_t> language_tag_token_ids_;
 };
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/qnn/online-recognizer-zipformer-transducer-qnn-impl.h
+++ b/sherpa-onnx/csrc/qnn/online-recognizer-zipformer-transducer-qnn-impl.h
@@ -63,7 +63,6 @@ inline OnlineRecognizerResult ConvertQnnResult(
 
   r.tokens.reserve(src.tokens.size());
   r.timestamps.reserve(src.timestamps.size());
-  r.ys_probs = std::move(src.ys_probs);
 
   std::string text;
   for (auto i : src.tokens) {


### PR DESCRIPTION
See #3671 #3664 

cc @paoloantinori @JulianPscheid

---

See models at
- https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models-qnn-binary-3
- https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models-qnn-3

In the following, we show how to run it on Xiaomi 17 Pro, which has Qualcomm SM8850

---

# Usage

## Download a model (with context binary files)
```
wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models-qnn-binary-3/sherpa-onnx-qnn-SM8850-binary-nemotron-3.5-asr-streaming-0.6b-1120ms.tar.bz2
tar xvf sherpa-onnx-qnn-SM8850-binary-nemotron-3.5-asr-streaming-0.6b-1120ms.tar.bz2
rm sherpa-onnx-qnn-SM8850-binary-nemotron-3.5-asr-streaming-0.6b-1120ms.tar.bz2
```

```
ls -lh sherpa-onnx-qnn-SM8850-binary-nemotron-3.5-asr-streaming-0.6b-1120ms/
total 1271816
-rw-r--r--@  1 fangjun  staff    29M  9 Jul 13:55 decoder.bin
-rw-r--r--@  1 fangjun  staff   583M  9 Jul 13:55 encoder.bin
-rw-r--r--@  1 fangjun  staff    21B  9 Jul 13:55 info.txt
-rw-r--r--@  1 fangjun  staff   9.3M  9 Jul 13:55 joiner.bin
drwxr-xr-x@ 11 fangjun  staff   352B  9 Jul 13:55 test_wavs
-rw-r--r--@  1 fangjun  staff   128K  9 Jul 13:55 tokens.txt
```

## Run it

Please follow https://k2-fsa.github.io/sherpa/onnx/qnn/run-executables-on-your-phone-binary.html

```

./sherpa-onnx \
   --model-type=nemo_transducer \
   --provider=qnn \
   --tokens=./sherpa-onnx-qnn-SM8850-binary-nemotron-3.5-asr-streaming-0.6b-1120ms/tokens.txt \
   --transducer.qnn-backend-lib=./libQnnHtp.so \
   --transducer.qnn-system-lib=./libQnnSystem.so \
   --transducer.qnn-context-binary=./sherpa-onnx-qnn-SM8850-binary-nemotron-3.5-asr-streaming-0.6b-1120ms/encoder.bin,./sherpa-onnx-qnn-SM8850-binary-nemotron-3.5-asr-streaming-0.6b-1120ms/decoder.bin,./sherpa-onnx-qnn-SM8850-binary-nemotron-3.5-asr-streaming-0.6b-1120ms/joiner.bin \
   ./sherpa-onnx-qnn-SM8850-binary-nemotron-3.5-asr-streaming-0.6b-1120ms/test_wavs/de.wav
```

The logs are:
```
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/parse-options.cc:Read:374 ./sherpa-onnx --model-type=nemo_transducer --provider=qnn --tokens=./sherpa-onnx-qnn-SM8850-binary-nemotron-3.5-asr-streaming-0.6b-1120ms/tokens.txt --transducer.qnn-backend-lib=./libQnnHtp.so --transducer.qnn-system-lib=./libQnnSystem.so --transducer.qnn-context-binary=./sherpa-onnx-qnn-SM8850-binary-nemotron-3.5-asr-streaming-0.6b-1120ms/encoder.bin,./sherpa-onnx-qnn-SM8850-binary-nemotron-3.5-asr-streaming-0.6b-1120ms/decoder.bin,./sherpa-onnx-qnn-SM8850-binary-nemotron-3.5-asr-streaming-0.6b-1120ms/joiner.bin ./sherpa-onnx-qnn-SM8850-binary-nemotron-3.5-asr-streaming-0.6b-1120ms/test_wavs/en.wav

OnlineRecognizerConfig(feat_config=FeatureExtractorConfig(sampling_rate=16000, feature_dim=80, low_freq=20, high_freq=-400, dither=0, normalize_samples=True, snip_edges=False), model_config=OnlineModelConfig(transducer=OnlineTransducerModelConfig(encoder="", decoder="", joiner="", qnn_config=QnnConfig(backend_lib="./libQnnHtp.so", context_binary="./sherpa-onnx-qnn-SM8850-binary-nemotron-3.5-asr-streaming-0.6b-1120ms/encoder.bin,./sherpa-onnx-qnn-SM8850-binary-nemotron-3.5-asr-streaming-0.6b-1120ms/decoder.bin,./sherpa-onnx-qnn-SM8850-binary-nemotron-3.5-asr-streaming-0.6b-1120ms/joiner.bin", system_lib="./libQnnSystem.so")), paraformer=OnlineParaformerModelConfig(encoder="", decoder=""), wenet_ctc=OnlineWenetCtcModelConfig(model="", chunk_size=16, num_left_chunks=4), zipformer2_ctc=OnlineZipformer2CtcModelConfig(model=""), nemo_ctc=OnlineNeMoCtcModelConfig(model=""), t_one_ctc=OnlineToneCtcModelConfig(model=""), provider_config=ProviderConfig(device=0, provider="qnn", cuda_config=CudaConfig(cudnn_conv_algo_search=1), trt_config=TensorrtConfig(trt_max_workspace_size=2147483647, trt_max_partition_iterations=10, trt_min_subgraph_size=5, trt_fp16_enable="True", trt_detailed_build_log="False", trt_engine_cache_enable="True", trt_engine_cache_path=".", trt_timing_cache_enable="True", trt_timing_cache_path=".",trt_dump_subgraphs="False" )), tokens="./sherpa-onnx-qnn-SM8850-binary-nemotron-3.5-asr-streaming-0.6b-1120ms/tokens.txt", num_threads=1, warm_up=0, debug=False, model_type="nemo_transducer", modeling_unit="cjkchar", bpe_vocab=""), lm_config=OnlineLMConfig(model="", scale=0.5, lodr_scale=0.01, lodr_fst="", lodr_backoff_id=-1, shallow_fusion=True), endpoint_config=EndpointConfig(rule1=EndpointRule(must_contain_nonsilence=False, min_trailing_silence=2.4, min_utterance_length=0), rule2=EndpointRule(must_contain_nonsilence=True, min_trailing_silence=1.2, min_utterance_length=0), rule3=EndpointRule(must_contain_nonsilence=False, min_trailing_silence=0, min_utterance_length=20)), ctc_fst_decoder_config=OnlineCtcFstDecoderConfig(graph="", max_active=3000), enable_endpoint=True, max_active_paths=4, hotwords_score=1.5, hotwords_file="", decoding_method="greedy_search", blank_penalty=0, temperature_scale=2, rule_fsts="", rule_fars="", reset_encoder=False, hr=HomophoneReplacerConfig(lexicon="", rule_fsts=""))
Start to create recognizer
     0.0ms [WARN   ] QnnDsp <W> Initializing HtpProvider
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/utils.cc:CopyGraphsInfo:548 version: 3
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/utils.cc:CopyGraphsInfo:548 version: 3
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/utils.cc:CopyGraphsInfo:548 version: 3
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
Recognizer created in 6.36714 s
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/features.cc:AcceptWaveformImpl:111 Creating a resampler:
   in_sample_rate: 24000
   output_sample_rate: 16000

./sherpa-onnx-qnn-SM8850-binary-nemotron-3.5-asr-streaming-0.6b-1120ms/test_wavs/en.wav
Number of threads: 1, Elapsed seconds: 1.4, Audio duration (s): 3.8, Real time factor (RTF) = 1.4/3.8 = 0.37
Ask not what your country can do for you.  Ask what you can do for your country
{ "text": "Ask not what your country can do for you.  Ask what you can do for your country", "tokens": [" A", "sk", " not", " what", " your", " c", "ou", "n", "t", "ry", " can", " ", "do", " for", " you", ".", " ", " A", "sk", " what", " you", " can", " ", "do", " for", " your", " c", "ou", "n", "t", "ry"], "timestamps": [0.24, 0.48, 0.72, 0.96, 1.12, 1.20, 1.20, 1.20, 1.28, 1.28, 1.44, 1.60, 1.60, 1.76, 1.92, 2.24, 2.24, 2.40, 2.56, 2.64, 2.80, 2.88, 3.04, 3.04, 3.20, 3.36, 3.52, 3.52, 3.52, 3.60, 3.60], "ys_probs": [], "lm_probs": [], "context_scores": [], "segment": 0, "words": [], "start_time": 0.00, "is_final": false, "is_eof": false}

     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new export workflows for the Nemotron streaming ASR model, including per-chunk processing and QNN packaging.
  * Added tooling to generate, export, and validate ONNX/QNN model artifacts for streaming ASR.
  * Expanded QNN recognition support for language-specific prompts and streaming model handling.

* **Bug Fixes**
  * Improved model export stability with stricter dependency versions and updated setup steps.
  * Updated result handling to better preserve timestamps and filter language-tag tokens in recognition output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->