### PR TITLE
Fix build warnings

### DIFF
--- a/.github/workflows/run-python-test.yaml
+++ b/.github/workflows/run-python-test.yaml
@@ -37,19 +37,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-24.04
+          - os: ubuntu-latest
             python-version: "3.8"
-          - os: ubuntu-24.04
+          - os: ubuntu-latest
             python-version: "3.9"
 
-          - os: ubuntu-24.04
+          - os: ubuntu-latest
             python-version: "3.10"
-          - os: ubuntu-24.04
+          - os: ubuntu-latest
             python-version: "3.11"
-          - os: ubuntu-24.04
+          - os: ubuntu-latest
             python-version: "3.12"
-          - os: ubuntu-24.04
+          - os: ubuntu-latest
             python-version: "3.13"
+          - os: ubuntu-latest
+            python-version: "3.14"
 
     steps:
       - uses: actions/checkout@v4

--- a/cmake/openfst.cmake
+++ b/cmake/openfst.cmake
@@ -3,17 +3,17 @@
 function(download_openfst)
   include(FetchContent)
 
-  set(openfst_URL  "https://github.com/csukuangfj/openfst/archive/refs/tags/v1.8.5-2026-04-11.tar.gz")
-  set(openfst_HASH "SHA256=57fbc4b950ae81b1a0e1e298af15652da968a6723a592b7874e9b4027a80a5b4")
+  set(openfst_URL  "https://github.com/csukuangfj/openfst/archive/ae4c5f0e416e9ed2db1044d9396e1f60a1ae5f7e.zip")
+  set(openfst_HASH "SHA256=0a78698ec4b23f7ce1d2053cfe23b2b8c43df69c649fcd46481ad4fb62f40070")
 
   # If you don't have access to the Internet,
   # please pre-download it
   set(possible_file_locations
-    $ENV{HOME}/Downloads/openfst-1.8.5-2026-04-11.tar.gz
-    ${CMAKE_SOURCE_DIR}/openfst-1.8.5-2026-04-11.tar.gz
-    ${CMAKE_BINARY_DIR}/openfst-1.8.5-2026-04-11.tar.gz
-    /tmp/openfst-1.8.5-2026-04-11.tar.gz
-    /star-fj/fangjun/download/github/openfst-1.8.5-2026-04-11.tar.gz
+    $ENV{HOME}/Downloads/openfst-ae4c5f0e416e9ed2db1044d9396e1f60a1ae5f7e.zip
+    ${CMAKE_SOURCE_DIR}/openfst-ae4c5f0e416e9ed2db1044d9396e1f60a1ae5f7e.zip
+    ${CMAKE_BINARY_DIR}/openfst-ae4c5f0e416e9ed2db1044d9396e1f60a1ae5f7e.zip
+    /tmp/openfst-ae4c5f0e416e9ed2db1044d9396e1f60a1ae5f7e.zip
+    /star-fj/fangjun/download/github/openfst-ae4c5f0e416e9ed2db1044d9396e1f60a1ae5f7e.zip
   )
 
   foreach(f IN LISTS possible_file_locations)

--- a/cmake/openfst.cmake
+++ b/cmake/openfst.cmake
@@ -3,17 +3,17 @@
 function(download_openfst)
   include(FetchContent)
 
-  set(openfst_URL  "https://github.com/csukuangfj/openfst/archive/ae4c5f0e416e9ed2db1044d9396e1f60a1ae5f7e.zip")
-  set(openfst_HASH "SHA256=0a78698ec4b23f7ce1d2053cfe23b2b8c43df69c649fcd46481ad4fb62f40070")
+  set(openfst_URL  "https://github.com/csukuangfj/openfst/archive/refs/tags/v1.8.5-2026-07-09.tar.gz")
+  set(openfst_HASH "SHA256=2ff712a32952fcb01d351121a6bc8ccf4fdc6b2aa06ce8df2b3095dedd518c0e")
 
   # If you don't have access to the Internet,
   # please pre-download it
   set(possible_file_locations
-    $ENV{HOME}/Downloads/openfst-ae4c5f0e416e9ed2db1044d9396e1f60a1ae5f7e.zip
-    ${CMAKE_SOURCE_DIR}/openfst-ae4c5f0e416e9ed2db1044d9396e1f60a1ae5f7e.zip
-    ${CMAKE_BINARY_DIR}/openfst-ae4c5f0e416e9ed2db1044d9396e1f60a1ae5f7e.zip
-    /tmp/openfst-ae4c5f0e416e9ed2db1044d9396e1f60a1ae5f7e.zip
-    /star-fj/fangjun/download/github/openfst-ae4c5f0e416e9ed2db1044d9396e1f60a1ae5f7e.zip
+    $ENV{HOME}/Downloads/openfst-1.8.5-2026-07-09.tar.gz
+    ${CMAKE_SOURCE_DIR}/openfst-1.8.5-2026-07-09.tar.gz
+    ${CMAKE_BINARY_DIR}/openfst-1.8.5-2026-07-09.tar.gz
+    /tmp/openfst-1.8.5-2026-07-09.tar.gz
+    /star-fj/fangjun/download/github/openfst-1.8.5-2026-07-09.tar.gz
   )
 
   foreach(f IN LISTS possible_file_locations)


### PR DESCRIPTION
Fix the following build warnings:
```
[ 24%] Building CXX object sherpa-onnx/csrc/CMakeFiles/sherpa-onnx-core.dir/offline-stream.cc.o
[ 24%] Building CXX object sherpa-onnx/csrc/CMakeFiles/sherpa-onnx-core.dir/offline-transducer-greedy-search-decoder.cc.o
In file included from /Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/offline-recognizer-impl.cc:25:
/Users/fangjun/open-source/sherpa-onnx/build-android-arm64-v8a/_deps/openfst-src/src/include/fst/extensions/far/far.h:283:66: warning: 'Open' is deprecated: Use OpenWithStatus in
stead. [-Wdeprecated-declarations]
        fst::WrapUnique(STTableReader<Fst<Arc>, FstReader<Arc>>::Open(source));
                                                                 ^
/Users/fangjun/open-source/sherpa-onnx/build-android-arm64-v8a/_deps/openfst-src/src/include/fst/extensions/far/far.h:492:35: note: in instantiation of member function 'fst::STTa
bleFarReader<fst::ArcTpl<fst::TropicalWeightTpl<float>, int, int>>::Open' requested here
    return STTableFarReader<Arc>::Open(source);
                                  ^
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/offline-recognizer-impl.cc:839:40: note: in instantiation of member function 'fst::FarReader<fst::ArcTpl<fst::TropicalWeig
htTpl<float>, int, int>>::Open' requested here
          fst::FarReader<fst::StdArc>::Open(f));
                                       ^
/Users/fangjun/open-source/sherpa-onnx/build-android-arm64-v8a/_deps/openfst-src/src/include/fst/extensions/far/sttable.h:152:5: note: 'Open' has been explicitly marked deprecate
d here
  [[deprecated("Use OpenWithStatus instead.")]]
    ^
[ 25%] Building CXX object sherpa-onnx/csrc/CMakeFiles/sherpa-onnx-core.dir/offline-transducer-greedy-search-nemo-decoder.cc.o
[ 25%] Building CXX object sherpa-onnx/csrc/CMakeFiles/sherpa-onnx-core.dir/offline-transducer-model.cc.o
[ 25%] Building CXX object sherpa-onnx/csrc/CMakeFiles/sherpa-onnx-core.dir/offline-transducer-modified-beam-search-decoder.cc.o
[ 27%] Building CXX object sherpa-onnx/csrc/CMakeFiles/sherpa-onnx-core.dir/online-ctc-fst-decoder.cc.o
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the Python test matrix to include the latest supported Python release and broadened the runner environment.
* **Chores**
  * Refreshed a bundled third-party download to a newer dated release and updated the associated fallback lookup paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->