### PR TITLE
Fix ScaleSilence copying past the pause interval when scale > 1

### DIFF
--- a/sherpa-onnx/csrc/offline-tts.cc
+++ b/sherpa-onnx/csrc/offline-tts.cc
@@ -79,10 +79,21 @@ GeneratedAudio GeneratedAudio::ScaleSilence(float scale) const {
     ans.samples.insert(ans.samples.end(), samples.begin() + i,
                        samples.begin() + interval.start);
     i = interval.end;
-    int32_t n = static_cast<int32_t>((interval.end - interval.start) * scale);
+    int32_t len = interval.end - interval.start;
+    int32_t n = static_cast<int32_t>(len * scale);
 
-    ans.samples.insert(ans.samples.end(), samples.begin() + interval.start,
-                       samples.begin() + interval.start + n);
+    if (n <= len) {
+      ans.samples.insert(ans.samples.end(), samples.begin() + interval.start,
+                         samples.begin() + interval.start + n);
+    } else {
+      // scale > 1: copying n samples from interval.start would run past the
+      // end of the pause into the following speech (audible as a repeated
+      // word onset) and can read out of bounds on the final interval.
+      // Copy the pause once, then extend it with silence.
+      ans.samples.insert(ans.samples.end(), samples.begin() + interval.start,
+                         samples.begin() + interval.end);
+      ans.samples.insert(ans.samples.end(), n - len, 0.0f);
+    }
   }
 
   if (i < num_samples) {


### PR DESCRIPTION
`GeneratedAudio::ScaleSilence()` lengthens each detected pause by copying
`n = (interval.end - interval.start) * scale` samples starting at `interval.start`:

```cpp
int32_t n = static_cast<int32_t>((interval.end - interval.start) * scale);

ans.samples.insert(ans.samples.end(), samples.begin() + interval.start,
                   samples.begin() + interval.start + n);
```

When `scale > 1`, `n` exceeds the length of the interval, so the copy runs past
the end of the pause. Three consequences:

1. **The following word's onset is duplicated into the pause.** Audible as a
   stutter after every pause.
2. **Out-of-bounds read on a trailing pause.** If the last interval runs to the
   end of the buffer then `interval.end == num_samples`, and
   `samples.begin() + interval.start + n` is past `samples.end()`.
3. **The pause is not lengthened at all** in that trailing case — the requested
   scaling silently does not happen.

Copying the pause once and padding with zeros gives the intended behaviour. For
`scale <= 1` nothing changes, and `scale == 1` still returns early before
reaching this code.

## Measured

Built at `97293f0`, Kokoro `kokoro-multi-lang-v1_0`, `--sid=10`, text
`"First sentence here. Second sentence follows. Third one ends it."`

Same binary before and after the patch, `--tts-silence-scale=2.0`, compared
against the `--tts-silence-scale=1.0` output as reference (scale 1 returns early,
so it is unscaled ground truth). Counting samples above the same `0.01` threshold
`ScaleSilence` itself uses to detect silence:

| Output | samples > 0.01 | vs reference |
|--------|----------------|--------------|
| reference, `scale=1.0` | 58996 | — |
| **unpatched**, `scale=2.0` | **87375** | **+28379** |
| patched, `scale=2.0` | 59098 | +102 |

The unpatched build invents **28379 speech-like samples — 1.18 s of audio** that
the reference does not contain. That is duplicated speech pasted into the pauses.
The patched build adds silence only; the +102 residue is boundary rounding.

Applying the same pause detector to the outputs is another way to see it: the
reference has 4 pauses and the patched output has 4, but the unpatched output
reports **7** — the duplicated words split each pause into two.

The out-of-bounds read (2) follows by construction from
`interval.end == num_samples`; it was not separately exercised under a sanitizer.

## Reproducing

```bash
sherpa-onnx-offline-tts \
  --kokoro-model=model.onnx --kokoro-voices=voices.bin \
  --kokoro-tokens=tokens.txt --kokoro-data-dir=espeak-ng-data \
  --kokoro-lexicon=lexicon-us-en.txt \
  --sid=10 --tts-silence-scale=2.0 \
  --output-filename=out.wav \
  "First sentence here. Second sentence follows. Third one ends it."
```

The onset of each sentence is audibly repeated inside the pause preceding it.

---

Checked with `clang-format --dry-run --Werror` using the repo's own
`.clang-format`; it reports no changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text-to-speech pause scaling when increasing silence duration.
  * Prevented speech audio from being incorrectly included in extended pauses.
  * Ensured longer pauses are filled with silence for cleaner, more accurate audio output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->