### PR TITLE
Guard ScaleSilence against invalid silence scales

### DIFF
--- a/sherpa-onnx/csrc/offline-tts.cc
+++ b/sherpa-onnx/csrc/offline-tts.cc
@@ -35,6 +35,17 @@ GeneratedAudio GeneratedAudio::ScaleSilence(float scale) const {
   if (scale == 1) {
     return *this;
   }
+
+  // scale is used to shorten long pauses, so it is normally within (0, 1).
+  // Values outside this range are rejected: n below is computed as
+  // interval_length * scale and converted to an int32_t, and NaN, infinity or
+  // a very large scale make that conversion undefined. Note that any
+  // comparison with NaN is false, so NaN is rejected here as well.
+  if (!(scale >= 0.01f && scale <= 2.0f)) {
+    SHERPA_ONNX_LOGE("Silence scale %f is not in [0.01, 2]. Skip scaling.",
+                     scale);
+    return *this;
+  }
   // if the interval is larger than 0.2 second, then we assume it is a pause
   int32_t threshold = static_cast<int32_t>(sample_rate * 0.2);
 


### PR DESCRIPTION
Follow-up to #3744. A [review comment](https://github.com/k2-fsa/sherpa-onnx/pull/3744#discussion_r3555824716) on that PR pointed out that a
negative or NaN `scale` could produce a negative `n`. It was **partly correct**:
there is undefined behaviour here, but not quite where it said, and the
suggested fix would not have removed it.

## What is actually wrong

`ScaleSilence` computes

```cpp
int32_t n = static_cast<int32_t>(len * scale);
```

Converting NaN or infinity to `int32_t` is undefined, and a finite but very
large `scale` overflows the conversion. All three abort the process today:

```
--tts-silence-scale=nan   terminate called after throwing 'std::length_error'
--tts-silence-scale=inf   terminate called after throwing 'std::length_error'
--tts-silence-scale=1e9   terminate called after throwing 'std::length_error'
```

The bot suggested clamping `n` to `0` *after* the cast. That would not help:
the undefined behaviour is *at* the cast, so NaN and infinity still get through,
and it does not address overflow at all.

**Negative values are already handled.** `OfflineTtsConfig::Validate()` requires
`silence_scale >= 0.001` and the CLI calls it, so `--tts-silence-scale=-1` is
rejected cleanly. But:

- `NaN < 0.001` is `false`, so **NaN passes `Validate()`**.
- Callers of the `Generate` API pass `GeneratedAudioConfig::silence_scale`
  directly and **bypass `Validate()` entirely**.

## The change

Reject any scale outside `[0.01, 2]`, log, and return the audio unscaled rather
than aborting.

_Edited after review: the merged version uses the single range check
@csukuangfj suggested, not the guard originally proposed here. Note that
`scale == 0` is now rejected too; it was already unreachable from the CLI, since
`Validate()` requires `silence_scale >= 0.001`, but a caller of the `Generate`
API could previously pass `0` to remove pauses._

## Before / after

Same build, `kokoro-multi-lang-v1_0`, `--sid=10`,
`"First sentence here. Second sentence follows."`

| `--tts-silence-scale` | before | after |
|---|---|---|
| `nan`  | **abort** (`std::length_error`) | logs, returns unscaled audio |
| `inf`  | **abort** (`std::length_error`) | logs, returns unscaled audio |
| `1e9`  | **abort** (`std::length_error`) | logs, returns unscaled audio |
| `-inf` | rejected by `Validate()` | rejected by `Validate()` |
| `-1`   | rejected by `Validate()` | rejected by `Validate()` |
| `2.0`  | scaled | scaled (unchanged) |
| `1.0`  | early return | early return (unchanged) |

Checked with `clang-format --dry-run --Werror` using the repo's own
`.clang-format`; it reports no changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for audio silence scaling.
  * Prevented invalid (negative, NaN/∞, or out-of-range) scaling values from modifying generated audio.
  * Audio remains unchanged when an invalid scale is provided, with an error logged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
