### PR TITLE
Align the silence scale range between Validate() and ScaleSilence

### DIFF
--- a/sherpa-onnx/csrc/offline-tts.cc
+++ b/sherpa-onnx/csrc/offline-tts.cc
@@ -31,19 +31,26 @@ struct SilenceInterval {
   int32_t end;
 };
 
+// Supported range for --tts-silence-scale. The lower bound keeps a pause from
+// collapsing to nothing; the upper bound is a sanity limit, far below the
+// value at which interval_length * scale would overflow an int32_t.
+static constexpr float kMinSilenceScale = 0.01f;
+static constexpr float kMaxSilenceScale = 10.0f;
+
 GeneratedAudio GeneratedAudio::ScaleSilence(float scale) const {
   if (scale == 1) {
     return *this;
   }
 
-  // scale is used to shorten long pauses, so it is normally within (0, 1).
-  // Values outside this range are rejected: n below is computed as
-  // interval_length * scale and converted to an int32_t, and NaN, infinity or
-  // a very large scale make that conversion undefined. Note that any
-  // comparison with NaN is false, so NaN is rejected here as well.
-  if (!(scale >= 0.01f && scale <= 2.0f)) {
-    SHERPA_ONNX_LOGE("Silence scale %f is not in [0.01, 2]. Skip scaling.",
-                     scale);
+  // scale is normally within (0, 1), since it is used to shorten long pauses,
+  // but scaling a pause up is also useful. Values outside the supported range
+  // are rejected: n below is computed as interval_length * scale and converted
+  // to an int32_t, and NaN, infinity or a very large scale make that
+  // conversion undefined. Note that any comparison with NaN is false, so NaN
+  // is rejected here as well.
+  if (!(scale >= kMinSilenceScale && scale <= kMaxSilenceScale)) {
+    SHERPA_ONNX_LOGE("Silence scale %f is not in [%.2f, %.2f]. Skip scaling.",
+                     scale, kMinSilenceScale, kMaxSilenceScale);
     return *this;
   }
   // if the interval is larger than 0.2 second, then we assume it is a pause
@@ -195,7 +202,7 @@ void OfflineTtsConfig::Register(ParseOptions *po) {
 
   po->Register("tts-silence-scale", &silence_scale,
                "Duration of the pause is scaled by this number. So a smaller "
-               "value leads to a shorter pause.");
+               "value leads to a shorter pause. Must be in [0.01, 10].");
 }
 
 bool OfflineTtsConfig::Validate() const {
@@ -221,8 +228,10 @@ bool OfflineTtsConfig::Validate() const {
     }
   }
 
-  if (silence_scale < 0.001) {
-    SHERPA_ONNX_LOGE("--tts-silence-scale '%.3f' is too small", silence_scale);
+  if (!(silence_scale >= kMinSilenceScale &&
+        silence_scale <= kMaxSilenceScale)) {
+    SHERPA_ONNX_LOGE("--tts-silence-scale '%.3f' is not in [%.2f, %.2f]",
+                     silence_scale, kMinSilenceScale, kMaxSilenceScale);
     return false;
   }
 


### PR DESCRIPTION
Follow-up to #3745, from a review comment on it.

After #3745, `ScaleSilence` accepts `[0.01, 2]`, but `OfflineTtsConfig::Validate()`
still only rejects `silence_scale < 0.001`. So `--tts-silence-scale=0.005` or `=5`
passes validation and is then silently skipped at run time: the user asks for
scaling and gets unscaled audio back, with only a log line.

This puts both checks on one pair of constants, documents the range in the
`--tts-silence-scale` help text, and makes bad input fail before synthesis rather
than after it. The check inside `ScaleSilence` stays, because callers of the
`Generate` API pass `GeneratedAudioConfig::silence_scale` directly and bypass
`Validate()`.

## One question: should the upper bound be 2, or higher?

I raised it to **10** here. Happy to change it back to 2 — it is a one-line
revert, and it is your call.

The reason to raise it: nothing breaks until far higher. Overflow of the
`int32_t` conversion needs `pause_length * scale > 2^31`, which for a 1 s pause at
24 kHz means a scale around **89000**, and for a 5 s pause around **17900**. At
`scale = 10` a 1 s pause becomes 10 s, which is 1 MB of float32. Only NaN,
infinity and negative values are actually dangerous, and those are rejected
regardless of where the ceiling sits.

`2` also rules out reasonable uses of scaling a pause *up* — long dramatic pauses
in an audiobook, say. For comparison, `speed` has no upper bound at all, only
`speed <= 0` is rejected.

If you prefer to keep the tighter limit, say so and I will set both constants
back to 2.

## Verified

Built and run against `kokoro-multi-lang-v1_0`.

| `--tts-silence-scale` | before | after |
|---|---|---|
| `0.0099` | passes `Validate()`, then silently skipped | rejected by `Validate()` |
| `0.01` | scaled | scaled |
| `2.0` | scaled | scaled |
| `2.001` | passes `Validate()`, then silently skipped | scaled |
| `10` | passes `Validate()`, then silently skipped | scaled |
| `10.001` | passes `Validate()`, then silently skipped | rejected by `Validate()` |
| `0`, `-1`, `nan`, `inf`, `1e9` | `Validate()` catches `0`/`-1`; `nan`/`inf`/`1e9` skipped in `ScaleSilence` | all rejected by `Validate()` |

`scale = 10` produces 19.25 s from a 4.17 s clip, and the count of samples above
the 0.01 silence threshold is unchanged (`-1`), so the added audio is silence.

Checked with `clang-format --dry-run --Werror`; no changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded validation for the TTS silence scaling option.
  * Values must now fall within the supported range of 0.01 to 10, with clearer error messages for invalid settings.
  * Updated option guidance to reflect the valid range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->