### PR TITLE
Fix process abort when espeak-ng rejects the voice (e.g. invalid --kokoro-lang)

### DIFF
--- a/sherpa-onnx/csrc/piper-phonemize-lexicon.cc
+++ b/sherpa-onnx/csrc/piper-phonemize-lexicon.cc
@@ -4,6 +4,7 @@
 
 #include "sherpa-onnx/csrc/piper-phonemize-lexicon.h"
 
+#include <exception>
 #include <fstream>
 #include <locale>
 #include <map>
@@ -63,10 +64,20 @@ void CallPhonemizeEspeak(const std::string &text,
                          std::vector<std::vector<piper::Phoneme>> *phonemes) {
   static std::mutex espeak_mutex;
 
+  // keep multi threads from calling into piper::phonemize_eSpeak
   std::lock_guard<std::mutex> lock(espeak_mutex);
 
-  // keep multi threads from calling into piper::phonemize_eSpeak
-  piper::phonemize_eSpeak(text, config, *phonemes);
+  try {
+    piper::phonemize_eSpeak(text, config, *phonemes);
+  } catch (const std::exception &ex) {
+    // piper::phonemize_eSpeak() throws if espeak-ng does not recognize
+    // config.voice, e.g., when a user passes an unsupported --kokoro-lang.
+    // Return no phonemes so that the caller fails the generation instead
+    // of the uncaught exception terminating the whole process.
+    SHERPA_ONNX_LOGE("Failed to phonemize '%s' with espeak-ng voice '%s': %s",
+                     text.c_str(), config.voice.c_str(), ex.what());
+    phonemes->clear();
+  }
 }
 
 static std::unordered_map<char32_t, int32_t> ReadTokens(std::istream &is) {


### PR DESCRIPTION
### Problem

An unsupported `--kokoro-lang` value kills the whole process:

```
$ sherpa-onnx-offline-tts \
    --kokoro-model=./kokoro-multi-lang-v1_0/model.onnx \
    ... \
    --kokoro-lang=en-gb --sid=21 --output-filename=/tmp/t.wav "test"

terminate called after throwing an instance of 'std::runtime_error'
  what():  Failed to set eSpeak-ng voice
Aborted (core dumped)
```

Easy to hit innocently: the espeak-ng data in `kokoro-multi-lang-v1_0` has `en-GB-x-rp`, `en-GB-scotland` etc., but no plain `en-GB` — so asking for British English dumps core, after the model has already been loaded.

### Cause

- `piper::phonemize_eSpeak()` throws `std::runtime_error` when `espeak_SetVoiceByName()` fails (piper-phonemize `src/phonemize.cpp`)
- nothing catches it on the way out of `Generate()`
- for a user of the C/C++ API, the uncaught exception takes the host process down with it

### Fix

Catch it in `CallPhonemizeEspeak()` — the single espeak boundary shared by the kokoro, matcha and piper frontends. Log the text, the voice and the reason, return no phonemes. The callers already handle empty phoneme lists, so generation fails the same way other invalid parameters do:

```
Failed to phonemize 'test' with espeak-ng voice 'en-gb': Failed to set eSpeak-ng voice
Error in generating audio. Please read previous error messages.
```

Exit code 1, no core dump.

### Tested

Linux x86_64, kokoro-multi-lang-v1_0:

- `--kokoro-lang=en-gb`, `--kokoro-lang=xyzzy`: SIGABRT before, clean exit 1 after
- `--kokoro-lang=fr`, `--kokoro-lang=en-GB-x-rp`, default (no lang): unchanged, audio verified

Two notes on scope. `std::exception` is caught rather than only `std::runtime_error`, since anything escaping through this boundary kills the process the same way. And validating the voice name up front (at `Validate()` time, before the model loads) would give an even earlier error but needs espeak initialized first — happy to do that as a follow-up if you think it's worth it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of speech phonemization errors.
  * Prevented unexpected application termination when phonemization fails.
  * Added diagnostic logging with the input text, selected voice, and error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->