### PR TITLE
Add C++ runtime for Moonshine ASR with QNN for Qualcomm NPU

### DIFF
--- a/sherpa-onnx/csrc/CMakeLists.txt
+++ b/sherpa-onnx/csrc/CMakeLists.txt
@@ -261,6 +261,7 @@ if(SHERPA_ONNX_ENABLE_QNN)
     ./qnn/offline-sense-voice-model-qnn.cc
     ./qnn/offline-paraformer-model-qnn.cc
     ./qnn/offline-whisper-model-qnn.cc
+    ./qnn/offline-moonshine-model-qnn.cc
     ./qnn/offline-zipformer-transducer-model-qnn.cc
     ./qnn/offline-zipformer-ctc-model-qnn.cc
     ./qnn/online-nemo-transducer-model-qnn.cc

--- a/sherpa-onnx/csrc/offline-model-config.cc
+++ b/sherpa-onnx/csrc/offline-model-config.cc
@@ -149,7 +149,9 @@ bool OfflineModelConfig::Validate() const {
     return sense_voice.Validate();
   }
 
-  if (!moonshine.encoder.empty()) {
+  if (!moonshine.encoder.empty() ||
+      !moonshine.decoder.empty() ||
+      !moonshine.qnn_config.context_binary.empty()) {
     return moonshine.Validate();
   }
 

--- a/sherpa-onnx/csrc/offline-moonshine-model-config.cc
+++ b/sherpa-onnx/csrc/offline-moonshine-model-config.cc
@@ -19,18 +19,16 @@ static bool IsQnnModelLibFile(const std::string &filename) {
 
 static bool IsQnnMoonshineArtifact(const OfflineMoonshineModelConfig &config) {
   return IsQnnModelLibFile(config.encoder) ||
-         IsQnnModelLibFile(config.merged_decoder) ||
+         IsQnnModelLibFile(config.decoder) ||
          !config.qnn_config.context_binary.empty();
 }
 
-static bool ValidateQnnContextBinaries(const std::string &context_binary,
-                                       std::vector<std::string> &filenames) {
-  filenames.clear();
-
+static bool ValidateQnnContextBinaries(const std::string &context_binary) {
   if (context_binary.empty()) {
     return true;
   }
 
+  std::vector<std::string> filenames;
   SplitStringToVector(context_binary, ",", true, &filenames);
   if (filenames.size() != 2) {
     SHERPA_ONNX_LOGE(
@@ -49,8 +47,9 @@ void OfflineMoonshineModelConfig::Register(ParseOptions *po) {
       "Path to onnx preprocessor of moonshine v1, e.g., preprocess.onnx");
 
   po->Register("moonshine-encoder", &encoder,
-               "Path to onnx encoder of moonshine v1 or v2, e.g., encode.onnx "
-               "for v1, encoder_model.onnx for v2");
+               "Path to moonshine encoder. Can be an ONNX model (v1 or v2) "
+               "or a QNN model library (*.so) when no context binary is "
+               "provided.");
 
   po->Register("moonshine-uncached-decoder", &uncached_decoder,
                "Path to onnx uncached_decoder of moonshine v1, e.g., "
@@ -61,8 +60,12 @@ void OfflineMoonshineModelConfig::Register(ParseOptions *po) {
       "Path to onnx cached_decoder of moonshine v1, e.g., cached_decode.onnx");
 
   po->Register("moonshine-merged-decoder", &merged_decoder,
-               "Path to onnx merged decoder of moonshine v2, e.g., "
-               "decoder_model_merged.onnx");
+               "Path to moonshine v2 merged decoder ONNX model "
+               "(decoder_model_merged.onnx).");
+
+  po->Register("moonshine-decoder", &decoder,
+               "Path to moonshine decoder for QNN. Can be a model library "
+               "(*.so) when no context binary is provided.");
 
   std::string prefix = "moonshine";
   ParseOptions p(prefix, po);
@@ -73,9 +76,7 @@ bool OfflineMoonshineModelConfig::Validate() const {
   bool uses_qnn = IsQnnMoonshineArtifact(*this);
 
   if (uses_qnn) {
-    std::vector<std::string> context_binaries;
-    if (!ValidateQnnContextBinaries(qnn_config.context_binary,
-                                    context_binaries)) {
+    if (!ValidateQnnContextBinaries(qnn_config.context_binary)) {
       return false;
     }
 
@@ -83,17 +84,30 @@ bool OfflineMoonshineModelConfig::Validate() const {
       return false;
     }
 
-    // When using context binaries, encoder/decoder lib files are not required
-    if (qnn_config.context_binary.empty()) {
-      // Need model lib files if no context binary
+    // Parse context binaries to check each independently
+    std::vector<std::string> context_filenames;
+    if (!qnn_config.context_binary.empty()) {
+      SplitStringToVector(qnn_config.context_binary, ",", true,
+                          &context_filenames);
+    }
+
+    bool has_encoder_context =
+        context_filenames.size() == 2 && FileExists(context_filenames[0]);
+    bool has_decoder_context =
+        context_filenames.size() == 2 && FileExists(context_filenames[1]);
+
+    if (!has_encoder_context) {
       if (encoder.empty()) {
-        SHERPA_ONNX_LOGE("Please provide --moonshine-encoder");
+        SHERPA_ONNX_LOGE(
+            "Please provide --moonshine-encoder or encoder context binary");
         return false;
       }
+    }
 
-      if (merged_decoder.empty()) {
+    if (!has_decoder_context) {
+      if (decoder.empty()) {
         SHERPA_ONNX_LOGE(
-            "Please provide --moonshine-merged-decoder for QNN");
+            "Please provide --moonshine-decoder or decoder context binary");
         return false;
       }
     }
@@ -187,6 +201,7 @@ std::string OfflineMoonshineModelConfig::ToString() const {
   os << "uncached_decoder=\"" << uncached_decoder << "\", ";
   os << "cached_decoder=\"" << cached_decoder << "\", ";
   os << "merged_decoder=\"" << merged_decoder << "\", ";
+  os << "decoder=\"" << decoder << "\", ";
   if (!qnn_config.backend_lib.empty()) {
     os << "qnn_config=" << qnn_config.ToString() << ", ";
   }

--- a/sherpa-onnx/csrc/offline-moonshine-model-config.cc
+++ b/sherpa-onnx/csrc/offline-moonshine-model-config.cc
@@ -5,11 +5,43 @@
 #include "sherpa-onnx/csrc/offline-moonshine-model-config.h"
 
 #include <string>
+#include <vector>
 
 #include "sherpa-onnx/csrc/file-utils.h"
 #include "sherpa-onnx/csrc/macros.h"
+#include "sherpa-onnx/csrc/text-utils.h"
 
 namespace sherpa_onnx {
+
+static bool IsQnnModelLibFile(const std::string &filename) {
+  return EndsWith(filename, ".so");
+}
+
+static bool IsQnnMoonshineArtifact(const OfflineMoonshineModelConfig &config) {
+  return IsQnnModelLibFile(config.encoder) ||
+         IsQnnModelLibFile(config.merged_decoder) ||
+         !config.qnn_config.context_binary.empty();
+}
+
+static bool ValidateQnnContextBinaries(const std::string &context_binary,
+                                       std::vector<std::string> &filenames) {
+  filenames.clear();
+
+  if (context_binary.empty()) {
+    return true;
+  }
+
+  SplitStringToVector(context_binary, ",", true, &filenames);
+  if (filenames.size() != 2) {
+    SHERPA_ONNX_LOGE(
+        "For moonshine with QNN, you should provide 2 context "
+        "binaries separated by commas (encoder,decoder). Given '%s'",
+        context_binary.c_str());
+    return false;
+  }
+
+  return true;
+}
 
 void OfflineMoonshineModelConfig::Register(ParseOptions *po) {
   po->Register(
@@ -31,10 +63,45 @@ void OfflineMoonshineModelConfig::Register(ParseOptions *po) {
   po->Register("moonshine-merged-decoder", &merged_decoder,
                "Path to onnx merged decoder of moonshine v2, e.g., "
                "decoder_model_merged.onnx");
+
+  std::string prefix = "moonshine";
+  ParseOptions p(prefix, po);
+  qnn_config.Register(&p);
 }
 
 bool OfflineMoonshineModelConfig::Validate() const {
-  // both v1 and v2 require a encoder model
+  bool uses_qnn = IsQnnMoonshineArtifact(*this);
+
+  if (uses_qnn) {
+    std::vector<std::string> context_binaries;
+    if (!ValidateQnnContextBinaries(qnn_config.context_binary,
+                                    context_binaries)) {
+      return false;
+    }
+
+    if (!qnn_config.Validate()) {
+      return false;
+    }
+
+    // When using context binaries, encoder/decoder lib files are not required
+    if (qnn_config.context_binary.empty()) {
+      // Need model lib files if no context binary
+      if (encoder.empty()) {
+        SHERPA_ONNX_LOGE("Please provide --moonshine-encoder");
+        return false;
+      }
+
+      if (merged_decoder.empty()) {
+        SHERPA_ONNX_LOGE(
+            "Please provide --moonshine-merged-decoder for QNN");
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  // Non-QNN path: both v1 and v2 require an encoder model
   if (encoder.empty()) {
     SHERPA_ONNX_LOGE("Please provide --moonshine-encoder");
     return false;
@@ -119,7 +186,11 @@ std::string OfflineMoonshineModelConfig::ToString() const {
   os << "encoder=\"" << encoder << "\", ";
   os << "uncached_decoder=\"" << uncached_decoder << "\", ";
   os << "cached_decoder=\"" << cached_decoder << "\", ";
-  os << "merged_decoder=\"" << merged_decoder << "\")";
+  os << "merged_decoder=\"" << merged_decoder << "\", ";
+  if (!qnn_config.backend_lib.empty()) {
+    os << "qnn_config=" << qnn_config.ToString() << ", ";
+  }
+  os << ")";
 
   return os.str();
 }

--- a/sherpa-onnx/csrc/offline-moonshine-model-config.h
+++ b/sherpa-onnx/csrc/offline-moonshine-model-config.h
@@ -28,6 +28,9 @@ struct OfflineMoonshineModelConfig {
 
   std::string merged_decoder;
 
+  // For QNN: path to decoder model lib (*.so) or context binary
+  std::string decoder;
+
   QnnConfig qnn_config;
 
   OfflineMoonshineModelConfig() = default;

--- a/sherpa-onnx/csrc/offline-moonshine-model-config.h
+++ b/sherpa-onnx/csrc/offline-moonshine-model-config.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "sherpa-onnx/csrc/parse-options.h"
+#include "sherpa-onnx/csrc/qnn-config.h"
 
 namespace sherpa_onnx {
 
@@ -26,6 +27,8 @@ struct OfflineMoonshineModelConfig {
   std::string cached_decoder;
 
   std::string merged_decoder;
+
+  QnnConfig qnn_config;
 
   OfflineMoonshineModelConfig() = default;
   OfflineMoonshineModelConfig(const std::string &preprocessor,

--- a/sherpa-onnx/csrc/offline-recognizer-impl.cc
+++ b/sherpa-onnx/csrc/offline-recognizer-impl.cc
@@ -218,6 +218,7 @@ std::unique_ptr<OfflineRecognizerImpl> OfflineRecognizerImpl::Create(
       return std::make_unique<
           OfflineRecognizerWhisperTplImpl<OfflineWhisperModelQnn>>(config);
     } else if (!config.model_config.moonshine.encoder.empty() ||
+               !config.model_config.moonshine.decoder.empty() ||
                !config.model_config.moonshine.qnn_config.context_binary.empty()) {
       return std::make_unique<OfflineRecognizerMoonshineQnnImpl>(config);
     } else {

--- a/sherpa-onnx/csrc/offline-recognizer-impl.cc
+++ b/sherpa-onnx/csrc/offline-recognizer-impl.cc
@@ -74,6 +74,7 @@
 #include "sherpa-onnx/csrc/qnn/offline-recognizer-zipformer-ctc-qnn-impl.h"
 #include "sherpa-onnx/csrc/qnn/offline-sense-voice-model-qnn.h"
 #include "sherpa-onnx/csrc/qnn/offline-whisper-model-qnn.h"
+#include "sherpa-onnx/csrc/qnn/offline-recognizer-moonshine-qnn-impl.h"
 #endif
 
 namespace sherpa_onnx {
@@ -216,11 +217,14 @@ std::unique_ptr<OfflineRecognizerImpl> OfflineRecognizerImpl::Create(
                !config.model_config.whisper.qnn_config.context_binary.empty()) {
       return std::make_unique<
           OfflineRecognizerWhisperTplImpl<OfflineWhisperModelQnn>>(config);
+    } else if (!config.model_config.moonshine.encoder.empty() ||
+               !config.model_config.moonshine.qnn_config.context_binary.empty()) {
+      return std::make_unique<OfflineRecognizerMoonshineQnnImpl>(config);
     } else {
       SHERPA_ONNX_LOGE(
           "Only SenseVoice, Paraformer, Zipformer transducer, Zipformer CTC, "
-          "NeMo CTC (Parakeet), Parakeet TDT, and Whisper models are "
-          "currently supported by QNN for non-streaming ASR.");
+          "NeMo CTC (Parakeet), Parakeet TDT, Whisper, and Moonshine models "
+          "are currently supported by QNN for non-streaming ASR.");
       SHERPA_ONNX_EXIT(-1);
       return nullptr;
     }
@@ -582,11 +586,14 @@ std::unique_ptr<OfflineRecognizerImpl> OfflineRecognizerImpl::Create(
                !config.model_config.whisper.qnn_config.context_binary.empty()) {
       return std::make_unique<
           OfflineRecognizerWhisperTplImpl<OfflineWhisperModelQnn>>(mgr, config);
+    } else if (!config.model_config.moonshine.encoder.empty() ||
+               !config.model_config.moonshine.qnn_config.context_binary.empty()) {
+      return std::make_unique<OfflineRecognizerMoonshineQnnImpl>(mgr, config);
     } else {
       SHERPA_ONNX_LOGE(
           "Only SenseVoice, Paraformer, Zipformer transducer, Zipformer CTC, "
-          "NeMo CTC (Parakeet), Parakeet TDT, and Whisper models are "
-          "currently supported by QNN for non-streaming ASR.");
+          "NeMo CTC (Parakeet), Parakeet TDT, Whisper, and Moonshine models "
+          "are currently supported by QNN for non-streaming ASR.");
       SHERPA_ONNX_EXIT(-1);
       return nullptr;
     }

--- a/sherpa-onnx/csrc/qnn/offline-moonshine-model-qnn.cc
+++ b/sherpa-onnx/csrc/qnn/offline-moonshine-model-qnn.cc
@@ -1,0 +1,452 @@
+// sherpa-onnx/csrc/qnn/offline-moonshine-model-qnn.cc
+//
+// Copyright (c)  2026  Xiaomi Corporation
+
+#include "sherpa-onnx/csrc/qnn/offline-moonshine-model-qnn.h"
+
+#include <algorithm>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#if __ANDROID_API__ >= 9
+#include "android/asset_manager.h"
+#include "android/asset_manager_jni.h"
+#endif
+
+#if __OHOS__
+#include "rawfile/raw_file_manager.h"
+#endif
+
+#include "sherpa-onnx/csrc/file-utils.h"
+#include "sherpa-onnx/csrc/macros.h"
+#include "sherpa-onnx/csrc/math.h"
+#include "sherpa-onnx/csrc/qnn/qnn-backend.h"
+#include "sherpa-onnx/csrc/qnn/qnn-model.h"
+#include "sherpa-onnx/csrc/text-utils.h"
+
+namespace sherpa_onnx {
+
+class OfflineMoonshineModelQnn::Impl {
+ public:
+  explicit Impl(const OfflineModelConfig &config) : config_(config) {
+    InitEncoder();
+    InitDecoder();
+    PostInit();
+  }
+
+  template <typename Manager>
+  Impl(Manager *mgr, const OfflineModelConfig &config) : config_(config) {
+    SHERPA_ONNX_LOGE(
+        "Please copy all files from assets to SD card and set assetManager to "
+        "null");
+    SHERPA_ONNX_EXIT(-1);
+  }
+
+  OfflineMoonshineDecoderResult Run(
+      const std::vector<float> &audio_samples) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    OfflineMoonshineDecoderResult r;
+
+    if (audio_samples.empty()) {
+      return r;
+    }
+
+    // Pad or truncate audio to fixed length
+    std::vector<float> audio = audio_samples;
+    if (static_cast<int32_t>(audio.size()) < max_audio_len_) {
+      audio.resize(max_audio_len_, 0);
+    } else if (static_cast<int32_t>(audio.size()) > max_audio_len_) {
+      SHERPA_ONNX_LOGE(
+          "Input audio length %d is too long. Truncate it to %d samples.",
+          static_cast<int32_t>(audio.size()), max_audio_len_);
+
+      SHERPA_ONNX_LOGE(
+          "Recognition result may be truncated/incomplete. Please select a "
+          "model accepting longer audios or use VAD to cut your audio into "
+          "small chunks.");
+
+      audio.resize(max_audio_len_);
+    }
+
+    // Run encoder
+    RunEncoder(audio);
+
+    // Get cross KV from encoder and transpose for QNN
+    // QNN expects (1, hidden_size, enc_seq_len) instead of (1, enc_seq_len, hidden_size)
+    std::vector<std::vector<float>> cross_kv(num_layers_ * 2);
+    for (int32_t i = 0; i < num_layers_; ++i) {
+      auto cross_k = encoder_model_->GetOutputTensorData(
+          "cross_k_" + std::to_string(i));
+      auto cross_v = encoder_model_->GetOutputTensorData(
+          "cross_v_" + std::to_string(i));
+
+      cross_kv[i * 2] = Transpose(cross_k.data(), enc_seq_len_, hidden_size_);
+      cross_kv[i * 2 + 1] = Transpose(cross_v.data(), enc_seq_len_, hidden_size_);
+    }
+
+    // Initialize self KV cache (pre-allocated, all zeros)
+    // QNN cache shape: (1, hidden_size, max_seq_len)
+    std::vector<float> self_kv(num_layers_ * 2 * self_kv_size_, 0);
+
+    // Initialize mask (all ones = all masked)
+    std::vector<int32_t> mask(mask_size_, 1);
+
+    // Decode loop
+    int32_t offset = 0;
+    int32_t token_id = bos_;
+    std::vector<float> logits;
+
+    // Assume ~15 tokens per second, with safety limit
+    int32_t max_tokens = std::min(mask_size_,
+                                   static_cast<int32_t>(audio_samples.size() / 16000.0 * 15));
+    max_tokens = std::min(max_tokens, mask_size_ - 1);
+
+    while (offset < max_tokens) {
+      logits = RunDecoder(token_id, offset, cross_kv, self_kv.data(), mask);
+
+      token_id = MaxElementIndex(logits.data(), logits.size());
+
+      if (token_id == eos_) {
+        break;
+      }
+
+      r.tokens.push_back(token_id);
+
+      UpdateSelfKvCache(self_kv.data(), offset);
+      mask[offset] = 0;
+      offset += 1;
+    }
+
+    return r;
+  }
+
+  int32_t MaxSeqLen() const { return mask_size_; }
+
+ private:
+  void InitEncoder() {
+    const auto &qnn_config = config_.moonshine.qnn_config;
+
+    encoder_backend_ = std::make_unique<QnnBackend>(qnn_config.backend_lib,
+                                                    config_.debug);
+
+    const auto &context_binary = qnn_config.context_binary;
+
+    std::vector<std::string> binary_filenames;
+    SplitStringToVector(context_binary, ",", true, &binary_filenames);
+
+    std::string encoder_binary;
+    if (binary_filenames.size() >= 1) {
+      encoder_binary = binary_filenames[0];
+    }
+
+    if (!encoder_binary.empty() && FileExists(encoder_binary)) {
+      // Use context binary directly
+      if (config_.debug) {
+        SHERPA_ONNX_LOGE("Init encoder from context binary '%s'",
+                         encoder_binary.c_str());
+      }
+
+      const auto &system_lib = qnn_config.system_lib;
+      encoder_model_ = std::make_unique<QnnModel>(encoder_binary, system_lib,
+                                                   encoder_backend_.get(),
+                                                   BinaryContextTag{},
+                                                   config_.debug);
+    } else {
+      // Need model lib file
+      const auto &encoder_path = config_.moonshine.encoder;
+      if (encoder_path.empty()) {
+        SHERPA_ONNX_LOGE(
+            "Please provide --moonshine-encoder or context binary for encoder");
+        SHERPA_ONNX_EXIT(-1);
+      }
+
+      encoder_backend_->InitContext();
+      encoder_model_ = std::make_unique<QnnModel>(encoder_path,
+                                                   encoder_backend_.get(),
+                                                   config_.debug);
+
+      // Save context binary if path specified but file doesn't exist
+      if (!encoder_binary.empty() && !FileExists(encoder_binary)) {
+        if (config_.debug) {
+          SHERPA_ONNX_LOGE("Saving context binary to '%s'", encoder_binary.c_str());
+        }
+        encoder_model_->SaveBinaryContext(encoder_binary);
+      }
+    }
+  }
+
+  void InitDecoder() {
+    const auto &qnn_config = config_.moonshine.qnn_config;
+
+    decoder_backend_ = std::make_unique<QnnBackend>(qnn_config.backend_lib,
+                                                    config_.debug);
+
+    const auto &context_binary = qnn_config.context_binary;
+
+    std::vector<std::string> binary_filenames;
+    SplitStringToVector(context_binary, ",", true, &binary_filenames);
+
+    std::string decoder_binary;
+    if (binary_filenames.size() >= 2) {
+      decoder_binary = binary_filenames[1];
+    }
+
+    if (!decoder_binary.empty() && FileExists(decoder_binary)) {
+      // Use context binary directly
+      if (config_.debug) {
+        SHERPA_ONNX_LOGE("Init decoder from context binary '%s'",
+                         decoder_binary.c_str());
+      }
+
+      const auto &system_lib = qnn_config.system_lib;
+      decoder_model_ = std::make_unique<QnnModel>(decoder_binary, system_lib,
+                                                   decoder_backend_.get(),
+                                                   BinaryContextTag{},
+                                                   config_.debug);
+    } else {
+      // Need model lib file
+      const auto &decoder_path = config_.moonshine.merged_decoder;
+      if (decoder_path.empty()) {
+        SHERPA_ONNX_LOGE(
+            "Please provide --moonshine-merged-decoder or context binary for decoder");
+        SHERPA_ONNX_EXIT(-1);
+      }
+
+      decoder_backend_->InitContext();
+      decoder_model_ = std::make_unique<QnnModel>(decoder_path,
+                                                   decoder_backend_.get(),
+                                                   config_.debug);
+
+      // Save context binary if path specified but file doesn't exist
+      if (!decoder_binary.empty() && !FileExists(decoder_binary)) {
+        if (config_.debug) {
+          SHERPA_ONNX_LOGE("Saving context binary to '%s'", decoder_binary.c_str());
+        }
+        decoder_model_->SaveBinaryContext(decoder_binary);
+      }
+    }
+  }
+
+  void PostInit() {
+    PostInitEncoder();
+    PostInitDecoder();
+    PreComputeTensorNames();
+  }
+
+  void PostInitEncoder() {
+    // Get encoder input shape: audio (1, max_audio_len)
+    auto audio_shape = encoder_model_->TensorShape("audio");
+    max_audio_len_ = audio_shape[1];
+
+    // Get encoder output shape: cross_k_0 (1, enc_seq_len, hidden_size)
+    auto cross_k_shape = encoder_model_->TensorShape("cross_k_0");
+    enc_seq_len_ = cross_k_shape[1];
+    hidden_size_ = cross_k_shape[2];
+
+    // Count layers from encoder outputs
+    const auto &output_names = encoder_model_->OutputTensorNames();
+    num_layers_ = output_names.size() / 2;
+
+    if (config_.debug) {
+      SHERPA_ONNX_LOGE("max_audio_len_: %d", max_audio_len_);
+      SHERPA_ONNX_LOGE("enc_seq_len_: %d", enc_seq_len_);
+      SHERPA_ONNX_LOGE("hidden_size_: %d", hidden_size_);
+      SHERPA_ONNX_LOGE("num_layers_: %d", num_layers_);
+    }
+  }
+
+  void PostInitDecoder() {
+    // Get decoder input/output info
+    // Inputs: tokens, self_k_0..N, self_v_0..N, cross_k_0..N, cross_v_0..N, offset, mask
+    // Outputs: logits, this_self_k_0..N, this_self_v_0..N
+
+    int32_t expected_inputs = 1 + num_layers_ * 2 + num_layers_ * 2 + 2;
+    int32_t actual_inputs = decoder_model_->InputTensorNames().size();
+    if (actual_inputs != expected_inputs) {
+      SHERPA_ONNX_LOGE("Expected %d decoder inputs, got %d",
+                       expected_inputs, actual_inputs);
+      SHERPA_ONNX_EXIT(-1);
+    }
+
+    // Get mask size
+    auto mask_shape = decoder_model_->TensorShape("mask");
+    mask_size_ = mask_shape[0];
+
+    // Get vocab size from logits
+    auto logits_shape = decoder_model_->TensorShape("logits");
+    vocab_size_ = logits_shape[2];
+
+    // Self KV cache size: max_seq_len * hidden_size
+    // QNN cache shape: (1, hidden_size, max_seq_len)
+    self_kv_size_ = mask_size_ * hidden_size_;
+    self_kv_stride_ = mask_size_;  // stride for the seq dimension
+
+    if (config_.debug) {
+      SHERPA_ONNX_LOGE("mask_size_: %d", mask_size_);
+      SHERPA_ONNX_LOGE("vocab_size_: %d", vocab_size_);
+      SHERPA_ONNX_LOGE("self_kv_size_: %d", self_kv_size_);
+      SHERPA_ONNX_LOGE("self_kv_stride_: %d", self_kv_stride_);
+    }
+  }
+
+  void PreComputeTensorNames() {
+    encoder_cross_k_.resize(num_layers_);
+    encoder_cross_v_.resize(num_layers_);
+    decoder_cross_k_.resize(num_layers_);
+    decoder_cross_v_.resize(num_layers_);
+    decoder_self_k_.resize(num_layers_);
+    decoder_self_v_.resize(num_layers_);
+    decoder_this_self_k_.resize(num_layers_);
+    decoder_this_self_v_.resize(num_layers_);
+
+    for (int32_t i = 0; i < num_layers_; ++i) {
+      std::string index = std::to_string(i);
+
+      encoder_cross_k_[i] = "cross_k_" + index;
+      encoder_cross_v_[i] = "cross_v_" + index;
+
+      decoder_cross_k_[i] = "cross_k_" + index;
+      decoder_cross_v_[i] = "cross_v_" + index;
+      decoder_self_k_[i] = "self_k_" + index;
+      decoder_self_v_[i] = "self_v_" + index;
+
+      decoder_this_self_k_[i] = "this_self_k_" + index;
+      decoder_this_self_v_[i] = "this_self_v_" + index;
+    }
+  }
+
+  void RunEncoder(const std::vector<float> &audio) const {
+    encoder_model_->SetInputTensorData("audio", audio.data(), audio.size());
+    encoder_model_->Run();
+  }
+
+  std::vector<float> RunDecoder(
+      int32_t token, int32_t offset,
+      const std::vector<std::vector<float>> &cross_kv,
+      const float *self_kv_data,
+      const std::vector<int32_t> &mask) const {
+    // Set tokens
+    decoder_model_->SetInputTensorData("tokens", &token, 1);
+
+    // Set self kv cache
+    for (int32_t i = 0; i < num_layers_; ++i) {
+      decoder_model_->SetInputTensorData(decoder_self_k_[i],
+                                         self_kv_data + (i * 2) * self_kv_size_,
+                                         self_kv_size_);
+
+      decoder_model_->SetInputTensorData(decoder_self_v_[i],
+                                         self_kv_data + (i * 2 + 1) * self_kv_size_,
+                                         self_kv_size_);
+    }
+
+    // Set cross kv cache (transposed)
+    for (int32_t i = 0; i < num_layers_; ++i) {
+      decoder_model_->SetInputTensorData(decoder_cross_k_[i],
+                                         cross_kv[i * 2].data(),
+                                         cross_kv[i * 2].size());
+
+      decoder_model_->SetInputTensorData(decoder_cross_v_[i],
+                                         cross_kv[i * 2 + 1].data(),
+                                         cross_kv[i * 2 + 1].size());
+    }
+
+    // Set offset
+    decoder_model_->SetInputTensorData("offset", &offset, 1);
+
+    // Set mask
+    decoder_model_->SetInputTensorData("mask", mask.data(), mask.size());
+
+    // Run decoder
+    decoder_model_->Run();
+
+    // Get logits
+    return decoder_model_->GetOutputTensorData("logits");
+  }
+
+  void UpdateSelfKvCache(float *self_kv_data, int32_t offset) const {
+    for (int32_t i = 0; i < num_layers_; ++i) {
+      // Update self_k
+      auto delta_k = decoder_model_->GetOutputTensorData(decoder_this_self_k_[i]);
+      float *self_k = self_kv_data + (i * 2) * self_kv_size_;
+      for (size_t r = 0; r != delta_k.size(); ++r) {
+        self_k[r * self_kv_stride_ + offset] += delta_k[r];
+      }
+
+      // Update self_v
+      auto delta_v = decoder_model_->GetOutputTensorData(decoder_this_self_v_[i]);
+      float *self_v = self_kv_data + (i * 2 + 1) * self_kv_size_;
+      for (size_t r = 0; r != delta_v.size(); ++r) {
+        self_v[r * self_kv_stride_ + offset] += delta_v[r];
+      }
+    }
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  OfflineModelConfig config_;
+
+  std::unique_ptr<QnnBackend> encoder_backend_;
+  std::unique_ptr<QnnModel> encoder_model_;
+
+  std::unique_ptr<QnnBackend> decoder_backend_;
+  std::unique_ptr<QnnModel> decoder_model_;
+
+  // Dimensions
+  int32_t max_audio_len_ = 0;
+  int32_t enc_seq_len_ = 0;
+  int32_t hidden_size_ = 0;
+  int32_t num_layers_ = 0;
+  int32_t mask_size_ = 0;
+  int32_t vocab_size_ = 0;
+  int32_t self_kv_size_ = 0;
+  int32_t self_kv_stride_ = 0;
+
+  // Pre-computed tensor names
+  std::vector<std::string> encoder_cross_k_;
+  std::vector<std::string> encoder_cross_v_;
+  std::vector<std::string> decoder_cross_k_;
+  std::vector<std::string> decoder_cross_v_;
+  std::vector<std::string> decoder_self_k_;
+  std::vector<std::string> decoder_self_v_;
+  std::vector<std::string> decoder_this_self_k_;
+  std::vector<std::string> decoder_this_self_v_;
+
+  // Special tokens
+  int32_t bos_ = 1;
+  int32_t eos_ = 2;
+};
+
+OfflineMoonshineModelQnn::OfflineMoonshineModelQnn(
+    const OfflineModelConfig &config)
+    : impl_(std::make_unique<Impl>(config)) {}
+
+template <typename Manager>
+OfflineMoonshineModelQnn::OfflineMoonshineModelQnn(
+    Manager *mgr, const OfflineModelConfig &config)
+    : impl_(std::make_unique<Impl>(mgr, config)) {}
+
+OfflineMoonshineModelQnn::~OfflineMoonshineModelQnn() = default;
+
+OfflineMoonshineDecoderResult OfflineMoonshineModelQnn::Run(
+    const std::vector<float> &audio_samples) const {
+  return impl_->Run(audio_samples);
+}
+
+int32_t OfflineMoonshineModelQnn::MaxSeqLen() const {
+  return impl_->MaxSeqLen();
+}
+
+#if __ANDROID_API__ >= 9
+template OfflineMoonshineModelQnn::OfflineMoonshineModelQnn(
+    AAssetManager *mgr, const OfflineModelConfig &config);
+#endif
+
+#if __OHOS__
+template OfflineMoonshineModelQnn::OfflineMoonshineModelQnn(
+    NativeResourceManager *mgr, const OfflineModelConfig &config);
+#endif
+
+}  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/qnn/offline-moonshine-model-qnn.cc
+++ b/sherpa-onnx/csrc/qnn/offline-moonshine-model-qnn.cc
@@ -122,8 +122,6 @@ class OfflineMoonshineModelQnn::Impl {
     return r;
   }
 
-  int32_t MaxSeqLen() const { return mask_size_; }
-
  private:
   void InitEncoder() {
     const auto &qnn_config = config_.moonshine.qnn_config;
@@ -452,10 +450,6 @@ OfflineMoonshineModelQnn::~OfflineMoonshineModelQnn() = default;
 OfflineMoonshineDecoderResult OfflineMoonshineModelQnn::Run(
     const std::vector<float> &audio_samples) const {
   return impl_->Run(audio_samples);
-}
-
-int32_t OfflineMoonshineModelQnn::MaxSeqLen() const {
-  return impl_->MaxSeqLen();
 }
 
 #if __ANDROID_API__ >= 9

--- a/sherpa-onnx/csrc/qnn/offline-moonshine-model-qnn.cc
+++ b/sherpa-onnx/csrc/qnn/offline-moonshine-model-qnn.cc
@@ -78,10 +78,8 @@ class OfflineMoonshineModelQnn::Impl {
     // QNN expects (1, hidden_size, enc_seq_len) instead of (1, enc_seq_len, hidden_size)
     std::vector<std::vector<float>> cross_kv(num_layers_ * 2);
     for (int32_t i = 0; i < num_layers_; ++i) {
-      auto cross_k = encoder_model_->GetOutputTensorData(
-          "cross_k_" + std::to_string(i));
-      auto cross_v = encoder_model_->GetOutputTensorData(
-          "cross_v_" + std::to_string(i));
+      auto cross_k = encoder_model_->GetOutputTensorData(encoder_cross_k_[i]);
+      auto cross_v = encoder_model_->GetOutputTensorData(encoder_cross_v_[i]);
 
       cross_kv[i * 2] = Transpose(cross_k.data(), enc_seq_len_, hidden_size_);
       cross_kv[i * 2 + 1] = Transpose(cross_v.data(), enc_seq_len_, hidden_size_);
@@ -100,8 +98,9 @@ class OfflineMoonshineModelQnn::Impl {
     std::vector<float> logits;
 
     // Assume ~15 tokens per second, with safety limit
+    int32_t active_audio_len = std::min(static_cast<int32_t>(audio.size()), max_audio_len_);
     int32_t max_tokens = std::min(mask_size_,
-                                   static_cast<int32_t>(audio_samples.size() / 16000.0 * 15));
+                                   static_cast<int32_t>(active_audio_len / 16000.0 * 15));
     max_tokens = std::min(max_tokens, mask_size_ - 1);
 
     while (offset < max_tokens) {
@@ -208,10 +207,10 @@ class OfflineMoonshineModelQnn::Impl {
                                                    config_.debug);
     } else {
       // Need model lib file
-      const auto &decoder_path = config_.moonshine.merged_decoder;
+      const auto &decoder_path = config_.moonshine.decoder;
       if (decoder_path.empty()) {
         SHERPA_ONNX_LOGE(
-            "Please provide --moonshine-merged-decoder or context binary for decoder");
+            "Please provide --moonshine-decoder or context binary for decoder");
         SHERPA_ONNX_EXIT(-1);
       }
 
@@ -239,15 +238,27 @@ class OfflineMoonshineModelQnn::Impl {
   void PostInitEncoder() {
     // Get encoder input shape: audio (1, max_audio_len)
     auto audio_shape = encoder_model_->TensorShape("audio");
+    if (audio_shape.size() < 2) {
+      SHERPA_ONNX_LOGE("Invalid encoder audio tensor rank");
+      SHERPA_ONNX_EXIT(-1);
+    }
     max_audio_len_ = audio_shape[1];
 
     // Get encoder output shape: cross_k_0 (1, enc_seq_len, hidden_size)
     auto cross_k_shape = encoder_model_->TensorShape("cross_k_0");
+    if (cross_k_shape.size() < 3) {
+      SHERPA_ONNX_LOGE("Invalid encoder cross_k_0 tensor rank");
+      SHERPA_ONNX_EXIT(-1);
+    }
     enc_seq_len_ = cross_k_shape[1];
     hidden_size_ = cross_k_shape[2];
 
     // Count layers from encoder outputs
     const auto &output_names = encoder_model_->OutputTensorNames();
+    if (output_names.empty() || output_names.size() % 2 != 0) {
+      SHERPA_ONNX_LOGE("Invalid encoder cross-KV output count");
+      SHERPA_ONNX_EXIT(-1);
+    }
     num_layers_ = output_names.size() / 2;
 
     if (config_.debug) {
@@ -273,10 +284,18 @@ class OfflineMoonshineModelQnn::Impl {
 
     // Get mask size
     auto mask_shape = decoder_model_->TensorShape("mask");
+    if (mask_shape.size() < 1) {
+      SHERPA_ONNX_LOGE("Invalid decoder mask tensor rank");
+      SHERPA_ONNX_EXIT(-1);
+    }
     mask_size_ = mask_shape[0];
 
     // Get vocab size from logits
     auto logits_shape = decoder_model_->TensorShape("logits");
+    if (logits_shape.size() < 3) {
+      SHERPA_ONNX_LOGE("Invalid decoder logits tensor rank");
+      SHERPA_ONNX_EXIT(-1);
+    }
     vocab_size_ = logits_shape[2];
 
     // Self KV cache size: max_seq_len * hidden_size

--- a/sherpa-onnx/csrc/qnn/offline-moonshine-model-qnn.h
+++ b/sherpa-onnx/csrc/qnn/offline-moonshine-model-qnn.h
@@ -29,8 +29,6 @@ class OfflineMoonshineModelQnn {
    */
   OfflineMoonshineDecoderResult Run(const std::vector<float> &audio_samples) const;
 
-  int32_t MaxSeqLen() const;
-
  private:
   class Impl;
   std::unique_ptr<Impl> impl_;

--- a/sherpa-onnx/csrc/qnn/offline-moonshine-model-qnn.h
+++ b/sherpa-onnx/csrc/qnn/offline-moonshine-model-qnn.h
@@ -9,7 +9,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/offline-model-config.h"
-#include "sherpa-onnx/csrc/offline-moonshine-greedy-search-decoder.h"
+#include "sherpa-onnx/csrc/offline-moonshine-decoder.h"
 
 namespace sherpa_onnx {
 

--- a/sherpa-onnx/csrc/qnn/offline-moonshine-model-qnn.h
+++ b/sherpa-onnx/csrc/qnn/offline-moonshine-model-qnn.h
@@ -1,0 +1,41 @@
+// sherpa-onnx/csrc/qnn/offline-moonshine-model-qnn.h
+//
+// Copyright (c)  2026  Xiaomi Corporation
+#ifndef SHERPA_ONNX_CSRC_QNN_OFFLINE_MOONSHINE_MODEL_QNN_H_
+#define SHERPA_ONNX_CSRC_QNN_OFFLINE_MOONSHINE_MODEL_QNN_H_
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "sherpa-onnx/csrc/offline-model-config.h"
+#include "sherpa-onnx/csrc/offline-moonshine-greedy-search-decoder.h"
+
+namespace sherpa_onnx {
+
+class OfflineMoonshineModelQnn {
+ public:
+  ~OfflineMoonshineModelQnn();
+
+  explicit OfflineMoonshineModelQnn(const OfflineModelConfig &config);
+
+  template <typename Manager>
+  OfflineMoonshineModelQnn(Manager *mgr, const OfflineModelConfig &config);
+
+  /** Run the model on raw audio samples.
+   *
+   * @param audio_samples float32 audio at 16kHz
+   * @return decoder result with token ids
+   */
+  OfflineMoonshineDecoderResult Run(const std::vector<float> &audio_samples) const;
+
+  int32_t MaxSeqLen() const;
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace sherpa_onnx
+
+#endif  // SHERPA_ONNX_CSRC_QNN_OFFLINE_MOONSHINE_MODEL_QNN_H_

--- a/sherpa-onnx/csrc/qnn/offline-recognizer-moonshine-qnn-impl.h
+++ b/sherpa-onnx/csrc/qnn/offline-recognizer-moonshine-qnn-impl.h
@@ -1,0 +1,87 @@
+// sherpa-onnx/csrc/qnn/offline-recognizer-moonshine-qnn-impl.h
+//
+// Copyright (c)  2026  Xiaomi Corporation
+
+#ifndef SHERPA_ONNX_CSRC_OFFLINE_RECOGNIZER_MOONSHINE_QNN_IMPL_H_
+#define SHERPA_ONNX_CSRC_OFFLINE_RECOGNIZER_MOONSHINE_QNN_IMPL_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "sherpa-onnx/csrc/macros.h"
+#include "sherpa-onnx/csrc/offline-model-config.h"
+#include "sherpa-onnx/csrc/offline-moonshine-decoder.h"
+#include "sherpa-onnx/csrc/offline-recognizer-impl.h"
+#include "sherpa-onnx/csrc/offline-recognizer.h"
+#include "offline-moonshine-model-qnn.h"
+#include "sherpa-onnx/csrc/symbol-table.h"
+
+namespace sherpa_onnx {
+
+// defined in ./offline-recognizer-moonshine-impl.h
+OfflineRecognitionResult Convert(const OfflineMoonshineDecoderResult &src,
+                                 const SymbolTable &sym_table);
+
+class OfflineRecognizerMoonshineQnnImpl : public OfflineRecognizerImpl {
+ public:
+  explicit OfflineRecognizerMoonshineQnnImpl(
+      const OfflineRecognizerConfig &config)
+      : OfflineRecognizerImpl(config),
+        config_(config),
+        symbol_table_(config_.model_config.tokens),
+        model_(std::make_unique<OfflineMoonshineModelQnn>(config.model_config)) {
+    Init();
+  }
+
+  template <typename Manager>
+  OfflineRecognizerMoonshineQnnImpl(Manager *mgr,
+                                    const OfflineRecognizerConfig &config)
+      : OfflineRecognizerImpl(mgr, config),
+        config_(config),
+        symbol_table_(mgr, config_.model_config.tokens),
+        model_(std::make_unique<OfflineMoonshineModelQnn>(mgr,
+                                                          config.model_config)) {
+    Init();
+  }
+
+  void Init() {
+    // tokens.txt is base64 encoded
+    symbol_table_.ApplyBase64Decode();
+  }
+
+  std::unique_ptr<OfflineStream> CreateStream() const override {
+    MoonshineTag tag;
+    return std::make_unique<OfflineStream>(tag);
+  }
+
+  void DecodeStreams(OfflineStream **ss, int32_t n) const override {
+    // batch decoding is not implemented yet
+    for (int32_t i = 0; i != n; ++i) {
+      DecodeStream(ss[i]);
+    }
+  }
+
+  OfflineRecognizerConfig GetConfig() const override { return config_; }
+
+ private:
+  void DecodeStream(OfflineStream *s) const {
+    std::vector<float> audio = s->GetFrames();
+
+    auto result = model_->Run(audio);
+
+    auto r = Convert(result, symbol_table_);
+    r.text = ApplyInverseTextNormalization(std::move(r.text));
+    r.text = ApplyHomophoneReplacer(std::move(r.text));
+    s->SetResult(r);
+  }
+
+ private:
+  OfflineRecognizerConfig config_;
+  SymbolTable symbol_table_;
+  std::unique_ptr<OfflineMoonshineModelQnn> model_;
+};
+
+}  // namespace sherpa_onnx
+
+#endif  // SHERPA_ONNX_CSRC_OFFLINE_RECOGNIZER_MOONSHINE_QNN_IMPL_H_

--- a/sherpa-onnx/csrc/qnn/offline-recognizer-moonshine-qnn-impl.h
+++ b/sherpa-onnx/csrc/qnn/offline-recognizer-moonshine-qnn-impl.h
@@ -39,10 +39,12 @@ class OfflineRecognizerMoonshineQnnImpl : public OfflineRecognizerImpl {
                                     const OfflineRecognizerConfig &config)
       : OfflineRecognizerImpl(mgr, config),
         config_(config),
-        symbol_table_(mgr, config_.model_config.tokens),
-        model_(std::make_unique<OfflineMoonshineModelQnn>(mgr,
-                                                          config.model_config)) {
-    Init();
+        symbol_table_(mgr, config_.model_config.tokens) {
+    SHERPA_ONNX_LOGE(
+        "Moonshine QNN does not support asset manager. "
+        "Please copy all files from assets to SD card and set assetManager to "
+        "null");
+    SHERPA_ONNX_EXIT(-1);
   }
 
   void Init() {


### PR DESCRIPTION
See also #3756

In the following, we demonstrate how to run moonshine-base-zh on Xiaomi 17 Pro with Qualcomm NPU via QNN.

# Download a model (context binary for SM8850)
See https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models-qnn-binary-3

```
wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models-qnn-binary-3/sherpa-onnx-qnn-SM8850-binary-moonshine-base-zh-5s.tar.bz2
tar xvf sherpa-onnx-qnn-SM8850-binary-moonshine-base-zh-5s.tar.bz2
rm sherpa-onnx-qnn-SM8850-binary-moonshine-base-zh-5s.tar.bz2
```

```
ls -lh sherpa-onnx-qnn-SM8850-binary-moonshine-base-zh-5s
total 280832
-rw-r--r--@ 1 fangjun  staff   100M 13 Jul 16:25 decoder.bin
-rw-r--r--@ 1 fangjun  staff    24M 13 Jul 16:25 encoder.bin
-rw-r--r--@ 1 fangjun  staff    44B 13 Jul 16:25 info.txt
drwxr-xr-x@ 3 fangjun  staff    96B 13 Jul 16:25 test_wavs
-rw-r--r--@ 1 fangjun  staff   536K 13 Jul 16:25 tokens.txt
```

# Run it
See https://k2-fsa.github.io/sherpa/onnx/qnn/run-executables-on-your-phone-binary.html

```
./sherpa-onnx-offline \
   --provider=qnn \
   --tokens=./sherpa-onnx-qnn-SM8850-binary-moonshine-base-zh-5s/tokens.txt \
   --moonshine.qnn-backend-lib=./libQnnHtp.so \
   --moonshine.qnn-system-lib=./libQnnSystem.so \
   --moonshine.qnn-context-binary=./sherpa-onnx-qnn-SM8850-binary-moonshine-base-zh-5s/encoder.bin,./sherpa-onnx-qnn-SM8850-binary-moonshine-base-zh-5s/decoder.bin \
   ./sherpa-onnx-qnn-SM8850-binary-moonshine-base-zh-5s/test_wavs/0.wav
```

Output logs:
```
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/parse-options.cc:Read:374 ./sherpa-onnx-offline --provider=qnn --tokens=./sherpa-onnx-qnn-SM8850-binary-moonshine-base-zh-5s/tokens.txt --moonshine.qnn-backend-lib=./libQnnHtp.so --moonshine.qnn-system-lib=./libQnnSystem.so --moonshine.qnn-context-binary=./sherpa-onnx-qnn-SM8850-binary-moonshine-base-zh-5s/encoder.bin,./sherpa-onnx-qnn-SM8850-binary-moonshine-base-zh-5s/decoder.bin ./sherpa-onnx-qnn-SM8850-binary-moonshine-base-zh-5s/test_wavs/0.wav

OfflineRecognizerConfig(feat_config=FeatureExtractorConfig(sampling_rate=16000, feature_dim=80, low_freq=20, high_freq=-400, dither=0, normalize_samples=True, snip_edges=False), model_config=OfflineModelConfig(transducer=OfflineTransducerModelConfig(encoder_filename="", decoder_filename="", joiner_filename=""), paraformer=OfflineParaformerModelConfig(model=""), nemo_ctc=OfflineNemoEncDecCtcModelConfig(model=""), whisper=OfflineWhisperModelConfig(encoder="", decoder="", language="", task="transcribe", tail_paddings=-1, enable_token_timestamps=False, enable_segment_timestamps=False, ), fire_red_asr=OfflineFireRedAsrModelConfig(encoder="", decoder=""), tdnn=OfflineTdnnModelConfig(model=""), zipformer_ctc=OfflineZipformerCtcModelConfig(model=""), wenet_ctc=OfflineWenetCtcModelConfig(model=""), sense_voice=OfflineSenseVoiceModelConfig(model="", language="auto", use_itn=False), moonshine=OfflineMoonshineModelConfig(preprocessor="", encoder="", uncached_decoder="", cached_decoder="", merged_decoder="", qnn_config=QnnConfig(backend_lib="./libQnnHtp.so", context_binary="./sherpa-onnx-qnn-SM8850-binary-moonshine-base-zh-5s/encoder.bin,./sherpa-onnx-qnn-SM8850-binary-moonshine-base-zh-5s/decoder.bin", system_lib="./libQnnSystem.so"), ), dolphin=OfflineDolphinModelConfig(model=""), canary=OfflineCanaryModelConfig(encoder="", decoder="", src_lang="", tgt_lang="", use_pnc=True), cohere_transcribe=OfflineCohereTranscribeModelConfig(encoder="", decoder="", language="", use_punct=True, use_itn=True), omnilingual=OfflineOmnilingualAsrCtcModelConfig(model=""), funasr_nano=OfflineFunASRNanoModelConfig(encoder_adaptor="", llm="", embedding="", tokenizer="", system_prompt="You are a helpful assistant.", user_prompt="语音转写：", max_new_tokens=512, temperature=1e-06, top_p=0.8, seed=42, language="", itn=True, hotwords=""), medasr=OfflineMedAsrCtcModelConfig(model=""), fire_red_asr_ctc=OfflineFireRedAsrCtcModelConfig(model=""), qwen3_asr=OfflineQwen3ASRModelConfig(conv_frontend="", encoder="", decoder="", tokenizer="", hotwords="", max_total_len=512, max_new_tokens=128, temperature=1e-06, top_p=0.8, seed=42), telespeech_ctc="", tokens="./sherpa-onnx-qnn-SM8850-binary-moonshine-base-zh-5s/tokens.txt", num_threads=2, debug=False, provider="qnn", model_type="", modeling_unit="cjkchar", bpe_vocab=""), lm_config=OfflineLMConfig(model="", scale=0.5, lodr_scale=0.01, lodr_fst="", lodr_backoff_id=-1), ctc_fst_decoder_config=OfflineCtcFstDecoderConfig(graph="", max_active=3000), decoding_method="greedy_search", max_active_paths=4, hotwords_file="", hotwords_score=1.5, blank_penalty=0, rule_fsts="", rule_fars="", hr=HomophoneReplacerConfig(lexicon="", rule_fsts=""))
Creating recognizer ...
     0.0ms [WARN   ] QnnDsp <W> Initializing HtpProvider
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/utils.cc:CopyGraphsInfo:548 version: 3
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/qnn/utils.cc:CopyGraphsInfo:548 version: 3
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
recognizer created in 0.454 s
Started
/Users/fangjun/open-source/sherpa-onnx/sherpa-onnx/csrc/offline-stream.cc:AcceptWaveformImpl:134 Creating a resampler:
   in_sample_rate: 24000
   output_sample_rate: 16000

Done!

./sherpa-onnx-qnn-SM8850-binary-moonshine-base-zh-5s/test_wavs/0.wav
{"lang": "", "emotion": "", "event": "", "text": "不要问你的国家能为你做什么，而要问你能为你的国家做什么。", "timestamps": [], "durations": [], "tokens":[" ", "不", "要", "问", "你", "的", "国", "家", "能", "为", "你", "<0xE5>", "<0x81>", "<0x9A>", "<0xE4>", "<0xBB>", "<0x80>", "么", "，", "而", "要", "问", "你", "能", "为", "你", "的", "国", "家", "<0xE5>", "<0x81>", "<0x9A>", "<0xE4>", "<0xBB>", "<0x80>", "么", "。"], "ys_log_probs": [], "words": []}
----
num threads: 2
decoding method: greedy_search
Elapsed seconds: 0.467 s
Real time factor (RTF): 0.467 / 4.759 = 0.098
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
     0.0ms [WARN   ] QnnDsp <W> m_CFBCallbackInfoObj is not initialized, return emptyList
```

----

To use the model lib files, e.g.,
[sherpa-onnx-qnn-moonshine-tiny-zh-5s-android-aarch64.tar.bz2](https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models-qnn-3/sherpa-onnx-qnn-moonshine-tiny-zh-5s-android-aarch64.tar.bz2)

Download the above model, unzip it, copy it to your phone, and run

```bash
./sherpa-onnx-offline \
   --provider=qnn \
   --moonshine-encoder=./sherpa-onnx-qnn-moonshine-tiny-zh-5s-android-aarch64/libencoder.so \
   --moonshine-decoder=./sherpa-onnx-qnn-moonshine-tiny-zh-5s-android-aarch64/libdecoder.so \
   --tokens=./sherpa-onnx-qnn-moonshine-tiny-zh-5s-android-aarch64/tokens.txt \
   --moonshine.qnn-backend-lib=./libQnnHtp.so \
   --moonshine.qnn-system-lib=./libQnnSystem.so \
   --moonshine.qnn-context-binary=./sherpa-onnx-qnn-moonshine-tiny-zh-5s-android-aarch64/encoder.bin,./sherpa-onnx-qnn-moonshine-tiny-zh-5s-android-aarch64/decoder.bin \
   ./sherpa-onnx-qnn-moonshine-tiny-zh-5s-android-aarch64/test_wavs/0.wav
```

```
ls -lh sherpa-onnx-qnn-moonshine-tiny-zh-5s-android-aarch64/
total 250752
-rw-r--r--@ 1 fangjun  staff    67B 13 Jul 17:19 info.txt
-rwxr-xr-x@ 1 fangjun  staff   107M 13 Jul 17:19 libdecoder.so
-rwxr-xr-x@ 1 fangjun  staff   9.2M 13 Jul 17:19 libencoder.so
drwxr-xr-x@ 3 fangjun  staff    96B 13 Jul 17:19 test_wavs
-rw-r--r--@ 1 fangjun  staff   536K 13 Jul 17:19 tokens.txt
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added QNN-backed offline Moonshine recognition with token generation and transcription.
  * Moonshine QNN models can be initialized using QNN context binaries (encoder/decoder) or QNN model libraries.
  * Improved model selection so Moonshine is available when the QNN provider is selected, including updated error messaging.
  * Added platform constructors for Android and OpenHarmony resource managers.

* **Bug Fixes**
  * Strengthened Moonshine QNN configuration validation, including format checks for context binaries and conditional required fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->