### PR TITLE
rust: expose ys_log_probs in OfflineRecognizerResult

### DIFF
--- a/sherpa-onnx/rust/sherpa-onnx/src/offline_asr.rs
+++ b/sherpa-onnx/rust/sherpa-onnx/src/offline_asr.rs
@@ -621,6 +621,7 @@ pub struct OfflineRecognizerResult {
     pub tokens: Vec<String>,
     pub timestamps: Option<Vec<f32>>,
     pub durations: Option<Vec<f32>>,
+    pub ys_log_probs: Option<Vec<f32>>,
 }
 
 /// Offline speech recognizer.


### PR DESCRIPTION
The C API emits per-token `ys_log_probs` in the offline stream result JSON (`OfflineRecognitionResult::AsJsonString`), populated by the offline NeMo transducer greedy decoders. The Rust wrapper's `OfflineRecognizerResult` does not declare the field, so serde silently drops it during deserialization.

This adds the missing field. `Option<Vec<f32>>` keeps backwards compatibility with native libraries whose result JSON lacks the key (it deserializes to `None`), matching how `timestamps` and `durations` are declared.

Verified against the v1.13.4 prebuilt static libs with a GigaAM v3 NeMo transducer (`nemo_transducer`, greedy search): a 20 s Russian sample decodes to 107 tokens with 107 log probs, values matching the decoder's LogSoftmax output.

The online `RecognizerResult` could get the same treatment for its `ys_probs` field as a follow-up; this PR intentionally stays minimal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Offline speech recognition results can now include optional per-output log probability scores.
  - Applications can use these scores to assess recognition confidence and quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->