### PR TITLE
Support exporting Spleeter 4stems (vocals/drums/bass/other)

### DIFF
--- a/scripts/spleeter/.gitignore
+++ b/scripts/spleeter/.gitignore
@@ -1,2 +1,4 @@
 2stems.tar.gz
 2stems
+4stems.tar.gz
+4stems

--- a/scripts/spleeter/convert_to_torch.py
+++ b/scripts/spleeter/convert_to_torch.py
@@ -11,6 +11,27 @@ import torch
 
 from unet import UNet
 
+# Spleeter's instrument_list, in the order configs/<model>/base_config.json
+# declares it. That order is what fixes each stem's block of TF op names.
+STEMS = {
+    "2stems": ["vocals", "accompaniment"],
+    "4stems": ["vocals", "drums", "bass", "other"],
+}
+
+# The U-Net activations, also from base_config.json. 2stems ships "params": {},
+# i.e. the unet.unet defaults; 4stems asks for ELU on both. Architecture and
+# weight shapes are identical either way, so getting this wrong loads cleanly
+# and returns garbage rather than raising.
+ACTIVATIONS = {
+    "2stems": ("LeakyReLU", "ReLU"),
+    "4stems": ("ELU", "ELU"),
+}
+
+
+def op(family, index):
+    """TF names the first op of a family with no suffix: conv2d, conv2d_1, ..."""
+    return family if index == 0 else f"{family}_{index}"
+
 
 def load_graph(frozen_graph_filename):
     # This function is modified from
@@ -52,189 +73,93 @@ def get_param(graph, name):
 
 
 @torch.no_grad()
-def main(name):
-    graph = load_graph(f"./2stems/frozen_{name}_model.pb")
-    #  for op in graph.get_operations():
-    #      print(op.name)
+def main(name, model):
+    graph = load_graph(f"./{model}/frozen_{name}_model.pb")
     x = graph.get_tensor_by_name("waveform:0")
-    #  y = graph.get_tensor_by_name("Reshape:0")
     y0 = graph.get_tensor_by_name("strided_slice_3:0")
-    #  y1 = graph.get_tensor_by_name("leaky_re_lu_5/LeakyRelu:0")
-    #  y1 = graph.get_tensor_by_name("conv2d_5/BiasAdd:0")
-    #  y1 = graph.get_tensor_by_name("conv2d_transpose/BiasAdd:0")
-    #  y1 = graph.get_tensor_by_name("re_lu/Relu:0")
-    #  y1 = graph.get_tensor_by_name("batch_normalization_6/cond/FusedBatchNorm_1:0")
-    #  y1 = graph.get_tensor_by_name("concatenate/concat:0")
-    #  y1 = graph.get_tensor_by_name("concatenate_1/concat:0")
-    #  y1 = graph.get_tensor_by_name("concatenate_4/concat:0")
-    #  y1 = graph.get_tensor_by_name("batch_normalization_11/cond/FusedBatchNorm_1:0")
-    #  y1 = graph.get_tensor_by_name("conv2d_6/Sigmoid:0")
     y1 = graph.get_tensor_by_name(f"{name}_spectrogram/mul:0")
 
-    unet = UNet()
+    # Each stem's U-Net owns a contiguous block of TF op names, in
+    # instrument_list order. Per stem: 7 conv2d (conv..conv5 plus the final
+    # up7), 6 conv2d_transpose, and 12 batch_normalization indices -- of which
+    # only 11 exist, because conv5 has no BatchNorm, but the 12th index is
+    # allocated regardless. Hence the 6 rather than 5 below.
+    index = STEMS[model].index(name)
+    conv_offset = 7 * index
+    tconv_offset = 6 * index
+    bn_offset = 12 * index
+
+    unet = UNet(*ACTIVATIONS[model])
     unet.eval()
 
     # For the conv2d in tensorflow, weight shape is (kernel_h, kernel_w, in_channel, out_channel)
     # default input shape is NHWC
-
+    #
     # For the conv2d in torch, weight shape is (out_channel, in_channel, kernel_h, kernel_w)
     # default input shape is NCHW
     state_dict = unet.state_dict()
-    #  print(list(state_dict.keys()))
 
-    if name == "vocals":
-        state_dict["conv.weight"] = get_param(graph, "conv2d/kernel").permute(
-            3, 2, 0, 1
-        )
-        state_dict["conv.bias"] = get_param(graph, "conv2d/bias")
-
-        state_dict["bn.weight"] = get_param(graph, "batch_normalization/gamma")
-        state_dict["bn.bias"] = get_param(graph, "batch_normalization/beta")
-        state_dict["bn.running_mean"] = get_param(
-            graph, "batch_normalization/moving_mean"
-        )
-        state_dict["bn.running_var"] = get_param(
-            graph, "batch_normalization/moving_variance"
-        )
-
-        conv_offset = 0
-        bn_offset = 0
-    else:
-        state_dict["conv.weight"] = get_param(graph, "conv2d_7/kernel").permute(
-            3, 2, 0, 1
-        )
-        state_dict["conv.bias"] = get_param(graph, "conv2d_7/bias")
-
-        state_dict["bn.weight"] = get_param(graph, "batch_normalization_12/gamma")
-        state_dict["bn.bias"] = get_param(graph, "batch_normalization_12/beta")
-        state_dict["bn.running_mean"] = get_param(
-            graph, "batch_normalization_12/moving_mean"
-        )
-        state_dict["bn.running_var"] = get_param(
-            graph, "batch_normalization_12/moving_variance"
-        )
-        conv_offset = 7
-        bn_offset = 12
+    state_dict["conv.weight"] = get_param(
+        graph, f"{op('conv2d', conv_offset)}/kernel"
+    ).permute(3, 2, 0, 1)
+    state_dict["conv.bias"] = get_param(graph, f"{op('conv2d', conv_offset)}/bias")
 
     for i in range(1, 6):
         state_dict[f"conv{i}.weight"] = get_param(
-            graph, f"conv2d_{i+conv_offset}/kernel"
+            graph, f"{op('conv2d', i + conv_offset)}/kernel"
         ).permute(3, 2, 0, 1)
-        state_dict[f"conv{i}.bias"] = get_param(graph, f"conv2d_{i+conv_offset}/bias")
-        if i >= 5:
-            continue
-        state_dict[f"bn{i}.weight"] = get_param(
-            graph, f"batch_normalization_{i+bn_offset}/gamma"
-        )
-        state_dict[f"bn{i}.bias"] = get_param(
-            graph, f"batch_normalization_{i+bn_offset}/beta"
-        )
-        state_dict[f"bn{i}.running_mean"] = get_param(
-            graph, f"batch_normalization_{i+bn_offset}/moving_mean"
-        )
-        state_dict[f"bn{i}.running_var"] = get_param(
-            graph, f"batch_normalization_{i+bn_offset}/moving_variance"
+        state_dict[f"conv{i}.bias"] = get_param(
+            graph, f"{op('conv2d', i + conv_offset)}/bias"
         )
 
-    if name == "vocals":
-        state_dict["up1.weight"] = get_param(graph, "conv2d_transpose/kernel").permute(
-            3, 2, 0, 1
-        )
-        state_dict["up1.bias"] = get_param(graph, "conv2d_transpose/bias")
+    state_dict["up7.weight"] = get_param(
+        graph, f"{op('conv2d', 6 + conv_offset)}/kernel"
+    ).permute(3, 2, 0, 1)
+    state_dict["up7.bias"] = get_param(graph, f"{op('conv2d', 6 + conv_offset)}/bias")
 
-        state_dict["bn5.weight"] = get_param(graph, "batch_normalization_6/gamma")
-        state_dict["bn5.bias"] = get_param(graph, "batch_normalization_6/beta")
-        state_dict["bn5.running_mean"] = get_param(
-            graph, "batch_normalization_6/moving_mean"
-        )
-        state_dict["bn5.running_var"] = get_param(
-            graph, "batch_normalization_6/moving_variance"
-        )
-        conv_offset = 0
-        bn_offset = 0
-    else:
-        state_dict["up1.weight"] = get_param(
-            graph, "conv2d_transpose_6/kernel"
+    for i in range(6):
+        state_dict[f"up{i + 1}.weight"] = get_param(
+            graph, f"{op('conv2d_transpose', i + tconv_offset)}/kernel"
         ).permute(3, 2, 0, 1)
-        state_dict["up1.bias"] = get_param(graph, "conv2d_transpose_6/bias")
-
-        state_dict["bn5.weight"] = get_param(graph, "batch_normalization_18/gamma")
-        state_dict["bn5.bias"] = get_param(graph, "batch_normalization_18/beta")
-        state_dict["bn5.running_mean"] = get_param(
-            graph, "batch_normalization_18/moving_mean"
-        )
-        state_dict["bn5.running_var"] = get_param(
-            graph, "batch_normalization_18/moving_variance"
-        )
-        conv_offset = 6
-        bn_offset = 12
-
-    for i in range(1, 6):
-        state_dict[f"up{i+1}.weight"] = get_param(
-            graph, f"conv2d_transpose_{i+conv_offset}/kernel"
-        ).permute(3, 2, 0, 1)
-
-        state_dict[f"up{i+1}.bias"] = get_param(
-            graph, f"conv2d_transpose_{i+conv_offset}/bias"
+        state_dict[f"up{i + 1}.bias"] = get_param(
+            graph, f"{op('conv2d_transpose', i + tconv_offset)}/bias"
         )
 
-        state_dict[f"bn{5+i}.weight"] = get_param(
-            graph, f"batch_normalization_{6+i+bn_offset}/gamma"
-        )
-        state_dict[f"bn{5+i}.bias"] = get_param(
-            graph, f"batch_normalization_{6+i+bn_offset}/beta"
-        )
-        state_dict[f"bn{5+i}.running_mean"] = get_param(
-            graph, f"batch_normalization_{6+i+bn_offset}/moving_mean"
-        )
-        state_dict[f"bn{5+i}.running_var"] = get_param(
-            graph, f"batch_normalization_{6+i+bn_offset}/moving_variance"
-        )
-
-    if name == "vocals":
-        state_dict["up7.weight"] = get_param(graph, "conv2d_6/kernel").permute(
-            3, 2, 0, 1
-        )
-        state_dict["up7.bias"] = get_param(graph, "conv2d_6/bias")
-    else:
-        state_dict["up7.weight"] = get_param(graph, "conv2d_13/kernel").permute(
-            3, 2, 0, 1
-        )
-        state_dict["up7.bias"] = get_param(graph, "conv2d_13/bias")
+    # for the batchnormalization in tensorflow, default input shape is NHWC
+    # for the batchnormalization in torch, default input shape is NCHW
+    #
+    # bn..bn4 sit after conv..conv4; bn5..bn10 after up1..up6. Index 5 of the
+    # block is the one conv5 would have used and is skipped.
+    bn_indices = [0, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11]
+    bn_keys = ["bn"] + [f"bn{i}" for i in range(1, 11)]
+    for key, i in zip(bn_keys, bn_indices):
+        scope = op("batch_normalization", i + bn_offset)
+        state_dict[f"{key}.weight"] = get_param(graph, f"{scope}/gamma")
+        state_dict[f"{key}.bias"] = get_param(graph, f"{scope}/beta")
+        state_dict[f"{key}.running_mean"] = get_param(graph, f"{scope}/moving_mean")
+        state_dict[f"{key}.running_var"] = get_param(graph, f"{scope}/moving_variance")
 
     unet.load_state_dict(state_dict)
 
     with tf.compat.v1.Session(graph=graph) as sess:
         y0_out, y1_out = sess.run([y0, y1], feed_dict={x: generate_waveform()})
-        #  y0_out = sess.run(y0, feed_dict={x: generate_waveform()})
-        #  y1_out = sess.run(y1, feed_dict={x: generate_waveform()})
-        #  print(y0_out.shape)
-        #  print(y1_out.shape)
-
-    # for the batchnormalization in tensorflow,
-    # default input shape is NHWC
-
-    # for the batchnormalization in torch,
-    # default input shape is NCHW
 
     torch_y1_out = unet(torch.from_numpy(y0_out).permute(3, 0, 1, 2))
     torch_y1_out = torch_y1_out.permute(1, 0, 2, 3)
 
-    #  print(torch_y1_out.shape, torch.from_numpy(y1_out).permute(0, 3, 1, 2).shape)
     assert torch.allclose(
         torch_y1_out, torch.from_numpy(y1_out).permute(0, 3, 1, 2), atol=1e-1
     ), ((torch_y1_out - torch.from_numpy(y1_out).permute(0, 3, 1, 2)).abs().max())
-    torch.save(unet.state_dict(), f"2stems/{name}.pt")
+    torch.save(unet.state_dict(), f"{model}/{name}.pt")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--name",
-        type=str,
-        required=True,
-        choices=["vocals", "accompaniment"],
-    )
+    parser.add_argument("--model", type=str, default="2stems", choices=list(STEMS))
+    parser.add_argument("--name", type=str, required=True)
     args = parser.parse_args()
+    if args.name not in STEMS[args.model]:
+        parser.error(f"{args.model} has no stem {args.name!r}; "
+                     f"choose from {STEMS[args.model]}")
     print(vars(args))
-    main(args.name)
+    main(args.name, args.model)

--- a/scripts/spleeter/export_onnx.py
+++ b/scripts/spleeter/export_onnx.py
@@ -19,16 +19,16 @@ def export_onnx_fp16(onnx_fp32_path, onnx_fp16_path):
     onnxmltools.utils.save_model(onnx_fp16_model, onnx_fp16_path)
 
 
-def add_meta_data(filename, prefix, model):
-    conv_activation, deconv_activation = ACTIVATIONS[model]
+def add_meta_data(filename, prefix, model_id):
+    conv_activation, deconv_activation = ACTIVATIONS[model_id]
     meta_data = {
         "model_type": "spleeter",
         "sample_rate": 44100,
         "version": 1,
         "model_url": "https://github.com/deezer/spleeter",
-        "stems": len(STEMS[model]),
+        "stems": len(STEMS[model_id]),
         "comment": prefix,
-        "model_name": f"{model}.tar.gz",
+        "model_name": f"{model_id}.tar.gz",
         # Recorded so the next reader does not have to rediscover that 4stems
         # is ELU and 2stems is not.
         "conv_activation": conv_activation,

--- a/scripts/spleeter/export_onnx.py
+++ b/scripts/spleeter/export_onnx.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 # Copyright    2025  Xiaomi Corp.        (authors: Fangjun Kuang)
 
+import argparse
+
 import onnx
 import onnxmltools
 import torch
 from onnxmltools.utils.float16_converter import convert_float_to_float16
 from onnxruntime.quantization import QuantType, quantize_dynamic
 
+from convert_to_torch import ACTIVATIONS, STEMS
 from unet import UNet
 
 
@@ -16,15 +19,20 @@ def export_onnx_fp16(onnx_fp32_path, onnx_fp16_path):
     onnxmltools.utils.save_model(onnx_fp16_model, onnx_fp16_path)
 
 
-def add_meta_data(filename, prefix):
+def add_meta_data(filename, prefix, model):
+    conv_activation, deconv_activation = ACTIVATIONS[model]
     meta_data = {
         "model_type": "spleeter",
-        "sample_rate": 41000,
+        "sample_rate": 44100,
         "version": 1,
         "model_url": "https://github.com/deezer/spleeter",
-        "stems": 2,
+        "stems": len(STEMS[model]),
         "comment": prefix,
-        "model_name": "2stems.tar.gz",
+        "model_name": f"{model}.tar.gz",
+        # Recorded so the next reader does not have to rediscover that 4stems
+        # is ELU and 2stems is not.
+        "conv_activation": conv_activation,
+        "deconv_activation": deconv_activation,
     }
     model = onnx.load(filename)
 
@@ -44,13 +52,13 @@ def add_meta_data(filename, prefix):
     onnx.save(model, filename)
 
 
-def export(model, prefix):
+def export(net, prefix, model):
     num_splits = 1
     x = torch.rand(2, num_splits, 512, 1024, dtype=torch.float32)
 
-    filename = f"./2stems/{prefix}.onnx"
+    filename = f"./{model}/{prefix}.onnx"
     torch.onnx.export(
-        model,
+        net,
         x,
         filename,
         input_names=["x"],
@@ -61,33 +69,30 @@ def export(model, prefix):
         opset_version=13,
     )
 
-    add_meta_data(filename, prefix)
+    add_meta_data(filename, prefix, model)
 
-    filename_int8 = f"./2stems/{prefix}.int8.onnx"
+    filename_int8 = f"./{model}/{prefix}.int8.onnx"
     quantize_dynamic(
         model_input=filename,
         model_output=filename_int8,
         weight_type=QuantType.QUInt8,
     )
 
-    filename_fp16 = f"./2stems/{prefix}.fp16.onnx"
+    filename_fp16 = f"./{model}/{prefix}.fp16.onnx"
     export_onnx_fp16(filename, filename_fp16)
 
 
 @torch.no_grad()
 def main():
-    vocals = UNet()
-    state_dict = torch.load("./2stems/vocals.pt", map_location="cpu")
-    vocals.load_state_dict(state_dict)
-    vocals.eval()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=str, default="2stems", choices=list(STEMS))
+    args = parser.parse_args()
 
-    accompaniment = UNet()
-    state_dict = torch.load("./2stems/accompaniment.pt", map_location="cpu")
-    accompaniment.load_state_dict(state_dict)
-    accompaniment.eval()
-
-    export(vocals, "vocals")
-    export(accompaniment, "accompaniment")
+    for name in STEMS[args.model]:
+        net = UNet(*ACTIVATIONS[args.model])
+        net.load_state_dict(torch.load(f"./{args.model}/{name}.pt", map_location="cpu"))
+        net.eval()
+        export(net, name, args.model)
 
 
 if __name__ == "__main__":

--- a/scripts/spleeter/run.sh
+++ b/scripts/spleeter/run.sh
@@ -1,41 +1,52 @@
 #!/usr/bin/env bash
+#
+# Usage:  ./run.sh [2stems|4stems]      (default: 2stems)
+#
+# 4stems is not simply "the same thing with more stems". Spleeter's
+# configs/4stems/base_config.json asks for ELU activations where 2stems takes
+# the unet.unet defaults (LeakyReLU/ReLU). The architecture and every weight
+# shape are identical, so the wrong activation loads without complaint and
+# quietly returns garbage. convert_to_torch.py's ACTIVATIONS table keeps the
+# two apart.
 
+set -e
 
-if [ ! -f 2stems.tar.gz ]; then
-  curl -SL -O https://github.com/deezer/spleeter/releases/download/v1.4.0/2stems.tar.gz
+model=${1:-2stems}
+
+case "$model" in
+  2stems) stems="vocals accompaniment" ;;
+  4stems) stems="vocals drums bass other" ;;
+  *) echo "usage: $0 [2stems|4stems]" >&2; exit 1 ;;
+esac
+
+if [ ! -f $model.tar.gz ]; then
+  curl -SL -O https://github.com/deezer/spleeter/releases/download/v1.4.0/$model.tar.gz
 fi
 
-if [ ! -d ./2stems ]; then
-  mkdir -p 2stems
-  cd 2stems
-  tar xvf ../2stems.tar.gz
+if [ ! -d ./$model ]; then
+  mkdir -p $model
+  cd $model
+  tar xvf ../$model.tar.gz
   cd ..
 fi
 
 ls -lh
 
-ls -lh 2stems
+ls -lh $model
 
-if [ ! -f 2stems/frozen_vocals_model.pb ]; then
-  python3 ./convert_to_pb.py \
-    --model-dir ./2stems \
-    --output-node-names vocals_spectrogram/mul \
-    --output-filename ./2stems/frozen_vocals_model.pb
-fi
+for s in $stems; do
+  if [ ! -f $model/frozen_${s}_model.pb ]; then
+    python3 ./convert_to_pb.py \
+      --model-dir ./$model \
+      --output-node-names ${s}_spectrogram/mul \
+      --output-filename ./$model/frozen_${s}_model.pb
+  fi
 
-ls -lh 2stems
+  ls -lh $model
 
-if [ ! -f 2stems/frozen_accompaniment_model.pb ]; then
-  python3 ./convert_to_pb.py \
-    --model-dir ./2stems \
-    --output-node-names accompaniment_spectrogram/mul \
-    --output-filename ./2stems/frozen_accompaniment_model.pb
-fi
+  python3 ./convert_to_torch.py --model $model --name $s
+done
 
-ls -lh 2stems
+python3 ./export_onnx.py --model $model
 
-python3 ./convert_to_torch.py --name vocals
-python3 ./convert_to_torch.py --name accompaniment
-python3 ./export_onnx.py
-
-ls -lh 2stems
+ls -lh $model

--- a/scripts/spleeter/unet.py
+++ b/scripts/spleeter/unet.py
@@ -4,8 +4,17 @@ import torch
 
 
 class UNet(torch.nn.Module):
-    def __init__(self):
+    # Spleeter selects the two activations from configs/<model>/base_config.json.
+    # 2stems ships "params": {}, i.e. the unet.unet defaults LeakyReLU(0.2)/ReLU.
+    # 4stems ships conv_activation=ELU and deconv_activation=ELU.
+    #
+    # The architecture and every weight shape are identical either way, so the
+    # wrong choice loads without complaint and silently returns garbage. Defaults
+    # here match 2stems, so existing callers are unaffected.
+    def __init__(self, conv_activation="LeakyReLU", deconv_activation="ReLU"):
         super().__init__()
+        self.conv_activation = conv_activation
+        self.deconv_activation = deconv_activation
         self.conv = torch.nn.Conv2d(2, 16, kernel_size=5, stride=(2, 2), padding=0)
         self.bn = torch.nn.BatchNorm2d(
             16, track_running_stats=True, eps=1e-3, momentum=0.01
@@ -66,6 +75,20 @@ class UNet(torch.nn.Module):
         # output logit is False, so we need self.up7
         self.up7 = torch.nn.Conv2d(1, 2, kernel_size=4, dilation=2, padding=3)
 
+    def _conv_act(self, x):
+        if self.conv_activation == "ELU":
+            return torch.nn.functional.elu(x)
+        if self.conv_activation == "ReLU":
+            return torch.nn.functional.relu(x)
+        return torch.nn.functional.leaky_relu(x, negative_slope=0.2)
+
+    def _deconv_act(self, x):
+        if self.deconv_activation == "ELU":
+            return torch.nn.functional.elu(x)
+        if self.deconv_activation == "LeakyReLU":
+            return torch.nn.functional.leaky_relu(x, negative_slope=0.2)
+        return torch.nn.functional.relu(x)
+
     def forward(self, x):
         """
         Args:
@@ -80,76 +103,68 @@ class UNet(torch.nn.Module):
         x = torch.nn.functional.pad(x, (1, 2, 1, 2), "constant", 0)
         conv1 = self.conv(x)
         batch1 = self.bn(conv1)
-        rel1 = torch.nn.functional.leaky_relu(batch1, negative_slope=0.2)
+        rel1 = self._conv_act(batch1)
 
         x = torch.nn.functional.pad(rel1, (1, 2, 1, 2), "constant", 0)
         conv2 = self.conv1(x)  # (3, 32, 128, 256)
         batch2 = self.bn1(conv2)
-        rel2 = torch.nn.functional.leaky_relu(
-            batch2, negative_slope=0.2
-        )  # (3, 32, 128, 256)
+        rel2 = self._conv_act(batch2)  # (3, 32, 128, 256)
 
         x = torch.nn.functional.pad(rel2, (1, 2, 1, 2), "constant", 0)
         conv3 = self.conv2(x)  # (3, 64, 64, 128)
         batch3 = self.bn2(conv3)
-        rel3 = torch.nn.functional.leaky_relu(
-            batch3, negative_slope=0.2
-        )  # (3, 64, 64, 128)
+        rel3 = self._conv_act(batch3)  # (3, 64, 64, 128)
 
         x = torch.nn.functional.pad(rel3, (1, 2, 1, 2), "constant", 0)
         conv4 = self.conv3(x)  # (3, 128, 32, 64)
         batch4 = self.bn3(conv4)
-        rel4 = torch.nn.functional.leaky_relu(
-            batch4, negative_slope=0.2
-        )  # (3, 128, 32, 64)
+        rel4 = self._conv_act(batch4)  # (3, 128, 32, 64)
 
         x = torch.nn.functional.pad(rel4, (1, 2, 1, 2), "constant", 0)
         conv5 = self.conv4(x)  # (3, 256, 16, 32)
         batch5 = self.bn4(conv5)
-        rel6 = torch.nn.functional.leaky_relu(
-            batch5, negative_slope=0.2
-        )  # (3, 256, 16, 32)
+        rel6 = self._conv_act(batch5)  # (3, 256, 16, 32)
 
         x = torch.nn.functional.pad(rel6, (1, 2, 1, 2), "constant", 0)
         conv6 = self.conv5(x)  # (3, 512, 8, 16)
 
         up1 = self.up1(conv6)
         up1 = up1[:, :, 1:-2, 1:-2]  # (3, 256, 16, 32)
-        up1 = torch.nn.functional.relu(up1)
+        up1 = self._deconv_act(up1)
         batch7 = self.bn5(up1)
         merge1 = torch.cat([conv5, batch7], axis=1)  # (3, 512, 16, 32)
 
         up2 = self.up2(merge1)
         up2 = up2[:, :, 1:-2, 1:-2]
-        up2 = torch.nn.functional.relu(up2)
+        up2 = self._deconv_act(up2)
         batch8 = self.bn6(up2)
 
         merge2 = torch.cat([conv4, batch8], axis=1)  # (3, 256, 32, 64)
 
         up3 = self.up3(merge2)
         up3 = up3[:, :, 1:-2, 1:-2]
-        up3 = torch.nn.functional.relu(up3)
+        up3 = self._deconv_act(up3)
         batch9 = self.bn7(up3)
 
         merge3 = torch.cat([conv3, batch9], axis=1)  # (3, 128, 64, 128)
 
         up4 = self.up4(merge3)
         up4 = up4[:, :, 1:-2, 1:-2]
-        up4 = torch.nn.functional.relu(up4)
+        up4 = self._deconv_act(up4)
         batch10 = self.bn8(up4)
 
         merge4 = torch.cat([conv2, batch10], axis=1)  # (3, 64, 128, 256)
 
         up5 = self.up5(merge4)
         up5 = up5[:, :, 1:-2, 1:-2]
-        up5 = torch.nn.functional.relu(up5)
+        up5 = self._deconv_act(up5)
         batch11 = self.bn9(up5)
 
         merge5 = torch.cat([conv1, batch11], axis=1)  # (3, 32, 256, 512)
 
         up6 = self.up6(merge5)
         up6 = up6[:, :, 1:-2, 1:-2]
-        up6 = torch.nn.functional.relu(up6)
+        up6 = self._deconv_act(up6)
         batch12 = self.bn10(up6)  # (3, 1, 512, 1024)  = (T, 1, 512, 1024)
 
         up7 = self.up7(batch12)

--- a/scripts/spleeter/unet.py
+++ b/scripts/spleeter/unet.py
@@ -2,6 +2,18 @@
 
 import torch
 
+# Resolved once at construction, and an unknown name raises rather than quietly
+# falling through to a default. That matters more than it looks: the reason this
+# parameter exists at all is that Spleeter's 2stems and 4stems have identical
+# architectures and identical weight shapes, so a wrong activation loads without
+# complaint and returns garbage. A silent default would reintroduce exactly the
+# failure this is here to prevent.
+_ACTIVATIONS = {
+    "ELU": lambda x: torch.nn.functional.elu(x),
+    "ReLU": lambda x: torch.nn.functional.relu(x),
+    "LeakyReLU": lambda x: torch.nn.functional.leaky_relu(x, negative_slope=0.2),
+}
+
 
 class UNet(torch.nn.Module):
     # Spleeter selects the two activations from configs/<model>/base_config.json.
@@ -13,8 +25,16 @@ class UNet(torch.nn.Module):
     # here match 2stems, so existing callers are unaffected.
     def __init__(self, conv_activation="LeakyReLU", deconv_activation="ReLU"):
         super().__init__()
+        for name in (conv_activation, deconv_activation):
+            if name not in _ACTIVATIONS:
+                raise ValueError(
+                    f"unknown activation {name!r}; "
+                    f"expected one of {sorted(_ACTIVATIONS)}"
+                )
         self.conv_activation = conv_activation
         self.deconv_activation = deconv_activation
+        self._conv_act = _ACTIVATIONS[conv_activation]
+        self._deconv_act = _ACTIVATIONS[deconv_activation]
         self.conv = torch.nn.Conv2d(2, 16, kernel_size=5, stride=(2, 2), padding=0)
         self.bn = torch.nn.BatchNorm2d(
             16, track_running_stats=True, eps=1e-3, momentum=0.01
@@ -74,20 +94,6 @@ class UNet(torch.nn.Module):
 
         # output logit is False, so we need self.up7
         self.up7 = torch.nn.Conv2d(1, 2, kernel_size=4, dilation=2, padding=3)
-
-    def _conv_act(self, x):
-        if self.conv_activation == "ELU":
-            return torch.nn.functional.elu(x)
-        if self.conv_activation == "ReLU":
-            return torch.nn.functional.relu(x)
-        return torch.nn.functional.leaky_relu(x, negative_slope=0.2)
-
-    def _deconv_act(self, x):
-        if self.deconv_activation == "ELU":
-            return torch.nn.functional.elu(x)
-        if self.deconv_activation == "LeakyReLU":
-            return torch.nn.functional.leaky_relu(x, negative_slope=0.2)
-        return torch.nn.functional.relu(x)
 
     def forward(self, x):
         """


### PR DESCRIPTION
`scripts/spleeter/` could only export 2stems, and the README/docs say so: *"We only support the `2-stem` model at present."* This adds 4stems.

Extending it hinged on one thing that isn't visible in the code, so leading with that.

## 4stems uses ELU

Spleeter selects the U-Net activations from config:

```jsonc
// configs/2stems/base_config.json
"model": { "type": "unet.unet", "params": {} }
//                              ^^ defaults: LeakyReLU(0.2) + ReLU

// configs/4stems/base_config.json
"model": { "type": "unet.unet", "params": {
    "conv_activation": "ELU", "deconv_activation": "ELU" } }
```

The architecture and **every weight shape are identical** between the two. So `unet.py`'s hardcoded `LeakyReLU`/`ReLU` loads the 4stems weights via `load_state_dict` **without complaint** and returns garbage. It presented as a max error of **945 against a TF output whose entire range was 178** — the error larger than the signal — with the op-name mapping, the input tensor, the inference-mode BatchNorm and the kernel shapes all checking out clean, because the bug was in none of them.

`UNet` now takes `conv_activation` / `deconv_activation`, **defaulting to the current values**, so 2stems is untouched.

Incidentally: your existing TF-vs-torch assertion in `convert_to_torch.py` is what made this findable instead of silent. Without it this ships wrong and you learn about it by ear, much later. It's a good check and I kept it as the proof below.

## Changes

- **`unet.py`** — `UNet(conv_activation="LeakyReLU", deconv_activation="ReLU")`. Defaults preserve current behaviour.
- **`convert_to_torch.py`** — `--model {2stems,4stems}`, and the per-stem op-name offsets are derived rather than enumerated. They were already regular: each stem's U-Net owns a contiguous block in `instrument_list` order — 7 `conv2d`, 6 `conv2d_transpose`, 12 `batch_normalization` indices. Verified by reproducing the existing 2stems mapping exactly. The 12-vs-11 BatchNorm gap is preserved and now commented (`conv5` has no BatchNorm but the index is still allocated, which is why `bn5` reads `batch_normalization_6`, not `_5`).
- **`export_onnx.py`** — `--model`, exports that model's stems, and writes `conv_activation`/`deconv_activation` into the ONNX metadata so the above doesn't have to be rediscovered.
- **`run.sh`** — `./run.sh [2stems|4stems]`, default `2stems`.
- **`.gitignore`** — `4stems`, `4stems.tar.gz`.
- Drive-by: `add_meta_data` said `sample_rate: 41000`. Spleeter is 44100.

Net −44 lines.

## Verification

Your assertion, every stem:

| | max err |
|---|---|
| `2stems/vocals` | 3.04e-04 *(unchanged)* |
| `2stems/accompaniment` | 1.07e-02 *(unchanged)* |
| `4stems/vocals` | 2.59e-04 |
| `4stems/drums` | 1.33e-02 |
| `4stems/bass` | 1.12e-03 |
| `4stems/other` | 2.59e-03 |

End-to-end, the exported 4stems graphs reconstruct the mix to **−153.1 dB** (the ratio masks sum to 1, so the stems must sum back to the input — that invariant tests the STFT, the mask, the band extension and the iSTFT at once). Inference is ~1.69 s for 30 s of 44.1 kHz stereo, all four stems, CPU.

```bash
cd scripts/spleeter && ./run.sh 4stems
```

## Notes

- **5stems is out of scope, and not for the reason I first assumed.** I originally wrote that it was "likely just another entry in `STEMS`/`ACTIVATIONS`". That's wrong — it uses `unet.softmax_unet`, not `unet.unet`. See the comment below for what it would actually take; it needs a different export shape, not a config entry.
- Possibly relevant to #2468 (source separation on Flutter/Android/iOS) — that's what I was doing when I hit this.
- Exported models and the full pipeline, if useful: https://huggingface.co/Best-Practice/spleeter-4stems-onnx · https://github.com/madewith-bestpractice/spleeter-4stems-onnx

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added parameterized support for both **2-stem** and **4-stem** model conversions and exports.
  * Introduced **configurable activation functions** in the separation network to match model variants.
  * Enhanced **ONNX exports** with model-specific metadata and variant-aware naming.
* **Bug Fixes**
  * Improved validation for selected stem names against the chosen model variant.
  * Added output consistency checks during the conversion process.
* **Chores**
  * Updated ignore rules for additional generated stem archive paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
