### PR TITLE
Add Japanese support for Kokoro multi-lang TTS

### DIFF
--- a/scripts/kokoro/v1.0/generate_lexicon_ja.py
+++ b/scripts/kokoro/v1.0/generate_lexicon_ja.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# Copyright    2026  (author: dora)
+"""
+Generate lexicon-ja.txt for kokoro-multi-lang-v1_0.
+
+Requirements:
+    pip install "misaki[ja]" wordfreq
+    python -m unidic download
+
+Note: kokoro-multi-lang-v1_0 was trained with phonemes produced by the
+*cutlet* version of misaki's Japanese G2P (e.g. こんにちは -> koɲɲiʨiβa).
+The newer pyopenjtalk-based G2P of misaki emits a pitch string
+(characters like _ ^ -) and extra phonemes (e.g. ᶄ) that are NOT in
+tokens.txt of v1.0, so we must use JAG2P(version='cutlet') here.
+
+The lexicon contains:
+  - the most frequent Japanese words (wordfreq) and their phonemes
+  - every single kana (hiragana + katakana) and small-kana combination,
+    so that any kana-only OOV text can still be synthesized
+  - explicit entries for particles such as は/へ, mapped to their
+    particle reading (wa/e). Longest-match lookup consumes real words
+    first, so a remaining single は is most likely a topic particle.
+"""
+
+from typing import Dict, List
+
+from misaki import ja
+from wordfreq import top_n_list
+
+NUM_WORDS = 100000
+NUM_PARTICLE_WORDS = 20000
+
+# Explicit overrides. Applied last, they win over generated entries.
+MANUAL = {
+    "は": "βa",  # topic particle
+    "へ": "e",  # direction particle
+    "を": "o",
+    "っ": "ʔ",
+    "ッ": "ʔ",
+    "ー": "ː",
+    "ん": "ɴ",
+    "ン": "ɴ",
+}
+
+HIRAGANA_SMALL = "ゃゅょぁぃぅぇぉゎ"
+KATAKANA_SMALL = "ャュョァィゥェォヮ"
+
+
+def is_kana(ch: str) -> bool:
+    return 0x3040 <= ord(ch) <= 0x309F or 0x30A0 <= ord(ch) <= 0x30FF
+
+
+def is_japanese_word(w: str) -> bool:
+    # kana or kanji only; skip latin/digits/mixed tokens
+    for ch in w:
+        if not (is_kana(ch) or 0x4E00 <= ord(ch) <= 0x9FFF or ch == "々"):
+            return False
+    return True
+
+
+def kana_units() -> List[str]:
+    """All single kana plus (kana + small kana) two-char units.
+
+    Small kana are paired only with bases of the same script, so no
+    cross-script combinations (e.g. あャ) are generated.
+    """
+    hiragana = [chr(c) for c in range(0x3041, 0x3097)]
+    katakana = [chr(c) for c in range(0x30A1, 0x30FB)]
+    units = hiragana + katakana
+    units += [b + s for b in hiragana for s in HIRAGANA_SMALL]
+    units += [b + s for b in katakana for s in KATAKANA_SMALL]
+    return units
+
+
+def main():
+    g2p = ja.JAG2P(version="cutlet")
+
+    def phonemize(w: str) -> str:
+        ps, _ = g2p(w)
+        ps = ps.replace(" ", "")
+        if not ps or "❓" in ps:
+            return ""
+        return ps
+
+    # dict keeps insertion order (Python 3.7+), deduplicates keys and
+    # makes the manual overrides O(1)
+    lexicon: Dict[str, str] = {}
+
+    words = [w for w in top_n_list("ja", NUM_WORDS) if is_japanese_word(w)]
+
+    for w in words:
+        if w in lexicon:
+            continue
+        ps = phonemize(w)
+        if ps:
+            lexicon[w] = ps
+
+    # Word + particle compounds (word+は, word+へ). The particle reading
+    # (wa / e) is context-dependent; adding the compound as a longer
+    # lexicon entry lets greedy longest-match resolve it correctly and
+    # win over collisions such as 今日|はい|い (はい = "yes").
+    for w in words[:NUM_PARTICLE_WORDS]:
+        for p in ("は", "へ"):
+            c = w + p
+            if c in lexicon:
+                continue
+            ps = phonemize(c)
+            if ps:
+                lexicon[c] = ps
+
+    for unit in kana_units():
+        if unit in lexicon or unit in MANUAL:
+            continue
+        ps = phonemize(unit)
+        if ps:
+            lexicon[unit] = ps
+
+    # Manual overrides win over generated entries.
+    lexicon.update(MANUAL)
+
+    with open("lexicon-ja.txt", "w", encoding="utf-8") as f:
+        for word, phones in lexicon.items():
+            tokens = " ".join(phones)
+            f.write(f"{word} {tokens}\n")
+
+    print(f"Wrote {len(lexicon)} entries to lexicon-ja.txt")
+
+
+if __name__ == "__main__":
+    main()

--- a/sherpa-onnx/csrc/kokoro-multi-lang-lexicon.cc
+++ b/sherpa-onnx/csrc/kokoro-multi-lang-lexicon.cc
@@ -71,13 +71,23 @@ class KokoroMultiLangLexicon::Impl {
     // how piper_phonemize handles punctuations inside the text
     std::string text = _text;
 
-    std::vector<std::pair<std::string, std::string>> replace_str_pairs = {
-        {"，", ","}, {":", ","},  {"、", ","}, {"；", ";"},   {"：", ":"},
-        {"。", "."}, {"？", "?"}, {"！", "!"}, {"\\s+", " "},
-    };
+    // The patterns are static; compile them only once.
+    static const std::vector<std::pair<std::regex, std::string>>
+        replace_str_pairs = [] {
+          std::vector<std::pair<std::string, std::string>> pairs = {
+              {"，", ","}, {":", ","},  {"、", ","}, {"；", ";"},  {"：", ":"},
+              {"。", "."}, {"？", "?"}, {"！", "!"}, {"「", "“"}, {"」", "”"},
+              {"『", "“"}, {"』", "”"}, {"・", " "}, {"　", " "}, {"\\s+", " "},
+          };
+          std::vector<std::pair<std::regex, std::string>> ans;
+          ans.reserve(pairs.size());
+          for (const auto &p : pairs) {
+            ans.emplace_back(std::regex(p.first), p.second);
+          }
+          return ans;
+        }();
     for (const auto &p : replace_str_pairs) {
-      std::regex re(p.first);
-      text = std::regex_replace(text, re, p.second);
+      text = std::regex_replace(text, p.first, p.second);
     }
 
     if (debug_) {
@@ -85,10 +95,25 @@ class KokoroMultiLangLexicon::Impl {
                        text.c_str());
     }
 
+    // If the language is Japanese, CJK runs (kana + kanji) are looked up
+    // in the Japanese lexicon (e.g., lexicon-ja.txt), and non-CJK runs
+    // fall back to the word lexicon + espeak-ng path.
+    // The comparison is case-insensitive (e.g., "ja", "JA", "Jpn").
+    std::string voice_lower = ToLowerCase(voice);
+    bool is_ja =
+        (voice_lower == "ja" || voice_lower == "jp" || voice_lower == "jpn");
+
     // https://en.cppreference.com/w/cpp/regex
     // https://stackoverflow.com/questions/37989081/how-to-use-unicode-range-in-c-regex
-    std::string expr_chinese = "([\\u4e00-\\u9fff]+)";
-    std::string expr_not_chinese = "([^\\u4e00-\\u9fff]+)";
+    // For Japanese we also match hiragana/katakana (぀-ヿ),
+    // the iteration mark 々 (々) and the long vowel mark ー (ー,
+    // included in the katakana block).
+    std::string expr_chinese = is_ja
+                                   ? "([\\u3005\\u3040-\\u30ff\\u4e00-\\u9fff]+)"
+                                   : "([\\u4e00-\\u9fff]+)";
+    std::string expr_not_chinese =
+        is_ja ? "([^\\u3005\\u3040-\\u30ff\\u4e00-\\u9fff]+)"
+              : "([^\\u4e00-\\u9fff]+)";
 
     std::string expr_both = expr_chinese + "|" + expr_not_chinese;
 
@@ -114,15 +139,21 @@ class KokoroMultiLangLexicon::Impl {
       std::vector<std::vector<int32_t>> ids_vec;
       if (std::regex_match(match_str, we_zh)) {
         if (debug_) {
-          SHERPA_ONNX_LOGE("Chinese: %s", ms.c_str());
+          SHERPA_ONNX_LOGE("%s: %s", is_ja ? "Japanese" : "Chinese", ms.c_str());
         }
-        ids_vec = ConvertChineseToTokenIDs(ms);
+        // For Japanese, insert a space token between matched words to
+        // keep the prosody close to the reference misaki G2P output.
+        ids_vec = ConvertChineseToTokenIDs(ms, /*add_space=*/is_ja);
       } else {
         if (debug_) {
-          SHERPA_ONNX_LOGE("Non-Chinese: %s", ms.c_str());
+          SHERPA_ONNX_LOGE("%s: %s", is_ja ? "Non-Japanese" : "Non-Chinese",
+                           ms.c_str());
         }
 
-        ids_vec = ConvertNonChineseToTokenIDs(ms, voice);
+        // In Japanese mode, non-CJK runs (e.g., embedded English words)
+        // use the word lexicon + espeak-ng fallback instead of
+        // phonemizing everything with an espeak "ja" voice.
+        ids_vec = ConvertNonChineseToTokenIDs(ms, is_ja ? "" : voice);
       }
 
       for (const auto &ids : ids_vec) {
@@ -210,7 +241,7 @@ class KokoroMultiLangLexicon::Impl {
   }
 
   std::vector<std::vector<int32_t>> ConvertChineseToTokenIDs(
-      const std::string &text) const {
+      const std::string &text, bool add_space = false) const {
     std::vector<std::string> words = SplitUtf8(text);
 
     if (debug_) {
@@ -255,6 +286,22 @@ class KokoroMultiLangLexicon::Impl {
         this_sentence.push_back(0);
       }
 
+      if (add_space && this_sentence.size() > 1) {
+        // 促音 ʔ の直後や長音 ː の直前で区切ると不自然な破裂音になるため
+        // その場合はスペースを入れない
+        bool skip = false;
+        if (token2id_.count("ʔ") &&
+            this_sentence.back() == token2id_.at("ʔ")) {
+          skip = true;
+        }
+        if (!ids.empty() && token2id_.count("ː") &&
+            ids[0] == token2id_.at("ː")) {
+          skip = true;
+        }
+        if (!skip) {
+          this_sentence.push_back(token2id_.at(" "));
+        }
+      }
       this_sentence.insert(this_sentence.end(), ids.begin(), ids.end());
     }  // for (const std::string &w : matcher)
 


### PR DESCRIPTION
## What does this PR do?

This PR adds Japanese TTS support to the Kokoro multi-lang models
(`kokoro-multi-lang-v1_0`), following the same lexicon-based design as the
existing Chinese support.

The model itself is already Japanese-capable: `voices.bin` contains the 5
Japanese speakers (`jf_alpha`, `jf_gongitsune`, `jf_nezumi`, `jf_tebukuro`,
`jm_kumo`, sid 37-41) and `tokens.txt` covers the Japanese phonemes. What was
missing is the text frontend: Japanese runs (kana + kanji) could not be
converted to token IDs.

## Changes

1. **`scripts/kokoro/v1.0/generate_lexicon_ja.py`** (new)
   Generates `lexicon-ja.txt` offline using misaki's *cutlet-version* Japanese
   G2P (this is the phoneme format v1.0 was trained with; the newer
   pyopenjtalk-based G2P of misaki emits pitch-string characters like `_ ^ -`
   that are not in v1.0 `tokens.txt`). The lexicon contains:
   - the ~100k most frequent Japanese words (wordfreq)
   - word + particle compounds (`word+は`, `word+へ`), so that greedy
     longest-match resolves the context-dependent particle readings
     (は=wa, へ=e) and wins over collisions such as 今日|はい|い
   - every single kana and small-kana combination as a fallback, so any
     kana-only OOV text is always synthesizable
   - 127,162 entries, ~2.3 MB (similar to `lexicon-zh.txt`)

2. **`sherpa-onnx/csrc/kokoro-multi-lang-lexicon.cc`**
   - When `--kokoro-lang=ja` is given, kana/kanji runs are routed to the
     lexicon phrase matcher. The default (no `lang`) is unchanged, so the
     existing Chinese/English behavior is fully backward compatible.
   - A space token is inserted between matched Japanese words, which keeps
     the prosody close to the reference sentence-level misaki G2P output.
   - Non-CJK runs (e.g. embedded English words) use the word lexicon +
     espeak-ng fallback instead of an espeak "ja" voice.
   - Japanese punctuation (「」『』・ and full-width space) is normalized.

## Usage

```bash
sherpa-onnx-offline-tts \
  --kokoro-model=./kokoro-multi-lang-v1_0/model.onnx \
  --kokoro-voices=./kokoro-multi-lang-v1_0/voices.bin \
  --kokoro-tokens=./kokoro-multi-lang-v1_0/tokens.txt \
  --kokoro-data-dir=./kokoro-multi-lang-v1_0/espeak-ng-data \
  --kokoro-lexicon=./lexicon-ja.txt,./kokoro-multi-lang-v1_0/lexicon-us-en.txt \
  --kokoro-lang=ja \
  --sid=38 \
  --output-filename=./ja.wav \
  "今日はいい天気ですね。映画を見に行きませんか。"
```

## How this was tested

- Verified via the C API (Windows x64, CPU) with
  `kokoro-multi-lang-v1_0`: Japanese runs are routed to the lexicon,
  embedded English words (e.g. "hobby") are routed to the English lexicon,
  and punctuation is normalized as expected (checked with `--debug`).
- Round-trip check with Whisper (ja): the synthesized audio for test
  sentences (greetings, weather, mixed Japanese/English) is transcribed back
  to the original text.
- Compared the lexicon-based phonemization against the reference
  sentence-level misaki G2P on a test sentence set: with the word+particle
  compound entries, the outputs match on all test sentences.

## Known limitations

- A word-level lexicon cannot fully disambiguate context-dependent readings
  (e.g. 今日 = きょう/こんにち, 行った = いった/おこなった). This is the
  same trade-off as the existing Chinese support (heteronyms).
- Numbers and symbols are not yet converted to their Japanese readings
  (no num2kana equivalent). This could be a follow-up (e.g. an FST like
  `number-zh.fst`).
- v1.0 was trained without pitch-accent information (cutlet phonemes), so
  pitch accent is up to the model. If a future Kokoro release is trained
  with misaki's newer pitch-aware Japanese format, only the lexicon needs
  to be regenerated.

## Note

The generated `lexicon-ja.txt` (127,162 entries, ~2.3 MB) is intentionally
not included in this PR, since lexicons are distributed inside the model
packages (like `lexicon-zh.txt` in `kokoro-multi-lang-v1_0.tar.bz2`) rather
than in the repository. I can provide the generated file for inclusion in
the kokoro-multi-lang model packages, or it can be regenerated with the
script added in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone Japanese lexicon generator that produces a new `lexicon-ja.txt`, including frequent-token coverage, particle compounds, full kana handling, and manual pronunciation overrides.
  * Added optional spacing insertion in generated Japanese token IDs to improve text rendering/shaping.
* **Bug Fixes**
  * Improved Japanese vs non-Japanese tokenization by normalizing quotes/punctuation/whitespace and using case-insensitive language detection for safer routing and more accurate matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->