### PR TITLE
Print per-stage timing for offline speaker diarization in debug mode

### DIFF
--- a/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
+++ b/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <cmath>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -104,6 +105,7 @@ class OfflineSpeakerDiarizationPyannoteImpl
     // segmentations[i] is for chunk_i
     // Each matrix is of shape (num_frames, num_powerset_classes)
     if (segmentations.empty()) {
+      // Timings are intentionally not logged since n can be non-positive.
       return {};
     }
 
@@ -126,18 +128,8 @@ class OfflineSpeakerDiarizationPyannoteImpl
 
       const auto process_end = std::chrono::steady_clock::now();
       if (config_.segmentation.debug) {
-        float segmentation_seconds =
-            std::chrono::duration<float>(segmentation_end - segmentation_begin)
-                .count();
-        float total_seconds =
-            std::chrono::duration<float>(process_end - process_begin).count();
-        float audio_duration = static_cast<float>(n) / SampleRate();
-
-        SHERPA_ONNX_LOGE("OfflineSpeakerDiarization: segmentation %.3f s",
-                         segmentation_seconds);
-        SHERPA_ONNX_LOGE(
-            "OfflineSpeakerDiarization: total %.3f s, audio %.3f s, RTF %.3f",
-            total_seconds, audio_duration, total_seconds / audio_duration);
+        LogTimings(process_begin, process_end, segmentation_begin,
+                   segmentation_end, std::nullopt, std::nullopt, n);
       }
 
       return result;
@@ -149,6 +141,11 @@ class OfflineSpeakerDiarizationPyannoteImpl
     Int32RowVector speakers_per_frame = ComputeSpeakersPerFrame(labels);
 
     if (speakers_per_frame.maxCoeff() == 0) {
+      const auto process_end = std::chrono::steady_clock::now();
+      if (config_.segmentation.debug) {
+        LogTimings(process_begin, process_end, segmentation_begin,
+                   segmentation_end, std::nullopt, std::nullopt, n);
+      }
       SHERPA_ONNX_LOGE("No speakers found in the audio samples");
       return {};
     }
@@ -198,6 +195,12 @@ class OfflineSpeakerDiarizationPyannoteImpl
     const auto clustering_end = std::chrono::steady_clock::now();
 
     if (cluster_labels.empty()) {
+      const auto process_end = std::chrono::steady_clock::now();
+      if (config_.segmentation.debug) {
+        LogTimings(process_begin, process_end, segmentation_begin,
+                   segmentation_end, embedding_end - embedding_begin,
+                   clustering_end - clustering_begin, n);
+      }
       SHERPA_ONNX_LOGE("No speakers found in the audio samples");
       return {};
     }
@@ -220,34 +223,45 @@ class OfflineSpeakerDiarizationPyannoteImpl
 
     const auto process_end = std::chrono::steady_clock::now();
     if (config_.segmentation.debug) {
-      float segmentation_seconds =
-          std::chrono::duration<float>(segmentation_end - segmentation_begin)
-              .count();
-      float embedding_seconds =
-          std::chrono::duration<float>(embedding_end - embedding_begin)
-              .count();
-      float clustering_seconds =
-          std::chrono::duration<float>(clustering_end - clustering_begin)
-              .count();
-      float total_seconds =
-          std::chrono::duration<float>(process_end - process_begin).count();
-      float audio_duration = static_cast<float>(n) / SampleRate();
-
-      SHERPA_ONNX_LOGE("OfflineSpeakerDiarization: segmentation %.3f s",
-                       segmentation_seconds);
-      SHERPA_ONNX_LOGE("OfflineSpeakerDiarization: embedding %.3f s",
-                       embedding_seconds);
-      SHERPA_ONNX_LOGE("OfflineSpeakerDiarization: clustering %.3f s",
-                       clustering_seconds);
-      SHERPA_ONNX_LOGE(
-          "OfflineSpeakerDiarization: total %.3f s, audio %.3f s, RTF %.3f",
-          total_seconds, audio_duration, total_seconds / audio_duration);
+      LogTimings(process_begin, process_end, segmentation_begin,
+                 segmentation_end, embedding_end - embedding_begin,
+                 clustering_end - clustering_begin, n);
     }
 
     return result;
   }
 
  private:
+  void LogTimings(
+      const std::chrono::steady_clock::time_point &process_begin,
+      const std::chrono::steady_clock::time_point &process_end,
+      const std::chrono::steady_clock::time_point &segmentation_begin,
+      const std::chrono::steady_clock::time_point &segmentation_end,
+      std::optional<std::chrono::duration<float>> embedding_duration,
+      std::optional<std::chrono::duration<float>> clustering_duration,
+      int32_t num_samples) const {
+    float segmentation_seconds =
+        std::chrono::duration<float>(segmentation_end - segmentation_begin)
+            .count();
+    float total_seconds =
+        std::chrono::duration<float>(process_end - process_begin).count();
+    float audio_duration = static_cast<float>(num_samples) / SampleRate();
+
+    SHERPA_ONNX_LOGE("OfflineSpeakerDiarization: segmentation %.3f s",
+                     segmentation_seconds);
+    if (embedding_duration) {
+      SHERPA_ONNX_LOGE("OfflineSpeakerDiarization: embedding %.3f s",
+                       embedding_duration->count());
+    }
+    if (clustering_duration) {
+      SHERPA_ONNX_LOGE("OfflineSpeakerDiarization: clustering %.3f s",
+                       clustering_duration->count());
+    }
+    SHERPA_ONNX_LOGE(
+        "OfflineSpeakerDiarization: total %.3f s, audio %.3f s, RTF %.3f",
+        total_seconds, audio_duration, total_seconds / audio_duration);
+  }
+
   void Init() { InitPowersetMapping(); }
 
   // see also

--- a/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
+++ b/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
@@ -5,6 +5,7 @@
 #define SHERPA_ONNX_CSRC_OFFLINE_SPEAKER_DIARIZATION_PYANNOTE_IMPL_H_
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <memory>
 #include <unordered_map>
@@ -96,7 +97,10 @@ class OfflineSpeakerDiarizationPyannoteImpl
       const float *audio, int32_t n,
       OfflineSpeakerDiarizationProgressCallback callback = nullptr,
       void *callback_arg = nullptr) const override {
+    const auto process_begin = std::chrono::steady_clock::now();
+    const auto segmentation_begin = process_begin;
     std::vector<Matrix2D> segmentations = RunSpeakerSegmentationModel(audio, n);
+    const auto segmentation_end = std::chrono::steady_clock::now();
     // segmentations[i] is for chunk_i
     // Each matrix is of shape (num_frames, num_powerset_classes)
     if (segmentations.empty()) {
@@ -117,7 +121,26 @@ class OfflineSpeakerDiarizationPyannoteImpl
         callback(1, 1, callback_arg);
       }
 
-      return HandleOneChunkSpecialCase(labels[0], n);
+      OfflineSpeakerDiarizationResult result =
+          HandleOneChunkSpecialCase(labels[0], n);
+
+      const auto process_end = std::chrono::steady_clock::now();
+      if (config_.segmentation.debug) {
+        float segmentation_seconds =
+            std::chrono::duration<float>(segmentation_end - segmentation_begin)
+                .count();
+        float total_seconds =
+            std::chrono::duration<float>(process_end - process_begin).count();
+        float audio_duration = static_cast<float>(n) / SampleRate();
+
+        SHERPA_ONNX_LOGE("OfflineSpeakerDiarization: segmentation %.3f s",
+                         segmentation_seconds);
+        SHERPA_ONNX_LOGE(
+            "OfflineSpeakerDiarization: total %.3f s, audio %.3f s, RTF %.3f",
+            total_seconds, audio_duration, total_seconds / audio_duration);
+      }
+
+      return result;
     }
 
     // labels[i] is a 0-1 matrix of shape (num_frames, num_speakers)
@@ -138,9 +161,11 @@ class OfflineSpeakerDiarizationPyannoteImpl
     std::vector<int32_t> valid_indexes;
     valid_indexes.reserve(chunk_speaker_samples_list_pair.second.size());
 
+    const auto embedding_begin = std::chrono::steady_clock::now();
     Matrix2D embeddings =
         ComputeEmbeddings(audio, n, chunk_speaker_samples_list_pair.second,
                           &valid_indexes, std::move(callback), callback_arg);
+    const auto embedding_end = std::chrono::steady_clock::now();
 
     if (valid_indexes.size() != chunk_speaker_samples_list_pair.second.size()) {
       std::vector<Int32Pair> chunk_speaker_pair;
@@ -167,8 +192,10 @@ class OfflineSpeakerDiarizationPyannoteImpl
       chunk_speaker_samples_list_pair.second = std::move(sample_indexes);
     }
 
+    const auto clustering_begin = std::chrono::steady_clock::now();
     std::vector<int32_t> cluster_labels = clustering_->Cluster(
         &embeddings(0, 0), embeddings.rows(), embeddings.cols());
+    const auto clustering_end = std::chrono::steady_clock::now();
 
     if (cluster_labels.empty()) {
       SHERPA_ONNX_LOGE("No speakers found in the audio samples");
@@ -190,6 +217,32 @@ class OfflineSpeakerDiarizationPyannoteImpl
         FinalizeLabels(speaker_count, speakers_per_frame);
 
     auto result = ComputeResult(final_labels);
+
+    const auto process_end = std::chrono::steady_clock::now();
+    if (config_.segmentation.debug) {
+      float segmentation_seconds =
+          std::chrono::duration<float>(segmentation_end - segmentation_begin)
+              .count();
+      float embedding_seconds =
+          std::chrono::duration<float>(embedding_end - embedding_begin)
+              .count();
+      float clustering_seconds =
+          std::chrono::duration<float>(clustering_end - clustering_begin)
+              .count();
+      float total_seconds =
+          std::chrono::duration<float>(process_end - process_begin).count();
+      float audio_duration = static_cast<float>(n) / SampleRate();
+
+      SHERPA_ONNX_LOGE("OfflineSpeakerDiarization: segmentation %.3f s",
+                       segmentation_seconds);
+      SHERPA_ONNX_LOGE("OfflineSpeakerDiarization: embedding %.3f s",
+                       embedding_seconds);
+      SHERPA_ONNX_LOGE("OfflineSpeakerDiarization: clustering %.3f s",
+                       clustering_seconds);
+      SHERPA_ONNX_LOGE(
+          "OfflineSpeakerDiarization: total %.3f s, audio %.3f s, RTF %.3f",
+          total_seconds, audio_duration, total_seconds / audio_duration);
+    }
 
     return result;
   }

--- a/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
+++ b/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
@@ -5,10 +5,8 @@
 #define SHERPA_ONNX_CSRC_OFFLINE_SPEAKER_DIARIZATION_PYANNOTE_IMPL_H_
 
 #include <algorithm>
-#include <chrono>
 #include <cmath>
 #include <memory>
-#include <optional>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -20,6 +18,7 @@
 #include "sherpa-onnx/csrc/offline-speaker-diarization-impl.h"
 #include "sherpa-onnx/csrc/offline-speaker-segmentation-pyannote-model.h"
 #include "sherpa-onnx/csrc/speaker-embedding-extractor.h"
+#include "sherpa-onnx/csrc/timer.h"
 
 namespace sherpa_onnx {
 
@@ -98,16 +97,16 @@ class OfflineSpeakerDiarizationPyannoteImpl
       const float *audio, int32_t n,
       OfflineSpeakerDiarizationProgressCallback callback = nullptr,
       void *callback_arg = nullptr) const override {
-    const auto process_begin = std::chrono::steady_clock::now();
-    const auto segmentation_begin = process_begin;
+    Timer total_timer(config_.segmentation.debug);
+    Timer segmentation_timer(config_.segmentation.debug);
     std::vector<Matrix2D> segmentations = RunSpeakerSegmentationModel(audio, n);
-    const auto segmentation_end = std::chrono::steady_clock::now();
     // segmentations[i] is for chunk_i
     // Each matrix is of shape (num_frames, num_powerset_classes)
     if (segmentations.empty()) {
       // Timings are intentionally not logged since n can be non-positive.
       return {};
     }
+    segmentation_timer.Log("OfflineSpeakerDiarization: segmentation");
 
     std::vector<Matrix2DInt32> labels;
     labels.reserve(segmentations.size());
@@ -126,10 +125,8 @@ class OfflineSpeakerDiarizationPyannoteImpl
       OfflineSpeakerDiarizationResult result =
           HandleOneChunkSpecialCase(labels[0], n);
 
-      const auto process_end = std::chrono::steady_clock::now();
       if (config_.segmentation.debug) {
-        LogTimings(process_begin, process_end, segmentation_begin,
-                   segmentation_end, std::nullopt, std::nullopt, n);
+        LogTotal(static_cast<float>(total_timer.Elapsed()), n);
       }
 
       return result;
@@ -141,10 +138,8 @@ class OfflineSpeakerDiarizationPyannoteImpl
     Int32RowVector speakers_per_frame = ComputeSpeakersPerFrame(labels);
 
     if (speakers_per_frame.maxCoeff() == 0) {
-      const auto process_end = std::chrono::steady_clock::now();
       if (config_.segmentation.debug) {
-        LogTimings(process_begin, process_end, segmentation_begin,
-                   segmentation_end, std::nullopt, std::nullopt, n);
+        LogTotal(static_cast<float>(total_timer.Elapsed()), n);
       }
       SHERPA_ONNX_LOGE("No speakers found in the audio samples");
       return {};
@@ -158,11 +153,11 @@ class OfflineSpeakerDiarizationPyannoteImpl
     std::vector<int32_t> valid_indexes;
     valid_indexes.reserve(chunk_speaker_samples_list_pair.second.size());
 
-    const auto embedding_begin = std::chrono::steady_clock::now();
+    Timer embedding_timer(config_.segmentation.debug);
     Matrix2D embeddings =
         ComputeEmbeddings(audio, n, chunk_speaker_samples_list_pair.second,
                           &valid_indexes, std::move(callback), callback_arg);
-    const auto embedding_end = std::chrono::steady_clock::now();
+    embedding_timer.Log("OfflineSpeakerDiarization: embedding");
 
     if (valid_indexes.size() != chunk_speaker_samples_list_pair.second.size()) {
       std::vector<Int32Pair> chunk_speaker_pair;
@@ -189,17 +184,14 @@ class OfflineSpeakerDiarizationPyannoteImpl
       chunk_speaker_samples_list_pair.second = std::move(sample_indexes);
     }
 
-    const auto clustering_begin = std::chrono::steady_clock::now();
+    Timer clustering_timer(config_.segmentation.debug);
     std::vector<int32_t> cluster_labels = clustering_->Cluster(
         &embeddings(0, 0), embeddings.rows(), embeddings.cols());
-    const auto clustering_end = std::chrono::steady_clock::now();
+    clustering_timer.Log("OfflineSpeakerDiarization: clustering");
 
     if (cluster_labels.empty()) {
-      const auto process_end = std::chrono::steady_clock::now();
       if (config_.segmentation.debug) {
-        LogTimings(process_begin, process_end, segmentation_begin,
-                   segmentation_end, embedding_end - embedding_begin,
-                   clustering_end - clustering_begin, n);
+        LogTotal(static_cast<float>(total_timer.Elapsed()), n);
       }
       SHERPA_ONNX_LOGE("No speakers found in the audio samples");
       return {};
@@ -221,45 +213,27 @@ class OfflineSpeakerDiarizationPyannoteImpl
 
     auto result = ComputeResult(final_labels);
 
-    const auto process_end = std::chrono::steady_clock::now();
     if (config_.segmentation.debug) {
-      LogTimings(process_begin, process_end, segmentation_begin,
-                 segmentation_end, embedding_end - embedding_begin,
-                 clustering_end - clustering_begin, n);
+      LogTotal(static_cast<float>(total_timer.Elapsed()), n);
     }
 
     return result;
   }
 
  private:
-  void LogTimings(
-      const std::chrono::steady_clock::time_point &process_begin,
-      const std::chrono::steady_clock::time_point &process_end,
-      const std::chrono::steady_clock::time_point &segmentation_begin,
-      const std::chrono::steady_clock::time_point &segmentation_end,
-      std::optional<std::chrono::duration<float>> embedding_duration,
-      std::optional<std::chrono::duration<float>> clustering_duration,
-      int32_t num_samples) const {
-    float segmentation_seconds =
-        std::chrono::duration<float>(segmentation_end - segmentation_begin)
-            .count();
-    float total_seconds =
-        std::chrono::duration<float>(process_end - process_begin).count();
+  void LogTotal(float total_seconds, int32_t num_samples) const {
     float audio_duration = static_cast<float>(num_samples) / SampleRate();
 
-    SHERPA_ONNX_LOGE("OfflineSpeakerDiarization: segmentation %.3f s",
-                     segmentation_seconds);
-    if (embedding_duration) {
-      SHERPA_ONNX_LOGE("OfflineSpeakerDiarization: embedding %.3f s",
-                       embedding_duration->count());
-    }
-    if (clustering_duration) {
-      SHERPA_ONNX_LOGE("OfflineSpeakerDiarization: clustering %.3f s",
-                       clustering_duration->count());
-    }
+#if __OHOS__
+    SHERPA_ONNX_LOGE(
+        "OfflineSpeakerDiarization: total %{public}.3f s, audio "
+        "%{public}.3f s, RTF %{public}.3f",
+        total_seconds, audio_duration, total_seconds / audio_duration);
+#else
     SHERPA_ONNX_LOGE(
         "OfflineSpeakerDiarization: total %.3f s, audio %.3f s, RTF %.3f",
         total_seconds, audio_duration, total_seconds / audio_duration);
+#endif
   }
 
   void Init() { InitPowersetMapping(); }

--- a/sherpa-onnx/csrc/timer.cc
+++ b/sherpa-onnx/csrc/timer.cc
@@ -7,30 +7,59 @@
 #include <chrono>
 #include <memory>
 
+#include "sherpa-onnx/csrc/macros.h"
+
 namespace sherpa_onnx {
 
 // modified from https://github.com/kaldi-asr/kaldi/blob/master/src/base/timer.h
 class Timer::Impl {
  public:
-  Impl() { Reset(); }
+  explicit Impl(bool debug) : debug_(debug) {
+    if (debug_) {
+      Reset();
+    }
+  }
 
   using high_resolution_clock = std::chrono::high_resolution_clock;
 
-  void Reset() { begin_ = high_resolution_clock::now(); }
+  void Reset() {
+    if (!debug_) {
+      return;
+    }
+
+    begin_ = high_resolution_clock::now();
+  }
 
   // Return time in seconds
   double Elapsed() {
+    if (!debug_) {
+      return 0;
+    }
+
     auto end = high_resolution_clock::now();
     auto diff =
         std::chrono::duration_cast<std::chrono::microseconds>(end - begin_);
     return diff.count() / 1000000.0;
   }
 
+  void Log(const char *tag) {
+    if (!debug_) {
+      return;
+    }
+
+#if __OHOS__
+    SHERPA_ONNX_LOGE("%{public}s %{public}.3f s", tag, Elapsed());
+#else
+    SHERPA_ONNX_LOGE("%s %.3f s", tag, Elapsed());
+#endif
+  }
+
  private:
+  bool debug_;
   high_resolution_clock::time_point begin_;
 };
 
-Timer::Timer() : impl_(std::make_unique<Impl>()) {}
+Timer::Timer(bool debug) : impl_(std::make_unique<Impl>(debug)) {}
 
 Timer::~Timer() = default;
 
@@ -38,5 +67,7 @@ void Timer::Reset() const { impl_->Reset(); }
 
 // Return time in seconds
 double Timer::Elapsed() const { return impl_->Elapsed(); }
+
+void Timer::Log(const char *tag) const { impl_->Log(tag); }
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/timer.h
+++ b/sherpa-onnx/csrc/timer.h
@@ -11,13 +11,15 @@ namespace sherpa_onnx {
 
 class Timer {
  public:
-  Timer();
+  explicit Timer(bool debug = true);
   ~Timer();
 
   void Reset() const;
 
   // Return time in seconds
   double Elapsed() const;
+
+  void Log(const char *tag) const;
 
  private:
   class Impl;


### PR DESCRIPTION
When `--segmentation.debug=true` is set, the offline pyannote diarization pipeline now logs per-stage wall-clock timings at the end of `Process()`:

```
OfflineSpeakerDiarization: segmentation 40.712 s
OfflineSpeakerDiarization: embedding 5.438 s
OfflineSpeakerDiarization: clustering 0.012 s
OfflineSpeakerDiarization: total 46.315 s, audio 180.000 s, RTF 0.257
```

Motivation: offline diarization is often the dominant cost in end-user pipelines (on mobile CPUs we see RTF 0.25+), and today there is no way to see how the time splits between the segmentation model, embedding extraction, and clustering without patching the source. Having the split visible makes it much easier to diagnose provider/backend regressions (e.g. the kind of slowdown reported in #2355) and to know which stage is worth optimizing on a given device.

Notes:

- Output is gated behind the existing `config_.segmentation.debug` flag; no new config field or API surface.
- The three stage lines bracket only the segmentation forward loop, `ComputeEmbeddings`, and `Cluster`; the total also includes label conversion, stitching, and relabeling, so the stages will not sum exactly to the total.
- The one-chunk shortcut path logs only segmentation and total (embedding/clustering do not run there).
- Early exits that occur after real work also log the stages that ran (segmentation only for the no-speakers exit; all stages for the empty-clustering exit) — those are exactly the runs where the split helps diagnose a regression. The empty-segmentations exit stays silent since it can be reached with `n <= 0`.
- Timings use `std::chrono::steady_clock`; the non-debug path only gains a few monotonic clock reads.
- The total is captured before the log lines are emitted, so logging I/O does not inflate it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Monitoring**
  * Added debug-controlled runtime timing logs for speaker diarization, covering segmentation, embedding computation, clustering, and overall processing duration.
  * When diagnostic mode is enabled, logs also report estimated audio duration and real-time factor (RTF) to improve end-to-end performance visibility.
  * In cases where diarization produces no output, concise total/RTF logging is still emitted for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->