### PR TITLE
Make the Pyannote segmentation window shift configurable

### DIFF
--- a/sherpa-onnx/csrc/offline-speaker-segmentation-pyannote-model-config.cc
+++ b/sherpa-onnx/csrc/offline-speaker-segmentation-pyannote-model-config.cc
@@ -14,9 +14,21 @@ namespace sherpa_onnx {
 void OfflineSpeakerSegmentationPyannoteModelConfig::Register(ParseOptions *po) {
   po->Register("pyannote-model", &model,
                "Path to model.onnx of the Pyannote segmentation model.");
+  po->Register(
+      "pyannote-window-shift-ratio", &window_shift_ratio,
+      "Window shift as a ratio of the Pyannote segmentation window size. "
+      "Default: 0.1. Valid range: 0 < ratio <= 1. Smaller values mean more "
+      "overlap, higher quality, and slower processing.");
 }
 
 bool OfflineSpeakerSegmentationPyannoteModelConfig::Validate() const {
+  if (!(window_shift_ratio > 0 && window_shift_ratio <= 1)) {
+    SHERPA_ONNX_LOGE(
+        "--pyannote-window-shift-ratio must be in (0, 1]. Given: %f",
+        window_shift_ratio);
+    return false;
+  }
+
   if (!FileExists(model)) {
     SHERPA_ONNX_LOGE("Pyannote segmentation model: '%s' does not exist",
                      model.c_str());
@@ -30,7 +42,8 @@ std::string OfflineSpeakerSegmentationPyannoteModelConfig::ToString() const {
   std::ostringstream os;
 
   os << "OfflineSpeakerSegmentationPyannoteModelConfig(";
-  os << "model=\"" << model << "\")";
+  os << "model=\"" << model << "\", ";
+  os << "window_shift_ratio=" << window_shift_ratio << ")";
 
   return os.str();
 }

--- a/sherpa-onnx/csrc/offline-speaker-segmentation-pyannote-model-config.h
+++ b/sherpa-onnx/csrc/offline-speaker-segmentation-pyannote-model-config.h
@@ -12,12 +12,13 @@ namespace sherpa_onnx {
 
 struct OfflineSpeakerSegmentationPyannoteModelConfig {
   std::string model;
+  float window_shift_ratio = 0.1f;
 
   OfflineSpeakerSegmentationPyannoteModelConfig() = default;
 
   explicit OfflineSpeakerSegmentationPyannoteModelConfig(
-      const std::string &model)
-      : model(model) {}
+      const std::string &model, float window_shift_ratio = 0.1f)
+      : model(model), window_shift_ratio(window_shift_ratio) {}
 
   void Register(ParseOptions *po);
   bool Validate() const;

--- a/sherpa-onnx/csrc/offline-speaker-segmentation-pyannote-model.cc
+++ b/sherpa-onnx/csrc/offline-speaker-segmentation-pyannote-model.cc
@@ -93,8 +93,24 @@ class OfflineSpeakerSegmentationPyannoteModel::Impl {
     SHERPA_ONNX_READ_META_DATA(meta_data_.sample_rate, "sample_rate");
     SHERPA_ONNX_READ_META_DATA(meta_data_.window_size, "window_size");
 
-    meta_data_.window_shift =
-        static_cast<int32_t>(0.1 * meta_data_.window_size);
+    const double window_shift =
+        static_cast<double>(config_.pyannote.window_shift_ratio) *
+        meta_data_.window_size;
+    if (!(window_shift >= 1)) {
+      SHERPA_ONNX_LOGE(
+          "Computed Pyannote window shift %f is less than 1 sample or "
+          "invalid. Clamping it to 1 sample.",
+          window_shift);
+      meta_data_.window_shift = 1;
+    } else if (window_shift > meta_data_.window_size) {
+      SHERPA_ONNX_LOGE(
+          "Computed Pyannote window shift %f exceeds window size %d. "
+          "Clamping it to %d samples.",
+          window_shift, meta_data_.window_size, meta_data_.window_size);
+      meta_data_.window_shift = meta_data_.window_size;
+    } else {
+      meta_data_.window_shift = static_cast<int32_t>(window_shift);
+    }
 
     SHERPA_ONNX_READ_META_DATA(meta_data_.receptive_field_size,
                                "receptive_field_size");

--- a/sherpa-onnx/csrc/offline-speaker-segmentation-pyannote-model.cc
+++ b/sherpa-onnx/csrc/offline-speaker-segmentation-pyannote-model.cc
@@ -6,6 +6,7 @@
 #include "sherpa-onnx/csrc/ort-env.h"
 #include "sherpa-onnx/csrc/macros.h"
 
+#include <cmath>
 #include <memory>
 #include <string>
 #include <utility>
@@ -96,7 +97,7 @@ class OfflineSpeakerSegmentationPyannoteModel::Impl {
     const double window_shift =
         static_cast<double>(config_.pyannote.window_shift_ratio) *
         meta_data_.window_size;
-    if (!(window_shift >= 1)) {
+    if (std::isnan(window_shift) || window_shift < 1) {
       SHERPA_ONNX_LOGE(
           "Computed Pyannote window shift %f is less than 1 sample or "
           "invalid. Clamping it to 1 sample.",


### PR DESCRIPTION
The pyannote segmentation sliding-window shift is currently hardcoded to 10% of the window size (a 10 s window sliding every 1 s, i.e. 90% overlap):

```c++
meta_data_.window_shift = static_cast<int32_t>(0.1 * meta_data_.window_size);
```

The shift directly scales the total work of the whole diarization pipeline: the number of chunks fed to BOTH the segmentation model and the embedding extractor is roughly proportional to 1/ratio. On CPU-only devices where offline diarization runs at RTF 0.25+, this is the single biggest speed knob, and it is not exposed anywhere today.

This PR adds `window_shift_ratio` to `OfflineSpeakerSegmentationPyannoteModelConfig` (CLI: `--segmentation.pyannote-window-shift-ratio`), default `0.1`:

- The default provably produces the identical `int32_t` shift as before (for the standard `window_size=160000`, both the old `0.1 * 160000` and the new float-stored ratio promoted to double truncate to 16000), so existing users see no change.
- `Validate()` rejects values outside `(0, 1]` (NaN-safe); the computed shift is additionally clamped to `[1, window_size]` with a warning for library callers that bypass `Validate()`, so a degenerate ratio can never produce a zero shift and an infinite chunk loop.
- No C API / binding changes in this PR to keep it reviewable; existing bindings keep the native default. Happy to add the field to the C API and bindings in a follow-up if you want it exposed there.

Measured effect (644 s two-speaker English WAV, `sherpa-onnx-pyannote-segmentation-3-0` + CAM++ zh_en advanced embedding, `--clustering.cluster-threshold=0.90`, 4 threads each, macOS arm64, this repo's CLI):

| ratio | wall time | speedup | segments | speakers | frame-level label agreement vs 0.10 |
|-------|-----------|---------|----------|----------|--------------------------------------|
| 0.10 (default) | 40 s | 1.00x | 60 | 2 | — |
| 0.15 | 27 s | 1.48x | 60 | 2 | 99.89% |
| 0.20 | 20 s | 2.00x | 60 | 2 | 99.93% |

(Agreement computed on a 10 ms grid over the full file including silence, best label mapping; segment boundaries move by at most a few tens of milliseconds on this material. Quality on harder audio will degrade sooner as overlap drops — which is exactly why the default stays 0.1 and this is opt-in.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable window-shift ratio for Pyannote-based offline speaker segmentation (default: 0.1).
* **Bug Fixes**
  * Validation now rejects window-shift ratios outside the supported range.
  * Window-shift calculations now clamp invalid values (e.g., NaN/out of bounds) to safe limits.
* **Documentation**
  * Configuration summary output now includes the selected window-shift ratio.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->