### PR TITLE
fix(tts): insert pad after BOS in PiperPhonemesToIdsVits (#3721)

### DIFF
--- a/sherpa-onnx/csrc/piper-phonemize-lexicon.cc
+++ b/sherpa-onnx/csrc/piper-phonemize-lexicon.cc
@@ -133,9 +133,14 @@ static std::vector<int64_t> PiperPhonemesToIdsVits(
   int32_t eos = token2id.at(U'$');
 
   std::vector<int64_t> ans;
-  ans.reserve(phonemes.size());
+  // bos + pad after bos + (phoneme + pad) * N + eos
+  ans.reserve(phonemes.size() * 2 + 3);
 
   ans.push_back(bos);
+  // Match piper-phonemize phoneme_ids.cpp and OfflineTtsImpl::AddBlank():
+  // pad must follow bos so every phoneme (including the first) is framed.
+  // See https://github.com/k2-fsa/sherpa-onnx/issues/3721
+  ans.push_back(pad);
   for (auto p : phonemes) {
     if (token2id.count(p)) {
       ans.push_back(token2id.at(p));


### PR DESCRIPTION
## Summary

`PiperPhonemesToIdsVits` built `[bos, p1, pad, p2, pad, ..., eos]` while piper-phonemize and this repo's `AddBlank()` use `[bos, pad, p1, pad, p2, ..., eos]`. Models loaded with `--vits-data-dir` skip `AddBlank()` and hit this path, so every phoneme is shifted by one vs training.

Fixes #3721

## Change

One pad push after BOS in `sherpa-onnx/csrc/piper-phonemize-lexicon.cc`, plus reserve size update.

## Evidence

- Bug still present at HEAD before this branch (`ans.push_back(bos)` then loop with no pad-after-bos).
- Upstream reference `rhasspy/piper-phonemize` `phoneme_ids.cpp`: after BOS, if `interspersePad`, inserts pad before the phoneme loop.
- Local `OfflineTtsImpl::AddBlank` wraps every token including the first (`buffer` starts with blank, first token at index 1).
- No full Windows CMake build in this session (no MSVC/g++ on PATH); change is the one-line fix described in the issue.

## AI assistance

Drafted with AI assistance (Cursor/Grok). Human author: Stan Shih (stantheman0128). Reviewed against piper-phonemize source and `AddBlank()` before push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected phoneme sequencing for VITS-based speech generation.
  - Improved compatibility with Piper phonemization behavior.
  - Ensured generated speech inputs use the expected sequence structure for more consistent voice synthesis results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->