### PR TITLE
fix(asr): stop forcing lowercase in mic and ALSA display (#3621)

### DIFF
--- a/sherpa-onnx/csrc/sherpa-onnx-alsa.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-alsa.cc
@@ -5,8 +5,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <algorithm>
-#include <cctype>  // std::tolower
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -134,10 +132,9 @@ as the device_name.
 
     if (!text.empty() && last_text != text) {
       last_text = text;
-
-      std::transform(text.begin(), text.end(), text.begin(),
-                     [](auto c) { return std::tolower(c); });
-
+      // Print raw model text (same as sherpa-onnx file decode). Do not force
+      // lowercase here; tokens.txt case must stay consistent across sources.
+      // See https://github.com/k2-fsa/sherpa-onnx/issues/3621
       display.Print(segment_index, text);
       fflush(stderr);
     }

--- a/sherpa-onnx/csrc/sherpa-onnx-microphone.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-microphone.cc
@@ -6,9 +6,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <algorithm>
-#include <clocale>
-#include <cwctype>
 #include <string>
 #include <vector>
 
@@ -39,31 +36,6 @@ static int32_t RecordCallback(const void *input_buffer,
 static void Handler(int32_t /*sig*/) {
   stop = true;
   fprintf(stderr, "\nCaught Ctrl + C. Exiting...\n");
-}
-
-static std::string tolowerUnicode(const std::string &input_str) {
-  // Use system locale
-  std::setlocale(LC_ALL, "");
-
-  // From char string to wchar string
-  std::wstring input_wstr(input_str.size() + 1, '\0');
-  std::mbstowcs(&input_wstr[0], input_str.c_str(), input_str.size());
-  std::wstring lowercase_wstr;
-
-  for (wchar_t wc : input_wstr) {
-    if (std::iswupper(wc)) {
-      lowercase_wstr += std::towlower(wc);
-    } else {
-      lowercase_wstr += wc;
-    }
-  }
-
-  // Back to char string
-  std::string lowercase_str(input_str.size() + 1, '\0');
-  std::wcstombs(&lowercase_str[0], lowercase_wstr.c_str(),
-                lowercase_wstr.size());
-
-  return lowercase_str;
 }
 
 int32_t main(int32_t argc, char *argv[]) {
@@ -164,7 +136,10 @@ for a list of pre-trained models to download.
 
     if (!text.empty() && last_text != text) {
       last_text = text;
-      display.Print(segment_index, tolowerUnicode(text));
+      // Print raw model text (same as sherpa-onnx file decode). Do not force
+      // lowercase here; tokens.txt case must stay consistent across sources.
+      // See https://github.com/k2-fsa/sherpa-onnx/issues/3621
+      display.Print(segment_index, text);
       fflush(stderr);
     }
 


### PR DESCRIPTION
## Summary

`sherpa-onnx-microphone` (and ALSA) forced lowercase before display, while `sherpa-onnx` file decode prints raw model text. For English zipformer models whose `tokens.txt` is uppercase, mic output looked all-lower and file output all-upper.

This removes the forced lowercase so live capture matches file decode.

Fixes #3621

## Change

- `sherpa-onnx-microphone.cc`: drop `tolowerUnicode` and print `text` as returned by the recognizer.
- `sherpa-onnx-alsa.cc`: drop `std::tolower` transform for the same reason.

Scope is intentionally the consistency bug only. A later optional flag for upper/lower/truecase (suggested in the issue thread) can be a separate change.

## Evidence

- Confirmed at HEAD: mic calls `tolowerUnicode(text)`; file path in `sherpa-onnx.cc` prints `r.text` unchanged.
- Dosu already identified the same root cause on the issue.
- No full Windows CMake build in this session (no MSVC on PATH). Diff is display-only in the two live binaries.

## AI assistance

Drafted with AI assistance (Cursor/Grok). Human author: Stan Shih (stantheman0128).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the original capitalization of recognized speech in ALSA and microphone transcription output.
  * Removed automatic lowercasing from streaming recognition results for more consistent token casing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->