### PR TITLE
Add Fono to 'Projects using sherpa-onnx'

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,20 @@ cross-platform Node.js microphone streaming library with prebuilt native binarie
 >
 > It natively integrates sherpa-onnx to power three offline ASR engines — FunASR, Qwen3-ASR, and FireRedASR — delivering high-accuracy Chinese and multilingual speech recognition entirely on-device, with no file uploads required.
 
+### [Fono](https://github.com/bogdanr/fono)
+
+> Talk to your computer. Fono is an open-source (GPL-3.0), complete voice-AI
+> stack (speech-to-text, text-to-speech, a local LLM, wake word, speaker ID) in
+> one small binary for the Linux, macOS, and Windows desktop. Press a key and
+> speak: it types into any app, answers as a voice assistant, or drives a coding
+> agent.
+
+It uses sherpa-onnx's Supertonic TTS models for text-to-speech, with the
+Supertonic text frontend ported to Rust. See also
+[#3750](https://github.com/k2-fsa/sherpa-onnx/pull/3750), which fixes dropped
+diacritics in the Supertonic frontend for Romanian, Czech, Polish, Hungarian,
+Turkish, Vietnamese, and other non-English Latin-script languages.
+
 [silero-vad]: https://github.com/snakers4/silero-vad
 [Raspberry Pi]: https://www.raspberrypi.com/
 [RV1126]: https://www.rock-chips.com/uploads/pdf/2022.8.26/191/RV1126%20Brief%20Datasheet.pdf


### PR DESCRIPTION
Hi! Following up on #3750 (the Supertonic diacritics fix I contributed): that fix came out of building Fono, an open-source voice-AI stack for the desktop that ships sherpa-onnx's Supertonic TTS models with the text frontend ported to Rust. This PR adds Fono to the "Projects using sherpa-onnx" list.

Thanks for the great project, and for merging #3750!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Fono to the list of projects using sherpa-onnx.
  * Described Fono’s voice-AI capabilities and its use of Supertonic text-to-speech models.
  * Included a link to related Supertonic frontend improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->