### PR TITLE
Allocate FireRedASR decoder KV cache by estimated need instead of max…

### DIFF
--- a/sherpa-onnx/csrc/offline-fire-red-asr-greedy-search-decoder.cc
+++ b/sherpa-onnx/csrc/offline-fire-red-asr-greedy-search-decoder.cc
@@ -48,6 +48,8 @@ OfflineFireRedAsrGreedySearchDecoder::Decode(Ort::Value cross_k,
   int32_t num_possible_tokens = num_feature_frames / 100.0 * 6;
   num_possible_tokens =
       std::min<int32_t>(num_possible_tokens, meta_data.max_len / 2);
+  // clamp against pathological inputs so cache_len stays positive
+  num_possible_tokens = std::max<int32_t>(num_possible_tokens, 0);
 
   // The decoder loop below runs at most num_possible_tokens steps and the
   // offset advances by 1 per step, so num_possible_tokens + 4 cache entries

--- a/sherpa-onnx/csrc/offline-fire-red-asr-greedy-search-decoder.cc
+++ b/sherpa-onnx/csrc/offline-fire-red-asr-greedy-search-decoder.cc
@@ -44,7 +44,18 @@ OfflineFireRedAsrGreedySearchDecoder::Decode(Ort::Value cross_k,
 
   std::vector<OfflineFireRedAsrDecoderResult> ans(1);
 
-  auto self_kv_cache = model_->GetInitialSelfKVCache();
+  // assume at most 6 tokens per second
+  int32_t num_possible_tokens = num_feature_frames / 100.0 * 6;
+  num_possible_tokens =
+      std::min<int32_t>(num_possible_tokens, meta_data.max_len / 2);
+
+  // The decoder loop below runs at most num_possible_tokens steps and the
+  // offset advances by 1 per step, so num_possible_tokens + 4 cache entries
+  // are provably sufficient. Allocating less than max_len greatly reduces
+  // the per-step cache I/O, which dominates the decoder cost.
+  int32_t cache_len =
+      std::min<int32_t>(meta_data.max_len, num_possible_tokens + 4);
+  auto self_kv_cache = model_->GetInitialSelfKVCache(cache_len);
 
   std::tuple<Ort::Value, Ort::Value, Ort::Value, Ort::Value, Ort::Value,
              Ort::Value>
@@ -54,11 +65,6 @@ OfflineFireRedAsrGreedySearchDecoder::Decode(Ort::Value cross_k,
                      std::move(cross_k),
                      std::move(cross_v),
                      std::move(offset)};
-
-  // assume at most 6 tokens per second
-  int32_t num_possible_tokens = num_feature_frames / 100.0 * 6;
-  num_possible_tokens =
-      std::min<int32_t>(num_possible_tokens, meta_data.max_len / 2);
 
   for (int32_t i = 0; i < num_possible_tokens; ++i) {
     decoder_out = model_->ForwardDecoder(View(&tokens),

--- a/sherpa-onnx/csrc/offline-fire-red-asr-model.cc
+++ b/sherpa-onnx/csrc/offline-fire-red-asr-model.cc
@@ -158,10 +158,14 @@ class OfflineFireRedAsrModel::Impl {
         std::move(decoder_input[4]), std::move(decoder_input[5])};
   }
 
-  std::pair<Ort::Value, Ort::Value> GetInitialSelfKVCache() {
+  std::pair<Ort::Value, Ort::Value> GetInitialSelfKVCache(int32_t alloc_len) {
+    if (alloc_len <= 0 || alloc_len > meta_data_.max_len) {
+      alloc_len = meta_data_.max_len;
+    }
+
     int32_t batch_size = 1;
     std::array<int64_t, 5> shape{meta_data_.num_decoder_layers, batch_size,
-                                 meta_data_.max_len, meta_data_.num_head,
+                                 alloc_len, meta_data_.num_head,
                                  meta_data_.head_dim};
 
     Ort::Value n_layer_self_k_cache = Ort::Value::CreateTensor<float>(
@@ -320,8 +324,8 @@ OfflineFireRedAsrModel::ForwardDecoder(Ort::Value tokens,
 }
 
 std::pair<Ort::Value, Ort::Value>
-OfflineFireRedAsrModel::GetInitialSelfKVCache() const {
-  return impl_->GetInitialSelfKVCache();
+OfflineFireRedAsrModel::GetInitialSelfKVCache(int32_t alloc_len) const {
+  return impl_->GetInitialSelfKVCache(alloc_len);
 }
 
 OrtAllocator *OfflineFireRedAsrModel::Allocator() const {

--- a/sherpa-onnx/csrc/offline-fire-red-asr-model.h
+++ b/sherpa-onnx/csrc/offline-fire-red-asr-model.h
@@ -74,9 +74,9 @@ class OfflineFireRedAsrModel {
    *  - n_layer_self_v_cache A 5-D tensor of shape
    *              (num_decoder_layers, 1, alloc_len, num_head, head_dim).
    *
-   * @param alloc_len Number of frames to allocate for the cache. If it is
-   *                  not positive or is larger than the model's max_len,
-   *                  then max_len is used.
+   * @param alloc_len Number of decoder steps (token positions) to allocate for
+   *                  the cache. If it is not positive or is larger than the
+   *                  model's max_len, then max_len is used.
    */
   std::pair<Ort::Value, Ort::Value> GetInitialSelfKVCache(
       int32_t alloc_len = -1) const;

--- a/sherpa-onnx/csrc/offline-fire-red-asr-model.h
+++ b/sherpa-onnx/csrc/offline-fire-red-asr-model.h
@@ -70,11 +70,16 @@ class OfflineFireRedAsrModel {
 
   /** Return the initial self kv cache in a pair
    *  - n_layer_self_k_cache A 5-D tensor of shape
-   *                       (num_decoder_layers, N, max_len, num_head, head_dim).
+   *              (num_decoder_layers, 1, alloc_len, num_head, head_dim).
    *  - n_layer_self_v_cache A 5-D tensor of shape
-   *                       (num_decoder_layers, N, max_len, num_head, head_dim).
+   *              (num_decoder_layers, 1, alloc_len, num_head, head_dim).
+   *
+   * @param alloc_len Number of frames to allocate for the cache. If it is
+   *                  not positive or is larger than the model's max_len,
+   *                  then max_len is used.
    */
-  std::pair<Ort::Value, Ort::Value> GetInitialSelfKVCache() const;
+  std::pair<Ort::Value, Ort::Value> GetInitialSelfKVCache(
+      int32_t alloc_len = -1) const;
 
   const OfflineFireRedAsrModelMetaData &GetModelMetadata() const;
 


### PR DESCRIPTION
The self-attention KV cache was allocated with the full max_len=1024 entries, and every decoder step reads/writes it entirely. Measured per-step cost is ~9ms fixed + 0.075ms x cache_len, so cache I/O dominates the autoregressive decoder loop (~85%).

Since the greedy loop runs at most num_possible_tokens steps and the offset advances by 1 per step, num_possible_tokens + 4 entries are provably sufficient (write positions 0..num_possible_tokens-1).

Decoder is 3.5-5.4x faster; end-to-end RTF on macOS arm64, num-threads=2: 0.396->0.181 (10.1s audio), 0.503->0.247 (17.6s audio). Output is token-identical (verified on all bundled test wavs incl. dialects and a 76-token file). Cache memory drops from 2x84MB to 2x5-9MB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced memory allocation during FireRed ASR greedy decoding by sizing self-attention KV caches to a bounded, expected decoding length derived from the input.
  * Keeps decoding behavior efficient for shorter inputs while still using safe upper limits when necessary.
* **Compatibility**
  * Self-attention cache initialization now supports an optional allocation-length parameter.
  * Invalid or overly large values are clamped to valid maximums to ensure safe tensor sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->