### PR TITLE
Fix greedy search decoding for Nemo streaming transducer

### DIFF
--- a/sherpa-onnx/csrc/online-recognizer-transducer-nemo-impl.h
+++ b/sherpa-onnx/csrc/online-recognizer-transducer-nemo-impl.h
@@ -103,8 +103,8 @@ class OnlineRecognizerTransducerNeMoImpl : public OnlineRecognizerImpl {
     int32_t frame_shift_ms = 10;
     int32_t subsampling_factor = model_->SubsamplingFactor();
     const auto &decoder_result = s->GetResult();
-    bool has_language_tag = !language_tag_token_ids_.empty() &&
-                            ContainsLanguageTag(decoder_result);
+    bool has_language_tag =
+        !language_tag_token_ids_.empty() && ContainsLanguageTag(decoder_result);
     auto r = has_language_tag
                  ? Convert(FilterLanguageTags(decoder_result), symbol_table_,
                            frame_shift_ms, subsampling_factor,
@@ -150,6 +150,7 @@ class OnlineRecognizerTransducerNeMoImpl : public OnlineRecognizerImpl {
     s->SetStates(model_->GetEncoderInitStates());
 
     s->SetNeMoDecoderStates(model_->GetDecoderInitStates());
+    s->SetNeMoDecoderOut(nullptr);
 
     // Note: We only update counters. The underlying audio samples
     // are not discarded.
@@ -283,8 +284,7 @@ class OnlineRecognizerTransducerNeMoImpl : public OnlineRecognizerImpl {
 
     bool filter_ys_probs = src.ys_probs.size() == src.tokens.size();
     bool filter_lm_probs = src.lm_probs.size() == src.tokens.size();
-    bool filter_context_scores =
-        src.context_scores.size() == src.tokens.size();
+    bool filter_context_scores = src.context_scores.size() == src.tokens.size();
 
     if (filter_ys_probs) {
       ans.ys_probs.reserve(src.ys_probs.size());

--- a/sherpa-onnx/csrc/online-stream.cc
+++ b/sherpa-onnx/csrc/online-stream.cc
@@ -124,10 +124,18 @@ class OnlineStream::Impl {
   OnlineTransducerDecoderResultNoOrt &GetQnnResult() { return qnn_result_; }
 
   void SetNeMoDecoderStates(std::vector<Ort::Value> decoder_states) {
-    decoder_states_ = std::move(decoder_states);
+    nemo_decoder_states_ = std::move(decoder_states);
   }
 
-  std::vector<Ort::Value> &GetNeMoDecoderStates() { return decoder_states_; }
+  void SetNeMoDecoderOut(Ort::Value decoder_out) {
+    nemo_decoder_out_ = std::move(decoder_out);
+  }
+
+  std::vector<Ort::Value> &GetNeMoDecoderStates() {
+    return nemo_decoder_states_;
+  }
+
+  Ort::Value &GetNeMoDecoderOut() { return nemo_decoder_out_; }
 
   const ContextGraphPtr &GetContextGraph() const { return context_graph_; }
 
@@ -203,7 +211,11 @@ class OnlineStream::Impl {
   OnlineCtcDecoderResult ctc_result_;
   std::vector<Ort::Value> states_;  // states for transducer or ctc models
   std::vector<OnlineStreamStateTensor> qnn_states_;
-  std::vector<Ort::Value> decoder_states_;  // states for nemo transducer models
+
+  // states for nemo transducer models
+  std::vector<Ort::Value> nemo_decoder_states_;
+
+  Ort::Value nemo_decoder_out_;  // decoder out for nemo transducer models
   std::vector<float> paraformer_feat_cache_;
   std::vector<float> paraformer_encoder_out_cache_;
   std::vector<float> paraformer_alpha_cache_;
@@ -316,8 +328,16 @@ void OnlineStream::SetNeMoDecoderStates(
   return impl_->SetNeMoDecoderStates(std::move(decoder_states));
 }
 
+void OnlineStream::SetNeMoDecoderOut(Ort::Value decoder_out) {
+  return impl_->SetNeMoDecoderOut(std::move(decoder_out));
+}
+
 std::vector<Ort::Value> &OnlineStream::GetNeMoDecoderStates() {
   return impl_->GetNeMoDecoderStates();
+}
+
+Ort::Value &OnlineStream::GetNeMoDecoderOut() {
+  return impl_->GetNeMoDecoderOut();
 }
 
 const ContextGraphPtr &OnlineStream::GetContextGraph() const {

--- a/sherpa-onnx/csrc/online-stream.h
+++ b/sherpa-onnx/csrc/online-stream.h
@@ -100,7 +100,10 @@ class OnlineStream {
   OnlineTransducerDecoderResultNoOrt &GetQnnResult();
 
   void SetNeMoDecoderStates(std::vector<Ort::Value> decoder_states);
+  void SetNeMoDecoderOut(Ort::Value decoder_out);
+
   std::vector<Ort::Value> &GetNeMoDecoderStates();
+  Ort::Value &GetNeMoDecoderOut();
 
   /**
    * Get the context graph corresponding to this stream.
@@ -126,8 +129,7 @@ class OnlineStream {
   // Returns the value for the given key, or an empty string if the key
   // does not exist. No exception is thrown for missing keys.
   const std::string &GetOption(const std::string &key) const;
-  int32_t GetOptionInt(const std::string &key,
-                       int32_t default_value = 0) const;
+  int32_t GetOptionInt(const std::string &key, int32_t default_value = 0) const;
   float GetOptionFloat(const std::string &key,
                        float default_value = 0.0f) const;
 

--- a/sherpa-onnx/csrc/online-transducer-greedy-search-nemo-decoder.cc
+++ b/sherpa-onnx/csrc/online-transducer-greedy-search-nemo-decoder.cc
@@ -29,17 +29,6 @@ static Ort::Value BuildDecoderInput(int32_t token, OrtAllocator *allocator) {
   return decoder_input;
 }
 
-static std::vector<Ort::Value> BuildStateViews(
-    std::vector<Ort::Value> *states) {
-  std::vector<Ort::Value> ans;
-  ans.reserve(states->size());
-  for (auto &v : *states) {
-    ans.push_back(View(&v));
-  }
-
-  return ans;
-}
-
 static void DecodeOne(const float *encoder_out, int32_t num_rows,
                       int32_t num_cols, OnlineTransducerNeMoModel *model,
                       float blank_penalty, OnlineStream *s) {
@@ -51,20 +40,22 @@ static void DecodeOne(const float *encoder_out, int32_t num_rows,
 
   auto &r = s->GetResult();
 
-  Ort::Value decoder_out{nullptr};
-
   auto decoder_input = BuildDecoderInput(
       r.tokens.empty() ? blank_id : r.tokens.back(), model->Allocator());
 
+  Ort::Value &last_decoder_out = s->GetNeMoDecoderOut();
   std::vector<Ort::Value> &last_decoder_states = s->GetNeMoDecoderStates();
 
-  std::vector<Ort::Value> tmp_decoder_states;
-  tmp_decoder_states = BuildStateViews(&last_decoder_states);
-
   // decoder_output_pair.second returns the next decoder state
-  std::pair<Ort::Value, std::vector<Ort::Value>> decoder_output_pair =
-      model->RunDecoder(std::move(decoder_input),
-                        std::move(tmp_decoder_states));
+  std::pair<Ort::Value, std::vector<Ort::Value>> decoder_output_pair;
+
+  if (!last_decoder_out) {
+    decoder_output_pair = model->RunDecoder(std::move(decoder_input),
+                                            std::move(last_decoder_states));
+  } else {
+    decoder_output_pair.first = std::move(last_decoder_out);
+    decoder_output_pair.second = std::move(last_decoder_states);
+  }
 
   std::array<int64_t, 3> encoder_shape{1, num_cols, 1};
 
@@ -106,9 +97,8 @@ static void DecodeOne(const float *encoder_out, int32_t num_rows,
     }
   }
 
-  if (emitted) {
-    s->SetNeMoDecoderStates(std::move(decoder_output_pair.second));
-  }
+  s->SetNeMoDecoderOut(std::move(decoder_output_pair.first));
+  s->SetNeMoDecoderStates(std::move(decoder_output_pair.second));
 
   r.frame_offset += num_rows;
 }

--- a/sherpa-onnx/csrc/sherpa-onnx.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx.cc
@@ -5,6 +5,7 @@
 #include <stdio.h>
 
 #include <chrono>
+#include <cmath>
 #include <iomanip>
 #include <iostream>
 #include <memory>
@@ -102,6 +103,13 @@ for a list of pre-trained models to download.
     po.PrintUsage();
     fprintf(stderr, "Error! Please provide at lease 1 wav file\n");
     SHERPA_ONNX_EXIT(EXIT_FAILURE);
+  }
+
+  if (!std::isfinite(left_padding_second) ||
+      !std::isfinite(right_padding_second) || left_padding_second < 0 ||
+      right_padding_second < 0) {
+    fprintf(stderr, "Padding must be finite and non-negative\n");
+    return -1;
   }
 
   fprintf(stderr, "%s\n", config.ToString().c_str());

--- a/sherpa-onnx/csrc/sherpa-onnx.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx.cc
@@ -12,8 +12,8 @@
 #include <utility>
 #include <vector>
 
-#include "sherpa-onnx/csrc/online-recognizer.h"
 #include "sherpa-onnx/csrc/macros.h"
+#include "sherpa-onnx/csrc/online-recognizer.h"
 #include "sherpa-onnx/csrc/online-stream.h"
 #include "sherpa-onnx/csrc/parse-options.h"
 #include "sherpa-onnx/csrc/symbol-table.h"
@@ -83,10 +83,19 @@ for a list of pre-trained models to download.
   sherpa_onnx::OnlineRecognizerConfig config;
   std::string language;
 
+  float left_padding_second = 0.5;
+  float right_padding_second = 0.8;
+
   config.Register(&po);
   po.Register("language", &language,
               "Per-stream language hint for prompt-conditioned multilingual "
               "models, e.g., en, fr, ja, or auto. Empty means auto.");
+
+  po.Register("left-padding", &left_padding_second,
+              "Number of seconds for left padding");
+
+  po.Register("right-padding", &right_padding_second,
+              "Number of seconds for right padding");
 
   po.Read(argc, argv);
   if (po.NumArgs() < 1) {
@@ -117,7 +126,7 @@ for a list of pre-trained models to download.
     int32_t sampling_rate = -1;
 
     bool is_ok = false;
-    const std::vector<float> samples =
+    std::vector<float> samples =
         sherpa_onnx::ReadWave(wav_filename, &sampling_rate, &is_ok);
 
     if (!is_ok) {
@@ -132,13 +141,15 @@ for a list of pre-trained models to download.
       s->SetOption("language", language);
     }
 
-    std::vector<float> left_paddings(static_cast<int>(0.3 * sampling_rate));
+    std::vector<float> left_paddings(
+        static_cast<int>(left_padding_second * sampling_rate), 0);
     s->AcceptWaveform(sampling_rate, left_paddings.data(),
                       left_paddings.size());
 
     s->AcceptWaveform(sampling_rate, samples.data(), samples.size());
 
-    std::vector<float> tail_paddings(static_cast<int>(0.8 * sampling_rate));
+    std::vector<float> tail_paddings(
+        static_cast<int>(right_padding_second * sampling_rate), 0);
     // Note: We can call AcceptWaveform() multiple times.
     s->AcceptWaveform(sampling_rate, tail_paddings.data(),
                       tail_paddings.size());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable left and right audio padding options (in seconds) for streaming recognition.
  * Added support for accessing and updating NeMo decoder outputs during streaming.
* **Bug Fixes**
  * Improved reuse of existing decoder outputs to avoid unnecessary decoder runs when output is already available.
  * Updated decoder state/out updates to be more consistent across decoding steps, including when no tokens are emitted.
  * Ensured NeMo decoder output is cleared properly on stream reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->