### PR TITLE
Fix adaptive KV cache for models with hard-coded cache length

### DIFF
--- a/sherpa-onnx/csrc/offline-fire-red-asr-model.cc
+++ b/sherpa-onnx/csrc/offline-fire-red-asr-model.cc
@@ -159,7 +159,11 @@ class OfflineFireRedAsrModel::Impl {
   }
 
   std::pair<Ort::Value, Ort::Value> GetInitialSelfKVCache(int32_t alloc_len) {
-    if (alloc_len <= 0 || alloc_len > meta_data_.max_len) {
+    if (fixed_cache_len_ > 0) {
+      // Some models (e.g., FireRedASR v1) hard-code the cache length in the
+      // decoder graph. We have to follow the model in that case.
+      alloc_len = fixed_cache_len_;
+    } else if (alloc_len <= 0 || alloc_len > meta_data_.max_len) {
       alloc_len = meta_data_.max_len;
     }
 
@@ -252,6 +256,20 @@ class OfflineFireRedAsrModel::Impl {
 
     GetOutputNames(decoder_sess_.get(), &decoder_output_names_,
                    &decoder_output_names_ptr_);
+
+    // Detect whether the cache length is hard-coded in the model, e.g.,
+    // FireRedASR v1 uses 1024 while FireRedASR2 uses a dynamic length.
+    for (size_t i = 0; i != decoder_input_names_.size(); ++i) {
+      if (decoder_input_names_[i] == "in_n_layer_self_k_cache") {
+        auto shape = decoder_sess_->GetInputTypeInfo(i)
+                         .GetTensorTypeAndShapeInfo()
+                         .GetShape();
+        if (shape.size() >= 3 && shape[2] > 0) {
+          fixed_cache_len_ = static_cast<int32_t>(shape[2]);
+        }
+        break;
+      }
+    }
   }
 
   void InitCudaIOBinding() {
@@ -292,6 +310,10 @@ class OfflineFireRedAsrModel::Impl {
   std::vector<const char *> decoder_output_names_ptr_;
 
   OfflineFireRedAsrModelMetaData meta_data_;
+
+  // If > 0, the decoder model hard-codes the KV cache length (e.g.,
+  // FireRedASR v1 uses 1024); 0 means the length is dynamic.
+  int32_t fixed_cache_len_ = 0;
 };
 
 OfflineFireRedAsrModel::OfflineFireRedAsrModel(const OfflineModelConfig &config)


### PR DESCRIPTION
This PR fixes the CI failure reported after #3777.

#3777 assumed the decoder KV cache length is dynamic, but FireRedASR v1 models hard-code it to 1024 in the ONNX graph.

Fix: detect the hard-coded length from `in_n_layer_self_k_cache` input shape and use it when present. v2 models with dynamic length continue to use adaptive allocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with speech recognition models that use a fixed decoder cache length.
  * Enhanced decoder initialization to automatically detect and apply the model’s configured cache size.
  * Preserved existing cache-length validation and fallback behavior for models without a fixed cache length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->