### PR TITLE
Fix C API for write raw bytes into the stream to ensure embedded NULs are preserved

### DIFF
--- a/sherpa-onnx/c-api/c-api.cc
+++ b/sherpa-onnx/c-api/c-api.cc
@@ -2055,7 +2055,8 @@ const SherpaOnnxWave *SherpaOnnxReadWaveFromBinaryData(const char *data,
   int32_t sample_rate = -1;
   bool is_ok = false;
 
-  std::istringstream is(std::string(data, n));
+  std::stringstream is(std::ios::in | std::ios::out | std::ios::binary);
+  is.write(data, n);
 
   std::vector<float> samples = sherpa_onnx::ReadWave(is, &sample_rate, &is_ok);
   if (!is_ok) {


### PR DESCRIPTION
for write raw bytes into the stream to ensure embedded NULs are preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reading mono WAV data directly from in-memory binary input.
  * Added the ability to write normalized PCM samples into a caller-provided WAV output buffer.
* **Bug Fixes**
  * Improved handling when reading waveforms from binary data, increasing reliability for inputs containing arbitrary binary content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->