### PR TITLE
Forward `SessionConfig.`-prefixed provider-config keys to Ort::SessionOptions::AddConfigEntry

### DIFF
--- a/sherpa-onnx/csrc/CMakeLists.txt
+++ b/sherpa-onnx/csrc/CMakeLists.txt
@@ -832,6 +832,7 @@ if(SHERPA_ONNX_ENABLE_TESTS)
     packed-sequence-test.cc
     pad-sequence-test.cc
     regex-lang-test.cc
+    session-test.cc
     slice-test.cc
     stack-test.cc
     text-utils-test.cc

--- a/sherpa-onnx/csrc/session-test.cc
+++ b/sherpa-onnx/csrc/session-test.cc
@@ -1,0 +1,72 @@
+// sherpa-onnx/csrc/session-test.cc
+//
+// Copyright (c)  2026  Kevin Castillo
+
+#include "sherpa-onnx/csrc/session.h"
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+#include "gtest/gtest.h"
+
+namespace sherpa_onnx {
+
+static bool HasConfigEntry(const Ort::SessionOptions &sess_opts,
+                           const char *key) {
+  int has = 0;
+  Ort::ThrowOnError(Ort::GetApi().HasSessionConfigEntry(
+      static_cast<const OrtSessionOptions *>(sess_opts), key, &has));
+  return has != 0;
+}
+
+static std::string GetConfigEntry(const Ort::SessionOptions &sess_opts,
+                                  const char *key) {
+  size_t size = 0;
+  Ort::ThrowOnError(Ort::GetApi().GetSessionConfigEntry(
+      static_cast<const OrtSessionOptions *>(sess_opts), key, nullptr, &size));
+  std::string value(size, '\0');
+  Ort::ThrowOnError(Ort::GetApi().GetSessionConfigEntry(
+      static_cast<const OrtSessionOptions *>(sess_opts), key, value.data(),
+      &size));
+  if (!value.empty() && value.back() == '\0') {
+    value.pop_back();
+  }
+  return value;
+}
+
+TEST(SessionConfigPassthrough, ForwardsPrefixedKeysAndIgnoresOthers) {
+  const std::string config_path = "session-test-provider-config.txt";
+  {
+    std::ofstream os(config_path);
+    os << "# comment line\n";
+    os << "SessionConfig.mlas.disable_kleidiai=1\n";
+    os << "SessionConfig.session.disable_prepacking = 1\n";
+    os << "EnableCpuMemArena=0\n";
+    os << "SPACEMIT_EP_USE_GLOBAL_INTRA_THREAD=1\n";
+    os << "SessionConfig.=1\n";
+  }
+
+  auto sess_opts = GetSessionOptionsImpl(1, "cpu:" + config_path);
+
+  // SessionConfig.-prefixed keys are forwarded with the prefix stripped.
+  EXPECT_TRUE(HasConfigEntry(sess_opts, "mlas.disable_kleidiai"));
+  EXPECT_EQ(GetConfigEntry(sess_opts, "mlas.disable_kleidiai"), "1");
+  EXPECT_TRUE(HasConfigEntry(sess_opts, "session.disable_prepacking"));
+  EXPECT_EQ(GetConfigEntry(sess_opts, "session.disable_prepacking"), "1");
+
+  // The prefixed spelling itself is not registered.
+  EXPECT_FALSE(
+      HasConfigEntry(sess_opts, "SessionConfig.mlas.disable_kleidiai"));
+
+  // Known sherpa-onnx keys are consumed, not forwarded.
+  EXPECT_FALSE(HasConfigEntry(sess_opts, "EnableCpuMemArena"));
+
+  // Un-prefixed provider-specific keys are left alone.
+  EXPECT_FALSE(
+      HasConfigEntry(sess_opts, "SPACEMIT_EP_USE_GLOBAL_INTRA_THREAD"));
+
+  std::remove(config_path.c_str());
+}
+
+}  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/session-test.cc
+++ b/sherpa-onnx/csrc/session-test.cc
@@ -8,9 +8,62 @@
 #include <fstream>
 #include <string>
 
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
 #include "gtest/gtest.h"
 
 namespace sherpa_onnx {
+
+namespace {
+
+// RAII temporary provider-config file, following the TempFile pattern in
+// wave-reader-test.cc (mkstemp / GetTempFileNameA).
+class TempConfigFile {
+ public:
+  explicit TempConfigFile(const std::string &contents) {
+#if defined(_WIN32)
+    char temp_path[MAX_PATH];
+    char temp_file[MAX_PATH];
+    DWORD path_len = GetTempPathA(MAX_PATH, temp_path);
+    if (path_len > 0 && path_len < MAX_PATH &&
+        GetTempFileNameA(temp_path, "soc", 0, temp_file) != 0) {
+      path_ = temp_file;
+    }
+#else
+    char temp_template[] = "/tmp/sherpa_onnx_session_test_XXXXXX";
+    int fd = mkstemp(temp_template);
+    if (fd != -1) {
+      close(fd);
+      path_ = temp_template;
+    }
+#endif
+    if (path_.empty()) {
+      return;
+    }
+    std::ofstream os(path_);
+    ok_ = os.is_open();
+    os << contents;
+  }
+
+  ~TempConfigFile() {
+    if (!path_.empty()) {
+      std::remove(path_.c_str());
+    }
+  }
+
+  const std::string &Path() const { return path_; }
+  bool Ok() const { return ok_; }
+
+ private:
+  std::string path_;
+  bool ok_ = false;
+};
+
+}  // namespace
 
 static bool HasConfigEntry(const Ort::SessionOptions &sess_opts,
                            const char *key) {
@@ -36,18 +89,16 @@ static std::string GetConfigEntry(const Ort::SessionOptions &sess_opts,
 }
 
 TEST(SessionConfigPassthrough, ForwardsPrefixedKeysAndIgnoresOthers) {
-  const std::string config_path = "session-test-provider-config.txt";
-  {
-    std::ofstream os(config_path);
-    os << "# comment line\n";
-    os << "SessionConfig.mlas.disable_kleidiai=1\n";
-    os << "SessionConfig.session.disable_prepacking = 1\n";
-    os << "EnableCpuMemArena=0\n";
-    os << "SPACEMIT_EP_USE_GLOBAL_INTRA_THREAD=1\n";
-    os << "SessionConfig.=1\n";
-  }
+  TempConfigFile config(
+      "# comment line\n"
+      "SessionConfig.mlas.disable_kleidiai=1\n"
+      "SessionConfig.session.disable_prepacking = 1\n"
+      "EnableCpuMemArena=0\n"
+      "SPACEMIT_EP_USE_GLOBAL_INTRA_THREAD=1\n"
+      "SessionConfig.=1\n");
+  ASSERT_TRUE(config.Ok());
 
-  auto sess_opts = GetSessionOptionsImpl(1, "cpu:" + config_path);
+  auto sess_opts = GetSessionOptionsImpl(1, "cpu:" + config.Path());
 
   // SessionConfig.-prefixed keys are forwarded with the prefix stripped.
   EXPECT_TRUE(HasConfigEntry(sess_opts, "mlas.disable_kleidiai"));
@@ -66,7 +117,10 @@ TEST(SessionConfigPassthrough, ForwardsPrefixedKeysAndIgnoresOthers) {
   EXPECT_FALSE(
       HasConfigEntry(sess_opts, "SPACEMIT_EP_USE_GLOBAL_INTRA_THREAD"));
 
-  std::remove(config_path.c_str());
+  // "SessionConfig.=1" (empty key after the prefix) is ignored: nothing is
+  // registered under the empty key or under the raw spelling.
+  EXPECT_FALSE(HasConfigEntry(sess_opts, ""));
+  EXPECT_FALSE(HasConfigEntry(sess_opts, "SessionConfig."));
 }
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/session.cc
+++ b/sherpa-onnx/csrc/session.cc
@@ -55,6 +55,9 @@ static void ParseConfigFile(
   // For spacemit, the config file can contain the following
   // SPACEMIT_EP_USE_GLOBAL_INTRA_THREAD=1
   // ... and so on.
+  // Keys prefixed with "SessionConfig." are forwarded (prefix stripped) to
+  // Ort::SessionOptions::AddConfigEntry, e.g.,
+  // SessionConfig.mlas.disable_kleidiai=1
   // # is treated as comment. Empty lines are ignored. The legacy key:value
   // format is still supported for backward compatibility.
   // additionally, DEBUG=1 can be set to print all configs read from the file.
@@ -199,6 +202,36 @@ Ort::SessionOptions GetSessionOptionsImpl(
       sess_opts.DisableCpuMemArena();
     }
     config.erase("EnableCpuMemArena");
+  }
+
+  // Keys prefixed with "SessionConfig." are forwarded verbatim (prefix
+  // stripped) to Ort::SessionOptions::AddConfigEntry, e.g.,
+  //   SessionConfig.mlas.disable_kleidiai=1
+  // becomes AddConfigEntry("mlas.disable_kleidiai", "1"). This exposes
+  // onnxruntime session configuration entries
+  // (see onnxruntime_session_options_config_keys.h) without requiring a
+  // dedicated sherpa-onnx option for each of them. Only this explicit
+  // namespace is forwarded, so provider-specific and other un-prefixed keys
+  // retain their current behavior.
+  {
+    static constexpr const char kSessionConfigPrefix[] = "SessionConfig.";
+    static constexpr size_t kSessionConfigPrefixLen =
+        sizeof(kSessionConfigPrefix) - 1;
+    for (auto it = config.begin(); it != config.end();) {
+      if (it->first.compare(0, kSessionConfigPrefixLen, kSessionConfigPrefix) ==
+          0) {
+        std::string key = it->first.substr(kSessionConfigPrefixLen);
+        if (key.empty()) {
+          SHERPA_ONNX_LOGE("Ignore empty session config key: %s",
+                           it->first.c_str());
+        } else {
+          sess_opts.AddConfigEntry(key.c_str(), it->second.c_str());
+        }
+        it = config.erase(it);
+      } else {
+        ++it;
+      }
+    }
   }
 
   // If you want to speed up initialization, please uncomment the following line


### PR DESCRIPTION
## Description

The provider config file mechanism (`provider: "cpu:/path/to/config.conf"`) currently understands a fixed set of keys (`GraphOptimizationLevel`, `LogSeverityLevel`, `ProfilingFilePrefix`, `EnableMemPattern`, `EnableCpuMemArena`, plus provider-specific ones); everything else is silently dropped. That means onnxruntime session configuration entries (`onnxruntime_session_options_config_keys.h`) are unreachable without a dedicated sherpa-onnx option for each.

This PR forwards keys carrying an explicit `SessionConfig.` prefix to `Ort::SessionOptions::AddConfigEntry`, with the prefix stripped:

```
# provider config file
SessionConfig.mlas.disable_kleidiai=1
```

becomes `AddConfigEntry("mlas.disable_kleidiai", "1")`.

Only the explicit namespace is forwarded — unknown un-prefixed keys keep their current behavior, so provider-specific keys (e.g. `SPACEMIT_EP_*`) and un-prefixed typos are not silently passed to onnxruntime. (A typo *inside* the `SessionConfig.` namespace is intentionally treated as an ORT session-config entry; unsupported entries may be ignored by ORT.)

## Tests

`session-test.cc` (registered in `sherpa_onnx_test_srcs`) covers: prefixed keys forwarded with the prefix stripped (verified via `HasSessionConfigEntry`/`GetSessionConfigEntry`), the prefixed spelling itself not registered, known sherpa-onnx keys (`EnableCpuMemArena`) consumed and not forwarded, un-prefixed provider-specific keys (`SPACEMIT_EP_*`) left alone, and the empty-key edge (`SessionConfig.=1`) ignored without error.

## Motivation

While diagnosing #3791 (darwin-arm64 KWS/zipformer2-streaming breakage in 1.13.4: bundled ORT 1.27.0's KleidiAI SME Conv miscomputes axis-asymmetric `pads`, fixed upstream in ORT 1.27.1 via microsoft/onnxruntime#28571 / #29628), the verified user-side mitigation was the ORT session config entry `mlas.disable_kleidiai=1` — but there is currently no way to reach it through sherpa-onnx. A generic, namespaced passthrough makes this class of runtime workaround (and legitimate tuning entries like `session.disable_prepacking`, `session.dynamic_block_base`, etc.) available without new sherpa-onnx releases.

This is independent of — and complementary to — bumping the bundled ORT to 1.27.1 or later (the actual fix for #3791).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider configuration files can now forward `SessionConfig.*` entries into ONNX Runtime session options.
  * The `SessionConfig.` prefix is automatically stripped for the forwarded session setting names.
* **Bug Fixes**
  * Ensures only `SessionConfig.*` keys are forwarded, and ignores empty `SessionConfig.` keys.
* **Tests**
  * Added a dedicated session configuration test to verify correct forwarding, filtering, and key-handling behavior when tests are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->