### PR TITLE
Fix macOS release code signatures

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -144,6 +144,18 @@ jobs:
         if: matrix.build_type == 'Release'
         shell: bash
         run: |
+          sign_macos_tree() {
+            root_dir="$1"
+
+            while IFS= read -r -d '' f; do
+              if file -b "$f" | grep -q '^Mach-O'; then
+                codesign --force --sign - --timestamp=none \
+                  --preserve-metadata=identifier,entitlements,flags,runtime "$f"
+                codesign --verify --strict --verbose=2 "$f"
+              fi
+            done < <(find "$root_dir" -type f \( -path "$root_dir/bin/*" -o -path "$root_dir/lib/*.dylib*" \) -print0)
+          }
+
           thin_macos_tree() {
             src_dir="$1"
             dst_dir="$2"
@@ -179,6 +191,7 @@ jobs:
           brew install tree
           tree $dst
 
+          sign_macos_tree "$dst"
           tar cjvf ${dst}.tar.bz2 $dst
 
           lib_dst=${dst}-lib
@@ -191,6 +204,7 @@ jobs:
             rm -f ${lib_dst}/lib/libcargs.a
           fi
           tree ${lib_dst}
+          sign_macos_tree "$lib_dst"
           tar cjvf ${lib_dst}.tar.bz2 ${lib_dst}
 
           for arch in x86_64 arm64; do
@@ -203,11 +217,13 @@ jobs:
             arch_dst=${dst/osx-universal2/osx-${arch_name}}
             thin_macos_tree "$dst" "$arch_dst" "$arch"
             tree "$arch_dst"
+            sign_macos_tree "$arch_dst"
             tar cjvf ${arch_dst}.tar.bz2 ${arch_dst}
 
             arch_lib_dst=${lib_dst/osx-universal2/osx-${arch_name}}
             thin_macos_tree "$lib_dst" "$arch_lib_dst" "$arch"
             tree "$arch_lib_dst"
+            sign_macos_tree "$arch_lib_dst"
             tar cjvf ${arch_lib_dst}.tar.bz2 ${arch_lib_dst}
           done
 


### PR DESCRIPTION
## Summary

- ad-hoc sign every Mach-O binary in each final macOS release tree
- preserve existing signing metadata and verify each signature with `codesign --verify --strict` before archiving
- cover universal2, x64, and arm64 full and lib-only packages

## Verification

- reproduced the invalid signature from the official v1.13.4 arm64 asset (`b4e5d097...`)
- applied the exact workflow helper to the official assets: universal2 4/4 and arm64 33/33 Mach-O files passed strict verification
- ran the exact sign/thin/sign path for x86_64 and arm64: 4/4 passed for each architecture, with no architecture mismatches
- ran `sherpa-onnx-version` successfully from the repaired arm64 tree
- `actionlint` and `shellcheck` passed for the changed workflow/helper

Fixes #3790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * macOS release packages now include properly code-signed Mach-O binaries.
  * Added signature verification before release archives are created to improve installation and execution reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->