### PR TITLE
Raise FireRedASR decode cap from 6 to 8 tokens/sec for fast speech

### DIFF
--- a/sherpa-onnx/csrc/offline-fire-red-asr-decoder.h
+++ b/sherpa-onnx/csrc/offline-fire-red-asr-decoder.h
@@ -27,12 +27,14 @@ class OfflineFireRedAsrDecoder {
    *                              (num_decoder_layers, N, T, d_model).
    * @param n_layer_cross_v       A 4-D tensor of shape
    *                              (num_decoder_layers, N, T, d_model).
+   * @param num_feature_frames    Number of feature frames in the input audio.
+   * @param max_token_per_second  Maximum tokens generated per second of audio.
    *
    * @return Return a vector of size `N` containing the decoded results.
    */
   virtual std::vector<OfflineFireRedAsrDecoderResult> Decode(
       Ort::Value n_layer_cross_k, Ort::Value n_layer_cross_v,
-      int32_t num_feature_frames) = 0;
+      int32_t num_feature_frames, int32_t max_token_per_second) = 0;
 };
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/offline-fire-red-asr-greedy-search-decoder.cc
+++ b/sherpa-onnx/csrc/offline-fire-red-asr-greedy-search-decoder.cc
@@ -16,9 +16,9 @@ namespace sherpa_onnx {
 
 // Note: this functions works only for batch size == 1 at present
 std::vector<OfflineFireRedAsrDecoderResult>
-OfflineFireRedAsrGreedySearchDecoder::Decode(Ort::Value cross_k,
-                                             Ort::Value cross_v,
-                                             int32_t num_feature_frames) {
+OfflineFireRedAsrGreedySearchDecoder::Decode(
+    Ort::Value cross_k, Ort::Value cross_v, int32_t num_feature_frames,
+    int32_t max_token_per_second) {
   const auto &meta_data = model_->GetModelMetadata();
 
   auto memory_info =
@@ -44,8 +44,8 @@ OfflineFireRedAsrGreedySearchDecoder::Decode(Ort::Value cross_k,
 
   std::vector<OfflineFireRedAsrDecoderResult> ans(1);
 
-  // assume at most 6 tokens per second
-  int32_t num_possible_tokens = num_feature_frames / 100.0 * 6;
+  int32_t num_possible_tokens =
+      num_feature_frames / 100.0 * max_token_per_second;
   num_possible_tokens =
       std::min<int32_t>(num_possible_tokens, meta_data.max_len / 2);
   // clamp against pathological inputs so cache_len stays positive

--- a/sherpa-onnx/csrc/offline-fire-red-asr-greedy-search-decoder.h
+++ b/sherpa-onnx/csrc/offline-fire-red-asr-greedy-search-decoder.h
@@ -18,8 +18,8 @@ class OfflineFireRedAsrGreedySearchDecoder : public OfflineFireRedAsrDecoder {
       : model_(model) {}
 
   std::vector<OfflineFireRedAsrDecoderResult> Decode(
-      Ort::Value cross_k, Ort::Value cross_v,
-      int32_t num_feature_frames) override;
+      Ort::Value cross_k, Ort::Value cross_v, int32_t num_feature_frames,
+      int32_t max_token_per_second) override;
 
  private:
   OfflineFireRedAsrModel *model_;  // not owned

--- a/sherpa-onnx/csrc/offline-recognizer-fire-red-asr-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-fire-red-asr-impl.h
@@ -121,8 +121,11 @@ class OfflineRecognizerFireRedAsrImpl : public OfflineRecognizerImpl {
 
     auto cross_kv = model_->ForwardEncoder(std::move(x), std::move(x_len));
 
+    int32_t max_token_per_second = s->GetOptionInt("max_token_per_second", 6);
+
     auto results = decoder_->Decode(std::move(cross_kv.first),
-                                    std::move(cross_kv.second), num_frames);
+                                    std::move(cross_kv.second), num_frames,
+                                    max_token_per_second);
 
     auto r = Convert(results[0], symbol_table_);
 


### PR DESCRIPTION
Trades ~31% larger KV cache and ~3% e2e time for truncation safety up to 8 tokens/s. Texts verified token-identical on test wavs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speech recognition decoding capacity for longer or faster-spoken audio by using a configurable token-rate limit during greedy decoding.
  * Reduced the risk of prematurely limiting decoding steps by replacing a fixed token-per-second heuristic with the stream option value (default remains 6), with minimal impact to decoding time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->