### PR TITLE
Set FireRedASR default max_token_per_second to 8

### DIFF
--- a/sherpa-onnx/csrc/offline-recognizer-fire-red-asr-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-fire-red-asr-impl.h
@@ -121,7 +121,7 @@ class OfflineRecognizerFireRedAsrImpl : public OfflineRecognizerImpl {
 
     auto cross_kv = model_->ForwardEncoder(std::move(x), std::move(x_len));
 
-    int32_t max_token_per_second = s->GetOptionInt("max_token_per_second", 6);
+    int32_t max_token_per_second = s->GetOptionInt("max_token_per_second", 8);
 
     auto results = decoder_->Decode(std::move(cross_kv.first),
                                     std::move(cross_kv.second), num_frames,


### PR DESCRIPTION
As discussed in #3796, this PR changes the default value of `max_token_per_second` for FireRedASR from 6 to 8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the default token processing rate for offline speech recognition, improving decoding throughput when no custom rate is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->