### PR TITLE
fix UB

### DIFF
--- a/sherpa-onnx/csrc/homophone-replacer.h
+++ b/sherpa-onnx/csrc/homophone-replacer.h
@@ -19,7 +19,7 @@ struct HomophoneReplacerConfig {
   // comma separated fst files, e.g. a.fst,b.fst,c.fst
   std::string rule_fsts;
 
-  bool debug;
+  bool debug{false};
 
   HomophoneReplacerConfig() = default;
 


### PR DESCRIPTION
Default constructor does not init `debug` variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability by ensuring homophone replacement debugging is disabled by default.
  * Prevented unpredictable behavior caused by an uninitialized debug setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->