### PR TITLE
build(cmake): update spacemit-ort version

### DIFF
--- a/cmake/onnxruntime-linux-riscv64-spacemit.cmake
+++ b/cmake/onnxruntime-linux-riscv64-spacemit.cmake
@@ -13,10 +13,10 @@ if(NOT BUILD_SHARED_LIBS)
   message(FATAL_ERROR "This file is for building shared libraries. BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}, SHERPA_ONNX_ENABLE_SPACEMIT: ${SHERPA_ONNX_ENABLE_SPACEMIT}")
 endif()
 
-set(onnxruntime_version "2.0.2")
+set(onnxruntime_version "2.0.6")
 set(onnxruntime_pkg_name "spacemit-ort.riscv64.${onnxruntime_version}.tar.gz")
 set(onnxruntime_URL  "https://github.com/spacemit-com/onnxruntime/releases/download/${onnxruntime_version}/${onnxruntime_pkg_name}")
-set(onnxruntime_HASH "SHA256=b9d038eab644c42712b93e14648427467a02d1b66115795033093efbeb53c868")
+set(onnxruntime_HASH "SHA256=bebcdfb7df6b49eefa3863afcd85a3da2aa83c3ae9252d7d856188c38a70b0e6")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.

--- a/cxx-api-examples/version-cxx-api.cc
+++ b/cxx-api-examples/version-cxx-api.cc
@@ -7,11 +7,12 @@
 #include "sherpa-onnx/c-api/cxx-api.h"
 
 auto main() -> int {
-  std::cout << "sherpa-onnx version : " << sherpa_onnx::GetVersionStr()
+  using namespace sherpa_onnx::cxx;  // NOLINT
+  std::cout << "sherpa-onnx version : " << GetVersionStr()
             << "\n";
-  std::cout << "sherpa-onnx Git SHA1: " << sherpa_onnx::GetGitSha1() << "\n";
-  std::cout << "sherpa-onnx Git date: " << sherpa_onnx::GetGitDate() << "\n";
-  std::cout << "onnxruntime version : " << sherpa_onnx::GetOnnxruntimeVersionStr()
+  std::cout << "sherpa-onnx Git SHA1: " << GetGitSha1() << "\n";
+  std::cout << "sherpa-onnx Git date: " << GetGitDate() << "\n";
+  std::cout << "onnxruntime version : " << GetOnnxruntimeVersionStr()
             << "\n";
 
   return 0;


### PR DESCRIPTION
update spacemit onnxruntime version  from 2.0.2 to 2.0.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the ONNX Runtime package used for RISC-V Linux builds to version 2.0.6.
  * Updated the package verification checksum to match the new release.
* **Documentation**
  * Refreshed the C++ API example’s version-reporting output to reflect the latest API usage style.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->