### PR TITLE
Publish an android-x64 .NET runtime package

### DIFF
--- a/scripts/dotnet/.gitignore
+++ b/scripts/dotnet/.gitignore
@@ -4,6 +4,7 @@ macos-x64
 linux-x64
 linux-arm64
 android-arm64
+android-x64
 windows-arm64
 windows-x64
 windows-x86

--- a/scripts/dotnet/generate.py
+++ b/scripts/dotnet/generate.py
@@ -121,6 +121,7 @@ def main():
     process_linux(s, "x64")
     process_linux(s, "arm64")
     process_android(s, "arm64")
+    process_android(s, "x64")
     process_windows(s, "x64")
     process_windows(s, "x86")
     process_windows(s, "arm64")

--- a/scripts/dotnet/run.sh
+++ b/scripts/dotnet/run.sh
@@ -24,7 +24,7 @@ export src_dir
 mkdir -p $src_dir
 pushd $src_dir
 
-RIDS=(linux-x64 linux-arm64 android-arm64 macos-x64 macos-arm64 windows-x64 windows-x86 windows-arm64)
+RIDS=(linux-x64 linux-arm64 android-arm64 android-x64 macos-x64 macos-arm64 windows-x64 windows-x86 windows-arm64)
 
 mkdir -p ${RIDS[@]}
 
@@ -34,8 +34,8 @@ linux_x64_wheel=$src_dir/$linux_x64_wheel_filename
 linux_arm64_wheel_filename=sherpa_onnx_core-${SHERPA_ONNX_VERSION}-py3-none-manylinux2014_aarch64.whl
 linux_arm64_wheel=$src_dir/$linux_arm64_wheel_filename
 
-android_arm64_tarball_filename=sherpa-onnx-v$SHERPA_ONNX_VERSION-android.tar.bz2
-android_arm64_tarball=$src_dir/$android_arm64_tarball_filename
+android_tarball_filename=sherpa-onnx-v$SHERPA_ONNX_VERSION-android.tar.bz2
+android_tarball=$src_dir/$android_tarball_filename
 
 macos_x64_wheel_filename=sherpa_onnx_core-${SHERPA_ONNX_VERSION}-py3-none-macosx_10_15_x86_64.whl
 macos_x64_wheel=$src_dir/$macos_x64_wheel_filename
@@ -88,24 +88,32 @@ if [ ! -f $src_dir/linux-arm64/libsherpa-onnx-c-api.so ]; then
   cd ..
 fi
 
-if [ ! -f $src_dir/android-arm64/libsherpa-onnx-c-api.so ]; then
-  echo "---android arm64---"
-  cd android-arm64
+if [ ! -f $src_dir/android-arm64/libsherpa-onnx-c-api.so ] || [ ! -f $src_dir/android-x64/libsherpa-onnx-c-api.so ]; then
+  echo "---android---"
   mkdir -p tarball
   cd tarball
-  if [ -f $android_arm64_tarball  ]; then
-    cp -v $android_arm64_tarball .
+  if [ -f $android_tarball  ]; then
+    cp -v $android_tarball .
   else
-    curl -OL "https://github.com/k2-fsa/sherpa-onnx/releases/download/v$SHERPA_ONNX_VERSION/$android_arm64_tarball_filename"
+    curl -OL "https://github.com/k2-fsa/sherpa-onnx/releases/download/v$SHERPA_ONNX_VERSION/$android_tarball_filename"
   fi
-  tar xjf $android_arm64_tarball_filename
-  cp -v jniLibs/arm64-v8a/lib{onnxruntime,sherpa-onnx-c-api}.so ../
+  tar xjf $android_tarball_filename
+
+  if [ ! -f $src_dir/android-arm64/libsherpa-onnx-c-api.so ]; then
+    echo "---android arm64---"
+    cp -v jniLibs/arm64-v8a/lib{onnxruntime,sherpa-onnx-c-api}.so ../android-arm64/
+    ls -lh ../android-arm64
+  fi
+
+  if [ ! -f $src_dir/android-x64/libsherpa-onnx-c-api.so ]; then
+    echo "---android x64---"
+    cp -v jniLibs/x86_64/lib{onnxruntime,sherpa-onnx-c-api}.so ../android-x64/
+    ls -lh ../android-x64
+  fi
 
   cd ..
 
   rm -rf tarball
-  ls -lh
-  cd ..
 fi
 
 if [ ! -f $src_dir/macos-x64/libsherpa-onnx-c-api.dylib ]; then

--- a/scripts/dotnet/sherpa-onnx.csproj.in
+++ b/scripts/dotnet/sherpa-onnx.csproj.in
@@ -5,7 +5,7 @@
     <OutputType>Library</OutputType>
     <LangVersion>10.0</LangVersion>
     <TargetFrameworks>net10.0;net8.0;net7.0;net6.0;net45;net40;net35;net20;netstandard2.0</TargetFrameworks>
-    <RuntimeIdentifiers>linux-x64;linux-arm64;android-arm64;osx-x64;osx-arm64;win-x64;win-x86;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>linux-x64;linux-arm64;android-arm64;android-x64;osx-x64;osx-arm64;win-x64;win-x86;win-arm64</RuntimeIdentifiers>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>sherpa-onnx</AssemblyName>
     <Version>{{ version }}</Version>
@@ -51,6 +51,7 @@
     <PackageReference Include="org.k2fsa.sherpa.onnx.runtime.linux-x64" Version="{{ version }}" />
     <PackageReference Include="org.k2fsa.sherpa.onnx.runtime.linux-arm64" Version="{{ version }}" />
     <PackageReference Include="org.k2fsa.sherpa.onnx.runtime.android-arm64" Version="{{ version }}" />
+    <PackageReference Include="org.k2fsa.sherpa.onnx.runtime.android-x64" Version="{{ version }}" />
     <PackageReference Include="org.k2fsa.sherpa.onnx.runtime.osx-x64"   Version="{{ version }}" />
     <PackageReference Include="org.k2fsa.sherpa.onnx.runtime.osx-arm64" Version="{{ version }}" />
     <PackageReference Include="org.k2fsa.sherpa.onnx.runtime.win-x64"   Version="{{ version }}" />


### PR DESCRIPTION
Fixes #3817


## Problem

The .NET distribution ships per-RID native packages plus the `org.k2fsa.sherpa.onnx` meta-package, but there is no `android-x64` runtime package. The .NET RID graph falls back `android-x64` → `linux-bionic-x64` → `linux-x64`, so any .NET for Android or MAUI app building for the `x86_64` ABI silently resolves the **manylinux glibc** binaries from `org.k2fsa.sherpa.onnx.runtime.linux-x64` and packs them into `lib/x86_64/` of the APK/AAB. Those binaries cannot load under bionic at all, and additionally fail Google Play's 16 KB page size requirement (which blocks app updates from 31 May 2026).

`android-x64` is the only affected ABI: `android-arm64` already has a more specific package that wins RID resolution, and the 32-bit Android RIDs have no `linux-arm`/`linux-x86` packages to fall back to, so they fail loudly at restore/build time instead of packing broken binaries.

## Evidence

Broken binaries currently resolved via fallback — `org.k2fsa.sherpa.onnx.runtime.linux-x64` 1.13.4, `runtimes/linux-x64/native/`:

```
libsherpa-onnx-c-api.so
  PT_LOAD p_align: 0x1000
  NEEDED: libpthread.so.0, libonnxruntime.so, libdl.so.2, libm.so.6,
          libstdc++.so.6, libgcc_s.so.1, libc.so.6, ld-linux-x86-64.so.2
libonnxruntime.so
  PT_LOAD p_align: 0x1000
  NEEDED: libdl.so.2, librt.so.1, libpthread.so.0, libstdc++.so.6,
          libm.so.6, libgcc_s.so.1, libc.so.6, ld-linux-x86-64.so.2
```

4 KB `p_align` fails the 16 KB page size requirement; the glibc/`ld-linux-x86-64.so.2` dependencies cannot be satisfied by bionic.

Correct binaries already published — `sherpa-onnx-v1.13.4-android.tar.bz2`, `jniLibs/x86_64/`:

```
libsherpa-onnx-c-api.so
  PT_LOAD p_align: 0x4000
  NEEDED: libandroid.so, liblog.so, libonnxruntime.so, libm.so, libdl.so, libc.so
libonnxruntime.so
  PT_LOAD p_align: 0x4000
  NEEDED: libdl.so, liblog.so, libm.so, libc.so
```

16 KB aligned, bionic-only dependencies. This is the same release asset the `android-arm64` package is already built from — the fix is packaging only; nothing is recompiled.

## Changes

- `scripts/dotnet/run.sh` — add `android-x64` to `RIDS`; restructure the Android download block so the single `sherpa-onnx-v<VERSION>-android.tar.bz2` is downloaded at most once and feeds both `android-arm64` (from `jniLibs/arm64-v8a/`) and `android-x64` (from `jniLibs/x86_64/`), keeping the per-RID idempotency guards. Renamed `android_arm64_tarball*` vars to `android_tarball*` since the tarball was never arm64-specific.
- `scripts/dotnet/generate.py` — add `process_android(s, "x64")`; `process_android` was already RID-parameterized.
- `scripts/dotnet/sherpa-onnx.csproj.in` — add `android-x64` to `<RuntimeIdentifiers>` and a `PackageReference` to `org.k2fsa.sherpa.onnx.runtime.android-x64` in the meta-package.
- `scripts/dotnet/.gitignore` — ignore the generated `android-x64/` staging directory, matching the other RID directories.

Verified locally: `bash -n run.sh` and `ast.parse(generate.py)` pass; rendering `sherpa-onnx.csproj.runtime.in` for `android-x64` produces `<RuntimeIdentifier>android-x64</RuntimeIdentifier>`, `<PackageId>org.k2fsa.sherpa.onnx.runtime.android-x64</PackageId>`, and `PackagePath` `runtimes/android-x64/native/%(Filename)%(Extension)`; the meta template renders the new RID and package reference.

No changes to `.github/workflows/` were needed: `dot-net.yaml` and `test-dot-net.yaml` invoke `scripts/dotnet/run.sh` and push `org.k2fsa.sherpa.onnx.*.nupkg` with a wildcard — they don't enumerate RIDs. All other `android-arm64` grep hits are NDK build scripts (`build-android-arm64-v8a.sh`), APK scripts, or Flutter packaging, which are unrelated to .NET RIDs.

## Notes

- This takes effect for consumers only after a maintainer with NuGet publish credentials runs `scripts/dotnet/run.sh` (via the `dot-net.yaml` release workflow) for a release; merging alone publishes nothing.
- `android-arm` / `android-x86` (32-bit) are deliberately not added. They are not silently broken today — with no `linux-arm`/`linux-x86` fallback packages, resolution fails visibly instead of packing wrong binaries. The tarball does contain `armeabi-v7a/` and `x86/` libraries, so the same pattern could add them later if anyone still targets 32-bit Android; kept out of scope here to keep the review focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Android x64 runtime distribution alongside Android arm64.
  - Android x64 native libraries are now included in generated .NET runtime packages.

- **Bug Fixes**
  - Improved Android runtime packaging to reliably acquire and include required native libraries for both supported architectures.

- **Chores**
  - Updated runtime configuration and build automation to recognize the Android x64 target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->