### PR TITLE
Fix non_streaming_server.py crash with --decoding-method modified_beam_search

### DIFF
--- a/python-api-examples/non_streaming_server.py
+++ b/python-api-examples/non_streaming_server.py
@@ -490,7 +490,7 @@ def check_args(args):
         raise ValueError(f"Unsupported decoding method {args.decoding_method}")
 
     if args.decoding_method == "modified_beam_search":
-        assert args.num_active_paths > 0, args.num_active_paths
+        assert args.max_active_paths > 0, args.max_active_paths
         assert Path(args.encoder).is_file(), args.encoder
         assert Path(args.decoder).is_file(), args.decoder
         assert Path(args.joiner).is_file(), args.joiner


### PR DESCRIPTION
`python-api-examples/non_streaming_server.py` defines the flag as `--max-active-paths` (line 434) and consumes `args.max_active_paths` (line 970), but `check_args()` asserts on `args.num_active_paths`, which this script never defines. Starting the server with `--decoding-method modified_beam_search` (or with `--hotwords-file`, which `check_args` gates behind it) has always crashed at startup:

```
File ".../non_streaming_server.py", line 493, in check_args
    assert args.num_active_paths > 0, args.num_active_paths
AttributeError: 'Namespace' object has no attribute 'num_active_paths'
```

The gap dates to b094868f (#259), which adapted `streaming_server.py` (where the flag is consistently `--num-active-paths`) but renamed the flag without updating `check_args`. This aligns `check_args` with the name the script already defines and consumes, keeping the CLI unchanged; the greedy_search path is untouched.

Tested with `sherpa-onnx-zipformer-en-2023-04-01`: on master the command above crashes as shown; with this change the same command loads the model and binds the port (`server listening on 0.0.0.0:16125`). A greedy_search control starts cleanly before and after. Hit this while running the server locally for transcription and switching the decoding method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected validation for the modified beam search option so the configured maximum active paths value is checked properly before recognition starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->