### PR TITLE
Fix process crash when --kokoro-voices is missing or empty (#3748)

### DIFF
--- a/sherpa-onnx/csrc/offline-tts-kokoro-model-config.cc
+++ b/sherpa-onnx/csrc/offline-tts-kokoro-model-config.cc
@@ -60,6 +60,16 @@ bool OfflineTtsKokoroModelConfig::Validate() const {
     return false;
   }
 
+  if (voices.empty()) {
+    SHERPA_ONNX_LOGE("Please provide --kokoro-voices");
+    return false;
+  }
+
+  if (!FileExists(voices)) {
+    SHERPA_ONNX_LOGE("--kokoro-voices: '%s' does not exist", voices.c_str());
+    return false;
+  }
+
   if (!lexicon.empty()) {
     std::vector<std::string> files;
     SplitStringToVector(lexicon, ",", false, &files);

--- a/sherpa-onnx/python/tests/CMakeLists.txt
+++ b/sherpa-onnx/python/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(py_test_files
   test_feature_extractor_config.py
   test_keyword_spotter.py
   test_offline_recognizer.py
+  test_offline_tts_config.py
   test_online_recognizer.py
   test_online_transducer_model_config.py
   test_speaker_recognition.py

--- a/sherpa-onnx/python/tests/test_offline_tts_config.py
+++ b/sherpa-onnx/python/tests/test_offline_tts_config.py
@@ -1,0 +1,73 @@
+# sherpa-onnx/python/tests/test_offline_tts_config.py
+#
+# Copyright (c)  2026  Xiaomi Corporation
+#
+# To run this single test, use
+#
+#  ctest --verbose -R  test_offline_tts_config_py
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import _sherpa_onnx
+
+
+def _touch(path: Path):
+    path.write_text("dummy")
+
+
+def _create_kokoro_files(d: Path):
+    _touch(d / "model.onnx")
+    _touch(d / "voices.bin")
+    _touch(d / "tokens.txt")
+
+    data_dir = d / "espeak-ng-data"
+    data_dir.mkdir()
+    for name in ["phontab", "phonindex", "phondata", "intonations"]:
+        _touch(data_dir / name)
+
+
+def _make_kokoro_config(d: Path, **kwargs):
+    args = {
+        "model": str(d / "model.onnx"),
+        "voices": str(d / "voices.bin"),
+        "tokens": str(d / "tokens.txt"),
+        "data_dir": str(d / "espeak-ng-data"),
+    }
+    args.update(kwargs)
+    return _sherpa_onnx.OfflineTtsKokoroModelConfig(**args)
+
+
+class TestOfflineTtsKokoroModelConfig(unittest.TestCase):
+    def test_all_files_exist(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _create_kokoro_files(d)
+            config = _make_kokoro_config(d)
+            assert config.validate(), str(config)
+
+    def test_missing_voices_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _create_kokoro_files(d)
+            config = _make_kokoro_config(d, voices=str(d / "not-exist.bin"))
+            assert not config.validate(), str(config)
+
+    def test_empty_voices(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _create_kokoro_files(d)
+            config = _make_kokoro_config(d, voices="")
+            assert not config.validate(), str(config)
+
+    def test_missing_model_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _create_kokoro_files(d)
+            config = _make_kokoro_config(d, model=str(d / "not-exist.onnx"))
+            assert not config.validate(), str(config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #3748

## Problem

`OfflineTtsKokoroModelConfig::Validate()` checks `model`, `tokens`, `lexicon`, and `data_dir`, but never `voices`. The model loader then reads the voices file unconditionally and terminates the whole process if it is missing:

```c++
// sherpa-onnx/csrc/offline-tts-kokoro-model.cc:198-204
SHERPA_ONNX_LOGE(
    "Corrupted --kokoro-voices '%s'. Expected #floats: %d, actual: %d", ...);
SHERPA_ONNX_EXIT(-1);
```

So a config with `voices` unset or mistyped passes `validate()` and the embedding process dies with no catchable error. That is what the reporter of #3748 hit from the Java API. We hit the same thing from the Python API while testing Kokoro locally: a wrong voices path kills the interpreter instead of failing validation.

## Fix

Add the missing empty/`FileExists` check for `voices` to `Validate()`, copying the block the Kitten config uses for the same field (offline-tts-kitten-model-config.cc). Kitten, VITS, Matcha, and ZipVoice all validate their data files; Kokoro's `voices` was the only one skipped. The gap dates to ffc6b480 (#1715), which registered `--kokoro-voices` but omitted it from `Validate()`. The JNI layer (jni/offline-tts.cc:483) already gates construction on `Validate()`, so this turns the crash in #3748 into a clean failure.

## Tested

Before (master, kokoro-en-v0_19, nonexistent voices path):

```
validate() -> True
offline-tts-kokoro-model.cc:Init:201 Corrupted --kokoro-voices '...'. Expected #floats: 1438976, actual: 0
EXIT=255   (process killed; same with voices='')
```

After (same misconfiguration):

```
offline-tts-kokoro-model-config.cc:Validate:69 --kokoro-voices: '...' does not exist
validate() -> False, EXIT=0   (with voices='': "Please provide --kokoro-voices")
```

Adds a model-free regression test, `sherpa-onnx/python/tests/test_offline_tts_config.py` (registered in the tests CMakeLists.txt), which fails on master without this change and passes with it. A correct config still constructs and generates audio. `./scripts/check_style_cpplint.sh` passes.

Only touches the Kokoro config validation plus the new test; the loader and all other TTS configs are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Kokoro text-to-speech configuration now requires a valid voices file path.
  * Configuration validation reports errors when the voices path is empty or the file is missing.

* **Tests**
  * Added coverage for valid and invalid Kokoro model configurations, including missing model and voices files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->