### PR TITLE
Fix streaming paraformer feature frontend drift from its training config

### DIFF
--- a/sherpa-onnx/csrc/online-recognizer-paraformer-impl.h
+++ b/sherpa-onnx/csrc/online-recognizer-paraformer-impl.h
@@ -116,9 +116,7 @@ class OnlineRecognizerParaformerImpl : public OnlineRecognizerImpl {
       SHERPA_ONNX_EXIT(-1);
     }
 
-    // Paraformer models assume input samples are in the range
-    // [-32768, 32767], so we set normalize_samples to false
-    config_.feat_config.normalize_samples = false;
+    InitFeatConfig();
   }
 
   template <typename Manager>
@@ -139,9 +137,7 @@ class OnlineRecognizerParaformerImpl : public OnlineRecognizerImpl {
       SHERPA_ONNX_EXIT(-1);
     }
 
-    // Paraformer models assume input samples are in the range
-    // [-32768, 32767], so we set normalize_samples to false
-    config_.feat_config.normalize_samples = false;
+    InitFeatConfig();
   }
 
   OnlineRecognizerParaformerImpl(const OnlineRecognizerParaformerImpl &) =
@@ -229,6 +225,15 @@ class OnlineRecognizerParaformerImpl : public OnlineRecognizerImpl {
   }
 
  private:
+  void InitFeatConfig() {
+    // Paraformer models assume input samples are in the range
+    // [-32768, 32767], so we set normalize_samples to false
+    config_.feat_config.normalize_samples = false;
+    config_.feat_config.window_type = "hamming";
+    config_.feat_config.high_freq = 0;
+    config_.feat_config.snip_edges = true;
+  }
+
   void DecodeStream(OnlineStream *s) const {
     const auto num_processed_frames = s->GetNumProcessedFrames();
     int32_t available_frames = s->NumFramesReady() - num_processed_frames;

--- a/sherpa-onnx/python/tests/test_online_recognizer.py
+++ b/sherpa-onnx/python/tests/test_online_recognizer.py
@@ -286,6 +286,44 @@ class TestOnlineRecognizer(unittest.TestCase):
                 print(f"{wave_filename}\n{result}")
                 print("-" * 10)
 
+    def test_streaming_paraformer(self):
+        m = "sherpa-onnx-streaming-paraformer-bilingual-zh-en"
+        encoder = f"{d}/{m}/encoder.int8.onnx"
+        decoder = f"{d}/{m}/decoder.int8.onnx"
+        tokens = f"{d}/{m}/tokens.txt"
+        wave2 = f"{d}/{m}/test_wavs/2.wav"
+
+        if not Path(encoder).is_file():
+            print("skipping test_streaming_paraformer()")
+            return
+
+        recognizer = sherpa_onnx.OnlineRecognizer.from_paraformer(
+            encoder=encoder,
+            decoder=decoder,
+            tokens=tokens,
+            num_threads=1,
+            provider="cpu",
+        )
+
+        s = recognizer.create_stream()
+        samples, sample_rate = read_wave(wave2)
+        s.accept_waveform(sample_rate, samples)
+
+        tail_paddings = np.zeros(int(0.66 * sample_rate), dtype=np.float32)
+        s.accept_waveform(sample_rate, tail_paddings)
+        s.input_finished()
+        while recognizer.is_ready(s):
+            recognizer.decode_stream(s)
+        result = recognizer.get_result(s)
+        print(f"{wave2}\n{result}")
+
+        # The reference transcript is obtained with the feature frontend
+        # the model was trained with (hamming window, snip_edges=True,
+        # high_freq=0, see InitFeatConfig in
+        # sherpa-onnx/csrc/online-recognizer-paraformer-impl.h); with the
+        # default frontend, 频繁 is misrecognized as 平繁/苹繁.
+        self.assertEqual(result, "这个是频繁的啊不认识接下来 frequently 频繁的")
+
     def test_wenet_ctc(self):
         models = [
             "sherpa-onnx-zh-wenet-aishell",


### PR DESCRIPTION
## Problem

The offline paraformer configures the feature frontend the model was trained with (offline-recognizer-paraformer-impl.h:210-217):

```cpp
void InitFeatConfig() {
  // Paraformer models assume input samples are in the range
  // [-32768, 32767], so we set normalize_samples to false
  config_.feat_config.normalize_samples = false;
  config_.feat_config.window_type = "hamming";
  config_.feat_config.high_freq = 0;
  config_.feat_config.snip_edges = true;
}
```

The online paraformer sets only `normalize_samples`, in both constructors, so streaming decoding runs on the fbank defaults (povey window, high_freq=-400, snip_edges=false) while the model's upstream config.yaml (modelscope speech_paraformer, online variant) specifies `window: hamming`. We noticed this while running the streaming and offline paraformer on the same audio: the streaming output was consistently worse, and the frontend difference turned out to be the reason. A user in #3511 found the same drift and worked around it with `--high-freq=0 --snip-edges=true --window-type=hamming`. Related: #3511.

## Fix

Give the online impl the same private `InitFeatConfig()` and call it from both constructors. The gap dates to 6038e2aa (#263), which copied the offline paraformer's then-current frontend handling; 25f0a104 (#1148) later upgraded only the offline impl.

## Tested

New `test_streaming_paraformer` in test_online_recognizer.py decodes test_wavs/2.wav of sherpa-onnx-streaming-paraformer-bilingual-zh-en (greedy search, deterministic):

```
before: 这个是平繁的啊不认识接下来 frequently 苹繁的
after:  这个是频繁的啊不认识接下来 frequently 频繁的
```

The audio says 频繁 twice; the default frontend misrecognizes it both times. Individual tokens on other utterances can flip either way, but aggregate accuracy improves (about 10 errors fixed on a 4-minute zh recording, converging toward the offline paraformer's output on the same audio). The test fails on master without this change and passes with it; the full test_online_recognizer.py suite passes with no new skips. `./scripts/check_style_cpplint.sh` passes.

Only touches online-recognizer-paraformer-impl.h and its Python test; the offline paraformer and all other online recognizers are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Paraformer streaming speech recognition feature configuration for more consistent audio processing.

* **Tests**
  * Added coverage for streaming Paraformer recognition with bilingual Chinese-English transcription.
  * Validates decoding results against an expected transcript.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->