### PR TITLE
Use SPM in iOS examples

### DIFF
--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -27,10 +27,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Build SherpaOnnx
         shell: bash
         run: |
+          set -euo pipefail
           cd ios-swiftui/SherpaOnnx
           xcodebuild -project SherpaOnnx.xcodeproj \
             -scheme SherpaOnnx \
@@ -44,10 +46,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Build SherpaOnnx2Pass
         shell: bash
         run: |
+          set -euo pipefail
           cd ios-swiftui/SherpaOnnx2Pass
           xcodebuild -project SherpaOnnx2Pass.xcodeproj \
             -scheme SherpaOnnx2Pass \
@@ -61,10 +65,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Build SherpaOnnxLangID
         shell: bash
         run: |
+          set -euo pipefail
           cd ios-swiftui/SherpaOnnxLangID
           xcodebuild -project SherpaOnnxLangID.xcodeproj \
             -scheme SherpaOnnxLangID \
@@ -78,10 +84,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Build SherpaOnnxSubtitle
         shell: bash
         run: |
+          set -euo pipefail
           cd ios-swiftui/SherpaOnnxSubtitle
           xcodebuild -project SherpaOnnxSubtitle.xcodeproj \
             -scheme SherpaOnnxSubtitle \
@@ -95,10 +103,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Build SherpaOnnxTts
         shell: bash
         run: |
+          set -euo pipefail
           cd ios-swiftui/SherpaOnnxTts
           xcodebuild -project SherpaOnnxTts.xcodeproj \
             -scheme SherpaOnnxTts \

--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -1,0 +1,107 @@
+name: ios
+
+on:
+  push:
+    branches:
+      - master
+      - ios-spm
+    paths:
+      - '.github/workflows/ios.yaml'
+      - 'ios-swiftui/**'
+      - 'swift-api-examples/**'
+      - 'Package.swift'
+
+  workflow_dispatch:
+
+concurrency:
+  group: ios-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  sherpa-onnx:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build SherpaOnnx
+        shell: bash
+        run: |
+          cd ios-swiftui/SherpaOnnx
+          xcodebuild -project SherpaOnnx.xcodeproj \
+            -scheme SherpaOnnx \
+            -destination 'generic/platform=iOS Simulator' \
+            -skipPackagePluginValidation \
+            build | tail -20
+
+  sherpa-onnx-2pass:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build SherpaOnnx2Pass
+        shell: bash
+        run: |
+          cd ios-swiftui/SherpaOnnx2Pass
+          xcodebuild -project SherpaOnnx2Pass.xcodeproj \
+            -scheme SherpaOnnx2Pass \
+            -destination 'generic/platform=iOS Simulator' \
+            -skipPackagePluginValidation \
+            build | tail -20
+
+  sherpa-onnx-lang-id:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build SherpaOnnxLangID
+        shell: bash
+        run: |
+          cd ios-swiftui/SherpaOnnxLangID
+          xcodebuild -project SherpaOnnxLangID.xcodeproj \
+            -scheme SherpaOnnxLangID \
+            -destination 'generic/platform=iOS Simulator' \
+            -skipPackagePluginValidation \
+            build | tail -20
+
+  sherpa-onnx-subtitle:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build SherpaOnnxSubtitle
+        shell: bash
+        run: |
+          cd ios-swiftui/SherpaOnnxSubtitle
+          xcodebuild -project SherpaOnnxSubtitle.xcodeproj \
+            -scheme SherpaOnnxSubtitle \
+            -destination 'generic/platform=iOS Simulator' \
+            -skipPackagePluginValidation \
+            build | tail -20
+
+  sherpa-onnx-tts:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build SherpaOnnxTts
+        shell: bash
+        run: |
+          cd ios-swiftui/SherpaOnnxTts
+          xcodebuild -project SherpaOnnxTts.xcodeproj \
+            -scheme SherpaOnnxTts \
+            -destination 'generic/platform=iOS Simulator' \
+            -skipPackagePluginValidation \
+            build | tail -20

--- a/build-swift-macos.sh
+++ b/build-swift-macos.sh
@@ -46,6 +46,11 @@ xcodebuild -create-xcframework \
   -headers install/include/sherpa-onnx/c-api \
   -output sherpa-onnx.xcframework
 
+# Remove the module map from the install directory to prevent swiftc from
+# auto-discovering it. The module map is only needed inside the xcframework
+# (used by SPM). For direct swiftc builds, the bridging header is used instead.
+rm -fv ./install/include/sherpa-onnx/c-api/module.modulemap
+
 SHERPA_ONNX_VERSION=v$(grep "SHERPA_ONNX_VERSION" ../CMakeLists.txt | cut -d " " -f 2 | cut -d '"' -f 2)
 
 rm -f sherpa-onnx-${SHERPA_ONNX_VERSION}-macos.xcframework.zip

--- a/ios-swiftui/.gitignore
+++ b/ios-swiftui/.gitignore
@@ -89,3 +89,4 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+swiftpm

--- a/ios-swiftui/SherpaOnnx/SherpaOnnx.xcodeproj/project.pbxproj
+++ b/ios-swiftui/SherpaOnnx/SherpaOnnx.xcodeproj/project.pbxproj
@@ -14,12 +14,10 @@
 		C924F33F29DDAC0D00A440A5 /* SherpaOnnxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C924F33E29DDAC0D00A440A5 /* SherpaOnnxTests.swift */; };
 		C924F34929DDAC0D00A440A5 /* SherpaOnnxUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C924F34829DDAC0D00A440A5 /* SherpaOnnxUITests.swift */; };
 		C924F34B29DDAC0D00A440A5 /* SherpaOnnxUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C924F34A29DDAC0D00A440A5 /* SherpaOnnxUITestsLaunchTests.swift */; };
-		C924F35929DDACED00A440A5 /* SherpaOnnx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C924F35829DDACED00A440A5 /* SherpaOnnx.swift */; };
-		C924F35C29DDAE4000A440A5 /* sherpa-onnx.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C924F35B29DDAE4000A440A5 /* sherpa-onnx.xcframework */; };
 		C924F35E29DDAE8200A440A5 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = C924F35D29DDAE8200A440A5 /* Model.swift */; };
-		C924F36029DDB05D00A440A5 /* onnxruntime.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C924F35F29DDB05D00A440A5 /* onnxruntime.xcframework */; };
 		C924F36229DDB15D00A440A5 /* Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C924F36129DDB15D00A440A5 /* Extension.swift */; };
 		C924F36429DDB1D500A440A5 /* SherpaOnnxViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C924F36329DDB1D500A440A5 /* SherpaOnnxViewModel.swift */; };
+		C9SP000000000001 /* sherpa-onnx in Frameworks */ = {isa = PBXBuildFile; productRef = C9SP000000000002 /* sherpa-onnx */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -50,11 +48,7 @@
 		C924F34429DDAC0D00A440A5 /* SherpaOnnxUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SherpaOnnxUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C924F34829DDAC0D00A440A5 /* SherpaOnnxUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaOnnxUITests.swift; sourceTree = "<group>"; };
 		C924F34A29DDAC0D00A440A5 /* SherpaOnnxUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaOnnxUITestsLaunchTests.swift; sourceTree = "<group>"; };
-		C924F35729DDACED00A440A5 /* SherpaOnnx-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SherpaOnnx-Bridging-Header.h"; path = "../../../swift-api-examples/SherpaOnnx-Bridging-Header.h"; sourceTree = "<group>"; };
-		C924F35829DDACED00A440A5 /* SherpaOnnx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SherpaOnnx.swift; path = "../../../swift-api-examples/SherpaOnnx.swift"; sourceTree = "<group>"; };
-		C924F35B29DDAE4000A440A5 /* sherpa-onnx.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = "sherpa-onnx.xcframework"; path = "../../build-ios/sherpa-onnx.xcframework"; sourceTree = "<group>"; };
 		C924F35D29DDAE8200A440A5 /* Model.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };
-		C924F35F29DDB05D00A440A5 /* onnxruntime.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = onnxruntime.xcframework; path = "../../build-ios/ios-onnxruntime/onnxruntime.xcframework"; sourceTree = "<group>"; };
 		C924F36129DDB15D00A440A5 /* Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extension.swift; sourceTree = "<group>"; };
 		C924F36329DDB1D500A440A5 /* SherpaOnnxViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SherpaOnnxViewModel.swift; sourceTree = "<group>"; };
 		DEFC34EE2BBA8AD100E174E9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -65,8 +59,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C924F36029DDB05D00A440A5 /* onnxruntime.xcframework in Frameworks */,
-				C924F35C29DDAE4000A440A5 /* sherpa-onnx.xcframework in Frameworks */,
+				C9SP000000000001 /* sherpa-onnx in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -94,7 +87,6 @@
 				C924F33D29DDAC0D00A440A5 /* SherpaOnnxTests */,
 				C924F34729DDAC0D00A440A5 /* SherpaOnnxUITests */,
 				C924F32B29DDAC0B00A440A5 /* Products */,
-				C924F35A29DDAE3F00A440A5 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -115,8 +107,6 @@
 				C924F36329DDB1D500A440A5 /* SherpaOnnxViewModel.swift */,
 				C924F36129DDB15D00A440A5 /* Extension.swift */,
 				C924F35D29DDAE8200A440A5 /* Model.swift */,
-				C924F35729DDACED00A440A5 /* SherpaOnnx-Bridging-Header.h */,
-				C924F35829DDACED00A440A5 /* SherpaOnnx.swift */,
 				C924F32D29DDAC0B00A440A5 /* SherpaOnnxApp.swift */,
 				C924F32F29DDAC0B00A440A5 /* ContentView.swift */,
 				C924F33129DDAC0D00A440A5 /* Assets.xcassets */,
@@ -150,15 +140,6 @@
 			path = SherpaOnnxUITests;
 			sourceTree = "<group>";
 		};
-		C924F35A29DDAE3F00A440A5 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				C924F35F29DDB05D00A440A5 /* onnxruntime.xcframework */,
-				C924F35B29DDAE4000A440A5 /* sherpa-onnx.xcframework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -167,7 +148,6 @@
 			buildConfigurationList = C924F34E29DDAC0D00A440A5 /* Build configuration list for PBXNativeTarget "SherpaOnnx" */;
 			buildPhases = (
 				C924F32629DDAC0B00A440A5 /* Sources */,
-				C924F32729DDAC0B00A440A5 /* Frameworks */,
 				C924F32829DDAC0B00A440A5 /* Resources */,
 			);
 			buildRules = (
@@ -175,6 +155,9 @@
 			dependencies = (
 			);
 			name = SherpaOnnx;
+			packageProductDependencies = (
+				C9SP000000000002 /* sherpa-onnx */,
+			);
 			productName = SherpaOnnx;
 			productReference = C924F32A29DDAC0B00A440A5 /* SherpaOnnx.app */;
 			productType = "com.apple.product-type.application";
@@ -184,7 +167,6 @@
 			buildConfigurationList = C924F35129DDAC0D00A440A5 /* Build configuration list for PBXNativeTarget "SherpaOnnxTests" */;
 			buildPhases = (
 				C924F33629DDAC0D00A440A5 /* Sources */,
-				C924F33729DDAC0D00A440A5 /* Frameworks */,
 				C924F33829DDAC0D00A440A5 /* Resources */,
 			);
 			buildRules = (
@@ -202,7 +184,6 @@
 			buildConfigurationList = C924F35429DDAC0D00A440A5 /* Build configuration list for PBXNativeTarget "SherpaOnnxUITests" */;
 			buildPhases = (
 				C924F34029DDAC0D00A440A5 /* Sources */,
-				C924F34129DDAC0D00A440A5 /* Frameworks */,
 				C924F34229DDAC0D00A440A5 /* Resources */,
 			);
 			buildRules = (
@@ -247,6 +228,9 @@
 				Base,
 			);
 			mainGroup = C924F32129DDAC0B00A440A5;
+				packageReferences = (
+					C9SP000000000003 /* XCRemoteSwiftPackageReference "sherpa-onnx" */,
+				);
 			productRefGroup = C924F32B29DDAC0B00A440A5 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -291,7 +275,6 @@
 			files = (
 				C924F36229DDB15D00A440A5 /* Extension.swift in Sources */,
 				C924F33029DDAC0B00A440A5 /* ContentView.swift in Sources */,
-				C924F35929DDACED00A440A5 /* SherpaOnnx.swift in Sources */,
 				C924F32E29DDAC0B00A440A5 /* SherpaOnnxApp.swift in Sources */,
 				C924F36429DDB1D500A440A5 /* SherpaOnnxViewModel.swift in Sources */,
 				C924F35E29DDAE8200A440A5 /* Model.swift in Sources */,
@@ -468,11 +451,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.k2-fsa.org.SherpaOnnx";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "${PROJECT_DIR}/../../swift-api-examples/SherpaOnnx-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -501,11 +482,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.k2-fsa.org.SherpaOnnx";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "${PROJECT_DIR}/../../swift-api-examples/SherpaOnnx-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -625,4 +604,12 @@
 /* End XCConfigurationList section */
 	};
 	rootObject = C924F32229DDAC0B00A440A5 /* Project object */;
+
+/* Begin XCSwiftPackageProductDependency section */
+		C9SP000000000002 /* sherpa-onnx */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C9SP000000000003 /* XCRemoteSwiftPackageReference "sherpa-onnx" */;
+			productName = "sherpa-onnx";
+		};
+/* End XCSwiftPackageProductDependency section */
 }

--- a/ios-swiftui/SherpaOnnx/SherpaOnnx.xcodeproj/project.pbxproj
+++ b/ios-swiftui/SherpaOnnx/SherpaOnnx.xcodeproj/project.pbxproj
@@ -605,6 +605,17 @@
 	};
 	rootObject = C924F32229DDAC0B00A440A5 /* Project object */;
 
+/* Begin XCRemoteSwiftPackageReference section */
+		C9SP000000000003 /* XCRemoteSwiftPackageReference "sherpa-onnx" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/k2-fsa/sherpa-onnx";
+			requirement = {
+				kind = branch;
+				branch = master;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		C9SP000000000002 /* sherpa-onnx */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/ios-swiftui/SherpaOnnx/SherpaOnnx/ContentView.swift
+++ b/ios-swiftui/SherpaOnnx/SherpaOnnx/ContentView.swift
@@ -5,6 +5,7 @@
 //  Created by fangjun on 2023/4/5.
 //
 
+import SherpaOnnx
 import SwiftUI
 
 struct ContentView: View {

--- a/ios-swiftui/SherpaOnnx/SherpaOnnx/Extension.swift
+++ b/ios-swiftui/SherpaOnnx/SherpaOnnx/Extension.swift
@@ -5,6 +5,7 @@
 //  Created by knight on 2023/4/5.
 //
 
+import SherpaOnnx
 import AVFoundation
 
 extension AudioBuffer {

--- a/ios-swiftui/SherpaOnnx/SherpaOnnx/Model.swift
+++ b/ios-swiftui/SherpaOnnx/SherpaOnnx/Model.swift
@@ -1,3 +1,4 @@
+import SherpaOnnx
 import Foundation
 
 func getResource(_ forResource: String, _ ofType: String) -> String {

--- a/ios-swiftui/SherpaOnnx/SherpaOnnx/SherpaOnnxApp.swift
+++ b/ios-swiftui/SherpaOnnx/SherpaOnnx/SherpaOnnxApp.swift
@@ -5,6 +5,7 @@
 //  Created by fangjun on 2023/4/5.
 //
 
+import SherpaOnnx
 import SwiftUI
 
 @main

--- a/ios-swiftui/SherpaOnnx/SherpaOnnx/SherpaOnnxViewModel.swift
+++ b/ios-swiftui/SherpaOnnx/SherpaOnnx/SherpaOnnxViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by knight on 2023/4/5.
 //
 
+import SherpaOnnx
 import AVFoundation
 import Foundation
 

--- a/ios-swiftui/SherpaOnnx2Pass/SherpaOnnx2Pass.xcodeproj/project.pbxproj
+++ b/ios-swiftui/SherpaOnnx2Pass/SherpaOnnx2Pass.xcodeproj/project.pbxproj
@@ -363,6 +363,17 @@
 	};
 	rootObject = C9A258712AAEFFF100E555CA /* Project object */;
 
+/* Begin XCRemoteSwiftPackageReference section */
+		C9SP000000000003 /* XCRemoteSwiftPackageReference "sherpa-onnx" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/k2-fsa/sherpa-onnx";
+			requirement = {
+				kind = branch;
+				branch = master;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		C9SP000000000002 /* sherpa-onnx */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/ios-swiftui/SherpaOnnx2Pass/SherpaOnnx2Pass.xcodeproj/project.pbxproj
+++ b/ios-swiftui/SherpaOnnx2Pass/SherpaOnnx2Pass.xcodeproj/project.pbxproj
@@ -15,9 +15,7 @@
 		C9A2588E2AAF039D00E555CA /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A2588A2AAF039D00E555CA /* Model.swift */; };
 		C9A258902AAF039D00E555CA /* SherpaOnnxViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A2588C2AAF039D00E555CA /* SherpaOnnxViewModel.swift */; };
 		C9A258912AAF039D00E555CA /* Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A2588D2AAF039D00E555CA /* Extension.swift */; };
-		C9A258932AAF057E00E555CA /* SherpaOnnx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A258922AAF057E00E555CA /* SherpaOnnx.swift */; };
-		C9A258962AAF05D100E555CA /* sherpa-onnx.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9A258952AAF05D100E555CA /* sherpa-onnx.xcframework */; };
-		C9A258982AAF05E400E555CA /* onnxruntime.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9A258972AAF05E400E555CA /* onnxruntime.xcframework */; };
+		C9SP000000000001 /* sherpa-onnx in Frameworks */ = {isa = PBXBuildFile; productRef = C9SP000000000002 /* sherpa-onnx */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,9 +28,6 @@
 		C9A2588A2AAF039D00E555CA /* Model.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };
 		C9A2588C2AAF039D00E555CA /* SherpaOnnxViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SherpaOnnxViewModel.swift; sourceTree = "<group>"; };
 		C9A2588D2AAF039D00E555CA /* Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extension.swift; sourceTree = "<group>"; };
-		C9A258922AAF057E00E555CA /* SherpaOnnx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SherpaOnnx.swift; path = "../../../swift-api-examples/SherpaOnnx.swift"; sourceTree = "<group>"; };
-		C9A258952AAF05D100E555CA /* sherpa-onnx.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = "sherpa-onnx.xcframework"; path = "../../build-ios/sherpa-onnx.xcframework"; sourceTree = "<group>"; };
-		C9A258972AAF05E400E555CA /* onnxruntime.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = onnxruntime.xcframework; path = "../../build-ios/ios-onnxruntime/1.26.0/onnxruntime.xcframework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -40,8 +35,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C9A258982AAF05E400E555CA /* onnxruntime.xcframework in Frameworks */,
-				C9A258962AAF05D100E555CA /* sherpa-onnx.xcframework in Frameworks */,
+				C9SP000000000001 /* sherpa-onnx in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -53,7 +47,6 @@
 			children = (
 				C9A2587B2AAEFFF100E555CA /* SherpaOnnx2Pass */,
 				C9A2587A2AAEFFF100E555CA /* Products */,
-				C9A258942AAF05D100E555CA /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -69,7 +62,6 @@
 			isa = PBXGroup;
 			children = (
 				C981264F2BFEED7C000AD7AA /* Info.plist */,
-				C9A258922AAF057E00E555CA /* SherpaOnnx.swift */,
 				C9A2588D2AAF039D00E555CA /* Extension.swift */,
 				C9A2588A2AAF039D00E555CA /* Model.swift */,
 				C9A2588C2AAF039D00E555CA /* SherpaOnnxViewModel.swift */,
@@ -89,15 +81,6 @@
 			path = "Preview Content";
 			sourceTree = "<group>";
 		};
-		C9A258942AAF05D100E555CA /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				C9A258972AAF05E400E555CA /* onnxruntime.xcframework */,
-				C9A258952AAF05D100E555CA /* sherpa-onnx.xcframework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -106,7 +89,6 @@
 			buildConfigurationList = C9A258872AAEFFF200E555CA /* Build configuration list for PBXNativeTarget "SherpaOnnx2Pass" */;
 			buildPhases = (
 				C9A258752AAEFFF100E555CA /* Sources */,
-				C9A258762AAEFFF100E555CA /* Frameworks */,
 				C9A258772AAEFFF100E555CA /* Resources */,
 			);
 			buildRules = (
@@ -114,6 +96,9 @@
 			dependencies = (
 			);
 			name = SherpaOnnx2Pass;
+			packageProductDependencies = (
+				C9SP000000000002 /* sherpa-onnx */,
+			);
 			productName = SherpaOnnx2Pass;
 			productReference = C9A258792AAEFFF100E555CA /* SherpaOnnx2Pass.app */;
 			productType = "com.apple.product-type.application";
@@ -142,6 +127,9 @@
 				Base,
 			);
 			mainGroup = C9A258702AAEFFF100E555CA;
+				packageReferences = (
+					C9SP000000000003 /* XCRemoteSwiftPackageReference "sherpa-onnx" */,
+				);
 			productRefGroup = C9A2587A2AAEFFF100E555CA /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -173,7 +161,6 @@
 				C9A258902AAF039D00E555CA /* SherpaOnnxViewModel.swift in Sources */,
 				C9A258912AAF039D00E555CA /* Extension.swift in Sources */,
 				C9A2587F2AAEFFF100E555CA /* ContentView.swift in Sources */,
-				C9A258932AAF057E00E555CA /* SherpaOnnx.swift in Sources */,
 				C9A2587D2AAEFFF100E555CA /* SherpaOnnx2PassApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -315,11 +302,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.k2-fsa.org.SherpaOnnx2Pass";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "${PROJECT_DIR}/../../swift-api-examples/SherpaOnnx-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -345,11 +330,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.k2-fsa.org.SherpaOnnx2Pass";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "${PROJECT_DIR}/../../swift-api-examples/SherpaOnnx-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -379,4 +362,12 @@
 /* End XCConfigurationList section */
 	};
 	rootObject = C9A258712AAEFFF100E555CA /* Project object */;
+
+/* Begin XCSwiftPackageProductDependency section */
+		C9SP000000000002 /* sherpa-onnx */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C9SP000000000003 /* XCRemoteSwiftPackageReference "sherpa-onnx" */;
+			productName = "sherpa-onnx";
+		};
+/* End XCSwiftPackageProductDependency section */
 }

--- a/ios-swiftui/SherpaOnnx2Pass/SherpaOnnx2Pass/ContentView.swift
+++ b/ios-swiftui/SherpaOnnx2Pass/SherpaOnnx2Pass/ContentView.swift
@@ -5,6 +5,7 @@
 //  Created by fangjun on 2023/9/11.
 //
 
+import SherpaOnnx
 import SwiftUI
 
 struct ContentView: View {

--- a/ios-swiftui/SherpaOnnx2Pass/SherpaOnnx2Pass/Extension.swift
+++ b/ios-swiftui/SherpaOnnx2Pass/SherpaOnnx2Pass/Extension.swift
@@ -5,6 +5,7 @@
 //  Created by knight on 2023/4/5.
 //
 
+import SherpaOnnx
 import AVFoundation
 
 extension AudioBuffer {

--- a/ios-swiftui/SherpaOnnx2Pass/SherpaOnnx2Pass/Model.swift
+++ b/ios-swiftui/SherpaOnnx2Pass/SherpaOnnx2Pass/Model.swift
@@ -1,3 +1,4 @@
+import SherpaOnnx
 import Foundation
 
 func getResource(_ forResource: String, _ ofType: String) -> String {

--- a/ios-swiftui/SherpaOnnx2Pass/SherpaOnnx2Pass/SherpaOnnx2PassApp.swift
+++ b/ios-swiftui/SherpaOnnx2Pass/SherpaOnnx2Pass/SherpaOnnx2PassApp.swift
@@ -5,6 +5,7 @@
 //  Created by fangjun on 2023/9/11.
 //
 
+import SherpaOnnx
 import SwiftUI
 
 @main

--- a/ios-swiftui/SherpaOnnx2Pass/SherpaOnnx2Pass/SherpaOnnxViewModel.swift
+++ b/ios-swiftui/SherpaOnnx2Pass/SherpaOnnx2Pass/SherpaOnnxViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by knight on 2023/4/5.
 //
 
+import SherpaOnnx
 import Foundation
 import AVFoundation
 

--- a/ios-swiftui/SherpaOnnxLangID/SherpaOnnxLangID.xcodeproj/project.pbxproj
+++ b/ios-swiftui/SherpaOnnxLangID/SherpaOnnxLangID.xcodeproj/project.pbxproj
@@ -621,6 +621,17 @@
 	};
 	rootObject = DEBB2D6A2BBAAA3500864EF5 /* Project object */;
 
+/* Begin XCRemoteSwiftPackageReference section */
+		C9SP000000000003 /* XCRemoteSwiftPackageReference "sherpa-onnx" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/k2-fsa/sherpa-onnx";
+			requirement = {
+				kind = branch;
+				branch = master;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		C9SP000000000002 /* sherpa-onnx */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/ios-swiftui/SherpaOnnxLangID/SherpaOnnxLangID.xcodeproj/project.pbxproj
+++ b/ios-swiftui/SherpaOnnxLangID/SherpaOnnxLangID.xcodeproj/project.pbxproj
@@ -18,11 +18,7 @@
 		DEBB2DA12BBAAAD800864EF5 /* Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBB2DA02BBAAAD800864EF5 /* Extension.swift */; };
 		DEBB2DA32BBAAAE700864EF5 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBB2DA22BBAAAE700864EF5 /* Model.swift */; };
 		DEBB2DA52BBAAAFD00864EF5 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBB2DA42BBAAAFD00864EF5 /* ViewModel.swift */; };
-		DEBB2DAC2BBAAC6200864EF5 /* onnxruntime.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEBB2DAB2BBAAC6200864EF5 /* onnxruntime.xcframework */; };
-		DEBB2DAD2BBAAC6200864EF5 /* onnxruntime.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DEBB2DAB2BBAAC6200864EF5 /* onnxruntime.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		DEBB2DAF2BBAAC6400864EF5 /* sherpa-onnx.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEBB2DA72BBAAC4D00864EF5 /* sherpa-onnx.xcframework */; };
-		DEBB2DB02BBAAC6400864EF5 /* sherpa-onnx.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DEBB2DA72BBAAC4D00864EF5 /* sherpa-onnx.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		DEBB2DB22BBAAD0000864EF5 /* SherpaOnnx.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBB2DB12BBAAD0000864EF5 /* SherpaOnnx.swift */; };
+		C9SP000000000001 /* sherpa-onnx in Frameworks */ = {isa = PBXBuildFile; productRef = C9SP000000000002 /* sherpa-onnx */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -42,20 +38,6 @@
 		};
 /* End PBXContainerItemProxy section */
 
-/* Begin PBXCopyFilesBuildPhase section */
-		DEBB2DAE2BBAAC6200864EF5 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				DEBB2DAD2BBAAC6200864EF5 /* onnxruntime.xcframework in Embed Frameworks */,
-				DEBB2DB02BBAAC6400864EF5 /* sherpa-onnx.xcframework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		C98126512BFEEDB7000AD7AA /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -69,13 +51,9 @@
 		DEBB2D8C2BBAAA3600864EF5 /* SherpaOnnxLangIDUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SherpaOnnxLangIDUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DEBB2D902BBAAA3600864EF5 /* SherpaOnnxLangIDUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaOnnxLangIDUITests.swift; sourceTree = "<group>"; };
 		DEBB2D922BBAAA3600864EF5 /* SherpaOnnxLangIDUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaOnnxLangIDUITestsLaunchTests.swift; sourceTree = "<group>"; };
-		DEBB2D9F2BBAAACD00864EF5 /* SherpaOnnx-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SherpaOnnx-Bridging-Header.h"; path = "../../../swift-api-examples/SherpaOnnx-Bridging-Header.h"; sourceTree = "<group>"; };
 		DEBB2DA02BBAAAD800864EF5 /* Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Extension.swift; path = ../../SherpaOnnx/SherpaOnnx/Extension.swift; sourceTree = "<group>"; };
 		DEBB2DA22BBAAAE700864EF5 /* Model.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Model.swift; path = ../../SherpaOnnx/SherpaOnnx/Model.swift; sourceTree = "<group>"; };
 		DEBB2DA42BBAAAFD00864EF5 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
-		DEBB2DA72BBAAC4D00864EF5 /* sherpa-onnx.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = "sherpa-onnx.xcframework"; path = "../../build-ios/sherpa-onnx.xcframework"; sourceTree = "<group>"; };
-		DEBB2DAB2BBAAC6200864EF5 /* onnxruntime.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = onnxruntime.xcframework; path = "../../build-ios/ios-onnxruntime/1.26.0/onnxruntime.xcframework"; sourceTree = "<group>"; };
-		DEBB2DB12BBAAD0000864EF5 /* SherpaOnnx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SherpaOnnx.swift; path = "../../../swift-api-examples/SherpaOnnx.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -83,8 +61,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DEBB2DAC2BBAAC6200864EF5 /* onnxruntime.xcframework in Frameworks */,
-				DEBB2DAF2BBAAC6400864EF5 /* sherpa-onnx.xcframework in Frameworks */,
+				C9SP000000000001 /* sherpa-onnx in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -112,7 +89,6 @@
 				DEBB2D852BBAAA3600864EF5 /* SherpaOnnxLangIDTests */,
 				DEBB2D8F2BBAAA3600864EF5 /* SherpaOnnxLangIDUITests */,
 				DEBB2D732BBAAA3500864EF5 /* Products */,
-				DEBB2DA62BBAAC4D00864EF5 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -133,8 +109,6 @@
 				DEBB2D752BBAAA3500864EF5 /* SherpaOnnxLangIDApp.swift */,
 				DEBB2D772BBAAA3500864EF5 /* ContentView.swift */,
 				DEBB2DA42BBAAAFD00864EF5 /* ViewModel.swift */,
-				DEBB2D9F2BBAAACD00864EF5 /* SherpaOnnx-Bridging-Header.h */,
-				DEBB2DB12BBAAD0000864EF5 /* SherpaOnnx.swift */,
 				DEBB2DA02BBAAAD800864EF5 /* Extension.swift */,
 				DEBB2DA22BBAAAE700864EF5 /* Model.swift */,
 				DEBB2D792BBAAA3600864EF5 /* Assets.xcassets */,
@@ -168,15 +142,6 @@
 			path = SherpaOnnxLangIDUITests;
 			sourceTree = "<group>";
 		};
-		DEBB2DA62BBAAC4D00864EF5 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				DEBB2DAB2BBAAC6200864EF5 /* onnxruntime.xcframework */,
-				DEBB2DA72BBAAC4D00864EF5 /* sherpa-onnx.xcframework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -185,15 +150,16 @@
 			buildConfigurationList = DEBB2D962BBAAA3600864EF5 /* Build configuration list for PBXNativeTarget "SherpaOnnxLangID" */;
 			buildPhases = (
 				DEBB2D6E2BBAAA3500864EF5 /* Sources */,
-				DEBB2D6F2BBAAA3500864EF5 /* Frameworks */,
 				DEBB2D702BBAAA3500864EF5 /* Resources */,
-				DEBB2DAE2BBAAC6200864EF5 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
 			name = SherpaOnnxLangID;
+			packageProductDependencies = (
+				C9SP000000000002 /* sherpa-onnx */,
+			);
 			productName = SherpaOnnxLangID;
 			productReference = DEBB2D722BBAAA3500864EF5 /* SherpaOnnxLangID.app */;
 			productType = "com.apple.product-type.application";
@@ -203,7 +169,6 @@
 			buildConfigurationList = DEBB2D992BBAAA3600864EF5 /* Build configuration list for PBXNativeTarget "SherpaOnnxLangIDTests" */;
 			buildPhases = (
 				DEBB2D7E2BBAAA3600864EF5 /* Sources */,
-				DEBB2D7F2BBAAA3600864EF5 /* Frameworks */,
 				DEBB2D802BBAAA3600864EF5 /* Resources */,
 			);
 			buildRules = (
@@ -221,7 +186,6 @@
 			buildConfigurationList = DEBB2D9C2BBAAA3600864EF5 /* Build configuration list for PBXNativeTarget "SherpaOnnxLangIDUITests" */;
 			buildPhases = (
 				DEBB2D882BBAAA3600864EF5 /* Sources */,
-				DEBB2D892BBAAA3600864EF5 /* Frameworks */,
 				DEBB2D8A2BBAAA3600864EF5 /* Resources */,
 			);
 			buildRules = (
@@ -266,6 +230,9 @@
 				Base,
 			);
 			mainGroup = DEBB2D692BBAAA3500864EF5;
+				packageReferences = (
+					C9SP000000000003 /* XCRemoteSwiftPackageReference "sherpa-onnx" */,
+				);
 			productRefGroup = DEBB2D732BBAAA3500864EF5 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -310,7 +277,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				DEBB2DA52BBAAAFD00864EF5 /* ViewModel.swift in Sources */,
-				DEBB2DB22BBAAD0000864EF5 /* SherpaOnnx.swift in Sources */,
 				DEBB2DA12BBAAAD800864EF5 /* Extension.swift in Sources */,
 				DEBB2D782BBAAA3500864EF5 /* ContentView.swift in Sources */,
 				DEBB2D762BBAAA3500864EF5 /* SherpaOnnxLangIDApp.swift in Sources */,
@@ -494,12 +460,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.k2-fsa.org.SherpaOnnxLangID";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "${PROJECT_DIR}/../../swift-api-examples/SherpaOnnx-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -529,12 +493,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.k2-fsa.org.SherpaOnnxLangID";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "${PROJECT_DIR}/../../swift-api-examples/SherpaOnnx-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -658,4 +620,12 @@
 /* End XCConfigurationList section */
 	};
 	rootObject = DEBB2D6A2BBAAA3500864EF5 /* Project object */;
+
+/* Begin XCSwiftPackageProductDependency section */
+		C9SP000000000002 /* sherpa-onnx */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C9SP000000000003 /* XCRemoteSwiftPackageReference "sherpa-onnx" */;
+			productName = "sherpa-onnx";
+		};
+/* End XCSwiftPackageProductDependency section */
 }

--- a/ios-swiftui/SherpaOnnxLangID/SherpaOnnxLangID/ContentView.swift
+++ b/ios-swiftui/SherpaOnnxLangID/SherpaOnnxLangID/ContentView.swift
@@ -5,6 +5,7 @@
 //  Created by knight on 2024/4/1.
 //
 
+import SherpaOnnx
 import SwiftUI
 
 struct ContentView: View {

--- a/ios-swiftui/SherpaOnnxLangID/SherpaOnnxLangID/SherpaOnnxLangIDApp.swift
+++ b/ios-swiftui/SherpaOnnxLangID/SherpaOnnxLangID/SherpaOnnxLangIDApp.swift
@@ -5,6 +5,7 @@
 //  Created by knight on 2024/4/1.
 //
 
+import SherpaOnnx
 import SwiftUI
 
 @main

--- a/ios-swiftui/SherpaOnnxLangID/SherpaOnnxLangID/ViewModel.swift
+++ b/ios-swiftui/SherpaOnnxLangID/SherpaOnnxLangID/ViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by knight on 2024/4/1.
 //
 
+import SherpaOnnx
 import SwiftUI
 import AVFoundation
 

--- a/ios-swiftui/SherpaOnnxSubtitle/SherpaOnnxSubtitle.xcodeproj/project.pbxproj
+++ b/ios-swiftui/SherpaOnnxSubtitle/SherpaOnnxSubtitle.xcodeproj/project.pbxproj
@@ -7,14 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		DE081A8F2ABF287C00E8CD63 /* SherpaOnnx.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE081A8E2ABF287C00E8CD63 /* SherpaOnnx.swift */; };
 		DE081A922ABF28D400E8CD63 /* SubtitleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE081A912ABF28D400E8CD63 /* SubtitleViewModel.swift */; };
 		DE081A952ABFC60E00E8CD63 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE081A942ABFC60E00E8CD63 /* Model.swift */; };
 		DE081AAF2ABFF35400E8CD63 /* UTType.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE081AAE2ABFF35400E8CD63 /* UTType.swift */; };
 		DE081AB12ABFFEEE00E8CD63 /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE081AB02ABFFEEE00E8CD63 /* Document.swift */; };
 		DE081AB32ABFFF2600E8CD63 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE081AB22ABFFF2600E8CD63 /* Errors.swift */; };
-		DE8C85A62ABF23E100F667E3 /* onnxruntime.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE8C85A52ABF23E100F667E3 /* onnxruntime.xcframework */; };
-		DE8C85AA2ABF23FA00F667E3 /* sherpa-onnx.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE8C85A92ABF23FA00F667E3 /* sherpa-onnx.xcframework */; };
 		DE8C85B22ABF257200F667E3 /* SpeechSegment.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C85B12ABF257200F667E3 /* SpeechSegment.swift */; };
 		DEA657152ABF19730066A81D /* SherpaOnnxSubtitleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA657142ABF19730066A81D /* SherpaOnnxSubtitleApp.swift */; };
 		DEA657172ABF19730066A81D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA657162ABF19730066A81D /* ContentView.swift */; };
@@ -22,18 +19,16 @@
 		DEA6571C2ABF19740066A81D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DEA6571B2ABF19740066A81D /* Preview Assets.xcassets */; };
 		DEA657232ABF20130066A81D /* Audio.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA657222ABF20130066A81D /* Audio.swift */; };
 		DED059702AC136FF00122A60 /* Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED0596F2AC136FF00122A60 /* Extension.swift */; };
+		C9SP000000000001 /* sherpa-onnx in Frameworks */ = {isa = PBXBuildFile; productRef = C9SP000000000002 /* sherpa-onnx */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		DE081A8E2ABF287C00E8CD63 /* SherpaOnnx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SherpaOnnx.swift; path = "../../../swift-api-examples/SherpaOnnx.swift"; sourceTree = "<group>"; };
 		DE081A912ABF28D400E8CD63 /* SubtitleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtitleViewModel.swift; sourceTree = "<group>"; };
 		DE081A942ABFC60E00E8CD63 /* Model.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Model.swift; path = ../../SherpaOnnx2Pass/SherpaOnnx2Pass/Model.swift; sourceTree = "<group>"; };
 		DE081AAC2ABFF30A00E8CD63 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		DE081AAE2ABFF35400E8CD63 /* UTType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UTType.swift; sourceTree = "<group>"; };
 		DE081AB02ABFFEEE00E8CD63 /* Document.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Document.swift; sourceTree = "<group>"; };
 		DE081AB22ABFFF2600E8CD63 /* Errors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
-		DE8C85A52ABF23E100F667E3 /* onnxruntime.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = onnxruntime.xcframework; path = "../../build-ios/ios-onnxruntime/1.26.0/onnxruntime.xcframework"; sourceTree = "<group>"; };
-		DE8C85A92ABF23FA00F667E3 /* sherpa-onnx.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = "sherpa-onnx.xcframework"; path = "../../build-ios/sherpa-onnx.xcframework"; sourceTree = "<group>"; };
 		DE8C85B12ABF257200F667E3 /* SpeechSegment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechSegment.swift; sourceTree = "<group>"; };
 		DEA657112ABF19730066A81D /* SherpaOnnxSubtitle.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SherpaOnnxSubtitle.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DEA657142ABF19730066A81D /* SherpaOnnxSubtitleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SherpaOnnxSubtitleApp.swift; sourceTree = "<group>"; };
@@ -49,8 +44,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DE8C85A62ABF23E100F667E3 /* onnxruntime.xcframework in Frameworks */,
-				DE8C85AA2ABF23FA00F667E3 /* sherpa-onnx.xcframework in Frameworks */,
+				C9SP000000000001 /* sherpa-onnx in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -77,21 +71,11 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
-		DE8C85A42ABF23E100F667E3 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				DE8C85A92ABF23FA00F667E3 /* sherpa-onnx.xcframework */,
-				DE8C85A52ABF23E100F667E3 /* onnxruntime.xcframework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		DEA657082ABF19730066A81D = {
 			isa = PBXGroup;
 			children = (
 				DEA657132ABF19730066A81D /* SherpaOnnxSubtitle */,
 				DEA657122ABF19730066A81D /* Products */,
-				DE8C85A42ABF23E100F667E3 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -107,7 +91,6 @@
 			isa = PBXGroup;
 			children = (
 				DE081AAC2ABFF30A00E8CD63 /* Info.plist */,
-				DE081A8E2ABF287C00E8CD63 /* SherpaOnnx.swift */,
 				DEA657142ABF19730066A81D /* SherpaOnnxSubtitleApp.swift */,
 				DEA657162ABF19730066A81D /* ContentView.swift */,
 				DE081A912ABF28D400E8CD63 /* SubtitleViewModel.swift */,
@@ -136,7 +119,6 @@
 			buildConfigurationList = DEA6571F2ABF19740066A81D /* Build configuration list for PBXNativeTarget "SherpaOnnxSubtitle" */;
 			buildPhases = (
 				DEA6570D2ABF19730066A81D /* Sources */,
-				DEA6570E2ABF19730066A81D /* Frameworks */,
 				DEA6570F2ABF19730066A81D /* Resources */,
 			);
 			buildRules = (
@@ -144,6 +126,9 @@
 			dependencies = (
 			);
 			name = SherpaOnnxSubtitle;
+			packageProductDependencies = (
+				C9SP000000000002 /* sherpa-onnx */,
+			);
 			productName = SherpaOnnxSubtitle;
 			productReference = DEA657112ABF19730066A81D /* SherpaOnnxSubtitle.app */;
 			productType = "com.apple.product-type.application";
@@ -172,6 +157,9 @@
 				Base,
 			);
 			mainGroup = DEA657082ABF19730066A81D;
+				packageReferences = (
+					C9SP000000000003 /* XCRemoteSwiftPackageReference "sherpa-onnx" */,
+				);
 			productRefGroup = DEA657122ABF19730066A81D /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -207,7 +195,6 @@
 				DEA657152ABF19730066A81D /* SherpaOnnxSubtitleApp.swift in Sources */,
 				DE081AB32ABFFF2600E8CD63 /* Errors.swift in Sources */,
 				DEA657232ABF20130066A81D /* Audio.swift in Sources */,
-				DE081A8F2ABF287C00E8CD63 /* SherpaOnnx.swift in Sources */,
 				DE081A952ABFC60E00E8CD63 /* Model.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -357,11 +344,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = net.duoziwei.SherpaOnnxSubtitle;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "${PROJECT_DIR}/../../swift-api-examples/SherpaOnnx-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -390,11 +375,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = net.duoziwei.SherpaOnnxSubtitle;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "${PROJECT_DIR}/../../swift-api-examples/SherpaOnnx-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -424,4 +407,12 @@
 /* End XCConfigurationList section */
 	};
 	rootObject = DEA657092ABF19730066A81D /* Project object */;
+
+/* Begin XCSwiftPackageProductDependency section */
+		C9SP000000000002 /* sherpa-onnx */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C9SP000000000003 /* XCRemoteSwiftPackageReference "sherpa-onnx" */;
+			productName = "sherpa-onnx";
+		};
+/* End XCSwiftPackageProductDependency section */
 }

--- a/ios-swiftui/SherpaOnnxSubtitle/SherpaOnnxSubtitle.xcodeproj/project.pbxproj
+++ b/ios-swiftui/SherpaOnnxSubtitle/SherpaOnnxSubtitle.xcodeproj/project.pbxproj
@@ -408,6 +408,17 @@
 	};
 	rootObject = DEA657092ABF19730066A81D /* Project object */;
 
+/* Begin XCRemoteSwiftPackageReference section */
+		C9SP000000000003 /* XCRemoteSwiftPackageReference "sherpa-onnx" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/k2-fsa/sherpa-onnx";
+			requirement = {
+				kind = branch;
+				branch = master;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		C9SP000000000002 /* sherpa-onnx */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/ios-swiftui/SherpaOnnxSubtitle/SherpaOnnxSubtitle/ContentView.swift
+++ b/ios-swiftui/SherpaOnnxSubtitle/SherpaOnnxSubtitle/ContentView.swift
@@ -5,6 +5,7 @@
 //  Created by knight on 2023/9/23.
 //
 
+import SherpaOnnx
 import AVKit
 import MediaPlayer
 import PhotosUI

--- a/ios-swiftui/SherpaOnnxSubtitle/SherpaOnnxSubtitle/SherpaOnnxSubtitleApp.swift
+++ b/ios-swiftui/SherpaOnnxSubtitle/SherpaOnnxSubtitle/SherpaOnnxSubtitleApp.swift
@@ -5,6 +5,7 @@
 //  Created by knight on 2023/9/23.
 //
 
+import SherpaOnnx
 import SwiftUI
 
 @main

--- a/ios-swiftui/SherpaOnnxSubtitle/SherpaOnnxSubtitle/SubtitleViewModel.swift
+++ b/ios-swiftui/SherpaOnnxSubtitle/SherpaOnnxSubtitle/SubtitleViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by knight on 2023/9/23.
 //
 
+import SherpaOnnx
 import AVFoundation
 import PhotosUI
 import SwiftUI

--- a/ios-swiftui/SherpaOnnxTts/SherpaOnnxTts.xcodeproj/project.pbxproj
+++ b/ios-swiftui/SherpaOnnxTts/SherpaOnnxTts.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -12,9 +12,7 @@
 		C917B4E92B0EEF3C005245AC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C917B4E82B0EEF3C005245AC /* Assets.xcassets */; };
 		C917B4EC2B0EEF3C005245AC /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C917B4EB2B0EEF3C005245AC /* Preview Assets.xcassets */; };
 		C9FE9FE52B0F33CD009F1003 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9FE9FE42B0F33CD009F1003 /* ViewModel.swift */; };
-		C9FE9FE72B0F3620009F1003 /* SherpaOnnx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9FE9FE62B0F3620009F1003 /* SherpaOnnx.swift */; };
-		C9FE9FEA2B0F3754009F1003 /* sherpa-onnx.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9FE9FE92B0F3754009F1003 /* sherpa-onnx.xcframework */; };
-		C9FE9FEF2B0F3EFB009F1003 /* onnxruntime.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9FE9FEB2B0F3785009F1003 /* onnxruntime.xcframework */; };
+		C9SP000000000001 /* sherpa-onnx in Frameworks */ = {isa = PBXBuildFile; productRef = C9SP000000000002 /* sherpa-onnx */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -23,10 +21,10 @@
 		C917B4E62B0EEF3B005245AC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		C917B4E82B0EEF3C005245AC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C917B4EB2B0EEF3C005245AC /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		C9E3B5CE3019B6D50057554A /* espeak-ng-data */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "espeak-ng-data"; sourceTree = "<group>"; };
+		C9E3B5CF3019B6D50057554A /* en_US-amy-low.onnx */ = {isa = PBXFileReference; lastKnownFileType = file; path = "en_US-amy-low.onnx"; sourceTree = "<group>"; };
+		C9E3B5D03019B6D50057554A /* tokens.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = tokens.txt; sourceTree = "<group>"; };
 		C9FE9FE42B0F33CD009F1003 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
-		C9FE9FE62B0F3620009F1003 /* SherpaOnnx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SherpaOnnx.swift; path = "../../../swift-api-examples/SherpaOnnx.swift"; sourceTree = "<group>"; };
-		C9FE9FE92B0F3754009F1003 /* sherpa-onnx.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = "sherpa-onnx.xcframework"; path = "../../build-ios/sherpa-onnx.xcframework"; sourceTree = "<group>"; };
-		C9FE9FEB2B0F3785009F1003 /* onnxruntime.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = onnxruntime.xcframework; path = "../../build-ios/ios-onnxruntime/1.26.0/onnxruntime.xcframework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -34,8 +32,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C9FE9FEF2B0F3EFB009F1003 /* onnxruntime.xcframework in Frameworks */,
-				C9FE9FEA2B0F3754009F1003 /* sherpa-onnx.xcframework in Frameworks */,
+				C9SP000000000001 /* sherpa-onnx in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -45,9 +42,11 @@
 		C917B4D82B0EEF3B005245AC = {
 			isa = PBXGroup;
 			children = (
+				C9E3B5CF3019B6D50057554A /* en_US-amy-low.onnx */,
+				C9E3B5CE3019B6D50057554A /* espeak-ng-data */,
+				C9E3B5D03019B6D50057554A /* tokens.txt */,
 				C917B4E32B0EEF3B005245AC /* SherpaOnnxTts */,
 				C917B4E22B0EEF3B005245AC /* Products */,
-				C9FE9FE82B0F3754009F1003 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -62,7 +61,6 @@
 		C917B4E32B0EEF3B005245AC /* SherpaOnnxTts */ = {
 			isa = PBXGroup;
 			children = (
-				C9FE9FE62B0F3620009F1003 /* SherpaOnnx.swift */,
 				C9FE9FE42B0F33CD009F1003 /* ViewModel.swift */,
 				C917B4E42B0EEF3B005245AC /* SherpaOnnxTtsApp.swift */,
 				C917B4E62B0EEF3B005245AC /* ContentView.swift */,
@@ -78,15 +76,6 @@
 				C917B4EB2B0EEF3C005245AC /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
-			sourceTree = "<group>";
-		};
-		C9FE9FE82B0F3754009F1003 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				C9FE9FEB2B0F3785009F1003 /* onnxruntime.xcframework */,
-				C9FE9FE92B0F3754009F1003 /* sherpa-onnx.xcframework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -105,6 +94,9 @@
 			dependencies = (
 			);
 			name = SherpaOnnxTts;
+			packageProductDependencies = (
+				C9SP000000000002 /* sherpa-onnx */,
+			);
 			productName = SherpaOnnxTts;
 			productReference = C917B4E12B0EEF3B005245AC /* SherpaOnnxTts.app */;
 			productType = "com.apple.product-type.application";
@@ -133,6 +125,9 @@
 				Base,
 			);
 			mainGroup = C917B4D82B0EEF3B005245AC;
+			packageReferences = (
+				C9SP000000000003 /* XCLocalSwiftPackageReference "../../" */,
+			);
 			productRefGroup = C917B4E22B0EEF3B005245AC /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -160,7 +155,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				C917B4E72B0EEF3B005245AC /* ContentView.swift in Sources */,
-				C9FE9FE72B0F3620009F1003 /* SherpaOnnx.swift in Sources */,
 				C9FE9FE52B0F33CD009F1003 /* ViewModel.swift in Sources */,
 				C917B4E52B0EEF3B005245AC /* SherpaOnnxTtsApp.swift in Sources */,
 			);
@@ -292,9 +286,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SherpaOnnxTts/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
-				FRAMEWORK_SEARCH_PATHS = "${PROJECT_DIR}/../../build-ios";
 				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = "${PROJECT_DIR}/../../build-ios/sherpa-onnx.xcframework/Headers";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -305,11 +297,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.k2-fsa.org.SherpaOnnxTts";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "${PROJECT_DIR}/../../swift-api-examples/SherpaOnnx-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -324,9 +314,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SherpaOnnxTts/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
-				FRAMEWORK_SEARCH_PATHS = "${PROJECT_DIR}/../../build-ios";
 				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = "${PROJECT_DIR}/../../build-ios/sherpa-onnx.xcframework/Headers";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -337,11 +325,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.k2-fsa.org.SherpaOnnxTts";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "${PROJECT_DIR}/../../swift-api-examples/SherpaOnnx-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -369,6 +355,34 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		C9SP000000000003 /* XCRemoteSwiftPackageReference "sherpa-onnx" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/k2-fsa/sherpa-onnx";
+			requirement = {
+				kind = branch;
+				branch = master;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		/*
+		C9SP000000000003 XCLocalSwiftPackageReference "../../" = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../../;
+		};
+		*/
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		C9SP000000000002 /* sherpa-onnx */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C9SP000000000003 /* XCRemoteSwiftPackageReference "sherpa-onnx" */;
+			productName = "sherpa-onnx";
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = C917B4D92B0EEF3B005245AC /* Project object */;
 }

--- a/ios-swiftui/SherpaOnnxTts/SherpaOnnxTts/ContentView.swift
+++ b/ios-swiftui/SherpaOnnxTts/SherpaOnnxTts/ContentView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 import AVFoundation
+import SherpaOnnx
 import UniformTypeIdentifiers
 
 class TtsProgressHandler: ObservableObject {

--- a/ios-swiftui/SherpaOnnxTts/SherpaOnnxTts/ViewModel.swift
+++ b/ios-swiftui/SherpaOnnxTts/SherpaOnnxTts/ViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SherpaOnnx
 
 // used to get the path to espeak-ng-data
 func resourceURL(to path: String) -> String {
@@ -199,7 +200,7 @@ func getTtsFor_kokoro_multi_lang_v1_0() -> SherpaOnnxOfflineTtsWrapper {
     model: model, voices: voices, tokens: tokens, dataDir: dataDir,
     lexicon: lexicon)
   let modelConfig = sherpaOnnxOfflineTtsModelConfig(kokoro: kokoro)
-  var config = sherpaOnnxOfflineTtsConfig(model: modelConfig)
+  var config = sherpaOnnxOfflineTtsConfig(model: modelConfig, ruleFsts: ruleFsts)
 
   return SherpaOnnxOfflineTtsWrapper(config: &config)
 }

--- a/swift-api-examples/SherpaOnnx.swift
+++ b/swift-api-examples/SherpaOnnx.swift
@@ -209,7 +209,7 @@ public func sherpaOnnxOnlineRecognizerConfig(
 ///  let result = recognizer.getResult()
 ///  print("text: \(result.text)")
 ///
-public class SherpaOnnxOnlineRecongitionResult {
+public class SherpaOnnxOnlineRecognitionResult {
   /// A pointer to the underlying counterpart in C
   private let result: UnsafePointer<SherpaOnnxOnlineRecognizerResult>
 
@@ -291,11 +291,11 @@ public class SherpaOnnxRecognizer {
   }
 
   /// Get the decoding results so far
-  public func getResult() -> SherpaOnnxOnlineRecongitionResult {
+  public func getResult() -> SherpaOnnxOnlineRecognitionResult {
     guard let result = SherpaOnnxGetOnlineStreamResult(recognizer, stream) else {
       fatalError("SherpaOnnxGetOnlineStreamResult returned nil")
     }
-    return SherpaOnnxOnlineRecongitionResult(result: result)
+    return SherpaOnnxOnlineRecognitionResult(result: result)
   }
 
   /// Reset the recognizer, which clears the neural network model state
@@ -674,7 +674,7 @@ public func sherpaOnnxOfflineRecognizerConfig(
   )
 }
 
-public class SherpaOnnxOfflineRecongitionResult {
+public class SherpaOnnxOfflineRecognitionResult {
   /// A pointer to the underlying counterpart in C
   public let result: UnsafePointer<SherpaOnnxOfflineRecognizerResult>
 
@@ -788,7 +788,7 @@ public class SherpaOnnxOfflineRecognizer {
   ///   - samples: Audio samples normalized to the range [-1, 1]
   ///   - sampleRate: Sample rate of the input audio samples. Must match
   ///                 the one expected by the model.
-  public func decode(samples: [Float], sampleRate: Int = 16_000) -> SherpaOnnxOfflineRecongitionResult {
+  public func decode(samples: [Float], sampleRate: Int = 16_000) -> SherpaOnnxOfflineRecognitionResult {
     let stream = createStream()
     stream.acceptWaveform(samples: samples, sampleRate: sampleRate)
     decode(stream: stream)
@@ -811,12 +811,12 @@ public class SherpaOnnxOfflineRecognizer {
     SherpaOnnxDecodeOfflineStream(recognizer, stream.stream)
   }
 
-  public func getResult(stream: SherpaOnnxOfflineStreamWrapper) -> SherpaOnnxOfflineRecongitionResult {
+  public func getResult(stream: SherpaOnnxOfflineStreamWrapper) -> SherpaOnnxOfflineRecognitionResult {
     guard let resultPtr = SherpaOnnxGetOfflineStreamResult(stream.stream) else {
       fatalError("Failed to get offline recognition result")
     }
 
-    return SherpaOnnxOfflineRecongitionResult(result: resultPtr)
+    return SherpaOnnxOfflineRecognitionResult(result: resultPtr)
   }
 }
 

--- a/swift-api-examples/SherpaOnnx.swift
+++ b/swift-api-examples/SherpaOnnx.swift
@@ -13,7 +13,7 @@ import SherpaOnnxC
 ///   - s: The String to convert.
 /// - Returns: A pointer that can be passed to C as `const char*`
 
-func toCPointer(_ s: String) -> UnsafePointer<Int8>! {
+public func toCPointer(_ s: String) -> UnsafePointer<Int8>! {
   let cs = (s as NSString).utf8String
   return UnsafePointer<Int8>(cs)
 }
@@ -30,7 +30,7 @@ func toCPointer(_ s: String) -> UnsafePointer<Int8>! {
 ///   - joiner: Path to joiner.onnx
 ///
 /// - Returns: Return an instance of SherpaOnnxOnlineTransducerModelConfig
-func sherpaOnnxOnlineTransducerModelConfig(
+public func sherpaOnnxOnlineTransducerModelConfig(
   encoder: String = "",
   decoder: String = "",
   joiner: String = ""
@@ -53,7 +53,7 @@ func sherpaOnnxOnlineTransducerModelConfig(
 ///   - decoder: Path to decoder.onnx
 ///
 /// - Returns: Return an instance of SherpaOnnxOnlineParaformerModelConfig
-func sherpaOnnxOnlineParaformerModelConfig(
+public func sherpaOnnxOnlineParaformerModelConfig(
   encoder: String = "",
   decoder: String = ""
 ) -> SherpaOnnxOnlineParaformerModelConfig {
@@ -63,7 +63,7 @@ func sherpaOnnxOnlineParaformerModelConfig(
   )
 }
 
-func sherpaOnnxOnlineZipformer2CtcModelConfig(
+public func sherpaOnnxOnlineZipformer2CtcModelConfig(
   model: String = ""
 ) -> SherpaOnnxOnlineZipformer2CtcModelConfig {
   return SherpaOnnxOnlineZipformer2CtcModelConfig(
@@ -71,7 +71,7 @@ func sherpaOnnxOnlineZipformer2CtcModelConfig(
   )
 }
 
-func sherpaOnnxOnlineNemoCtcModelConfig(
+public func sherpaOnnxOnlineNemoCtcModelConfig(
   model: String = ""
 ) -> SherpaOnnxOnlineNemoCtcModelConfig {
   return SherpaOnnxOnlineNemoCtcModelConfig(
@@ -79,7 +79,7 @@ func sherpaOnnxOnlineNemoCtcModelConfig(
   )
 }
 
-func sherpaOnnxOnlineToneCtcModelConfig(
+public func sherpaOnnxOnlineToneCtcModelConfig(
   model: String = ""
 ) -> SherpaOnnxOnlineToneCtcModelConfig {
   return SherpaOnnxOnlineToneCtcModelConfig(
@@ -98,7 +98,7 @@ func sherpaOnnxOnlineToneCtcModelConfig(
 ///   - numThreads:  Number of threads to use for neural network computation.
 ///
 /// - Returns: Return an instance of SherpaOnnxOnlineTransducerModelConfig
-func sherpaOnnxOnlineModelConfig(
+public func sherpaOnnxOnlineModelConfig(
   tokens: String,
   transducer: SherpaOnnxOnlineTransducerModelConfig = sherpaOnnxOnlineTransducerModelConfig(),
   paraformer: SherpaOnnxOnlineParaformerModelConfig = sherpaOnnxOnlineParaformerModelConfig(),
@@ -133,7 +133,7 @@ func sherpaOnnxOnlineModelConfig(
   )
 }
 
-func sherpaOnnxFeatureConfig(
+public func sherpaOnnxFeatureConfig(
   sampleRate: Int = 16000,
   featureDim: Int = 80
 ) -> SherpaOnnxFeatureConfig {
@@ -142,7 +142,7 @@ func sherpaOnnxFeatureConfig(
     feature_dim: Int32(featureDim))
 }
 
-func sherpaOnnxOnlineCtcFstDecoderConfig(
+public func sherpaOnnxOnlineCtcFstDecoderConfig(
   graph: String = "",
   maxActive: Int = 3000
 ) -> SherpaOnnxOnlineCtcFstDecoderConfig {
@@ -151,7 +151,7 @@ func sherpaOnnxOnlineCtcFstDecoderConfig(
     max_active: Int32(maxActive))
 }
 
-func sherpaOnnxHomophoneReplacerConfig(
+public func sherpaOnnxHomophoneReplacerConfig(
   dictDir: String = "",
   lexicon: String = "",
   ruleFsts: String = ""
@@ -162,7 +162,7 @@ func sherpaOnnxHomophoneReplacerConfig(
     rule_fsts: toCPointer(ruleFsts))
 }
 
-func sherpaOnnxOnlineRecognizerConfig(
+public func sherpaOnnxOnlineRecognizerConfig(
   featConfig: SherpaOnnxFeatureConfig,
   modelConfig: SherpaOnnxOnlineModelConfig,
   enableEndpoint: Bool = false,
@@ -209,7 +209,7 @@ func sherpaOnnxOnlineRecognizerConfig(
 ///  let result = recognizer.getResult()
 ///  print("text: \(result.text)")
 ///
-class SherpaOnnxOnlineRecongitionResult {
+public class SherpaOnnxOnlineRecongitionResult {
   /// A pointer to the underlying counterpart in C
   private let result: UnsafePointer<SherpaOnnxOnlineRecognizerResult>
 
@@ -231,7 +231,7 @@ class SherpaOnnxOnlineRecongitionResult {
     return (0..<count).map { index in timestampsPointer[index] }
   }()
 
-  init(result: UnsafePointer<SherpaOnnxOnlineRecognizerResult>) {
+  public init(result: UnsafePointer<SherpaOnnxOnlineRecognizerResult>) {
     self.result = result
   }
 
@@ -242,23 +242,23 @@ class SherpaOnnxOnlineRecongitionResult {
   /// Return the actual recognition result.
   /// For English models, it contains words separated by spaces.
   /// For Chinese models, it contains Chinese words.
-  var text: String { _text }
+  public var text: String { _text }
 
-  var count: Int { Int(result.pointee.count) }
+  public var count: Int { Int(result.pointee.count) }
 
-  var tokens: [String] { _tokens }
+  public var tokens: [String] { _tokens }
 
-  var timestamps: [Float] { _timestamps }
+  public var timestamps: [Float] { _timestamps }
 }
 
-class SherpaOnnxRecognizer {
+public class SherpaOnnxRecognizer {
   /// A pointer to the underlying counterpart in C
   private let recognizer: OpaquePointer
   private var stream: OpaquePointer
   private let lock = NSLock()  // for thread-safe stream replacement
 
   /// Constructor taking a model config
-  init(
+  public init(
     config: UnsafePointer<SherpaOnnxOnlineRecognizerConfig>
   ) {
     self.recognizer = SherpaOnnxCreateOnlineRecognizer(config)
@@ -276,22 +276,22 @@ class SherpaOnnxRecognizer {
   ///   - samples: Audio samples normalized to the range [-1, 1]
   ///   - sampleRate: Sample rate of the input audio samples. Must match
   ///                 the one expected by the model.
-  func acceptWaveform(samples: [Float], sampleRate: Int = 16_000) {
+  public func acceptWaveform(samples: [Float], sampleRate: Int = 16_000) {
     SherpaOnnxOnlineStreamAcceptWaveform(stream, Int32(sampleRate), samples, Int32(samples.count))
   }
 
-  func isReady() -> Bool {
+  public func isReady() -> Bool {
     return SherpaOnnxIsOnlineStreamReady(recognizer, stream) != 0
   }
 
   /// If there are enough number of feature frames, it invokes the neural
   /// network computation and decoding. Otherwise, it is a no-op.
-  func decode() {
+  public func decode() {
     SherpaOnnxDecodeOnlineStream(recognizer, stream)
   }
 
   /// Get the decoding results so far
-  func getResult() -> SherpaOnnxOnlineRecongitionResult {
+  public func getResult() -> SherpaOnnxOnlineRecongitionResult {
     guard let result = SherpaOnnxGetOnlineStreamResult(recognizer, stream) else {
       fatalError("SherpaOnnxGetOnlineStreamResult returned nil")
     }
@@ -303,7 +303,7 @@ class SherpaOnnxRecognizer {
   /// If hotwords is an empty string, it just recreates the decoding stream
   /// If hotwords is not empty, it will create a new decoding stream with
   /// the given hotWords appended to the default hotwords.
-  func reset(hotwords: String? = nil) {
+  public func reset(hotwords: String? = nil) {
     guard let words = hotwords, !words.isEmpty else {
       SherpaOnnxOnlineStreamReset(recognizer, stream)
       return
@@ -323,19 +323,19 @@ class SherpaOnnxRecognizer {
 
   /// Signal that no more audio samples would be available.
   /// After this call, you cannot call acceptWaveform() any more.
-  func inputFinished() {
+  public func inputFinished() {
     SherpaOnnxOnlineStreamInputFinished(stream)
   }
 
   /// Return true is an endpoint has been detected.
-  func isEndpoint() -> Bool {
+  public func isEndpoint() -> Bool {
     return SherpaOnnxOnlineStreamIsEndpoint(recognizer, stream) != 0
   }
 }
 
 // For offline APIs
 
-func sherpaOnnxOfflineTransducerModelConfig(
+public func sherpaOnnxOfflineTransducerModelConfig(
   encoder: String = "",
   decoder: String = "",
   joiner: String = ""
@@ -347,7 +347,7 @@ func sherpaOnnxOfflineTransducerModelConfig(
   )
 }
 
-func sherpaOnnxOfflineParaformerModelConfig(
+public func sherpaOnnxOfflineParaformerModelConfig(
   model: String = ""
 ) -> SherpaOnnxOfflineParaformerModelConfig {
   return SherpaOnnxOfflineParaformerModelConfig(
@@ -355,7 +355,7 @@ func sherpaOnnxOfflineParaformerModelConfig(
   )
 }
 
-func sherpaOnnxOfflineZipformerCtcModelConfig(
+public func sherpaOnnxOfflineZipformerCtcModelConfig(
   model: String = ""
 ) -> SherpaOnnxOfflineZipformerCtcModelConfig {
   return SherpaOnnxOfflineZipformerCtcModelConfig(
@@ -363,7 +363,7 @@ func sherpaOnnxOfflineZipformerCtcModelConfig(
   )
 }
 
-func sherpaOnnxOfflineWenetCtcModelConfig(
+public func sherpaOnnxOfflineWenetCtcModelConfig(
   model: String = ""
 ) -> SherpaOnnxOfflineWenetCtcModelConfig {
   return SherpaOnnxOfflineWenetCtcModelConfig(
@@ -371,7 +371,7 @@ func sherpaOnnxOfflineWenetCtcModelConfig(
   )
 }
 
-func sherpaOnnxOfflineOmnilingualAsrCtcModelConfig(
+public func sherpaOnnxOfflineOmnilingualAsrCtcModelConfig(
   model: String = ""
 ) -> SherpaOnnxOfflineOmnilingualAsrCtcModelConfig {
   return SherpaOnnxOfflineOmnilingualAsrCtcModelConfig(
@@ -379,7 +379,7 @@ func sherpaOnnxOfflineOmnilingualAsrCtcModelConfig(
   )
 }
 
-func sherpaOnnxOfflineMedAsrCtcModelConfig(
+public func sherpaOnnxOfflineMedAsrCtcModelConfig(
   model: String = ""
 ) -> SherpaOnnxOfflineMedAsrCtcModelConfig {
   return SherpaOnnxOfflineMedAsrCtcModelConfig(
@@ -387,7 +387,7 @@ func sherpaOnnxOfflineMedAsrCtcModelConfig(
   )
 }
 
-func sherpaOnnxOfflineFireRedAsrCtcModelConfig(
+public func sherpaOnnxOfflineFireRedAsrCtcModelConfig(
   model: String = ""
 ) -> SherpaOnnxOfflineFireRedAsrCtcModelConfig {
   return SherpaOnnxOfflineFireRedAsrCtcModelConfig(
@@ -395,7 +395,7 @@ func sherpaOnnxOfflineFireRedAsrCtcModelConfig(
   )
 }
 
-func sherpaOnnxOfflineNemoEncDecCtcModelConfig(
+public func sherpaOnnxOfflineNemoEncDecCtcModelConfig(
   model: String = ""
 ) -> SherpaOnnxOfflineNemoEncDecCtcModelConfig {
   return SherpaOnnxOfflineNemoEncDecCtcModelConfig(
@@ -403,7 +403,7 @@ func sherpaOnnxOfflineNemoEncDecCtcModelConfig(
   )
 }
 
-func sherpaOnnxOfflineDolphinModelConfig(
+public func sherpaOnnxOfflineDolphinModelConfig(
   model: String = ""
 ) -> SherpaOnnxOfflineDolphinModelConfig {
   return SherpaOnnxOfflineDolphinModelConfig(
@@ -411,7 +411,7 @@ func sherpaOnnxOfflineDolphinModelConfig(
   )
 }
 
-func sherpaOnnxOfflineWhisperModelConfig(
+public func sherpaOnnxOfflineWhisperModelConfig(
   encoder: String = "",
   decoder: String = "",
   language: String = "",
@@ -431,7 +431,7 @@ func sherpaOnnxOfflineWhisperModelConfig(
   )
 }
 
-func sherpaOnnxOfflineCanaryModelConfig(
+public func sherpaOnnxOfflineCanaryModelConfig(
   encoder: String = "",
   decoder: String = "",
   srcLang: String = "en",
@@ -447,7 +447,7 @@ func sherpaOnnxOfflineCanaryModelConfig(
   )
 }
 
-func sherpaOnnxOfflineCohereTranscribeModelConfig(
+public func sherpaOnnxOfflineCohereTranscribeModelConfig(
   encoder: String = "",
   decoder: String = "",
   language: String = "",
@@ -463,7 +463,7 @@ func sherpaOnnxOfflineCohereTranscribeModelConfig(
   )
 }
 
-func sherpaOnnxOfflineFireRedAsrModelConfig(
+public func sherpaOnnxOfflineFireRedAsrModelConfig(
   encoder: String = "",
   decoder: String = ""
 ) -> SherpaOnnxOfflineFireRedAsrModelConfig {
@@ -476,7 +476,7 @@ func sherpaOnnxOfflineFireRedAsrModelConfig(
 // there are two versions of Moonshine
 // For v1, you need four models: preprocessor, encoder, uncachedDecoder, cachedDecoder
 // For v2, you need two models: encoder, mergedDecoder
-func sherpaOnnxOfflineMoonshineModelConfig(
+public func sherpaOnnxOfflineMoonshineModelConfig(
   preprocessor: String = "",
   encoder: String = "",
   uncachedDecoder: String = "",
@@ -492,7 +492,7 @@ func sherpaOnnxOfflineMoonshineModelConfig(
   )
 }
 
-func sherpaOnnxOfflineQwen3ASRModelConfig(
+public func sherpaOnnxOfflineQwen3ASRModelConfig(
   convFrontend: String = "",
   encoder: String = "",
   decoder: String = "",
@@ -518,7 +518,7 @@ func sherpaOnnxOfflineQwen3ASRModelConfig(
   )
 }
 
-func sherpaOnnxOfflineTdnnModelConfig(
+public func sherpaOnnxOfflineTdnnModelConfig(
   model: String = ""
 ) -> SherpaOnnxOfflineTdnnModelConfig {
   return SherpaOnnxOfflineTdnnModelConfig(
@@ -526,7 +526,7 @@ func sherpaOnnxOfflineTdnnModelConfig(
   )
 }
 
-func sherpaOnnxOfflineSenseVoiceModelConfig(
+public func sherpaOnnxOfflineSenseVoiceModelConfig(
   model: String = "",
   language: String = "",
   useInverseTextNormalization: Bool = false
@@ -538,7 +538,7 @@ func sherpaOnnxOfflineSenseVoiceModelConfig(
   )
 }
 
-func sherpaOnnxOfflineLMConfig(
+public func sherpaOnnxOfflineLMConfig(
   model: String = "",
   scale: Float = 1.0
 ) -> SherpaOnnxOfflineLMConfig {
@@ -548,7 +548,7 @@ func sherpaOnnxOfflineLMConfig(
   )
 }
 
-func sherpaOnnxOfflineFunASRNanoModelConfig(
+public func sherpaOnnxOfflineFunASRNanoModelConfig(
   encoderAdaptor: String = "",
   llm: String = "",
   embedding: String = "",
@@ -580,7 +580,7 @@ func sherpaOnnxOfflineFunASRNanoModelConfig(
   )
 }
 
-func sherpaOnnxOfflineModelConfig(
+public func sherpaOnnxOfflineModelConfig(
   tokens: String,
   transducer: SherpaOnnxOfflineTransducerModelConfig = sherpaOnnxOfflineTransducerModelConfig(),
   paraformer: SherpaOnnxOfflineParaformerModelConfig = sherpaOnnxOfflineParaformerModelConfig(),
@@ -646,7 +646,7 @@ func sherpaOnnxOfflineModelConfig(
   )
 }
 
-func sherpaOnnxOfflineRecognizerConfig(
+public func sherpaOnnxOfflineRecognizerConfig(
   featConfig: SherpaOnnxFeatureConfig,
   modelConfig: SherpaOnnxOfflineModelConfig,
   lmConfig: SherpaOnnxOfflineLMConfig = sherpaOnnxOfflineLMConfig(),
@@ -674,9 +674,9 @@ func sherpaOnnxOfflineRecognizerConfig(
   )
 }
 
-class SherpaOnnxOfflineRecongitionResult {
+public class SherpaOnnxOfflineRecongitionResult {
   /// A pointer to the underlying counterpart in C
-  let result: UnsafePointer<SherpaOnnxOfflineRecognizerResult>
+  public let result: UnsafePointer<SherpaOnnxOfflineRecognizerResult>
 
   private lazy var _text: String = {
     guard let cstr = result.pointee.text else { return "" }
@@ -729,12 +729,12 @@ class SherpaOnnxOfflineRecongitionResult {
   /// Return the actual recognition result.
   /// For English models, it contains words separated by spaces.
   /// For Chinese models, it contains Chinese words.
-  var text: String { _text }
-  var count: Int { Int(result.pointee.count) }
-  var timestamps: [Float] { _timestamps }
+  public var text: String { _text }
+  public var count: Int { Int(result.pointee.count) }
+  public var timestamps: [Float] { _timestamps }
 
   // Non-empty for TDT models. Empty for all other non-TDT models
-  var durations: [Float] { _durations }
+  public var durations: [Float] { _durations }
 
   // For SenseVoice models, it can be zh, en, ja, yue, ko
   // where zh is for Chinese
@@ -742,21 +742,21 @@ class SherpaOnnxOfflineRecongitionResult {
   // ja is for Japanese
   // yue is for Cantonese
   // ko is for Korean
-  var lang: String { _lang }
+  public var lang: String { _lang }
 
   // for SenseVoice models
-  var emotion: String { _emotion }
+  public var emotion: String { _emotion }
 
   // for SenseVoice models
-  var event: String { _event }
+  public var event: String { _event }
 
   // Segment-level timestamps (for Whisper with segment timestamps enabled)
-  var segmentCount: Int { Int(result.pointee.segment_count) }
-  var segmentTimestamps: [Float] { _segmentTimestamps }
-  var segmentDurations: [Float] { _segmentDurations }
-  var segmentTexts: [String] { _segmentTexts }
+  public var segmentCount: Int { Int(result.pointee.segment_count) }
+  public var segmentTimestamps: [Float] { _segmentTimestamps }
+  public var segmentDurations: [Float] { _segmentDurations }
+  public var segmentTexts: [String] { _segmentTexts }
 
-  init(result: UnsafePointer<SherpaOnnxOfflineRecognizerResult>) {
+  public init(result: UnsafePointer<SherpaOnnxOfflineRecognizerResult>) {
     self.result = result
   }
 
@@ -765,11 +765,11 @@ class SherpaOnnxOfflineRecongitionResult {
   }
 }
 
-class SherpaOnnxOfflineRecognizer {
+public class SherpaOnnxOfflineRecognizer {
   /// A pointer to the underlying counterpart in C
   private let recognizer: OpaquePointer
 
-  init(
+  public init(
     config: UnsafePointer<SherpaOnnxOfflineRecognizerConfig>
   ) {
     guard let ptr = SherpaOnnxCreateOfflineRecognizer(config) else {
@@ -788,18 +788,18 @@ class SherpaOnnxOfflineRecognizer {
   ///   - samples: Audio samples normalized to the range [-1, 1]
   ///   - sampleRate: Sample rate of the input audio samples. Must match
   ///                 the one expected by the model.
-  func decode(samples: [Float], sampleRate: Int = 16_000) -> SherpaOnnxOfflineRecongitionResult {
+  public func decode(samples: [Float], sampleRate: Int = 16_000) -> SherpaOnnxOfflineRecongitionResult {
     let stream = createStream()
     stream.acceptWaveform(samples: samples, sampleRate: sampleRate)
     decode(stream: stream)
     return getResult(stream: stream)
   }
 
-  func setConfig(config: UnsafePointer<SherpaOnnxOfflineRecognizerConfig>) {
+  public func setConfig(config: UnsafePointer<SherpaOnnxOfflineRecognizerConfig>) {
     SherpaOnnxOfflineRecognizerSetConfig(recognizer, config)
   }
 
-  func createStream() -> SherpaOnnxOfflineStreamWrapper {
+  public func createStream() -> SherpaOnnxOfflineStreamWrapper {
     guard let stream = SherpaOnnxCreateOfflineStream(recognizer) else {
       fatalError("Failed to create offline stream")
     }
@@ -807,11 +807,11 @@ class SherpaOnnxOfflineRecognizer {
     return SherpaOnnxOfflineStreamWrapper(stream: stream)
   }
 
-  func decode(stream: SherpaOnnxOfflineStreamWrapper) {
+  public func decode(stream: SherpaOnnxOfflineStreamWrapper) {
     SherpaOnnxDecodeOfflineStream(recognizer, stream.stream)
   }
 
-  func getResult(stream: SherpaOnnxOfflineStreamWrapper) -> SherpaOnnxOfflineRecongitionResult {
+  public func getResult(stream: SherpaOnnxOfflineStreamWrapper) -> SherpaOnnxOfflineRecongitionResult {
     guard let resultPtr = SherpaOnnxGetOfflineStreamResult(stream.stream) else {
       fatalError("Failed to get offline recognition result")
     }
@@ -820,10 +820,10 @@ class SherpaOnnxOfflineRecognizer {
   }
 }
 
-class SherpaOnnxOfflineStreamWrapper {
-  let stream: OpaquePointer
+public class SherpaOnnxOfflineStreamWrapper {
+  public let stream: OpaquePointer
 
-  init(stream: OpaquePointer) {
+  public init(stream: OpaquePointer) {
     self.stream = stream
   }
 
@@ -831,16 +831,16 @@ class SherpaOnnxOfflineStreamWrapper {
     SherpaOnnxDestroyOfflineStream(stream)
   }
 
-  func setOption(key: String, value: String) {
+  public func setOption(key: String, value: String) {
     SherpaOnnxOfflineStreamSetOption(stream, toCPointer(key), toCPointer(value))
   }
 
-  func acceptWaveform(samples: [Float], sampleRate: Int = 16_000) {
+  public func acceptWaveform(samples: [Float], sampleRate: Int = 16_000) {
     SherpaOnnxAcceptWaveformOffline(stream, Int32(sampleRate), samples, Int32(samples.count))
   }
 }
 
-func sherpaOnnxSileroVadModelConfig(
+public func sherpaOnnxSileroVadModelConfig(
   model: String = "",
   threshold: Float = 0.5,
   minSilenceDuration: Float = 0.25,
@@ -858,7 +858,7 @@ func sherpaOnnxSileroVadModelConfig(
   )
 }
 
-func sherpaOnnxTenVadModelConfig(
+public func sherpaOnnxTenVadModelConfig(
   model: String = "",
   threshold: Float = 0.5,
   minSilenceDuration: Float = 0.25,
@@ -876,7 +876,7 @@ func sherpaOnnxTenVadModelConfig(
   )
 }
 
-func sherpaOnnxVadModelConfig(
+public func sherpaOnnxVadModelConfig(
   sileroVad: SherpaOnnxSileroVadModelConfig = sherpaOnnxSileroVadModelConfig(),
   sampleRate: Int32 = 16000,
   numThreads: Int = 1,
@@ -894,10 +894,10 @@ func sherpaOnnxVadModelConfig(
   )
 }
 
-class SherpaOnnxCircularBufferWrapper {
+public class SherpaOnnxCircularBufferWrapper {
   private let buffer: OpaquePointer
 
-  init(capacity: Int) {
+  public init(capacity: Int) {
     guard let ptr = SherpaOnnxCreateCircularBuffer(Int32(capacity)) else {
       fatalError("Failed to create SherpaOnnxCircularBuffer")
     }
@@ -908,12 +908,12 @@ class SherpaOnnxCircularBufferWrapper {
     SherpaOnnxDestroyCircularBuffer(buffer)
   }
 
-  func push(samples: [Float]) {
+  public func push(samples: [Float]) {
     guard !samples.isEmpty else { return }
     SherpaOnnxCircularBufferPush(buffer, samples, Int32(samples.count))
   }
 
-  func get(startIndex: Int, n: Int) -> [Float] {
+  public func get(startIndex: Int, n: Int) -> [Float] {
     guard startIndex >= 0 else { return [] }
     guard n > 0 else { return [] }
 
@@ -925,24 +925,24 @@ class SherpaOnnxCircularBufferWrapper {
     return Array(UnsafeBufferPointer(start: ptr, count: n))
   }
 
-  func pop(n: Int) {
+  public func pop(n: Int) {
     guard n > 0 else { return }
     SherpaOnnxCircularBufferPop(buffer, Int32(n))
   }
 
-  func size() -> Int {
+  public func size() -> Int {
     return Int(SherpaOnnxCircularBufferSize(buffer))
   }
 
-  func reset() {
+  public func reset() {
     SherpaOnnxCircularBufferReset(buffer)
   }
 }
 
-class SherpaOnnxSpeechSegmentWrapper {
+public class SherpaOnnxSpeechSegmentWrapper {
   private let p: UnsafePointer<SherpaOnnxSpeechSegment>
 
-  init(p: UnsafePointer<SherpaOnnxSpeechSegment>) {
+  public init(p: UnsafePointer<SherpaOnnxSpeechSegment>) {
     self.p = p
   }
 
@@ -950,24 +950,24 @@ class SherpaOnnxSpeechSegmentWrapper {
     SherpaOnnxDestroySpeechSegment(p)
   }
 
-  var start: Int {
+  public var start: Int {
     Int(p.pointee.start)
   }
 
-  var n: Int {
+  public var n: Int {
     Int(p.pointee.n)
   }
 
-  lazy var samples: [Float] = {
+  public lazy var samples: [Float] = {
     Array(UnsafeBufferPointer(start: p.pointee.samples, count: n))
   }()
 }
 
-class SherpaOnnxVoiceActivityDetectorWrapper {
+public class SherpaOnnxVoiceActivityDetectorWrapper {
   /// A pointer to the underlying counterpart in C
   private let vad: OpaquePointer
 
-  init(config: UnsafePointer<SherpaOnnxVadModelConfig>, buffer_size_in_seconds: Float) {
+  public init(config: UnsafePointer<SherpaOnnxVadModelConfig>, buffer_size_in_seconds: Float) {
     guard let vad = SherpaOnnxCreateVoiceActivityDetector(config, buffer_size_in_seconds) else {
       fatalError("SherpaOnnxCreateVoiceActivityDetector returned nil")
     }
@@ -978,44 +978,44 @@ class SherpaOnnxVoiceActivityDetectorWrapper {
     SherpaOnnxDestroyVoiceActivityDetector(vad)
   }
 
-  func acceptWaveform(samples: [Float]) {
+  public func acceptWaveform(samples: [Float]) {
     SherpaOnnxVoiceActivityDetectorAcceptWaveform(vad, samples, Int32(samples.count))
   }
 
-  func isEmpty() -> Bool {
+  public func isEmpty() -> Bool {
     return SherpaOnnxVoiceActivityDetectorEmpty(vad) == 1
   }
 
-  func isSpeechDetected() -> Bool {
+  public func isSpeechDetected() -> Bool {
     return SherpaOnnxVoiceActivityDetectorDetected(vad) == 1
   }
 
-  func pop() {
+  public func pop() {
     SherpaOnnxVoiceActivityDetectorPop(vad)
   }
 
-  func clear() {
+  public func clear() {
     SherpaOnnxVoiceActivityDetectorClear(vad)
   }
 
-  func front() -> SherpaOnnxSpeechSegmentWrapper {
+  public func front() -> SherpaOnnxSpeechSegmentWrapper {
     guard let p = SherpaOnnxVoiceActivityDetectorFront(vad) else {
       fatalError("SherpaOnnxVoiceActivityDetectorFront returned nil")
     }
     return SherpaOnnxSpeechSegmentWrapper(p: p)
   }
 
-  func reset() {
+  public func reset() {
     SherpaOnnxVoiceActivityDetectorReset(vad)
   }
 
-  func flush() {
+  public func flush() {
     SherpaOnnxVoiceActivityDetectorFlush(vad)
   }
 }
 
 // offline tts
-func sherpaOnnxOfflineTtsVitsModelConfig(
+public func sherpaOnnxOfflineTtsVitsModelConfig(
   model: String = "",
   lexicon: String = "",
   tokens: String = "",
@@ -1037,7 +1037,7 @@ func sherpaOnnxOfflineTtsVitsModelConfig(
   )
 }
 
-func sherpaOnnxOfflineTtsMatchaModelConfig(
+public func sherpaOnnxOfflineTtsMatchaModelConfig(
   acousticModel: String = "",
   vocoder: String = "",
   lexicon: String = "",
@@ -1059,7 +1059,7 @@ func sherpaOnnxOfflineTtsMatchaModelConfig(
   )
 }
 
-func sherpaOnnxOfflineTtsKokoroModelConfig(
+public func sherpaOnnxOfflineTtsKokoroModelConfig(
   model: String = "",
   voices: String = "",
   tokens: String = "",
@@ -1081,7 +1081,7 @@ func sherpaOnnxOfflineTtsKokoroModelConfig(
   )
 }
 
-func sherpaOnnxOfflineTtsKittenModelConfig(
+public func sherpaOnnxOfflineTtsKittenModelConfig(
   model: String = "",
   voices: String = "",
   tokens: String = "",
@@ -1097,7 +1097,7 @@ func sherpaOnnxOfflineTtsKittenModelConfig(
   )
 }
 
-func sherpaOnnxOfflineTtsZipvoiceModelConfig(
+public func sherpaOnnxOfflineTtsZipvoiceModelConfig(
   tokens: String = "",
   encoder: String = "",
   decoder: String = "",
@@ -1123,7 +1123,7 @@ func sherpaOnnxOfflineTtsZipvoiceModelConfig(
   )
 }
 
-func sherpaOnnxOfflineTtsPocketModelConfig(
+public func sherpaOnnxOfflineTtsPocketModelConfig(
   lmFlow: String = "",
   lmMain: String = "",
   encoder: String = "",
@@ -1145,7 +1145,7 @@ func sherpaOnnxOfflineTtsPocketModelConfig(
   )
 }
 
-func sherpaOnnxOfflineTtsSupertonicModelConfig(
+public func sherpaOnnxOfflineTtsSupertonicModelConfig(
   durationPredictor: String = "",
   textEncoder: String = "",
   vectorEstimator: String = "",
@@ -1165,7 +1165,7 @@ func sherpaOnnxOfflineTtsSupertonicModelConfig(
   )
 }
 
-func sherpaOnnxOfflineTtsModelConfig(
+public func sherpaOnnxOfflineTtsModelConfig(
   vits: SherpaOnnxOfflineTtsVitsModelConfig = sherpaOnnxOfflineTtsVitsModelConfig(),
   matcha: SherpaOnnxOfflineTtsMatchaModelConfig = sherpaOnnxOfflineTtsMatchaModelConfig(),
   kokoro: SherpaOnnxOfflineTtsKokoroModelConfig = sherpaOnnxOfflineTtsKokoroModelConfig(),
@@ -1192,7 +1192,7 @@ func sherpaOnnxOfflineTtsModelConfig(
   )
 }
 
-func sherpaOnnxOfflineTtsConfig(
+public func sherpaOnnxOfflineTtsConfig(
   model: SherpaOnnxOfflineTtsModelConfig,
   ruleFsts: String = "",
   ruleFars: String = "",
@@ -1208,15 +1208,15 @@ func sherpaOnnxOfflineTtsConfig(
   )
 }
 
-class SherpaOnnxWaveWrapper {
-  let wave: UnsafePointer<SherpaOnnxWave>!
+public class SherpaOnnxWaveWrapper {
+  public let wave: UnsafePointer<SherpaOnnxWave>!
 
-  class func readWave(filename: String) -> SherpaOnnxWaveWrapper {
+  public class func readWave(filename: String) -> SherpaOnnxWaveWrapper {
     let wave = SherpaOnnxReadWave(toCPointer(filename))
     return SherpaOnnxWaveWrapper(wave: wave)
   }
 
-  init(wave: UnsafePointer<SherpaOnnxWave>!) {
+  public init(wave: UnsafePointer<SherpaOnnxWave>!) {
     self.wave = wave
   }
 
@@ -1226,15 +1226,15 @@ class SherpaOnnxWaveWrapper {
     }
   }
 
-  var numSamples: Int {
+  public var numSamples: Int {
     return Int(wave.pointee.num_samples)
   }
 
-  var sampleRate: Int {
+  public var sampleRate: Int {
     return Int(wave.pointee.sample_rate)
   }
 
-  var samples: [Float] {
+  public var samples: [Float] {
     if numSamples == 0 {
       return []
     } else {
@@ -1243,11 +1243,11 @@ class SherpaOnnxWaveWrapper {
   }
 }
 
-class SherpaOnnxGeneratedAudioWrapper {
+public class SherpaOnnxGeneratedAudioWrapper {
   /// A pointer to the underlying counterpart in C
-  let audio: UnsafePointer<SherpaOnnxGeneratedAudio>!
+  public let audio: UnsafePointer<SherpaOnnxGeneratedAudio>!
 
-  init(audio: UnsafePointer<SherpaOnnxGeneratedAudio>!) {
+  public init(audio: UnsafePointer<SherpaOnnxGeneratedAudio>!) {
     self.audio = audio
   }
 
@@ -1257,15 +1257,15 @@ class SherpaOnnxGeneratedAudioWrapper {
     }
   }
 
-  var n: Int32 {
+  public var n: Int32 {
     return audio.pointee.n
   }
 
-  var sampleRate: Int32 {
+  public var sampleRate: Int32 {
     return audio.pointee.sample_rate
   }
 
-  var samples: [Float] {
+  public var samples: [Float] {
     if let p = audio.pointee.samples {
       return [Float](UnsafeBufferPointer(start: p, count: Int(n)))
     } else {
@@ -1273,12 +1273,12 @@ class SherpaOnnxGeneratedAudioWrapper {
     }
   }
 
-  func save(filename: String) -> Int32 {
+  public func save(filename: String) -> Int32 {
     return SherpaOnnxWriteWave(audio.pointee.samples, n, sampleRate, toCPointer(filename))
   }
 }
 
-typealias TtsCallbackWithArg = (
+public typealias TtsCallbackWithArg = (
   @convention(c) (
     UnsafePointer<Float>?,  // const float* samples
     Int32,  // int32_t n
@@ -1286,32 +1286,43 @@ typealias TtsCallbackWithArg = (
   ) -> Int32
 )?
 
-class SherpaOnnxCallbackPair {
-  var cb: TtsCallbackWithArg
-  var arg: UnsafeMutableRawPointer?
-  init(cb: TtsCallbackWithArg, arg: UnsafeMutableRawPointer?) {
+public class SherpaOnnxCallbackPair {
+  public var cb: TtsCallbackWithArg
+  public var arg: UnsafeMutableRawPointer?
+  public init(cb: TtsCallbackWithArg, arg: UnsafeMutableRawPointer?) {
     self.cb = cb
     self.arg = arg
   }
 }
 
-typealias TtsProgressCallbackWithArg =
+public typealias TtsProgressCallbackWithArg =
   @convention(c) (
     UnsafePointer<Float>?, Int32, Float, UnsafeMutableRawPointer?
   ) -> Int32
 
-struct SherpaOnnxGenerationConfigSwift {
-  var silenceScale: Float = 0.2
-  var speed: Float = 1.0
-  var sid: Int = 0
-  var referenceAudio: [Float] = []
-  var referenceSampleRate: Int = 16000
-  var referenceText: String = ""
-  var numSteps: Int = 1
-  var extra: [String: Any] = [:]  // Any can be String, Int, Float, Double
+public struct SherpaOnnxGenerationConfigSwift {
+  public init(silenceScale: Float = 0.2, speed: Float = 1.0, sid: Int = 0, referenceAudio: [Float] = [], referenceSampleRate: Int = 16000, referenceText: String = "", numSteps: Int = 1, extra: [String: Any] = [:]) {
+    self.silenceScale = silenceScale
+    self.speed = speed
+    self.sid = sid
+    self.referenceAudio = referenceAudio
+    self.referenceSampleRate = referenceSampleRate
+    self.referenceText = referenceText
+    self.numSteps = numSteps
+    self.extra = extra
+  }
+
+  public var silenceScale: Float = 0.2
+  public var speed: Float = 1.0
+  public var sid: Int = 0
+  public var referenceAudio: [Float] = []
+  public var referenceSampleRate: Int = 16000
+  public var referenceText: String = ""
+  public var numSteps: Int = 1
+  public var extra: [String: Any] = [:]  // Any can be String, Int, Float, Double
 
   /// Convert the extra dictionary into a JSON string
-  func extraJsonString() -> String {
+  public func extraJsonString() -> String {
     var jsonCompatible: [String: Any] = [:]
 
     for (key, value) in extra {
@@ -1373,25 +1384,25 @@ final class SherpaOnnxGenerationConfigC {
   }
 }
 
-class SherpaOnnxOfflineTtsWrapper {
+public class SherpaOnnxOfflineTtsWrapper {
   /// A pointer to the underlying counterpart in C
-  let tts: OpaquePointer!
+  public let tts: OpaquePointer!
 
   /// Whether the model is a Supertonic TTS model
-  let isSupertonic: Bool
+  public let isSupertonic: Bool
 
   /// The sample rate of the generated audio
-  var sampleRate: Int32 {
+  public var sampleRate: Int32 {
     return SherpaOnnxOfflineTtsSampleRate(tts)
   }
 
   /// The number of speakers supported by the model
-  var numSpeakers: Int32 {
+  public var numSpeakers: Int32 {
     return SherpaOnnxOfflineTtsNumSpeakers(tts)
   }
 
   /// Constructor taking a model config
-  init(
+  public init(
     config: UnsafePointer<SherpaOnnxOfflineTtsConfig>!
   ) {
     isSupertonic = config.pointee.model.supertonic.duration_predictor != nil
@@ -1405,12 +1416,12 @@ class SherpaOnnxOfflineTtsWrapper {
     }
   }
 
-  func generate(text: String, sid: Int = 0, speed: Float = 1.0) -> SherpaOnnxGeneratedAudioWrapper {
+  public func generate(text: String, sid: Int = 0, speed: Float = 1.0) -> SherpaOnnxGeneratedAudioWrapper {
     let config = SherpaOnnxGenerationConfigSwift(speed: speed, sid: sid)
     return generateWithConfig(text: text, config: config, callback: nil, arg: nil)
   }
 
-  func generateWithCallbackWithArg(
+  public func generateWithCallbackWithArg(
     text: String, callback: TtsCallbackWithArg, arg: UnsafeMutableRawPointer, sid: Int = 0,
     speed: Float = 1.0
   ) -> SherpaOnnxGeneratedAudioWrapper {
@@ -1428,7 +1439,7 @@ class SherpaOnnxOfflineTtsWrapper {
     return result
   }
 
-  func generateWithConfig(
+  public func generateWithConfig(
     text: String,
     config: SherpaOnnxGenerationConfigSwift,
     callback: TtsProgressCallbackWithArg?,
@@ -1454,7 +1465,7 @@ class SherpaOnnxOfflineTtsWrapper {
 
 // spoken language identification
 
-func sherpaOnnxSpokenLanguageIdentificationWhisperConfig(
+public func sherpaOnnxSpokenLanguageIdentificationWhisperConfig(
   encoder: String,
   decoder: String,
   tailPaddings: Int = -1
@@ -1465,7 +1476,7 @@ func sherpaOnnxSpokenLanguageIdentificationWhisperConfig(
     tail_paddings: Int32(tailPaddings))
 }
 
-func sherpaOnnxSpokenLanguageIdentificationConfig(
+public func sherpaOnnxSpokenLanguageIdentificationConfig(
   whisper: SherpaOnnxSpokenLanguageIdentificationWhisperConfig,
   numThreads: Int = 1,
   debug: Int = 0,
@@ -1478,9 +1489,9 @@ func sherpaOnnxSpokenLanguageIdentificationConfig(
     provider: toCPointer(provider))
 }
 
-class SherpaOnnxSpokenLanguageIdentificationResultWrapper {
+public class SherpaOnnxSpokenLanguageIdentificationResultWrapper {
   /// A pointer to the underlying counterpart in C
-  let result: UnsafePointer<SherpaOnnxSpokenLanguageIdentificationResult>!
+  public let result: UnsafePointer<SherpaOnnxSpokenLanguageIdentificationResult>!
 
   /// Return the detected language.
   /// en for English
@@ -1488,11 +1499,11 @@ class SherpaOnnxSpokenLanguageIdentificationResultWrapper {
   /// es for Spanish
   /// de for German
   /// etc.
-  var lang: String {
+  public var lang: String {
     return String(cString: result.pointee.lang)
   }
 
-  init(result: UnsafePointer<SherpaOnnxSpokenLanguageIdentificationResult>!) {
+  public init(result: UnsafePointer<SherpaOnnxSpokenLanguageIdentificationResult>!) {
     self.result = result
   }
 
@@ -1503,11 +1514,11 @@ class SherpaOnnxSpokenLanguageIdentificationResultWrapper {
   }
 }
 
-class SherpaOnnxSpokenLanguageIdentificationWrapper {
+public class SherpaOnnxSpokenLanguageIdentificationWrapper {
   /// A pointer to the underlying counterpart in C
-  let slid: OpaquePointer!
+  public let slid: OpaquePointer!
 
-  init(
+  public init(
     config: UnsafePointer<SherpaOnnxSpokenLanguageIdentificationConfig>!
   ) {
     slid = SherpaOnnxCreateSpokenLanguageIdentification(config)
@@ -1519,7 +1530,7 @@ class SherpaOnnxSpokenLanguageIdentificationWrapper {
     }
   }
 
-  func decode(samples: [Float], sampleRate: Int = 16000)
+  public func decode(samples: [Float], sampleRate: Int = 16000)
     -> SherpaOnnxSpokenLanguageIdentificationResultWrapper
   {
     let stream: OpaquePointer! = SherpaOnnxSpokenLanguageIdentificationCreateOfflineStream(slid)
@@ -1537,19 +1548,19 @@ class SherpaOnnxSpokenLanguageIdentificationWrapper {
 
 // keyword spotting
 
-class SherpaOnnxKeywordResultWrapper {
+public class SherpaOnnxKeywordResultWrapper {
   /// A pointer to the underlying counterpart in C
-  let result: UnsafePointer<SherpaOnnxKeywordResult>!
+  public let result: UnsafePointer<SherpaOnnxKeywordResult>!
 
-  var keyword: String {
+  public var keyword: String {
     return String(cString: result.pointee.keyword)
   }
 
-  var count: Int32 {
+  public var count: Int32 {
     return result.pointee.count
   }
 
-  var tokens: [String] {
+  public var tokens: [String] {
     if let tokensPointer = result.pointee.tokens_arr {
       var tokens: [String] = []
       for index in 0..<count {
@@ -1565,7 +1576,7 @@ class SherpaOnnxKeywordResultWrapper {
     }
   }
 
-  init(result: UnsafePointer<SherpaOnnxKeywordResult>!) {
+  public init(result: UnsafePointer<SherpaOnnxKeywordResult>!) {
     self.result = result
   }
 
@@ -1576,7 +1587,7 @@ class SherpaOnnxKeywordResultWrapper {
   }
 }
 
-func sherpaOnnxKeywordSpotterConfig(
+public func sherpaOnnxKeywordSpotterConfig(
   featConfig: SherpaOnnxFeatureConfig,
   modelConfig: SherpaOnnxOnlineModelConfig,
   keywordsFile: String,
@@ -1600,12 +1611,12 @@ func sherpaOnnxKeywordSpotterConfig(
   )
 }
 
-class SherpaOnnxKeywordSpotterWrapper {
+public class SherpaOnnxKeywordSpotterWrapper {
   /// A pointer to the underlying counterpart in C
-  let spotter: OpaquePointer!
-  var stream: OpaquePointer!
+  public let spotter: OpaquePointer!
+  public var stream: OpaquePointer!
 
-  init(
+  public init(
     config: UnsafePointer<SherpaOnnxKeywordSpotterConfig>!
   ) {
     spotter = SherpaOnnxCreateKeywordSpotter(config)
@@ -1622,23 +1633,23 @@ class SherpaOnnxKeywordSpotterWrapper {
     }
   }
 
-  func acceptWaveform(samples: [Float], sampleRate: Int = 16000) {
+  public func acceptWaveform(samples: [Float], sampleRate: Int = 16000) {
     SherpaOnnxOnlineStreamAcceptWaveform(stream, Int32(sampleRate), samples, Int32(samples.count))
   }
 
-  func isReady() -> Bool {
+  public func isReady() -> Bool {
     return SherpaOnnxIsKeywordStreamReady(spotter, stream) == 1 ? true : false
   }
 
-  func decode() {
+  public func decode() {
     SherpaOnnxDecodeKeywordStream(spotter, stream)
   }
 
-  func reset() {
+  public func reset() {
     SherpaOnnxResetKeywordStream(spotter, stream)
   }
 
-  func getResult() -> SherpaOnnxKeywordResultWrapper {
+  public func getResult() -> SherpaOnnxKeywordResultWrapper {
     let result: UnsafePointer<SherpaOnnxKeywordResult>? = SherpaOnnxGetKeywordResult(
       spotter, stream)
     return SherpaOnnxKeywordResultWrapper(result: result)
@@ -1646,14 +1657,14 @@ class SherpaOnnxKeywordSpotterWrapper {
 
   /// Signal that no more audio samples would be available.
   /// After this call, you cannot call acceptWaveform() any more.
-  func inputFinished() {
+  public func inputFinished() {
     SherpaOnnxOnlineStreamInputFinished(stream)
   }
 }
 
 // Punctuation
 
-func sherpaOnnxOfflinePunctuationModelConfig(
+public func sherpaOnnxOfflinePunctuationModelConfig(
   ctTransformer: String,
   numThreads: Int = 1,
   debug: Int = 0,
@@ -1667,7 +1678,7 @@ func sherpaOnnxOfflinePunctuationModelConfig(
   )
 }
 
-func sherpaOnnxOfflinePunctuationConfig(
+public func sherpaOnnxOfflinePunctuationConfig(
   model: SherpaOnnxOfflinePunctuationModelConfig
 ) -> SherpaOnnxOfflinePunctuationConfig {
   return SherpaOnnxOfflinePunctuationConfig(
@@ -1675,12 +1686,12 @@ func sherpaOnnxOfflinePunctuationConfig(
   )
 }
 
-class SherpaOnnxOfflinePunctuationWrapper {
+public class SherpaOnnxOfflinePunctuationWrapper {
   /// A pointer to the underlying counterpart in C
-  let ptr: OpaquePointer!
+  public let ptr: OpaquePointer!
 
   /// Constructor taking a model config
-  init(
+  public init(
     config: UnsafePointer<SherpaOnnxOfflinePunctuationConfig>!
   ) {
     ptr = SherpaOnnxCreateOfflinePunctuation(config)
@@ -1692,7 +1703,7 @@ class SherpaOnnxOfflinePunctuationWrapper {
     }
   }
 
-  func addPunct(text: String) -> String {
+  public func addPunct(text: String) -> String {
     let cText = SherpaOfflinePunctuationAddPunct(ptr, toCPointer(text))
     let ans = String(cString: cText!)
     SherpaOfflinePunctuationFreeText(cText)
@@ -1700,7 +1711,7 @@ class SherpaOnnxOfflinePunctuationWrapper {
   }
 }
 
-func sherpaOnnxOnlinePunctuationModelConfig(
+public func sherpaOnnxOnlinePunctuationModelConfig(
   cnnBiLstm: String,
   bpeVocab: String,
   numThreads: Int = 1,
@@ -1715,18 +1726,18 @@ func sherpaOnnxOnlinePunctuationModelConfig(
     provider: toCPointer(provider))
 }
 
-func sherpaOnnxOnlinePunctuationConfig(
+public func sherpaOnnxOnlinePunctuationConfig(
   model: SherpaOnnxOnlinePunctuationModelConfig
 ) -> SherpaOnnxOnlinePunctuationConfig {
   return SherpaOnnxOnlinePunctuationConfig(model: model)
 }
 
-class SherpaOnnxOnlinePunctuationWrapper {
+public class SherpaOnnxOnlinePunctuationWrapper {
   /// A pointer to the underlying counterpart in C
-  let ptr: OpaquePointer!
+  public let ptr: OpaquePointer!
 
   /// Constructor taking a model config
-  init(
+  public init(
     config: UnsafePointer<SherpaOnnxOnlinePunctuationConfig>!
   ) {
     ptr = SherpaOnnxCreateOnlinePunctuation(config)
@@ -1738,7 +1749,7 @@ class SherpaOnnxOnlinePunctuationWrapper {
     }
   }
 
-  func addPunct(text: String) -> String {
+  public func addPunct(text: String) -> String {
     let cText = SherpaOnnxOnlinePunctuationAddPunct(ptr, toCPointer(text))
     let ans = String(cString: cText!)
     SherpaOnnxOnlinePunctuationFreeText(cText)
@@ -1746,13 +1757,13 @@ class SherpaOnnxOnlinePunctuationWrapper {
   }
 }
 
-func sherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig(model: String)
+public func sherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig(model: String)
   -> SherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig
 {
   return SherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig(model: toCPointer(model))
 }
 
-func sherpaOnnxOfflineSpeakerSegmentationModelConfig(
+public func sherpaOnnxOfflineSpeakerSegmentationModelConfig(
   pyannote: SherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig,
   numThreads: Int = 1,
   debug: Int = 0,
@@ -1766,13 +1777,13 @@ func sherpaOnnxOfflineSpeakerSegmentationModelConfig(
   )
 }
 
-func sherpaOnnxFastClusteringConfig(numClusters: Int = -1, threshold: Float = 0.5)
+public func sherpaOnnxFastClusteringConfig(numClusters: Int = -1, threshold: Float = 0.5)
   -> SherpaOnnxFastClusteringConfig
 {
   return SherpaOnnxFastClusteringConfig(num_clusters: Int32(numClusters), threshold: threshold)
 }
 
-func sherpaOnnxSpeakerEmbeddingExtractorConfig(
+public func sherpaOnnxSpeakerEmbeddingExtractorConfig(
   model: String,
   numThreads: Int = 1,
   debug: Int = 0,
@@ -1786,7 +1797,7 @@ func sherpaOnnxSpeakerEmbeddingExtractorConfig(
   )
 }
 
-func sherpaOnnxOfflineSpeakerDiarizationConfig(
+public func sherpaOnnxOfflineSpeakerDiarizationConfig(
   segmentation: SherpaOnnxOfflineSpeakerSegmentationModelConfig,
   embedding: SherpaOnnxSpeakerEmbeddingExtractorConfig,
   clustering: SherpaOnnxFastClusteringConfig,
@@ -1802,17 +1813,17 @@ func sherpaOnnxOfflineSpeakerDiarizationConfig(
   )
 }
 
-struct SherpaOnnxOfflineSpeakerDiarizationSegmentWrapper {
-  var start: Float = 0
-  var end: Float = 0
-  var speaker: Int = 0
+public struct SherpaOnnxOfflineSpeakerDiarizationSegmentWrapper {
+  public var start: Float = 0
+  public var end: Float = 0
+  public var speaker: Int = 0
 }
 
-class SherpaOnnxOfflineSpeakerDiarizationWrapper {
+public class SherpaOnnxOfflineSpeakerDiarizationWrapper {
   /// A pointer to the underlying counterpart in C
-  let impl: OpaquePointer!
+  public let impl: OpaquePointer!
 
-  init(
+  public init(
     config: UnsafePointer<SherpaOnnxOfflineSpeakerDiarizationConfig>!
   ) {
     impl = SherpaOnnxCreateOfflineSpeakerDiarization(config)
@@ -1824,16 +1835,16 @@ class SherpaOnnxOfflineSpeakerDiarizationWrapper {
     }
   }
 
-  var sampleRate: Int {
+  public var sampleRate: Int {
     return Int(SherpaOnnxOfflineSpeakerDiarizationGetSampleRate(impl))
   }
 
   // only config.clustering is used. All other fields are ignored
-  func setConfig(config: UnsafePointer<SherpaOnnxOfflineSpeakerDiarizationConfig>!) {
+  public func setConfig(config: UnsafePointer<SherpaOnnxOfflineSpeakerDiarizationConfig>!) {
     SherpaOnnxOfflineSpeakerDiarizationSetConfig(impl, config)
   }
 
-  func process(samples: [Float]) -> [SherpaOnnxOfflineSpeakerDiarizationSegmentWrapper] {
+  public func process(samples: [Float]) -> [SherpaOnnxOfflineSpeakerDiarizationSegmentWrapper] {
     let result = SherpaOnnxOfflineSpeakerDiarizationProcess(
       impl, samples, Int32(samples.count))
 
@@ -1864,10 +1875,10 @@ class SherpaOnnxOfflineSpeakerDiarizationWrapper {
   }
 }
 
-class SherpaOnnxOnlineStreamWrapper {
+public class SherpaOnnxOnlineStreamWrapper {
   /// A pointer to the underlying counterpart in C
-  let impl: OpaquePointer!
-  init(impl: OpaquePointer!) {
+  public let impl: OpaquePointer!
+  public init(impl: OpaquePointer!) {
     self.impl = impl
   }
 
@@ -1877,24 +1888,24 @@ class SherpaOnnxOnlineStreamWrapper {
     }
   }
 
-  func setOption(key: String, value: String) {
+  public func setOption(key: String, value: String) {
     SherpaOnnxOnlineStreamSetOption(impl, toCPointer(key), toCPointer(value))
   }
 
-  func acceptWaveform(samples: [Float], sampleRate: Int = 16000) {
+  public func acceptWaveform(samples: [Float], sampleRate: Int = 16000) {
     SherpaOnnxOnlineStreamAcceptWaveform(impl, Int32(sampleRate), samples, Int32(samples.count))
   }
 
-  func inputFinished() {
+  public func inputFinished() {
     SherpaOnnxOnlineStreamInputFinished(impl)
   }
 }
 
-class SherpaOnnxSpeakerEmbeddingExtractorWrapper {
+public class SherpaOnnxSpeakerEmbeddingExtractorWrapper {
   /// A pointer to the underlying counterpart in C
-  let impl: OpaquePointer!
+  public let impl: OpaquePointer!
 
-  init(
+  public init(
     config: UnsafePointer<SherpaOnnxSpeakerEmbeddingExtractorConfig>!
   ) {
     impl = SherpaOnnxCreateSpeakerEmbeddingExtractor(config)
@@ -1906,20 +1917,20 @@ class SherpaOnnxSpeakerEmbeddingExtractorWrapper {
     }
   }
 
-  var dim: Int {
+  public var dim: Int {
     return Int(SherpaOnnxSpeakerEmbeddingExtractorDim(impl))
   }
 
-  func createStream() -> SherpaOnnxOnlineStreamWrapper {
+  public func createStream() -> SherpaOnnxOnlineStreamWrapper {
     let newStream = SherpaOnnxSpeakerEmbeddingExtractorCreateStream(impl)
     return SherpaOnnxOnlineStreamWrapper(impl: newStream)
   }
 
-  func isReady(stream: SherpaOnnxOnlineStreamWrapper) -> Bool {
+  public func isReady(stream: SherpaOnnxOnlineStreamWrapper) -> Bool {
     return SherpaOnnxSpeakerEmbeddingExtractorIsReady(impl, stream.impl) == 1 ? true : false
   }
 
-  func compute(stream: SherpaOnnxOnlineStreamWrapper) -> [Float] {
+  public func compute(stream: SherpaOnnxOnlineStreamWrapper) -> [Float] {
     if !isReady(stream: stream) {
       return []
     }
@@ -1934,19 +1945,19 @@ class SherpaOnnxSpeakerEmbeddingExtractorWrapper {
   }
 }
 
-func sherpaOnnxOfflineSpeechDenoiserGtcrnModelConfig(model: String = "")
+public func sherpaOnnxOfflineSpeechDenoiserGtcrnModelConfig(model: String = "")
   -> SherpaOnnxOfflineSpeechDenoiserGtcrnModelConfig
 {
   return SherpaOnnxOfflineSpeechDenoiserGtcrnModelConfig(model: toCPointer(model))
 }
 
-func sherpaOnnxOfflineSpeechDenoiserDpdfNetModelConfig(model: String = "")
+public func sherpaOnnxOfflineSpeechDenoiserDpdfNetModelConfig(model: String = "")
   -> SherpaOnnxOfflineSpeechDenoiserDpdfNetModelConfig
 {
   return SherpaOnnxOfflineSpeechDenoiserDpdfNetModelConfig(model: toCPointer(model))
 }
 
-func sherpaOnnxOfflineSpeechDenoiserModelConfig(
+public func sherpaOnnxOfflineSpeechDenoiserModelConfig(
   gtcrn: SherpaOnnxOfflineSpeechDenoiserGtcrnModelConfig =
     sherpaOnnxOfflineSpeechDenoiserGtcrnModelConfig(),
   dpdfnet: SherpaOnnxOfflineSpeechDenoiserDpdfNetModelConfig =
@@ -1964,7 +1975,7 @@ func sherpaOnnxOfflineSpeechDenoiserModelConfig(
   )
 }
 
-func sherpaOnnxOfflineSpeechDenoiserConfig(
+public func sherpaOnnxOfflineSpeechDenoiserConfig(
   model: SherpaOnnxOfflineSpeechDenoiserModelConfig =
     sherpaOnnxOfflineSpeechDenoiserModelConfig()
 ) -> SherpaOnnxOfflineSpeechDenoiserConfig {
@@ -1972,11 +1983,11 @@ func sherpaOnnxOfflineSpeechDenoiserConfig(
     model: model)
 }
 
-class SherpaOnnxDenoisedAudioWrapper {
+public class SherpaOnnxDenoisedAudioWrapper {
   /// A pointer to the underlying counterpart in C
-  let audio: UnsafePointer<SherpaOnnxDenoisedAudio>!
+  public let audio: UnsafePointer<SherpaOnnxDenoisedAudio>!
 
-  init(audio: UnsafePointer<SherpaOnnxDenoisedAudio>!) {
+  public init(audio: UnsafePointer<SherpaOnnxDenoisedAudio>!) {
     self.audio = audio
   }
 
@@ -1986,21 +1997,21 @@ class SherpaOnnxDenoisedAudioWrapper {
     }
   }
 
-  var n: Int32 {
+  public var n: Int32 {
     guard let audio else {
       return 0
     }
     return audio.pointee.n
   }
 
-  var sampleRate: Int32 {
+  public var sampleRate: Int32 {
     guard let audio else {
       return 0
     }
     return audio.pointee.sample_rate
   }
 
-  var samples: [Float] {
+  public var samples: [Float] {
     guard let audio else {
       return []
     }
@@ -2017,7 +2028,7 @@ class SherpaOnnxDenoisedAudioWrapper {
     }
   }
 
-  func save(filename: String) -> Int32 {
+  public func save(filename: String) -> Int32 {
     guard let audio else {
       return 0
     }
@@ -2025,12 +2036,12 @@ class SherpaOnnxDenoisedAudioWrapper {
   }
 }
 
-class SherpaOnnxOfflineSpeechDenoiserWrapper {
+public class SherpaOnnxOfflineSpeechDenoiserWrapper {
   /// A pointer to the underlying counterpart in C
-  let impl: OpaquePointer!
+  public let impl: OpaquePointer!
 
   /// Constructor taking a model config
-  init(
+  public init(
     config: UnsafePointer<SherpaOnnxOfflineSpeechDenoiserConfig>!
   ) {
     impl = SherpaOnnxCreateOfflineSpeechDenoiser(config)
@@ -2042,29 +2053,29 @@ class SherpaOnnxOfflineSpeechDenoiserWrapper {
     }
   }
 
-  func run(samples: [Float], sampleRate: Int) -> SherpaOnnxDenoisedAudioWrapper {
+  public func run(samples: [Float], sampleRate: Int) -> SherpaOnnxDenoisedAudioWrapper {
     let audio: UnsafePointer<SherpaOnnxDenoisedAudio>? = SherpaOnnxOfflineSpeechDenoiserRun(
       impl, samples, Int32(samples.count), Int32(sampleRate))
 
     return SherpaOnnxDenoisedAudioWrapper(audio: audio)
   }
 
-  var sampleRate: Int {
+  public var sampleRate: Int {
     return Int(SherpaOnnxOfflineSpeechDenoiserGetSampleRate(impl))
   }
 }
 
-func sherpaOnnxOnlineSpeechDenoiserConfig(
+public func sherpaOnnxOnlineSpeechDenoiserConfig(
   model: SherpaOnnxOfflineSpeechDenoiserModelConfig =
     sherpaOnnxOfflineSpeechDenoiserModelConfig()
 ) -> SherpaOnnxOnlineSpeechDenoiserConfig {
   return SherpaOnnxOnlineSpeechDenoiserConfig(model: model)
 }
 
-class SherpaOnnxOnlineSpeechDenoiserWrapper {
-  let impl: OpaquePointer!
+public class SherpaOnnxOnlineSpeechDenoiserWrapper {
+  public let impl: OpaquePointer!
 
-  init(
+  public init(
     config: UnsafePointer<SherpaOnnxOnlineSpeechDenoiserConfig>!
   ) {
     impl = SherpaOnnxCreateOnlineSpeechDenoiser(config)
@@ -2076,51 +2087,51 @@ class SherpaOnnxOnlineSpeechDenoiserWrapper {
     }
   }
 
-  func run(samples: [Float], sampleRate: Int) -> SherpaOnnxDenoisedAudioWrapper {
+  public func run(samples: [Float], sampleRate: Int) -> SherpaOnnxDenoisedAudioWrapper {
     let audio: UnsafePointer<SherpaOnnxDenoisedAudio>? = SherpaOnnxOnlineSpeechDenoiserRun(
       impl, samples, Int32(samples.count), Int32(sampleRate))
     return SherpaOnnxDenoisedAudioWrapper(audio: audio)
   }
 
-  func flush() -> SherpaOnnxDenoisedAudioWrapper {
+  public func flush() -> SherpaOnnxDenoisedAudioWrapper {
     let audio: UnsafePointer<SherpaOnnxDenoisedAudio>? = SherpaOnnxOnlineSpeechDenoiserFlush(impl)
     return SherpaOnnxDenoisedAudioWrapper(audio: audio)
   }
 
-  func reset() {
+  public func reset() {
     SherpaOnnxOnlineSpeechDenoiserReset(impl)
   }
 
-  var sampleRate: Int {
+  public var sampleRate: Int {
     return Int(SherpaOnnxOnlineSpeechDenoiserGetSampleRate(impl))
   }
 
-  var frameShiftInSamples: Int {
+  public var frameShiftInSamples: Int {
     return Int(SherpaOnnxOnlineSpeechDenoiserGetFrameShiftInSamples(impl))
   }
 }
 
-func getSherpaOnnxVersion() -> String {
+public func getSherpaOnnxVersion() -> String {
   return String(cString: SherpaOnnxGetVersionStr())
 }
 
-func getSherpaOnnxGitSha1() -> String {
+public func getSherpaOnnxGitSha1() -> String {
   return String(cString: SherpaOnnxGetGitSha1())
 }
 
-func getSherpaOnnxGitDate() -> String {
+public func getSherpaOnnxGitDate() -> String {
   return String(cString: SherpaOnnxGetGitDate())
 }
 
 /// Return the onnxruntime version string used by the library.
-func getSherpaOnnxOnnxruntimeVersion() -> String {
+public func getSherpaOnnxOnnxruntimeVersion() -> String {
   return String(cString: SherpaOnnxGetOnnxruntimeVersionStr())
 }
 //---------------------------
 // Source separation
 //---------------------------
 
-struct AudioData {
+public struct AudioData {
   private enum Storage {
     case owned([Float])
     case wrapped(ManagedWave)
@@ -2133,11 +2144,11 @@ struct AudioData {
   }
 
   private let storage: Storage
-  let channelCount: Int
-  let samplesPerChannel: Int
-  let sampleRate: Int
+  public let channelCount: Int
+  public let samplesPerChannel: Int
+  public let sampleRate: Int
 
-  init(samples: [Float], channelCount: Int, sampleRate: Int) {
+  public init(samples: [Float], channelCount: Int, sampleRate: Int) {
     self.storage = .owned(samples)
     self.channelCount = channelCount
     self.sampleRate = sampleRate
@@ -2152,7 +2163,7 @@ struct AudioData {
     self.sampleRate = Int(ptr.pointee.sample_rate)
   }
 
-  func withUnsafeBufferPointer<R>(_ body: (UnsafeBufferPointer<Float>) -> R) -> R {
+  public func withUnsafeBufferPointer<R>(_ body: (UnsafeBufferPointer<Float>) -> R) -> R {
     switch storage {
     case .owned(let array):
       return array.withUnsafeBufferPointer(body)
@@ -2164,7 +2175,7 @@ struct AudioData {
   }
 
   @discardableResult
-  func save(to filename: String) -> Bool {
+  public func save(to filename: String) -> Bool {
     return withUnsafeBufferPointer { buf in
       guard let base = buf.baseAddress else { return false }
       // FIX: Explicitly type the array as Optional pointers to match C 'float* const*'
@@ -2181,20 +2192,20 @@ struct AudioData {
   }
 }
 
-struct SourceSeparationConfig {
-  struct Spleeter {
-    var vocals: String
-    var accompaniment: String
+public struct SourceSeparationConfig {
+  public struct Spleeter {
+    public var vocals: String
+    public var accompaniment: String
   }
-  struct Uvr { var model: String }
+  public struct Uvr { public var model: String }
 
-  var spleeter: Spleeter?
-  var uvr: Uvr?
-  var numThreads: Int = 1
-  var debug: Bool = false
-  var provider: String = "cpu"
+  public var spleeter: Spleeter?
+  public var uvr: Uvr?
+  public var numThreads: Int = 1
+  public var debug: Bool = false
+  public var provider: String = "cpu"
 
-  func withCConfig<R>(_ body: (UnsafePointer<SherpaOnnxOfflineSourceSeparationConfig>) -> R) -> R {
+  public func withCConfig<R>(_ body: (UnsafePointer<SherpaOnnxOfflineSourceSeparationConfig>) -> R) -> R {
     var cConfig = SherpaOnnxOfflineSourceSeparationConfig()
     cConfig.model.num_threads = Int32(self.numThreads)
     cConfig.model.debug = self.debug ? 1 : 0
@@ -2215,7 +2226,7 @@ struct SourceSeparationConfig {
   }
 }
 
-class SourceSeparator {
+public class SourceSeparator {
   private var engine: OpaquePointer?
 
   init?(config: SourceSeparationConfig) {
@@ -2230,7 +2241,7 @@ class SourceSeparator {
     }
   }
 
-  func process(buffer: AudioData) -> [AudioData]? {
+  public func process(buffer: AudioData) -> [AudioData]? {
     guard let engine = engine else { return nil }
 
     return buffer.withUnsafeBufferPointer { flatBuf in


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Updates**
  * Expanded the Swift public surface area across recognition (online/offline), streaming controls, text-to-speech, language ID, keyword spotting, punctuation, denoising, diarization, and source separation.
  * Exported additional metadata helpers and buffer/config utilities.
  * Updated offline TTS configuration to include rule FSTs.

* **Build & Quality**
  * Added an iOS Simulator GitHub Actions workflow covering five SwiftUI app variants.
  * Migrated iOS projects to Swift Package–based integration for the SherpaOnnx module (replacing bundled xcframework usage).

* **Chores**
  * Adjusted the macOS build script to remove the installed C module map after artifact generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->