### PR TITLE
Add Persian NeMo CTC ASR models (shenava koochik/rizeh/rizeh-pizeh)

### DIFF
--- a/.github/workflows/upload-models.yaml
+++ b/.github/workflows/upload-models.yaml
@@ -1234,6 +1234,36 @@ jobs:
 
           mv models/* .
 
+      - name: NeMo CTC Persian (shenava)
+        if: false
+        shell: bash
+        run: |
+          git lfs install
+
+          # Source repos on huggingface.co/mah92
+          models=(
+            sherpa-onnx-nemo-ctc-fa-shenava-koochik-v1.0-non-streaming-2026-06-26
+            sherpa-onnx-nemo-ctc-fa-shenava-koochik-v1.0-non-streaming-int8-2026-06-26
+            sherpa-onnx-nemo-ctc-fa-shenava-koochik-v1.0-streaming-2026-06-26
+            sherpa-onnx-nemo-ctc-fa-shenava-koochik-v1.0-streaming-int8-2026-06-26
+            sherpa-onnx-nemo-ctc-fa-shenava-rizeh-v1.0-non-streaming-2026-06-26
+            sherpa-onnx-nemo-ctc-fa-shenava-rizeh-v1.0-non-streaming-int8-2026-06-26
+            sherpa-onnx-nemo-ctc-fa-shenava-rizeh-v1.0-streaming-2026-06-26
+            sherpa-onnx-nemo-ctc-fa-shenava-rizeh-v1.0-streaming-int8-2026-06-26
+            sherpa-onnx-nemo-ctc-fa-shenava-rizeh-pizeh-v1.0-non-streaming-2026-06-26
+            sherpa-onnx-nemo-ctc-fa-shenava-rizeh-pizeh-v1.0-non-streaming-int8-2026-06-26
+            sherpa-onnx-nemo-ctc-fa-shenava-rizeh-pizeh-v1.0-streaming-2026-06-26
+            sherpa-onnx-nemo-ctc-fa-shenava-rizeh-pizeh-v1.0-streaming-int8-2026-06-26
+          )
+
+          for d in ${models[@]}; do
+            git clone https://huggingface.co/mah92/$d
+            rm -rf $d/.git
+            rm -rf $d/.gitattributes
+            tar cjfv $d.tar.bz2 $d
+            ls -lh $d.tar.bz2
+          done
+
       - name: Release
         if: true
         uses: svenstaro/upload-release-action@v2
@@ -1276,6 +1306,18 @@ jobs:
               sherpa-onnx-x-asr-zipformer-transducer-zh-en-int8-2026-06-03
               sherpa-onnx-x-asr-zipformer-transducer-zh-en-punct-2026-06-03
               sherpa-onnx-x-asr-zipformer-transducer-zh-en-punct-int8-2026-06-03
+              sherpa-onnx-nemo-ctc-fa-shenava-koochik-v1.0-non-streaming-2026-06-26
+              sherpa-onnx-nemo-ctc-fa-shenava-koochik-v1.0-non-streaming-int8-2026-06-26
+              sherpa-onnx-nemo-ctc-fa-shenava-koochik-v1.0-streaming-2026-06-26
+              sherpa-onnx-nemo-ctc-fa-shenava-koochik-v1.0-streaming-int8-2026-06-26
+              sherpa-onnx-nemo-ctc-fa-shenava-rizeh-v1.0-non-streaming-2026-06-26
+              sherpa-onnx-nemo-ctc-fa-shenava-rizeh-v1.0-non-streaming-int8-2026-06-26
+              sherpa-onnx-nemo-ctc-fa-shenava-rizeh-v1.0-streaming-2026-06-26
+              sherpa-onnx-nemo-ctc-fa-shenava-rizeh-v1.0-streaming-int8-2026-06-26
+              sherpa-onnx-nemo-ctc-fa-shenava-rizeh-pizeh-v1.0-non-streaming-2026-06-26
+              sherpa-onnx-nemo-ctc-fa-shenava-rizeh-pizeh-v1.0-non-streaming-int8-2026-06-26
+              sherpa-onnx-nemo-ctc-fa-shenava-rizeh-pizeh-v1.0-streaming-2026-06-26
+              sherpa-onnx-nemo-ctc-fa-shenava-rizeh-pizeh-v1.0-streaming-int8-2026-06-26
             )
             for d in ${models[@]}; do
               if [ ! -d $d ]; then


### PR DESCRIPTION
Add 12 Persian (fa) NeMo CTC models from huggingface.co/mah92:
- shenava-koochik: non-streaming/streaming + int8 variants (4 models)
- shenava-rizeh: non-streaming/streaming + int8 variants (4 models)
- shenava-rizeh-pizeh: non-streaming/streaming + int8 variants (4 models)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a disabled-by-default workflow step, **“NeMo CTC Persian (shenava)”**, that packages Persian NeMo CTC models for **shenava-koochik**, **shenava-rizeh**, and **shenava-rizeh-pizeh**.
  * Produces archives for both **streaming** and **non-streaming** variants, including **FP32** and **INT8**.
  * Updated **Publish to huggingface** to include these newly generated archives for the standard publishing cycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->