### PR TITLE
Fix heap-use-after-free in offline speaker diarization (likely #3253)

### DIFF
--- a/sherpa-onnx/c-api/c-api.cc
+++ b/sherpa-onnx/c-api/c-api.cc
@@ -3260,10 +3260,24 @@ const SherpaOnnxOfflineSpeakerDiarizationResult *
 SherpaOnnxOfflineSpeakerDiarizationProcess(
     const SherpaOnnxOfflineSpeakerDiarization *sd, const float *samples,
     int32_t n) {
-  auto ans = new SherpaOnnxOfflineSpeakerDiarizationResult;
-  ans->impl = sd->impl->Process(samples, n);
+  if (!sd || !sd->impl) return nullptr;
 
-  return ans;
+  try {
+    auto ans = new SherpaOnnxOfflineSpeakerDiarizationResult;
+    ans->impl = sd->impl->Process(samples, n);
+
+    return ans;
+  } catch (const std::exception &e) {
+    SHERPA_ONNX_LOGE("Speaker diarization failed: %s", e.what());
+    return nullptr;
+  } catch (...) {
+    // fastclustercpp::nan_error and fenv_error are thrown by hclust_fast() and
+    // do not derive from std::exception. Letting any C++ exception escape a
+    // C-linkage entry point is undefined behaviour for non-C++ callers (it
+    // crashes .NET/JVM P/Invoke frames rather than unwinding).
+    SHERPA_ONNX_LOGE("Speaker diarization failed with an unknown exception");
+    return nullptr;
+  }
 }
 
 void SherpaOnnxOfflineSpeakerDiarizationDestroyResult(
@@ -3277,10 +3291,20 @@ SherpaOnnxOfflineSpeakerDiarizationProcessWithCallback(
     const SherpaOnnxOfflineSpeakerDiarization *sd, const float *samples,
     int32_t n, SherpaOnnxOfflineSpeakerDiarizationProgressCallback callback,
     void *arg) {
-  auto ans = new SherpaOnnxOfflineSpeakerDiarizationResult;
-  ans->impl = sd->impl->Process(samples, n, callback, arg);
+  if (!sd || !sd->impl) return nullptr;
 
-  return ans;
+  try {
+    auto ans = new SherpaOnnxOfflineSpeakerDiarizationResult;
+    ans->impl = sd->impl->Process(samples, n, callback, arg);
+
+    return ans;
+  } catch (const std::exception &e) {
+    SHERPA_ONNX_LOGE("Speaker diarization failed: %s", e.what());
+    return nullptr;
+  } catch (...) {
+    SHERPA_ONNX_LOGE("Speaker diarization failed with an unknown exception");
+    return nullptr;
+  }
 }
 
 const SherpaOnnxOfflineSpeakerDiarizationResult *
@@ -3288,15 +3312,25 @@ SherpaOnnxOfflineSpeakerDiarizationProcessWithCallbackNoArg(
     const SherpaOnnxOfflineSpeakerDiarization *sd, const float *samples,
     int32_t n,
     SherpaOnnxOfflineSpeakerDiarizationProgressCallbackNoArg callback) {
+  if (!sd || !sd->impl) return nullptr;
+
   auto wrapper = [callback](int32_t num_processed_chunks,
                             int32_t num_total_chunks, void *) {
     return callback(num_processed_chunks, num_total_chunks);
   };
 
-  auto ans = new SherpaOnnxOfflineSpeakerDiarizationResult;
-  ans->impl = sd->impl->Process(samples, n, wrapper);
+  try {
+    auto ans = new SherpaOnnxOfflineSpeakerDiarizationResult;
+    ans->impl = sd->impl->Process(samples, n, wrapper);
 
-  return ans;
+    return ans;
+  } catch (const std::exception &e) {
+    SHERPA_ONNX_LOGE("Speaker diarization failed: %s", e.what());
+    return nullptr;
+  } catch (...) {
+    SHERPA_ONNX_LOGE("Speaker diarization failed with an unknown exception");
+    return nullptr;
+  }
 }
 #else
 

--- a/sherpa-onnx/csrc/fast-clustering.cc
+++ b/sherpa-onnx/csrc/fast-clustering.cc
@@ -4,6 +4,7 @@
 
 #include "sherpa-onnx/csrc/fast-clustering.h"
 
+#include <cmath>
 #include <vector>
 
 #include "Eigen/Dense"
@@ -41,6 +42,16 @@ class FastClustering::Impl {
 
         if (consine_dissimilarity < 0) {
           consine_dissimilarity = 0;
+        }
+
+        // hclust_fast() throws fastclustercpp::nan_error (which is not a
+        // std::exception) if the condensed distance matrix contains NaN, and
+        // that exception would unwind out through the C API. A non-finite
+        // distance can only come from a degenerate embedding, so treat it as
+        // "maximally dissimilar" instead of letting it abort the whole
+        // diarization.
+        if (!std::isfinite(consine_dissimilarity)) {
+          consine_dissimilarity = 2;
         }
 
         distance[k] = consine_dissimilarity;

--- a/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
+++ b/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
@@ -564,8 +564,16 @@ class OfflineSpeakerDiarizationPyannoteImpl
     }
 
     if (k != cur_row_index) {
-      auto seq = Eigen::seqN(0, cur_row_index);
-      ans = ans(seq, Eigen::placeholders::all);
+      // NOTE: `ans = ans(seq, all)` is an ALIASED assignment and is not safe
+      // here. Assigning an indexed view of `ans` back into `ans` changes its
+      // number of rows, so the assignment resizes `ans` first, and Eigen's
+      // DenseStorage::resize() frees the old buffer and allocates a new one
+      // whenever the total size changes. The right-hand side still refers to
+      // the old, now-freed buffer, so the copy reads freed memory
+      // (heap-use-after-free). Evaluate the selection into a temporary first.
+      Matrix2D valid =
+          ans(Eigen::seqN(0, cur_row_index), Eigen::placeholders::all);
+      ans = std::move(valid);
     }
 
     return ans;

--- a/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
+++ b/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
@@ -184,6 +184,14 @@ class OfflineSpeakerDiarizationPyannoteImpl
       chunk_speaker_samples_list_pair.second = std::move(sample_indexes);
     }
 
+    if (embeddings.rows() == 0) {
+      // Every embedding was rejected as non-finite. Taking &embeddings(0, 0)
+      // would index an empty matrix.
+      SHERPA_ONNX_LOGE(
+          "All speaker embeddings were non-finite; cannot cluster this audio");
+      return {};
+    }
+
     Timer clustering_timer(config_.segmentation.debug);
     std::vector<int32_t> cluster_labels = clustering_->Cluster(
         &embeddings(0, 0), embeddings.rows(), embeddings.cols());
@@ -524,7 +532,13 @@ class OfflineSpeakerDiarizationPyannoteImpl
     int32_t sample_rate = meta_data.sample_rate;
     Matrix2D ans(sample_indexes.size(), embedding_extractor_.Dim());
 
-    auto IsNaNWrapper = [](float f) -> bool { return std::isnan(f); };
+    // The embedding model may output NaN, and it may also output +/-Inf. Both
+    // have to be rejected here. An Inf passes an isnan() test but is still
+    // fatal downstream: FastClustering normalizes every row, which turns
+    // inf/inf into NaN, the NaN spreads through the cosine distance matrix,
+    // and hclust_fast() then throws fastclustercpp::nan_error out through the
+    // C API.
+    auto IsNonFinite = [](float f) -> bool { return !std::isfinite(f); };
 
     int32_t k = 0;
     int32_t cur_row_index = 0;
@@ -549,7 +563,7 @@ class OfflineSpeakerDiarizationPyannoteImpl
 
       std::vector<float> embedding = embedding_extractor_.Compute(stream.get());
 
-      if (std::none_of(embedding.begin(), embedding.end(), IsNaNWrapper)) {
+      if (std::none_of(embedding.begin(), embedding.end(), IsNonFinite)) {
         // a valid embedding
         std::copy(embedding.begin(), embedding.end(), &ans(cur_row_index, 0));
         cur_row_index += 1;


### PR DESCRIPTION
Fixes a heap-use-after-free in offline speaker diarization that has been crashing callers since at least 1.12.x, plus two pieces of hardening on the same fault path. Very likely the root cause of #3253 (`System.AccessViolationException` from .NET, SIGBUS from Python/macOS) — see the reasoning below.

## The bug

`OfflineSpeakerDiarizationPyannoteImpl::ComputeEmbeddings()` over-allocates the embedding matrix (one row per `(chunk, speaker)` pair), then compacts it to the rows that produced a usable embedding:

```cpp
if (k != cur_row_index) {
  auto seq = Eigen::seqN(0, cur_row_index);
  ans = ans(seq, Eigen::placeholders::all);   // aliased self-assignment
}
```

This is an **aliased** assignment. Shrinking the row count changes the total size, so the assignment resizes the destination *before* evaluating the source, and `DenseStorage::resize()` frees the old buffer and allocates a new one whenever the size changes (`Eigen/src/Core/DenseStorage.h`). The right-hand side `Block` still refers to the freed buffer, so the copy reads freed memory.

The branch runs **only when at least one embedding was discarded** — the case the code immediately above it already anticipates (*"The embedding model may output NaN"*). So the crash is data-dependent, reproduces on the same audio every time, and is invisible on well-conditioned audio.

ASan, against `sherpa-onnx-pyannote-segmentation-3-0` + `wespeaker_en_voxceleb_resnet34_LM`:

```
ERROR: AddressSanitizer: heap-use-after-free ... READ of size 16
  #0 Eigen ...::assignPacket<16,0,__simd128_float32_t>   AssignEvaluator.h:712
  #2 OfflineSpeakerDiarizationPyannoteImpl::ComputeEmbeddings   :548
  #3 OfflineSpeakerDiarizationPyannoteImpl::Process             :144
0x62c000000200 is located 0 bytes inside of 30720-byte region
freed by thread T0 here:
  #1 Eigen ...call_dense_assignment_loop   AssignEvaluator.h:821    <-- the resize
```

### Why this is probably #3253

Both reporters there describe symptoms this mechanism predicts, and one of them independently narrowed it to the exact precondition:

> *"The crash is content-dependent and reproducible on the same audio. Audio ≤ 10s always works; certain segments at 12–15s reliably crash. Same segment works fine if truncated to 10s — the crash is triggered when audio exceeds `window_size` (160000 samples / 10s) and enters the multi-chunk code path."*

That falls straight out of this bug: `Process()` short-circuits single-chunk audio through `HandleOneChunkSpecialCase()` and never reaches `ComputeEmbeddings()`, so only multi-chunk audio can reach the aliased shrink.

It also explains why the crash looks platform-specific. glibc/macOS malloc usually hands the same block straight back, so the read silently succeeds and the bug hides; allocators that quarantine freed chunks (Android's **Scudo**) fault hard. The `AccessViolationException` shape in #3253 is what this looks like from a .NET P/Invoke frame.

## What's in this PR

Three commits, smallest-blast-radius first:

1. **`Fix heap-use-after-free when compacting filtered speaker embeddings`** — evaluate the selection into a temporary before assigning. **This is the crash fix**; the other two are hardening.
2. **`Do not let a non-finite distance abort clustering`** — the embedding filter tested `std::isnan` only, so an `±Inf` embedding survived it. `FastClustering` normalizes every row, which maps `inf/inf` to NaN; the NaN spreads through the condensed cosine-distance matrix, and `hclust_fast()` then throws `fastclustercpp::nan_error`. This switches the filter to `!std::isfinite`, clamps any residual non-finite distance to maximum dissimilarity, and adds an early return when *every* embedding was rejected (which would otherwise index `&embeddings(0, 0)` on an empty matrix).
3. **`Do not let exceptions escape the diarization C API entries`** — the three `SherpaOnnxOfflineSpeakerDiarizationProcess*` functions had no `try`/`catch`, so `nan_error` could unwind out of a `extern "C"` boundary; that is UB for non-C++ callers and crashes .NET/JVM frames rather than unwinding. Note these need a bare `catch (...)`: `fastclustercpp::nan_error` and `fenv_error` do **not** derive from `std::exception`, so the `catch (const std::exception &)` idiom used elsewhere in `c-api.cc` is not sufficient on its own.

## Validation

Built with `-fsanitize=address,undefined` on macOS arm64 and run against two batteries with the real models.

**7 pathological fixtures** (32-bit float WAVs carrying non-finite / ~1e38 sample values, ~39 s each so they take the multi-chunk path):

| | before | after |
|---|---|---|
| heap-use-after-free | **4 of 7 fault** | **0 of 7** |
| output | — | all 7 return real speaker turns |

Minimal audio repro: **a single `+inf` sample anywhere in a 39-second clip.** (`f06` faults on some runs and not others on macOS — the allocator sometimes returns the same block, which is exactly why this is easy to miss locally and reliable on Android.)

**12 realistic clips** (two-speaker, digital silence, clipped, very quiet, DC offset, pure tone, overlapping speech, sparse bursts) — the check that matters for commit 2, since `!isfinite` rejects strictly more embeddings than `isnan`:

> speaker turns are **byte-identical before and after** on all 12 clips.

No healthy embedding was non-finite, so the stricter filter costs nothing on real audio. There is also a standalone reproduction of just the aliasing bug that needs **only Eigen** — no models, no audio, no sherpa sources — if that's useful for a regression test.

## How this was found

Reported by a .NET caller on Android arm64: one particular ~39-second clip killed the process on every run, always on the first `Process()` call of a freshly-constructed engine — which ruled out reuse, disposal and concurrency and pointed at something input-shaped. Config was `num_clusters = -1`, `cluster_threshold = 0.5`, pyannote segmentation-3.0 + wespeaker resnet34.

Two notes in the interest of full disclosure:

- **This diagnosis and fix were produced entirely by an AI agent** (Claude), including the ASan reproduction, the root-cause analysis, the patch, and the before/after validation described above. A human reviewed and approved submitting it, but did not independently re-derive the analysis. Please review it as you would any unfamiliar contributor's patch — the evidence above is meant to be checkable rather than taken on trust, and I'm happy to supply the fixtures, the standalone Eigen repro, or any of the raw ASan logs.
- The original crashing audio could **not** be recovered from that device, so the reproduction is synthesized. The link to that specific crash rests on the symptom match described above, not on a replay of the original input. The fix itself is validated directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speaker diarization stability when invalid or non-finite audio embeddings are encountered.
  * Prevented crashes and unexpected failures during diarization processing.
  * Added safer handling for empty or invalid diarization results.
  * Improved clustering reliability by guarding against invalid distance calculations.
  * Strengthened callback-based diarization error handling and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->