### PR TITLE
Set onnxruntime version to 1.27.1 in SPM

### DIFF
--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -22,6 +22,41 @@ permissions:
   contents: read
 
 jobs:
+  sherpa-onnx-local:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, macos-15-intel]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Patch to local package
+        shell: bash
+        run: |
+          set -euo pipefail
+          find ios-swiftui ios-swift -name "project.pbxproj" -exec sed -i '' \
+            -e 's|isa = XCRemoteSwiftPackageReference|isa = XCLocalSwiftPackageReference|' \
+            -e 's|repositoryURL = "https://github.com/k2-fsa/sherpa-onnx"|relativePath = ../../|' \
+            -e '/requirement = {/,/};/d' \
+            {} +
+          git diff
+          cat ios-swiftui/SherpaOnnxAsr/SherpaOnnxAsr.xcodeproj/project.pbxproj
+
+      - name: Build SherpaOnnx (local)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd ios-swiftui/SherpaOnnxAsr
+          xcodebuild -project SherpaOnnxAsr.xcodeproj \
+            -scheme SherpaOnnxAsr \
+            -destination 'generic/platform=iOS Simulator' \
+            -skipPackagePluginValidation \
+            build
+
   sherpa-onnx:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -41,6 +76,41 @@ jobs:
           cd ios-swiftui/SherpaOnnxAsr
           xcodebuild -project SherpaOnnxAsr.xcodeproj \
             -scheme SherpaOnnxAsr \
+            -destination 'generic/platform=iOS Simulator' \
+            -skipPackagePluginValidation \
+            build
+
+  sherpa-onnx-2pass-local:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, macos-15-intel]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Patch to local package
+        shell: bash
+        run: |
+          set -euo pipefail
+          find ios-swiftui ios-swift -name "project.pbxproj" -exec sed -i '' \
+            -e 's|isa = XCRemoteSwiftPackageReference|isa = XCLocalSwiftPackageReference|' \
+            -e 's|repositoryURL = "https://github.com/k2-fsa/sherpa-onnx"|relativePath = ../../|' \
+            -e '/requirement = {/,/};/d' \
+            {} +
+          git diff
+          cat ios-swiftui/SherpaOnnx2Pass/SherpaOnnx2Pass.xcodeproj/project.pbxproj
+
+      - name: Build SherpaOnnx2Pass (local)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd ios-swiftui/SherpaOnnx2Pass
+          xcodebuild -project SherpaOnnx2Pass.xcodeproj \
+            -scheme SherpaOnnx2Pass \
             -destination 'generic/platform=iOS Simulator' \
             -skipPackagePluginValidation \
             build
@@ -68,6 +138,41 @@ jobs:
             -skipPackagePluginValidation \
             build
 
+  sherpa-onnx-lang-id-local:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, macos-15-intel]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Patch to local package
+        shell: bash
+        run: |
+          set -euo pipefail
+          find ios-swiftui ios-swift -name "project.pbxproj" -exec sed -i '' \
+            -e 's|isa = XCRemoteSwiftPackageReference|isa = XCLocalSwiftPackageReference|' \
+            -e 's|repositoryURL = "https://github.com/k2-fsa/sherpa-onnx"|relativePath = ../../|' \
+            -e '/requirement = {/,/};/d' \
+            {} +
+          git diff
+          cat ios-swiftui/SherpaOnnxLangID/SherpaOnnxLangID.xcodeproj/project.pbxproj
+
+      - name: Build SherpaOnnxLangID (local)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd ios-swiftui/SherpaOnnxLangID
+          xcodebuild -project SherpaOnnxLangID.xcodeproj \
+            -scheme SherpaOnnxLangID \
+            -destination 'generic/platform=iOS Simulator' \
+            -skipPackagePluginValidation \
+            build
+
   sherpa-onnx-lang-id:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -87,6 +192,41 @@ jobs:
           cd ios-swiftui/SherpaOnnxLangID
           xcodebuild -project SherpaOnnxLangID.xcodeproj \
             -scheme SherpaOnnxLangID \
+            -destination 'generic/platform=iOS Simulator' \
+            -skipPackagePluginValidation \
+            build
+
+  sherpa-onnx-subtitle-local:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, macos-15-intel]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Patch to local package
+        shell: bash
+        run: |
+          set -euo pipefail
+          find ios-swiftui ios-swift -name "project.pbxproj" -exec sed -i '' \
+            -e 's|isa = XCRemoteSwiftPackageReference|isa = XCLocalSwiftPackageReference|' \
+            -e 's|repositoryURL = "https://github.com/k2-fsa/sherpa-onnx"|relativePath = ../../|' \
+            -e '/requirement = {/,/};/d' \
+            {} +
+          git diff
+          cat ios-swiftui/SherpaOnnxSubtitle/SherpaOnnxSubtitle.xcodeproj/project.pbxproj
+
+      - name: Build SherpaOnnxSubtitle (local)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd ios-swiftui/SherpaOnnxSubtitle
+          xcodebuild -project SherpaOnnxSubtitle.xcodeproj \
+            -scheme SherpaOnnxSubtitle \
             -destination 'generic/platform=iOS Simulator' \
             -skipPackagePluginValidation \
             build
@@ -114,6 +254,41 @@ jobs:
             -skipPackagePluginValidation \
             build
 
+  sherpa-onnx-tts-local:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, macos-15-intel]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Patch to local package
+        shell: bash
+        run: |
+          set -euo pipefail
+          find ios-swiftui ios-swift -name "project.pbxproj" -exec sed -i '' \
+            -e 's|isa = XCRemoteSwiftPackageReference|isa = XCLocalSwiftPackageReference|' \
+            -e 's|repositoryURL = "https://github.com/k2-fsa/sherpa-onnx"|relativePath = ../../|' \
+            -e '/requirement = {/,/};/d' \
+            {} +
+          git diff
+          cat ios-swiftui/SherpaOnnxTts/SherpaOnnxTts.xcodeproj/project.pbxproj
+
+      - name: Build SherpaOnnxTts (local)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd ios-swiftui/SherpaOnnxTts
+          xcodebuild -project SherpaOnnxTts.xcodeproj \
+            -scheme SherpaOnnxTts \
+            -destination 'generic/platform=iOS Simulator' \
+            -skipPackagePluginValidation \
+            build
+
   sherpa-onnx-tts:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -133,6 +308,41 @@ jobs:
           cd ios-swiftui/SherpaOnnxTts
           xcodebuild -project SherpaOnnxTts.xcodeproj \
             -scheme SherpaOnnxTts \
+            -destination 'generic/platform=iOS Simulator' \
+            -skipPackagePluginValidation \
+            build
+
+  sherpa-onnx-asr-local:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, macos-15-intel]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Patch to local package
+        shell: bash
+        run: |
+          set -euo pipefail
+          find ios-swiftui ios-swift -name "project.pbxproj" -exec sed -i '' \
+            -e 's|isa = XCRemoteSwiftPackageReference|isa = XCLocalSwiftPackageReference|' \
+            -e 's|repositoryURL = "https://github.com/k2-fsa/sherpa-onnx"|relativePath = ../../|' \
+            -e '/requirement = {/,/};/d' \
+            {} +
+          git diff
+          cat ios-swift/SherpaOnnxAsr/SherpaOnnxAsr.xcodeproj/project.pbxproj
+
+      - name: Build SherpaOnnxAsr ios-swift (local)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd ios-swift/SherpaOnnxAsr
+          xcodebuild -project SherpaOnnxAsr.xcodeproj \
+            -scheme SherpaOnnxAsr \
             -destination 'generic/platform=iOS Simulator' \
             -skipPackagePluginValidation \
             build

--- a/.github/workflows/test-spm.yaml
+++ b/.github/workflows/test-spm.yaml
@@ -8,14 +8,34 @@ on:
   workflow_dispatch:
 
 jobs:
-  test-spm-macos:
-    name: Test SPM (macOS)
+  test-local-spm-macos:
+    name: Test local SPM (macOS)
     runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build and run (macOS)
+      - name: Build and run local package (macOS)
+        shell: bash
+        run: |
+          cd spm-examples/macOS
+          # Use local package for CI testing
+          sed -i.bak 's|.package(url: "https://github.com/k2-fsa/sherpa-onnx", branch: "master")|.package(path: "../../")|' Package.swift
+          cat Package.swift
+          rm -rf .build
+          swift package resolve
+          swift package show-dependencies
+          swift build --verbose
+          swift run SherpaOnnxExample
+
+  test-remote-spm-macos:
+    name: Test remote SPM (macOS)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build and run remote package (macOS)
         shell: bash
         run: |
           cd spm-examples/macOS
@@ -25,14 +45,61 @@ jobs:
           swift build --verbose
           swift run SherpaOnnxExample
 
-  test-spm-ios:
-    name: Test SPM (iOS)
+  test-local-spm-ios:
+    name: Test local SPM (iOS)
     runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build and run for iOS Simulator
+      - name: Build and run local package (iOS)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd spm-examples/iOS
+
+          # Use local package for CI testing
+          sed -i.bak 's|.package(url: "https://github.com/k2-fsa/sherpa-onnx", branch: "master")|.package(path: "../../")|' Package.swift
+          cat Package.swift
+
+          echo "=== Resolving ==="
+          swift package resolve
+
+          echo "=== Building for iOS Simulator ==="
+          xcodebuild -scheme SherpaOnnxExample \
+            -destination "generic/platform=iOS Simulator" \
+            -skipPackagePluginValidation \
+            -verbose \
+            build 2>&1
+
+          echo "=== Finding built executable ==="
+          BINARY=$(find ~/Library/Developer/Xcode/DerivedData -path "*/Build/Products/*-iphonesimulator/SherpaOnnxExample" -type f | head -1)
+          echo "Binary: $BINARY"
+
+          echo "=== Booting iOS Simulator ==="
+          DEVICE=$(xcrun simctl list devices available -j | python3 -c "
+          import json, sys
+          devices = json.load(sys.stdin)['devices']
+          for key in devices:
+              for d in devices[key]:
+                  if d['isAvailable'] and 'iPhone' in d['name']:
+                      print(d['udid'])
+                      sys.exit(0)
+          ")
+          echo "Device: $DEVICE"
+          xcrun simctl boot "$DEVICE" 2>/dev/null || true
+
+          echo "=== Running on iOS Simulator ==="
+          xcrun simctl spawn "$DEVICE" "$BINARY"
+
+  test-remote-spm-ios:
+    name: Test remote SPM (iOS)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build and run remote package (iOS)
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/test-spm.yaml
+++ b/.github/workflows/test-spm.yaml
@@ -21,6 +21,7 @@ jobs:
           cd spm-examples/macOS
           # Use local package for CI testing
           sed -i.bak 's|.package(url: "https://github.com/k2-fsa/sherpa-onnx", branch: "master")|.package(path: "../../")|' Package.swift
+          git diff
           cat Package.swift
           rm -rf .build
           swift package resolve
@@ -60,6 +61,7 @@ jobs:
 
           # Use local package for CI testing
           sed -i.bak 's|.package(url: "https://github.com/k2-fsa/sherpa-onnx", branch: "master")|.package(path: "../../")|' Package.swift
+          git diff
           cat Package.swift
 
           echo "=== Resolving ==="

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/csukuangfj/onnxruntime-libs", branch: "master"),
+    .package(url: "https://github.com/csukuangfj/onnxruntime-libs", exact: "1.27.1"),
   ],
   targets: [
     .binaryTarget(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI and Testing**
  * Added validation for local and remote Swift package configurations on macOS and iOS.
  * Expanded iOS sample app builds across additional configurations, including speech recognition, translation, subtitles, language identification, and text-to-speech.
  * Improved automated iOS Simulator build and execution coverage.

* **Dependency Updates**
  * Pinned the ONNX Runtime dependency to version 1.27.1 for more consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->