### PR TITLE
Support linking onnxruntime statically in xcframework with shared lib.

### DIFF
--- a/.github/workflows/build-xcframework-shared-sherpa-with-static-onnxruntime.yaml
+++ b/.github/workflows/build-xcframework-shared-sherpa-with-static-onnxruntime.yaml
@@ -1,0 +1,213 @@
+name: build-xcframework-shared-sherpa-with-static-onnxruntime
+
+on:
+  push:
+    branches:
+      - master
+      - xcframework-2
+    tags:
+      - 'release-v[0-9]+.[0-9]+.[0-9]+*'
+
+  workflow_dispatch:
+
+concurrency:
+  group: build-xcframework-shared-sherpa-with-static-onnxruntime-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_macos_shared_onnxruntime_static:
+    name: macos-shared-onnxruntime-static
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tree
+        shell: bash
+        run: |
+          brew install tree
+
+      - name: Update version
+        shell: bash
+        run: |
+          ./new-release.sh
+          git diff .
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: macos-shared-onnxruntime-static
+
+      - name: Build macOS shared (onnxruntime static)
+        shell: bash
+        run: |
+          export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          ./build-macos-shared-sherpa-with-static-onnxruntime.sh
+
+      - name: Display build directory
+        shell: bash
+        run: |
+          ls -lh build-macos-shared-sherpa-with-static-onnxruntime
+          cd build-macos-shared-sherpa-with-static-onnxruntime/sherpa-onnx.xcframework
+          du -h -d1 .
+          tree .
+
+      - name: Display artifacts
+        shell: bash
+        run: |
+          ls -lh build-macos-shared-sherpa-with-static-onnxruntime/*.xcframework.zip
+          unzip -l build-macos-shared-sherpa-with-static-onnxruntime/*.xcframework.zip
+
+      - name: Test xcframework
+        shell: bash
+        run: |
+          mkdir -p /tmp/test-xcframework
+          cd /tmp/test-xcframework
+          unzip -o $GITHUB_WORKSPACE/build-macos-shared-sherpa-with-static-onnxruntime/*.xcframework.zip -d .
+          ls -lh sherpa-onnx.xcframework/
+
+          # Find the framework bundle
+          fw_path=$(find sherpa-onnx.xcframework -name "SherpaOnnxC.framework" -type d | head -1)
+          echo "fw_path: $fw_path"
+
+          test -f "$fw_path/Versions/A/SherpaOnnxC" || { echo "Binary not found"; exit 1; }
+          test -f "$fw_path/Versions/A/Headers/sherpa-onnx/c-api/c-api.h" || { echo "Header not found"; exit 1; }
+          test -f "$fw_path/Versions/A/Modules/module.modulemap" || { echo "Modulemap not found"; exit 1; }
+
+          # Verify onnxruntime is NOT a dynamic dependency
+          echo "Checking dynamic dependencies:"
+          otool -L "$fw_path/Versions/A/SherpaOnnxC"
+          if otool -L "$fw_path/Versions/A/SherpaOnnxC" | grep -q libonnxruntime; then
+            echo "ERROR: libonnxruntime is still a dynamic dependency!"
+            exit 1
+          fi
+          echo "OK: onnxruntime is statically linked"
+
+          # Test compilation
+          clang -o version-c-api $GITHUB_WORKSPACE/c-api-examples/version-c-api.c \
+            -I "$fw_path/Headers" \
+            "$fw_path/Versions/A/SherpaOnnxC" \
+            -framework CoreFoundation \
+            -framework Foundation \
+            -lc++ \
+            -Wl,-rpath,"$(dirname $fw_path)"
+
+          ./version-c-api
+
+      - name: Upload xcframework.zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: sherpa-onnx-macos-shared-onnxruntime-static-xcframework
+          path: ./build-macos-shared-sherpa-with-static-onnxruntime/*.xcframework.zip
+
+  build_ios_shared_onnxruntime_static:
+    name: ios-shared-onnxruntime-static
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tree
+        shell: bash
+        run: |
+          brew install tree
+
+      - name: Update version
+        shell: bash
+        run: |
+          ./new-release.sh
+          git diff .
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ios-shared-onnxruntime-static
+
+      - name: Build iOS shared (onnxruntime static)
+        shell: bash
+        run: |
+          export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          ./build-ios-shared-sherpa-with-static-onnxruntime.sh
+
+      - name: Display build directory
+        shell: bash
+        run: |
+          ls -lh build-ios-shared-sherpa-with-static-onnxruntime/
+          cd build-ios-shared-sherpa-with-static-onnxruntime/sherpa-onnx.xcframework
+          du -h -d1 .
+          tree .
+
+      - name: Display artifacts
+        shell: bash
+        run: |
+          ls -lh build-ios-shared-sherpa-with-static-onnxruntime/*.xcframework.zip
+
+      - name: Test xcframework
+        shell: bash
+        run: |
+          mkdir -p /tmp/test-xcframework
+          cd /tmp/test-xcframework
+          unzip -o $GITHUB_WORKSPACE/build-ios-shared-sherpa-with-static-onnxruntime/*.xcframework.zip -d .
+          ls -lh sherpa-onnx.xcframework/
+
+          # Verify xcframework structure (framework bundle)
+          fw_path=$(find sherpa-onnx.xcframework -path "*simulator*" -name "SherpaOnnxC.framework" -type d | head -1)
+          echo "fw_path: $fw_path"
+
+          test -f "$fw_path/SherpaOnnxC" || { echo "Binary not found"; exit 1; }
+          test -f "$fw_path/Headers/sherpa-onnx/c-api/c-api.h" || { echo "Header not found"; exit 1; }
+          test -f "$fw_path/Modules/module.modulemap" || { echo "Modulemap not found"; exit 1; }
+          test -f "$fw_path/Info.plist" || { echo "Info.plist not found"; exit 1; }
+
+          # Verify onnxruntime is NOT a dynamic dependency
+          echo "Checking dynamic dependencies:"
+          otool -L "$fw_path/SherpaOnnxC"
+          if otool -L "$fw_path/SherpaOnnxC" | grep -q onnxruntime; then
+            echo "ERROR: onnxruntime is still a dynamic dependency!"
+            exit 1
+          fi
+          echo "OK: onnxruntime is statically linked"
+
+          echo "iOS shared (onnxruntime static) xcframework structure verified"
+
+      - name: Upload xcframework.zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: sherpa-onnx-ios-shared-onnxruntime-static-xcframework
+          path: ./build-ios-shared-sherpa-with-static-onnxruntime/*.xcframework.zip
+
+  release:
+    name: release
+    needs:
+      - build_macos_shared_onnxruntime_static
+      - build_ios_shared_onnxruntime_static
+    # if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download all xcframework artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+
+      - name: Release xcframework (k2-fsa)
+        if: github.repository_owner == 'k2-fsa'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          overwrite: false
+          file: artifacts/**/*.xcframework.zip
+          tag: xcframework
+
+      - name: Release xcframework (csukuangfj)
+        if: github.repository_owner == 'csukuangfj'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file_glob: true
+          overwrite: true
+          file: artifacts/**/*.xcframework.zip
+          repo_name: k2-fsa/sherpa-onnx
+          repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
+          tag: xcframework

--- a/build-ios-shared-sherpa-with-static-onnxruntime.sh
+++ b/build-ios-shared-sherpa-with-static-onnxruntime.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+#
+# This script builds a shared xcframework for iOS with onnxruntime
+# statically linked in. The resulting libsherpa-onnx-c-api.dylib is
+# self-contained and does NOT require a separate onnxruntime framework.
+#
+# Differences from build-ios-shared.sh:
+#   - build-ios-shared.sh produces a shared libsherpa-onnx-c-api.dylib that
+#     DEPENDS on a separate onnxruntime.framework (shared, downloaded as xcframework).
+#     Users must ship both frameworks together.
+#   - This script downloads the STATIC onnxruntime iOS xcframework and links it into
+#     libsherpa-onnx-c-api.dylib. The output is a single self-contained dylib with
+#     no external onnxruntime dependency.
+#   - This script also strips debug symbols (strip -x) to reduce binary size, keeping
+#     the total xcframework under 100MB for pub.dev publishing.
+#
+# When to use which:
+#   - build-ios-shared.sh: when you want a smaller sherpa-onnx dylib and are OK
+#     shipping onnxruntime separately (e.g., SPM with separate onnxruntime xcframework).
+#   - This script: when you want a single dylib with everything included (e.g., for
+#     Flutter pub.dev where fewer files and size limits matter).
+
+set -e
+
+dir=build-ios-shared-sherpa-with-static-onnxruntime
+mkdir -p $dir
+cd $dir
+onnxruntime_version=${SHERPA_ONNX_ONNXRUNTIME_VERSION:-1.27.1}
+onnxruntime_dir=ios-onnxruntime/$onnxruntime_version
+
+CMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE:-OFF}
+
+if [ ! -f $onnxruntime_dir/onnxruntime.xcframework/ios-arm64/onnxruntime.framework/onnxruntime ]; then
+  mkdir -p $onnxruntime_dir
+  pushd $onnxruntime_dir
+  wget -c https://github.com/csukuangfj/onnxruntime-libs/releases/download/v${onnxruntime_version}/onnxruntime-ios-static-xcframework-${onnxruntime_version}.xcframework.zip
+  unzip onnxruntime-ios-static-xcframework-${onnxruntime_version}.xcframework.zip
+  rm onnxruntime-ios-static-xcframework-${onnxruntime_version}.xcframework.zip
+  cd ..
+  ln -sf $onnxruntime_version/onnxruntime.xcframework .
+  popd
+fi
+
+# First, for simulator (x86_64)
+echo "Building for simulator (x86_64)"
+
+export SHERPA_ONNXRUNTIME_LIB_DIR=$PWD/ios-onnxruntime/onnxruntime.xcframework/ios-arm64_x86_64-simulator
+export SHERPA_ONNXRUNTIME_INCLUDE_DIR=$PWD/ios-onnxruntime/onnxruntime.xcframework/ios-arm64_x86_64-simulator/onnxruntime.framework/Headers
+
+echo "SHERPA_ONNXRUNTIME_LIB_DIR: $SHERPA_ONNXRUNTIME_LIB_DIR"
+echo "SHERPA_ONNXRUNTIME_INCLUDE_DIR: $SHERPA_ONNXRUNTIME_INCLUDE_DIR"
+
+echo "Building for simulator (x86_64)"
+
+if [[ ! -f build/simulator_x86_64/install/lib/libsherpa-onnx-c-api.dylib ]]; then
+  cmake \
+    -DSHERPA_ONNX_ENABLE_BINARY=OFF \
+    -DBUILD_PIPER_PHONMIZE_EXE=OFF \
+    -DBUILD_PIPER_PHONMIZE_TESTS=OFF \
+    -DBUILD_ESPEAK_NG_EXE=OFF \
+    -DBUILD_ESPEAK_NG_TESTS=OFF \
+    -S .. -D CMAKE_VERBOSE_MAKEFILE=$CMAKE_VERBOSE_MAKEFILE \
+    -DCMAKE_TOOLCHAIN_FILE=./toolchains/ios.toolchain.cmake \
+    -DPLATFORM=SIMULATOR64 \
+    -DENABLE_BITCODE=0 \
+    -DENABLE_ARC=1 \
+    -DENABLE_VISIBILITY=1 \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=./build/simulator_x86_64/install \
+    -DBUILD_SHARED_LIBS=ON \
+    -DSHERPA_ONNX_ENABLE_PYTHON=OFF \
+    -DSHERPA_ONNX_ENABLE_TESTS=OFF \
+    -DSHERPA_ONNX_ENABLE_CHECK=OFF \
+    -DSHERPA_ONNX_ENABLE_PORTAUDIO=OFF \
+    -DSHERPA_ONNX_ENABLE_JNI=OFF \
+    -DSHERPA_ONNX_ENABLE_C_API=ON \
+    -DSHERPA_ONNX_ENABLE_WEBSOCKET=OFF \
+    -DDEPLOYMENT_TARGET=13.0 \
+    -B build/simulator_x86_64
+
+  cmake --build build/simulator_x86_64 -j 4 --target install
+else
+  echo "Skip building for simulator (x86_64)"
+fi
+
+echo "Building for simulator (arm64)"
+
+if [[ ! -f build/simulator_arm64/install/lib/libsherpa-onnx-c-api.dylib ]]; then
+  cmake \
+    -DSHERPA_ONNX_ENABLE_BINARY=OFF \
+    -DBUILD_PIPER_PHONMIZE_EXE=OFF \
+    -DBUILD_PIPER_PHONMIZE_TESTS=OFF \
+    -DBUILD_ESPEAK_NG_EXE=OFF \
+    -DBUILD_ESPEAK_NG_TESTS=OFF \
+    -S .. -D CMAKE_VERBOSE_MAKEFILE=$CMAKE_VERBOSE_MAKEFILE \
+    -DCMAKE_TOOLCHAIN_FILE=./toolchains/ios.toolchain.cmake \
+    -DPLATFORM=SIMULATORARM64 \
+    -DENABLE_BITCODE=0 \
+    -DENABLE_ARC=1 \
+    -DENABLE_VISIBILITY=1 \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=./build/simulator_arm64/install \
+    -DBUILD_SHARED_LIBS=ON \
+    -DSHERPA_ONNX_ENABLE_PYTHON=OFF \
+    -DSHERPA_ONNX_ENABLE_TESTS=OFF \
+    -DSHERPA_ONNX_ENABLE_CHECK=OFF \
+    -DSHERPA_ONNX_ENABLE_PORTAUDIO=OFF \
+    -DSHERPA_ONNX_ENABLE_JNI=OFF \
+    -DSHERPA_ONNX_ENABLE_C_API=ON \
+    -DSHERPA_ONNX_ENABLE_WEBSOCKET=OFF \
+    -DDEPLOYMENT_TARGET=13.0 \
+    -B build/simulator_arm64
+
+  cmake --build build/simulator_arm64 -j 4 --target install
+else
+  echo "Skip building for simulator (arm64)"
+fi
+
+echo "Building for arm64"
+
+if [[ ! -f build/os64/install/lib/libsherpa-onnx-c-api.dylib ]]; then
+  export SHERPA_ONNXRUNTIME_LIB_DIR=$PWD/ios-onnxruntime/onnxruntime.xcframework/ios-arm64
+  export SHERPA_ONNXRUNTIME_INCLUDE_DIR=$PWD/ios-onnxruntime/onnxruntime.xcframework/ios-arm64/onnxruntime.framework/Headers
+
+  cmake \
+    -DSHERPA_ONNX_ENABLE_BINARY=OFF \
+    -DBUILD_PIPER_PHONMIZE_EXE=OFF \
+    -DBUILD_PIPER_PHONMIZE_TESTS=OFF \
+    -DBUILD_ESPEAK_NG_EXE=OFF \
+    -DBUILD_ESPEAK_NG_TESTS=OFF \
+    -S .. -D CMAKE_VERBOSE_MAKEFILE=$CMAKE_VERBOSE_MAKEFILE \
+    -DCMAKE_TOOLCHAIN_FILE=./toolchains/ios.toolchain.cmake \
+    -DPLATFORM=OS64 \
+    -DENABLE_BITCODE=0 \
+    -DENABLE_ARC=1 \
+    -DENABLE_VISIBILITY=1 \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=./build/os64/install \
+    -DBUILD_SHARED_LIBS=ON \
+    -DSHERPA_ONNX_ENABLE_PYTHON=OFF \
+    -DSHERPA_ONNX_ENABLE_TESTS=OFF \
+    -DSHERPA_ONNX_ENABLE_CHECK=OFF \
+    -DSHERPA_ONNX_ENABLE_PORTAUDIO=OFF \
+    -DSHERPA_ONNX_ENABLE_JNI=OFF \
+    -DSHERPA_ONNX_ENABLE_C_API=ON \
+    -DSHERPA_ONNX_ENABLE_WEBSOCKET=OFF \
+    -DDEPLOYMENT_TARGET=13.0 \
+    -B build/os64
+
+  cmake --build build/os64 -j 4 --target install
+else
+  echo "Skip building for arm64"
+fi
+
+echo "Collect dynamic libraries"
+mkdir -p ios-arm64 ios-arm64-simulator ios-x86_64-simulator
+
+cp -v ./build/os64/install/lib/libsherpa-onnx-c-api.dylib ios-arm64/
+cp -v ./build/simulator_arm64/install/lib/libsherpa-onnx-c-api.dylib ios-arm64-simulator/
+cp -v ./build/simulator_x86_64/install/lib/libsherpa-onnx-c-api.dylib ios-x86_64-simulator/
+
+# Strip debug symbols to reduce size
+strip -x ios-arm64/libsherpa-onnx-c-api.dylib
+strip -x ios-arm64-simulator/libsherpa-onnx-c-api.dylib
+strip -x ios-x86_64-simulator/libsherpa-onnx-c-api.dylib
+
+# Create fat simulator binary
+rm -rf ios-arm64_x86_64-simulator
+mkdir ios-arm64_x86_64-simulator
+
+lipo \
+  -create \
+    ios-arm64-simulator/libsherpa-onnx-c-api.dylib \
+    ios-x86_64-simulator/libsherpa-onnx-c-api.dylib \
+  -output \
+    ios-arm64_x86_64-simulator/libsherpa-onnx-c-api.dylib
+
+rm -rf sherpa-onnx.xcframework
+
+# Create framework bundles so SPM can resolve the module
+create_framework() {
+  local lib_path=$1
+  local output_dir=$2
+
+  local fw_dir=$output_dir/SherpaOnnxC.framework
+  rm -rf $fw_dir
+
+  mkdir -p $fw_dir/Headers/sherpa-onnx/c-api
+  mkdir -p $fw_dir/Modules
+
+  cp $lib_path $fw_dir/SherpaOnnxC
+  cp build/os64/install/include/sherpa-onnx/c-api/c-api.h $fw_dir/Headers/sherpa-onnx/c-api/
+
+  cat > $fw_dir/Modules/module.modulemap << 'MEOF'
+framework module SherpaOnnxC {
+  header "sherpa-onnx/c-api/c-api.h"
+  export *
+}
+MEOF
+
+  cat > $fw_dir/Info.plist << 'PEOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>com.k2-fsa.sherpa-onnx</string>
+  <key>CFBundleName</key>
+  <string>SherpaOnnxC</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleExecutable</key>
+  <string>SherpaOnnxC</string>
+  <key>CFBundleVersion</key>
+  <string>20260707</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.13.4</string>
+  <key>MinimumOSVersion</key>
+  <string>13.0</string>
+  <key>CFBundleSupportedPlatforms</key>
+  <array>
+    <string>iPhoneOS</string>
+  </array>
+</dict>
+</plist>
+PEOF
+
+  # Fix dylib install name
+  install_name_tool -id @rpath/SherpaOnnxC.framework/SherpaOnnxC $fw_dir/SherpaOnnxC
+}
+
+create_framework ios-arm64/libsherpa-onnx-c-api.dylib ios-arm64
+create_framework ios-arm64_x86_64-simulator/libsherpa-onnx-c-api.dylib ios-arm64_x86_64-simulator
+
+xcodebuild -create-xcframework \
+  -framework "ios-arm64/SherpaOnnxC.framework" \
+  -framework "ios-arm64_x86_64-simulator/SherpaOnnxC.framework" \
+  -output sherpa-onnx.xcframework
+
+cd sherpa-onnx.xcframework
+echo "PWD: $PWD"
+ls -lh
+echo "---"
+ls -lh */*
+
+cd ..
+
+SHERPA_ONNX_VERSION=v$(grep "SHERPA_ONNX_VERSION" ../CMakeLists.txt | cut -d " " -f 2 | cut -d '"' -f 2)
+rm -f sherpa-onnx-${SHERPA_ONNX_VERSION}-ios-shared-onnxruntime-static.xcframework.zip
+zip -r -y sherpa-onnx-${SHERPA_ONNX_VERSION}-ios-shared-onnxruntime-static.xcframework.zip sherpa-onnx.xcframework
+
+echo "Checksum:"
+swift package compute-checksum sherpa-onnx-${SHERPA_ONNX_VERSION}-ios-shared-onnxruntime-static.xcframework.zip | tee checksum.txt

--- a/build-macos-shared-sherpa-with-static-onnxruntime.sh
+++ b/build-macos-shared-sherpa-with-static-onnxruntime.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#
+# This script builds a shared xcframework for macOS with onnxruntime
+# statically linked in. The resulting libsherpa-onnx-c-api.dylib is
+# self-contained and does NOT require a separate libonnxruntime.dylib.
+#
+# Differences from build-macos-shared.sh:
+#   - build-macos-shared.sh produces a shared libsherpa-onnx-c-api.dylib that
+#     DEPENDS on a separate libonnxruntime.dylib (downloaded via cmake at build time).
+#     Users must ship both dylibs together.
+#   - This script downloads the STATIC onnxruntime library (libonnxruntime.a) and
+#     links it into libsherpa-onnx-c-api.dylib. The output is a single self-contained
+#     dylib with no external onnxruntime dependency.
+#
+# When to use which:
+#   - build-macos-shared.sh: when you want a smaller sherpa-onnx dylib and are OK
+#     shipping onnxruntime separately (e.g., SPM with separate onnxruntime xcframework).
+#   - This script: when you want a single dylib with everything included (e.g., for
+#     Flutter pub.dev where fewer files and smaller total size matters).
+
+set -ex
+
+dir=build-macos-shared-sherpa-with-static-onnxruntime
+mkdir -p $dir
+cd $dir
+
+onnxruntime_version=${SHERPA_ONNX_ONNXRUNTIME_VERSION:-1.27.1}
+onnxruntime_dir=onnxruntime-static/$onnxruntime_version
+
+if [ ! -f $onnxruntime_dir/lib/libonnxruntime.a ]; then
+  mkdir -p $onnxruntime_dir
+  pushd $onnxruntime_dir
+  wget -c -q https://github.com/csukuangfj/onnxruntime-libs/releases/download/v${onnxruntime_version}/onnxruntime-osx-universal2-static_lib-${onnxruntime_version}.zip
+  unzip onnxruntime-osx-universal2-static_lib-${onnxruntime_version}.zip
+  mv onnxruntime-osx-universal2-static_lib-${onnxruntime_version}/* .
+  rm -rf onnxruntime-osx-universal2-static_lib-${onnxruntime_version}
+  rm onnxruntime-osx-universal2-static_lib-${onnxruntime_version}.zip
+  popd
+fi
+
+export SHERPA_ONNXRUNTIME_LIB_DIR=$PWD/$onnxruntime_dir/lib
+export SHERPA_ONNXRUNTIME_INCLUDE_DIR=$PWD/$onnxruntime_dir/include
+
+echo "SHERPA_ONNXRUNTIME_LIB_DIR: $SHERPA_ONNXRUNTIME_LIB_DIR"
+echo "SHERPA_ONNXRUNTIME_INCLUDE_DIR: $SHERPA_ONNXRUNTIME_INCLUDE_DIR"
+
+cmake \
+  -DSHERPA_ONNX_ENABLE_BINARY=OFF \
+  -DSHERPA_ONNX_BUILD_C_API_EXAMPLES=OFF \
+  -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
+  -DCMAKE_INSTALL_PREFIX=./install \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_SHARED_LIBS=ON \
+  -DSHERPA_ONNX_ENABLE_PYTHON=OFF \
+  -DSHERPA_ONNX_ENABLE_TESTS=OFF \
+  -DSHERPA_ONNX_ENABLE_CHECK=OFF \
+  -DSHERPA_ONNX_ENABLE_PORTAUDIO=OFF \
+  -DSHERPA_ONNX_ENABLE_JNI=OFF \
+  -DSHERPA_ONNX_ENABLE_C_API=ON \
+  -DSHERPA_ONNX_ENABLE_WEBSOCKET=OFF \
+  -DCMAKE_CXX_FLAGS="-DSHERPA_ONNX_DISABLE_COREML" \
+  -DCMAKE_C_FLAGS="-DSHERPA_ONNX_DISABLE_COREML" \
+  -DCMAKE_SHARED_LINKER_FLAGS="-framework Foundation" \
+  ../
+
+make -j4
+make install
+rm -fv ./install/include/cargs.h
+
+echo "Verifying onnxruntime is NOT a dynamic dependency:"
+otool -L ./install/lib/libsherpa-onnx-c-api.dylib
+if otool -L ./install/lib/libsherpa-onnx-c-api.dylib | grep -q libonnxruntime; then
+  echo "ERROR: libonnxruntime is still a dynamic dependency!"
+  exit 1
+fi
+echo "OK: onnxruntime is statically linked"
+
+# Create a framework bundle (like onnxruntime does) so SPM can resolve the module
+FRAMEWORK_DIR=SherpaOnnxC.framework
+rm -rf $FRAMEWORK_DIR
+
+mkdir -p $FRAMEWORK_DIR/Versions/A/Headers/sherpa-onnx/c-api
+mkdir -p $FRAMEWORK_DIR/Versions/A/Modules
+mkdir -p $FRAMEWORK_DIR/Versions/A/Resources
+
+# Binary
+cp install/lib/libsherpa-onnx-c-api.dylib $FRAMEWORK_DIR/Versions/A/SherpaOnnxC
+
+# Headers (preserve nested path for #include "sherpa-onnx/c-api/c-api.h")
+cp install/include/sherpa-onnx/c-api/c-api.h $FRAMEWORK_DIR/Versions/A/Headers/sherpa-onnx/c-api/
+
+# Modulemap
+cat > $FRAMEWORK_DIR/Versions/A/Modules/module.modulemap << 'EOF'
+framework module SherpaOnnxC {
+  header "sherpa-onnx/c-api/c-api.h"
+  export *
+}
+EOF
+
+# Info.plist
+cat > $FRAMEWORK_DIR/Versions/A/Resources/Info.plist << 'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>com.k2-fsa.sherpa-onnx</string>
+  <key>CFBundleName</key>
+  <string>SherpaOnnxC</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleExecutable</key>
+  <string>SherpaOnnxC</string>
+  <key>CFBundleVersion</key>
+  <string>20260707</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.13.4</string>
+</dict>
+</plist>
+EOF
+
+# Versioned symlinks
+pushd $FRAMEWORK_DIR/Versions
+ln -sf A Current
+popd
+
+ln -sf Versions/Current/SherpaOnnxC $FRAMEWORK_DIR/SherpaOnnxC
+ln -sf Versions/Current/Headers $FRAMEWORK_DIR/Headers
+ln -sf Versions/Current/Modules $FRAMEWORK_DIR/Modules
+ln -sf Versions/Current/Resources $FRAMEWORK_DIR/Resources
+
+# Fix dylib install name to use framework-relative path
+install_name_tool -id @rpath/SherpaOnnxC.framework/Versions/A/SherpaOnnxC $FRAMEWORK_DIR/Versions/A/SherpaOnnxC
+
+rm -rf sherpa-onnx.xcframework
+
+xcodebuild -create-xcframework \
+  -framework $FRAMEWORK_DIR \
+  -output sherpa-onnx.xcframework
+
+SHERPA_ONNX_VERSION=v$(grep "SHERPA_ONNX_VERSION" ../CMakeLists.txt | cut -d " " -f 2 | cut -d '"' -f 2)
+
+rm -f sherpa-onnx-${SHERPA_ONNX_VERSION}-macos-shared-onnxruntime-static.xcframework.zip
+zip -r -y sherpa-onnx-${SHERPA_ONNX_VERSION}-macos-shared-onnxruntime-static.xcframework.zip sherpa-onnx.xcframework
+
+echo "Checksum:"
+swift package compute-checksum sherpa-onnx-${SHERPA_ONNX_VERSION}-macos-shared-onnxruntime-static.xcframework.zip | tee checksum.txt

--- a/new-release.sh
+++ b/new-release.sh
@@ -36,6 +36,8 @@ sed -i.bak "$replace_str" ./build-ios-shared.sh
 sed -i.bak "$replace_str" ./build-ios-no-tts.sh
 sed -i.bak "$replace_str" ./build-macos.sh
 sed -i.bak "$replace_str" ./build-macos-shared.sh
+sed -i.bak "$replace_str" ./build-macos-shared-sherpa-with-static-onnxruntime.sh
+sed -i.bak "$replace_str" ./build-ios-shared-sherpa-with-static-onnxruntime.sh
 
 for f in ./build-ios.sh ./build-ios-shared.sh ./build-ios-no-tts.sh ./build-macos.sh ./build-macos-shared.sh; do
   sed -i.bak "s/$old_version_code/$new_version_code/g" "$f"


### PR DESCRIPTION
See prebuilt xcframeworks at https://github.com/k2-fsa/sherpa-onnx/releases/tag/xcframework

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated builds for macOS and iOS shared frameworks with statically linked ONNX Runtime.
  * Added packaging of device and simulator binaries as downloadable xcframework archives.
  * Added validation to confirm framework structure and dependency configuration.
  * Added release automation for publishing platform-specific framework artifacts.

* **Chores**
  * Updated release versioning to include the new platform build scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->