### PR TITLE
Fix building Python wheels on macOS

### DIFF
--- a/cmake/cmake_extension.py
+++ b/cmake/cmake_extension.py
@@ -364,6 +364,3 @@ class BuildExtension(build_ext):
             shutil.rmtree(f"{install_dir}/share")
         if Path(f"{install_dir}/lib/pkgconfig").is_dir():
             shutil.rmtree(f"{install_dir}/lib/pkgconfig")
-
-        if is_macos():
-            os.remove(f"{install_dir}/lib/libonnxruntime.dylib")


### PR DESCRIPTION
We have removed the `soversion` name from the lib name since onnxruntime 1.27.1, so there is no `libonnxruntime.x.y.z.dylib` anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * macOS installations now retain the `libonnxruntime.dylib` library during cleanup, preventing unintended removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->