### PR TITLE
Fix Dart speaker diarization input buffer leak

### DIFF
--- a/flutter/sherpa_onnx/lib/src/offline_speaker_diarization.dart
+++ b/flutter/sherpa_onnx/lib/src/offline_speaker_diarization.dart
@@ -268,20 +268,24 @@ class OfflineSpeakerDiarization {
 
     final n = samples.length;
     final Pointer<Float> p = calloc<Float>(n);
+    try {
+      final pList = p.asTypedList(n);
+      pList.setAll(0, samples);
 
-    final pList = p.asTypedList(n);
-    pList.setAll(0, samples);
-
-    final r = SherpaOnnxBindings.sherpaOnnxOfflineSpeakerDiarizationProcess
-            ?.call(ptr, p, n) ??
-        nullptr;
-
-    final ans = _processImpl(r);
-
-    SherpaOnnxBindings.sherpaOnnxOfflineSpeakerDiarizationDestroyResult
-        ?.call(r);
-
-    return ans;
+      final r = SherpaOnnxBindings.sherpaOnnxOfflineSpeakerDiarizationProcess
+              ?.call(ptr, p, n) ??
+          nullptr;
+      try {
+        return _processImpl(r);
+      } finally {
+        if (r != nullptr) {
+          SherpaOnnxBindings.sherpaOnnxOfflineSpeakerDiarizationDestroyResult
+              ?.call(r);
+        }
+      }
+    } finally {
+      calloc.free(p);
+    }
   }
 
   List<OfflineSpeakerDiarizationSegment> processWithCallback({
@@ -300,29 +304,34 @@ class OfflineSpeakerDiarization {
 
     final n = samples.length;
     final Pointer<Float> p = calloc<Float>(n);
+    try {
+      final pList = p.asTypedList(n);
+      pList.setAll(0, samples);
 
-    final pList = p.asTypedList(n);
-    pList.setAll(0, samples);
-
-    final wrapper = NativeCallable<
-            SherpaOnnxOfflineSpeakerDiarizationProgressCallbackNoArgNative>.isolateLocal(
-        (int numProcessedChunks, int numTotalChunks) {
-      return callback(numProcessedChunks, numTotalChunks);
-    }, exceptionalReturn: 0);
-
-    final r = SherpaOnnxBindings
-            .sherpaOnnxOfflineSpeakerDiarizationProcessWithCallbackNoArg
-            ?.call(ptr, p, n, wrapper.nativeFunction) ??
-        nullptr;
-
-    wrapper.close();
-
-    final ans = _processImpl(r);
-
-    SherpaOnnxBindings.sherpaOnnxOfflineSpeakerDiarizationDestroyResult
-        ?.call(r);
-
-    return ans;
+      final wrapper = NativeCallable<
+              SherpaOnnxOfflineSpeakerDiarizationProgressCallbackNoArgNative>.isolateLocal(
+          (int numProcessedChunks, int numTotalChunks) {
+        return callback(numProcessedChunks, numTotalChunks);
+      }, exceptionalReturn: 0);
+      try {
+        final r = SherpaOnnxBindings
+                .sherpaOnnxOfflineSpeakerDiarizationProcessWithCallbackNoArg
+                ?.call(ptr, p, n, wrapper.nativeFunction) ??
+            nullptr;
+        try {
+          return _processImpl(r);
+        } finally {
+          if (r != nullptr) {
+            SherpaOnnxBindings.sherpaOnnxOfflineSpeakerDiarizationDestroyResult
+                ?.call(r);
+          }
+        }
+      } finally {
+        wrapper.close();
+      }
+    } finally {
+      calloc.free(p);
+    }
   }
 
   List<OfflineSpeakerDiarizationSegment> _processImpl(


### PR DESCRIPTION
## Summary

- release the native waveform buffer allocated by Dart speaker diarization APIs
- clean up diarization results on every return or exception path
- close the progress callback wrapper reliably

## Root cause

Both `OfflineSpeakerDiarization.process()` and `processWithCallback()` copy the complete waveform into a `calloc<Float>` buffer, but never free that buffer. The allocation therefore remains in the process native heap after each call.

For example, a 30-minute 16 kHz waveform allocates 28.8 million floats, or 115.2 MB, per invocation.

## Validation

- `flutter pub get`
- `flutter analyze`
- `git diff --check`

The `flutter/sherpa_onnx` package currently has no unit test directory; this change is limited to deterministic FFI resource cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speaker diarization resource cleanup.
  * Ensured processing buffers and native results are released reliably, including when errors occur.
  * Improved callback cleanup after diarization completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->