### PR TITLE
Fix offline Paraformer LFR boundary padding

### DIFF
--- a/sherpa-onnx/csrc/CMakeLists.txt
+++ b/sherpa-onnx/csrc/CMakeLists.txt
@@ -24,6 +24,7 @@ set(sources
   hypothesis.cc
   keyword-spotter-impl.cc
   keyword-spotter.cc
+  lfr.cc
   lodr-fst.cc
   math.cc
   normal-data-generator.cc
@@ -827,6 +828,7 @@ if(SHERPA_ONNX_ENABLE_TESTS)
     cat-test.cc
     circular-buffer-test.cc
     context-graph-test.cc
+    lfr-test.cc
     math-test.cc
     offline-whisper-timestamp-rules-test.cc
     packed-sequence-test.cc

--- a/sherpa-onnx/csrc/ascend/offline-paraformer-model-ascend.cc
+++ b/sherpa-onnx/csrc/ascend/offline-paraformer-model-ascend.cc
@@ -26,6 +26,7 @@
 #include "sherpa-onnx/csrc/ascend/macros.h"
 #include "sherpa-onnx/csrc/ascend/utils.h"
 #include "sherpa-onnx/csrc/file-utils.h"
+#include "sherpa-onnx/csrc/lfr.h"
 #include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/math.h"
 #include "sherpa-onnx/csrc/text-utils.h"
@@ -87,7 +88,8 @@ class OfflineParaformerModelAscend::Impl {
     std::lock_guard<std::mutex> lock(mutex_);
 
     aclError ret_set_ctx = aclrtSetCurrentContext(*context_);
-    SHERPA_ONNX_ASCEND_CHECK(ret_set_ctx, "Failed to call aclrtSetCurrentContext");
+    SHERPA_ONNX_ASCEND_CHECK(ret_set_ctx,
+                            "Failed to call aclrtSetCurrentContext");
 
     features = ApplyLFR(std::move(features));
     if (features.empty()) {
@@ -305,7 +307,7 @@ class OfflineParaformerModelAscend::Impl {
 
   void Preallocate() {
     // max 30 seconds
-    max_num_frames_ = (30 * 100 - 7) / 6 + 1;
+    max_num_frames_ = (30 * 100 + 6 - 1) / 6;
 
     features_ptr_ = std::make_unique<AclDevicePtr>(max_num_frames_ * feat_dim_ *
                                                    sizeof(float));
@@ -323,18 +325,15 @@ class OfflineParaformerModelAscend::Impl {
                                                  sizeof(float));
   }
 
-  std::vector<float> ApplyLFR(std::vector<float> in) const {
-    int32_t lfr_window_size = 7;
-    int32_t lfr_window_shift = 6;
-    int32_t in_feat_dim = 80;
+  std::vector<float> ApplyLFR(const std::vector<float> &in) const {
+    constexpr int32_t kInputDim = 80;
+    constexpr int32_t kWindowSize = 7;
+    constexpr int32_t kWindowShift = 6;
+    constexpr int32_t kOutputDim = kInputDim * kWindowSize;
 
-    int32_t in_num_frames = in.size() / in_feat_dim;
-    if (in_num_frames < lfr_window_size) {
-      return {};
-    }
-
-    int32_t out_num_frames =
-        (in_num_frames - lfr_window_size) / lfr_window_shift + 1;
+    std::vector<float> out =
+        ApplyLfr(in, kInputDim, kWindowSize, kWindowShift);
+    int32_t out_num_frames = static_cast<int32_t>(out.size() / kOutputDim);
 
     if (out_num_frames > max_num_frames_) {
       SHERPA_ONNX_LOGE(
@@ -346,20 +345,7 @@ class OfflineParaformerModelAscend::Impl {
           "model accepting longer audios.");
 
       out_num_frames = max_num_frames_;
-    }
-
-    int32_t out_feat_dim = in_feat_dim * lfr_window_size;
-
-    std::vector<float> out(out_num_frames * out_feat_dim);
-
-    const float *p_in = in.data();
-    float *p_out = out.data();
-
-    for (int32_t i = 0; i != out_num_frames; ++i) {
-      std::copy(p_in, p_in + out_feat_dim, p_out);
-
-      p_out += out_feat_dim;
-      p_in += lfr_window_shift * in_feat_dim;
+      out.resize(static_cast<size_t>(out_num_frames) * kOutputDim);
     }
 
     return out;

--- a/sherpa-onnx/csrc/ascend/offline-sense-voice-model-ascend.cc
+++ b/sherpa-onnx/csrc/ascend/offline-sense-voice-model-ascend.cc
@@ -26,6 +26,7 @@
 #include "sherpa-onnx/csrc/ascend/macros.h"
 #include "sherpa-onnx/csrc/ascend/utils.h"
 #include "sherpa-onnx/csrc/file-utils.h"
+#include "sherpa-onnx/csrc/lfr.h"
 
 namespace sherpa_onnx {
 
@@ -57,7 +58,8 @@ class OfflineSenseVoiceModelAscend::Impl {
     std::lock_guard<std::mutex> lock(mutex_);
 
     aclError ret_set_ctx = aclrtSetCurrentContext(*context_);
-    SHERPA_ONNX_ASCEND_CHECK(ret_set_ctx, "Failed to call aclrtSetCurrentContext");
+    SHERPA_ONNX_ASCEND_CHECK(ret_set_ctx,
+                            "Failed to call aclrtSetCurrentContext");
 
     features = ApplyLFR(std::move(features));
     if (features.empty()) {
@@ -151,7 +153,8 @@ class OfflineSenseVoiceModelAscend::Impl {
 
   void Preallocate() {
     // max 30 seconds
-    max_num_frames_ = (30 * 100 - 7) / 6 + 1;
+    max_num_frames_ =
+        (30 * 100 + meta_data_.window_shift - 1) / meta_data_.window_shift;
     x_ptr_ = std::make_unique<AclDevicePtr>(max_num_frames_ * feat_dim_ *
                                             sizeof(float));
 
@@ -161,18 +164,13 @@ class OfflineSenseVoiceModelAscend::Impl {
                                                  vocab_size_ * sizeof(float));
   }
 
-  std::vector<float> ApplyLFR(std::vector<float> in) const {
-    int32_t lfr_window_size = meta_data_.window_size;
-    int32_t lfr_window_shift = meta_data_.window_shift;
-    int32_t in_feat_dim = 80;
-
-    int32_t in_num_frames = in.size() / in_feat_dim;
-    if (in_num_frames < lfr_window_size) {
-      return {};
-    }
-
+  std::vector<float> ApplyLFR(const std::vector<float> &in) const {
+    constexpr int32_t kInputDim = 80;
+    const int32_t output_dim = kInputDim * meta_data_.window_size;
+    std::vector<float> out = ApplyLfr(in, kInputDim, meta_data_.window_size,
+                                      meta_data_.window_shift);
     int32_t out_num_frames =
-        (in_num_frames - lfr_window_size) / lfr_window_shift + 1;
+        static_cast<int32_t>(out.size() / output_dim);
 
     if (out_num_frames > max_num_frames_) {
       SHERPA_ONNX_LOGE(
@@ -184,20 +182,7 @@ class OfflineSenseVoiceModelAscend::Impl {
           "model accepting longer audios.");
 
       out_num_frames = max_num_frames_;
-    }
-
-    int32_t out_feat_dim = in_feat_dim * lfr_window_size;
-
-    std::vector<float> out(out_num_frames * out_feat_dim);
-
-    const float *p_in = in.data();
-    float *p_out = out.data();
-
-    for (int32_t i = 0; i != out_num_frames; ++i) {
-      std::copy(p_in, p_in + out_feat_dim, p_out);
-
-      p_out += out_feat_dim;
-      p_in += lfr_window_shift * in_feat_dim;
+      out.resize(static_cast<size_t>(out_num_frames) * output_dim);
     }
 
     return out;

--- a/sherpa-onnx/csrc/ascend/offline-sense-voice-model-ascend.cc
+++ b/sherpa-onnx/csrc/ascend/offline-sense-voice-model-ascend.cc
@@ -66,7 +66,7 @@ class OfflineSenseVoiceModelAscend::Impl {
       return {};
     }
 
-    int32_t num_frames = features.size() / 560;
+    int32_t num_frames = features.size() / kLfrOutputDim;
 
     aclError ret =
         aclrtMemcpy(*x_ptr_, features.size() * sizeof(float), features.data(),
@@ -88,7 +88,7 @@ class OfflineSenseVoiceModelAscend::Impl {
     // dynamic shape input
     // https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/83RC1alpha003/appdevg/acldevg/aclcppdevg_000044.html
 
-    std::array<int64_t, 3> x_shape = {1, num_frames, 560};
+    std::array<int64_t, 3> x_shape = {1, num_frames, kLfrOutputDim};
     AclTensorDesc x_desc(ACL_FLOAT, x_shape.size(), x_shape.data(),
                          ACL_FORMAT_ND);
     input_dataset.SetTensorDesc(x_desc, 0);
@@ -153,9 +153,8 @@ class OfflineSenseVoiceModelAscend::Impl {
 
   void Preallocate() {
     // max 30 seconds
-    max_num_frames_ =
-        (30 * 100 + meta_data_.window_shift - 1) / meta_data_.window_shift;
-    x_ptr_ = std::make_unique<AclDevicePtr>(max_num_frames_ * feat_dim_ *
+    max_num_frames_ = (30 * 100 + kLfrWindowShift - 1) / kLfrWindowShift;
+    x_ptr_ = std::make_unique<AclDevicePtr>(max_num_frames_ * kLfrOutputDim *
                                             sizeof(float));
 
     prompt_ptr_ = std::make_unique<AclDevicePtr>(4 * sizeof(int32_t));
@@ -165,12 +164,9 @@ class OfflineSenseVoiceModelAscend::Impl {
   }
 
   std::vector<float> ApplyLFR(const std::vector<float> &in) const {
-    constexpr int32_t kInputDim = 80;
-    const int32_t output_dim = kInputDim * meta_data_.window_size;
-    std::vector<float> out = ApplyLfr(in, kInputDim, meta_data_.window_size,
-                                      meta_data_.window_shift);
-    int32_t out_num_frames =
-        static_cast<int32_t>(out.size() / output_dim);
+    std::vector<float> out =
+        ApplyLfr(in, kLfrInputDim, kLfrWindowSize, kLfrWindowShift);
+    int32_t out_num_frames = static_cast<int32_t>(out.size() / kLfrOutputDim);
 
     if (out_num_frames > max_num_frames_) {
       SHERPA_ONNX_LOGE(
@@ -182,13 +178,18 @@ class OfflineSenseVoiceModelAscend::Impl {
           "model accepting longer audios.");
 
       out_num_frames = max_num_frames_;
-      out.resize(static_cast<size_t>(out_num_frames) * output_dim);
+      out.resize(static_cast<size_t>(out_num_frames) * kLfrOutputDim);
     }
 
     return out;
   }
 
  private:
+  static constexpr int32_t kLfrInputDim = 80;
+  static constexpr int32_t kLfrWindowSize = 7;
+  static constexpr int32_t kLfrWindowShift = 6;
+  static constexpr int32_t kLfrOutputDim = kLfrInputDim * kLfrWindowSize;
+
   std::mutex mutex_;
   Acl acl_;
 
@@ -200,7 +201,6 @@ class OfflineSenseVoiceModelAscend::Impl {
   std::unique_ptr<AclModel> model_;
   int32_t vocab_size_ = 0;
   int32_t max_num_frames_ = 0;
-  int32_t feat_dim_ = 560;
 
   std::unique_ptr<AclDevicePtr> x_ptr_;
   std::unique_ptr<AclDevicePtr> prompt_ptr_;

--- a/sherpa-onnx/csrc/axcl/offline-sense-voice-model-axcl.cc
+++ b/sherpa-onnx/csrc/axcl/offline-sense-voice-model-axcl.cc
@@ -13,6 +13,7 @@
 
 #include "sherpa-onnx/csrc/axcl/axcl-model.h"
 #include "sherpa-onnx/csrc/file-utils.h"
+#include "sherpa-onnx/csrc/lfr.h"
 #include "sherpa-onnx/csrc/macros.h"
 
 namespace sherpa_onnx {
@@ -40,6 +41,10 @@ class OfflineSenseVoiceModelAxcl::Impl {
   std::vector<float> Run(std::vector<float> features, int32_t language,
                          int32_t text_norm) {
     features = ApplyLFR(std::move(features));
+    if (features.empty()) {
+      return {};
+    }
+
     std::array<int32_t, 4> prompt{language, 1, 2, text_norm};
 
     model_->SetInputTensorData("x", features.data(), features.size());
@@ -63,34 +68,10 @@ class OfflineSenseVoiceModelAxcl::Impl {
     }
   }
 
-  std::vector<float> ApplyLFR(std::vector<float> in) const {
-    int32_t lfr_window_size = meta_data_.window_size;
-    int32_t lfr_window_shift = meta_data_.window_shift;
-    int32_t in_feat_dim = 80;
-    int32_t in_num_frames = in.size() / in_feat_dim;
-    int32_t out_num_frames =
-        (in_num_frames - lfr_window_size) / lfr_window_shift + 1;
-
-    if (out_num_frames > num_input_frames_) {
-      SHERPA_ONNX_LOGE(
-          "Number of input frames %d is too large. Truncate it to %d frames.",
-          out_num_frames, num_input_frames_);
-      SHERPA_ONNX_LOGE(
-          "Recognition result may be truncated/incomplete. Please select a "
-          "model accepting longer audios.");
-      out_num_frames = num_input_frames_;
-    }
-
-    int32_t out_feat_dim = in_feat_dim * lfr_window_size;
-    std::vector<float> out(num_input_frames_ * out_feat_dim);
-    const float *p_in = in.data();
-    float *p_out = out.data();
-    for (int32_t i = 0; i != out_num_frames; ++i) {
-      std::copy(p_in, p_in + out_feat_dim, p_out);
-      p_out += out_feat_dim;
-      p_in += lfr_window_shift * in_feat_dim;
-    }
-    return out;
+  std::vector<float> ApplyLFR(const std::vector<float> &in) const {
+    return ApplyLfrForFixedShape(
+        in, /*input_dim=*/80, meta_data_.window_size, meta_data_.window_shift,
+        num_input_frames_);
   }
 
  private:

--- a/sherpa-onnx/csrc/axera/offline-sense-voice-model-axera.cc
+++ b/sherpa-onnx/csrc/axera/offline-sense-voice-model-axera.cc
@@ -25,6 +25,7 @@
 #include "sherpa-onnx/csrc/axera/ax-engine-guard.h"
 #include "sherpa-onnx/csrc/axera/utils.h"
 #include "sherpa-onnx/csrc/file-utils.h"
+#include "sherpa-onnx/csrc/lfr.h"
 #include "sherpa-onnx/csrc/macros.h"
 
 namespace sherpa_onnx {
@@ -59,6 +60,9 @@ class OfflineSenseVoiceModelAxera::Impl {
     std::lock_guard<std::mutex> lock(mutex_);
 
     features = ApplyLFR(std::move(features));
+    if (features.empty()) {
+      return {};
+    }
 
     std::array<int32_t, 4> prompt{language, 1, 2, text_norm};
 
@@ -133,36 +137,10 @@ class OfflineSenseVoiceModelAxera::Impl {
     }
   }
 
-  std::vector<float> ApplyLFR(std::vector<float> in) const {
-    int32_t lfr_window_size = meta_data_.window_size;
-    int32_t lfr_window_shift = meta_data_.window_shift;
-    int32_t in_feat_dim = 80;
-    int32_t in_num_frames = in.size() / in_feat_dim;
-    int32_t out_num_frames =
-        (in_num_frames - lfr_window_size) / lfr_window_shift + 1;
-
-    if (out_num_frames > num_input_frames_) {
-      SHERPA_ONNX_LOGE(
-          "Number of input frames %d is too large. Truncate it to %d frames.",
-          out_num_frames, num_input_frames_);
-      SHERPA_ONNX_LOGE(
-          "Recognition result may be truncated/incomplete. Please select a "
-          "model accepting longer audios.");
-      out_num_frames = num_input_frames_;
-    }
-
-    int32_t out_feat_dim = in_feat_dim * lfr_window_size;
-    std::vector<float> out(num_input_frames_ * out_feat_dim);
-    const float *p_in = in.data();
-    float *p_out = out.data();
-
-    for (int32_t i = 0; i != out_num_frames; ++i) {
-      std::copy(p_in, p_in + out_feat_dim, p_out);
-      p_out += out_feat_dim;
-      p_in += lfr_window_shift * in_feat_dim;
-    }
-
-    return out;
+  std::vector<float> ApplyLFR(const std::vector<float> &in) const {
+    return ApplyLfrForFixedShape(
+        in, /*input_dim=*/80, meta_data_.window_size, meta_data_.window_shift,
+        num_input_frames_);
   }
 
  private:

--- a/sherpa-onnx/csrc/lfr-test.cc
+++ b/sherpa-onnx/csrc/lfr-test.cc
@@ -4,6 +4,7 @@
 
 #include "sherpa-onnx/csrc/lfr.h"
 
+#include <limits>
 #include <numeric>
 #include <utility>
 #include <vector>
@@ -60,6 +61,39 @@ TEST(Lfr, PreservesFeatureDimensions) {
             expected);
 }
 
+TEST(Lfr, PadsFixedShapeWithZeros) {
+  std::vector<float> input(13);
+  std::iota(input.begin(), input.end(), 0.0f);
+  auto expected = ApplyLfr(input, /*input_dim=*/1, /*window_size=*/7,
+                           /*window_shift=*/6);
+  expected.resize(5 * 7, 0.0f);
+
+  EXPECT_EQ(ApplyLfrForFixedShape(input, /*input_dim=*/1,
+                                  /*window_size=*/7, /*window_shift=*/6,
+                                  /*output_frames=*/5),
+            expected);
+}
+
+TEST(Lfr, TruncatesFixedShape) {
+  std::vector<float> input(13);
+  std::iota(input.begin(), input.end(), 0.0f);
+  auto expected = ApplyLfr(input, /*input_dim=*/1, /*window_size=*/7,
+                           /*window_shift=*/6);
+  expected.resize(2 * 7);
+
+  EXPECT_EQ(ApplyLfrForFixedShape(input, /*input_dim=*/1,
+                                  /*window_size=*/7, /*window_shift=*/6,
+                                  /*output_frames=*/2),
+            expected);
+}
+
+TEST(Lfr, KeepsEmptyFixedShapeInputEmpty) {
+  EXPECT_TRUE(ApplyLfrForFixedShape({}, /*input_dim=*/80,
+                                    /*window_size=*/7, /*window_shift=*/6,
+                                    /*output_frames=*/500)
+                  .empty());
+}
+
 TEST(Lfr, EmptyInput) {
   EXPECT_TRUE(ApplyLfr({}, /*input_dim=*/80, /*window_size=*/7,
                        /*window_shift=*/6)
@@ -83,6 +117,15 @@ TEST(Lfr, RejectsInvalidArgumentsAtRuntime) {
       ApplyLfr({1.0f, 2.0f, 3.0f}, /*input_dim=*/2, /*window_size=*/7,
                /*window_shift=*/6),
       "ApplyLfr: input size .* is not divisible by input_dim 2");
+  EXPECT_DEATH_IF_SUPPORTED(
+      ApplyLfrForFixedShape({1.0f}, /*input_dim=*/1, /*window_size=*/7,
+                            /*window_shift=*/6, /*output_frames=*/0),
+      "ApplyLfrForFixedShape: output_frames must be positive");
+  EXPECT_DEATH_IF_SUPPORTED(
+      ApplyLfr({1.0f, 2.0f}, /*input_dim=*/2,
+               /*window_size=*/std::numeric_limits<int32_t>::max(),
+               /*window_shift=*/1),
+      "ApplyLfr: output dimension .* exceeds int32 capacity");
 }
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/lfr-test.cc
+++ b/sherpa-onnx/csrc/lfr-test.cc
@@ -1,0 +1,69 @@
+// sherpa-onnx/csrc/lfr-test.cc
+//
+// Copyright (c)  2026  Xiaomi Corporation
+
+#include "sherpa-onnx/csrc/lfr.h"
+
+#include <numeric>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace sherpa_onnx {
+
+TEST(Lfr, PadsFirstAndLastFrames) {
+  std::vector<float> input(13);
+  std::iota(input.begin(), input.end(), 0.0f);
+
+  const std::vector<float> expected = {
+      0, 0, 0, 0, 1, 2, 3,
+      3, 4, 5, 6, 7, 8, 9,
+      9, 10, 11, 12, 12, 12, 12,
+  };
+
+  EXPECT_EQ(ApplyLfr(input, /*input_dim=*/1, /*window_size=*/7,
+                     /*window_shift=*/6),
+            expected);
+}
+
+TEST(Lfr, UsesCeilingOutputFrameCount) {
+  const std::vector<std::pair<int32_t, int32_t>> test_cases = {
+      {1, 1}, {5, 1}, {6, 1}, {7, 2}, {12, 2}, {13, 3}, {20, 4},
+  };
+
+  for (const auto &[input_frames, expected_output_frames] : test_cases) {
+    std::vector<float> input(input_frames);
+    std::iota(input.begin(), input.end(), 0.0f);
+
+    auto output = ApplyLfr(input, /*input_dim=*/1, /*window_size=*/7,
+                           /*window_shift=*/6);
+    EXPECT_EQ(output.size(), expected_output_frames * 7)
+        << "input_frames=" << input_frames;
+  }
+}
+
+TEST(Lfr, RepeatsASingleInputFrame) {
+  const std::vector<float> expected(7, 42.0f);
+
+  EXPECT_EQ(ApplyLfr({42.0f}, /*input_dim=*/1, /*window_size=*/7,
+                     /*window_shift=*/6),
+            expected);
+}
+
+TEST(Lfr, PreservesFeatureDimensions) {
+  const std::vector<float> input = {0, 1, 2, 3};
+  const std::vector<float> expected = {0, 1, 0, 1, 2, 3};
+
+  EXPECT_EQ(ApplyLfr(input, /*input_dim=*/2, /*window_size=*/3,
+                     /*window_shift=*/2),
+            expected);
+}
+
+TEST(Lfr, EmptyInput) {
+  EXPECT_TRUE(ApplyLfr({}, /*input_dim=*/80, /*window_size=*/7,
+                       /*window_shift=*/6)
+                  .empty());
+}
+
+}  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/lfr-test.cc
+++ b/sherpa-onnx/csrc/lfr-test.cc
@@ -66,4 +66,23 @@ TEST(Lfr, EmptyInput) {
                   .empty());
 }
 
+TEST(Lfr, RejectsInvalidArgumentsAtRuntime) {
+  EXPECT_DEATH_IF_SUPPORTED(
+      ApplyLfr({1.0f}, /*input_dim=*/0, /*window_size=*/7,
+               /*window_shift=*/6),
+      "ApplyLfr: input_dim must be positive");
+  EXPECT_DEATH_IF_SUPPORTED(
+      ApplyLfr({1.0f}, /*input_dim=*/1, /*window_size=*/0,
+               /*window_shift=*/6),
+      "ApplyLfr: window_size must be positive");
+  EXPECT_DEATH_IF_SUPPORTED(
+      ApplyLfr({1.0f}, /*input_dim=*/1, /*window_size=*/7,
+               /*window_shift=*/0),
+      "ApplyLfr: window_shift must be positive");
+  EXPECT_DEATH_IF_SUPPORTED(
+      ApplyLfr({1.0f, 2.0f, 3.0f}, /*input_dim=*/2, /*window_size=*/7,
+               /*window_shift=*/6),
+      "ApplyLfr: input size .* is not divisible by input_dim 2");
+}
+
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/lfr.cc
+++ b/sherpa-onnx/csrc/lfr.cc
@@ -5,11 +5,44 @@
 #include "sherpa-onnx/csrc/lfr.h"
 
 #include <algorithm>
+#include <limits>
 #include <vector>
 
 #include "sherpa-onnx/csrc/macros.h"
 
 namespace sherpa_onnx {
+
+namespace {
+
+size_t GetOutputDim(int32_t input_dim, int32_t window_size,
+                    const char *caller) {
+  size_t output_dim =
+      static_cast<size_t>(input_dim) * static_cast<size_t>(window_size);
+  if (output_dim >
+      static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+    SHERPA_ONNX_LOGE("%s: output dimension %zu exceeds int32 capacity",
+                     caller, output_dim);
+    SHERPA_ONNX_EXIT(-1);
+  }
+
+  return output_dim;
+}
+
+size_t GetOutputSize(size_t output_frames, size_t output_dim,
+                     const char *caller) {
+  const std::vector<float> empty;
+  if (output_frames > empty.max_size() / output_dim) {
+    SHERPA_ONNX_LOGE(
+        "%s: output with %zu frames and dimension %zu exceeds vector "
+        "capacity",
+        caller, output_frames, output_dim);
+    SHERPA_ONNX_EXIT(-1);
+  }
+
+  return output_frames * output_dim;
+}
+
+}  // namespace
 
 std::vector<float> ApplyLfr(const std::vector<float> &input,
                             int32_t input_dim, int32_t window_size,
@@ -43,24 +76,84 @@ std::vector<float> ApplyLfr(const std::vector<float> &input,
     return {};
   }
 
-  int32_t input_frames = static_cast<int32_t>(input.size()) / input_dim;
-  int32_t output_frames = (input_frames + window_shift - 1) / window_shift;
-  int32_t output_dim = input_dim * window_size;
-  std::vector<float> output(output_frames * output_dim);
+  const size_t input_dim_size = static_cast<size_t>(input_dim);
+  const size_t window_size_size = static_cast<size_t>(window_size);
+  const size_t window_shift_size = static_cast<size_t>(window_shift);
+  const size_t input_frames = input.size() / input_dim_size;
+  if (input_frames >
+      static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+    SHERPA_ONNX_LOGE("ApplyLfr: input frame count %zu exceeds int32 capacity",
+                     input_frames);
+    SHERPA_ONNX_EXIT(-1);
+  }
+
+  const size_t output_frames =
+      1 + (input_frames - 1) / window_shift_size;
+  const size_t output_dim =
+      GetOutputDim(input_dim, window_size, "ApplyLfr");
+  std::vector<float> output(
+      GetOutputSize(output_frames, output_dim, "ApplyLfr"));
 
   float *dst = output.data();
-  for (int32_t i = 0; i != output_frames; ++i) {
-    int32_t first_input_frame =
-        i * window_shift - (window_size - 1) / 2;
-    for (int32_t j = 0; j != window_size; ++j) {
-      int32_t input_frame =
-          std::clamp(first_input_frame + j, 0, input_frames - 1);
-      const float *src = input.data() + input_frame * input_dim;
-      std::copy(src, src + input_dim, dst);
-      dst += input_dim;
+  const size_t left_context = (window_size_size - 1) / 2;
+  for (size_t i = 0; i != output_frames; ++i) {
+    const size_t center_frame = i * window_shift_size;
+    const size_t left_padding =
+        center_frame < left_context ? left_context - center_frame : 0;
+    const size_t first_input_frame =
+        center_frame < left_context ? 0 : center_frame - left_context;
+    const size_t max_offset = input_frames - 1 - first_input_frame;
+
+    for (size_t j = 0; j != window_size_size; ++j) {
+      size_t input_frame = 0;
+      if (j >= left_padding) {
+        const size_t offset = j - left_padding;
+        input_frame = offset > max_offset
+                          ? input_frames - 1
+                          : first_input_frame + offset;
+      }
+
+      const float *src = input.data() + input_frame * input_dim_size;
+      std::copy(src, src + input_dim_size, dst);
+      dst += input_dim_size;
     }
   }
 
+  return output;
+}
+
+std::vector<float> ApplyLfrForFixedShape(
+    const std::vector<float> &input, int32_t input_dim, int32_t window_size,
+    int32_t window_shift, int32_t output_frames) {
+  if (output_frames <= 0) {
+    SHERPA_ONNX_LOGE(
+        "ApplyLfrForFixedShape: output_frames must be positive. Given: %d",
+        output_frames);
+    SHERPA_ONNX_EXIT(-1);
+  }
+
+  std::vector<float> output =
+      ApplyLfr(input, input_dim, window_size, window_shift);
+  if (output.empty()) {
+    return {};
+  }
+
+  const size_t output_dim =
+      GetOutputDim(input_dim, window_size, "ApplyLfrForFixedShape");
+  const size_t output_frames_size = static_cast<size_t>(output_frames);
+  const size_t target_size = GetOutputSize(
+      output_frames_size, output_dim, "ApplyLfrForFixedShape");
+  const size_t actual_output_frames = output.size() / output_dim;
+  if (actual_output_frames > output_frames_size) {
+    SHERPA_ONNX_LOGE(
+        "Number of input frames %zu is too large. Truncate it to %d frames.",
+        actual_output_frames, output_frames);
+    SHERPA_ONNX_LOGE(
+        "Recognition result may be truncated/incomplete. Please select a "
+        "model accepting longer audios.");
+  }
+
+  output.resize(target_size, 0.0f);
   return output;
 }
 

--- a/sherpa-onnx/csrc/lfr.cc
+++ b/sherpa-onnx/csrc/lfr.cc
@@ -16,16 +16,18 @@ namespace {
 
 size_t GetOutputDim(int32_t input_dim, int32_t window_size,
                     const char *caller) {
-  size_t output_dim =
-      static_cast<size_t>(input_dim) * static_cast<size_t>(window_size);
-  if (output_dim >
-      static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
-    SHERPA_ONNX_LOGE("%s: output dimension %zu exceeds int32 capacity",
-                     caller, output_dim);
+  const size_t input_dim_size = static_cast<size_t>(input_dim);
+  const size_t window_size_size = static_cast<size_t>(window_size);
+  const size_t max_output_dim =
+      static_cast<size_t>(std::numeric_limits<int32_t>::max());
+  if (window_size_size > max_output_dim / input_dim_size) {
+    SHERPA_ONNX_LOGE(
+        "%s: output dimension %d * %d exceeds int32 capacity", caller,
+        input_dim, window_size);
     SHERPA_ONNX_EXIT(-1);
   }
 
-  return output_dim;
+  return input_dim_size * window_size_size;
 }
 
 size_t GetOutputSize(size_t output_frames, size_t output_dim,

--- a/sherpa-onnx/csrc/lfr.cc
+++ b/sherpa-onnx/csrc/lfr.cc
@@ -5,18 +5,39 @@
 #include "sherpa-onnx/csrc/lfr.h"
 
 #include <algorithm>
-#include <cassert>
 #include <vector>
+
+#include "sherpa-onnx/csrc/macros.h"
 
 namespace sherpa_onnx {
 
 std::vector<float> ApplyLfr(const std::vector<float> &input,
                             int32_t input_dim, int32_t window_size,
                             int32_t window_shift) {
-  assert(input_dim > 0);
-  assert(window_size > 0);
-  assert(window_shift > 0);
-  assert(input.size() % input_dim == 0);
+  if (input_dim <= 0) {
+    SHERPA_ONNX_LOGE("ApplyLfr: input_dim must be positive. Given: %d",
+                     input_dim);
+    SHERPA_ONNX_EXIT(-1);
+  }
+
+  if (window_size <= 0) {
+    SHERPA_ONNX_LOGE("ApplyLfr: window_size must be positive. Given: %d",
+                     window_size);
+    SHERPA_ONNX_EXIT(-1);
+  }
+
+  if (window_shift <= 0) {
+    SHERPA_ONNX_LOGE("ApplyLfr: window_shift must be positive. Given: %d",
+                     window_shift);
+    SHERPA_ONNX_EXIT(-1);
+  }
+
+  if (input.size() % static_cast<size_t>(input_dim) != 0) {
+    SHERPA_ONNX_LOGE(
+        "ApplyLfr: input size %zu is not divisible by input_dim %d",
+        input.size(), input_dim);
+    SHERPA_ONNX_EXIT(-1);
+  }
 
   if (input.empty()) {
     return {};

--- a/sherpa-onnx/csrc/lfr.cc
+++ b/sherpa-onnx/csrc/lfr.cc
@@ -1,6 +1,6 @@
 // sherpa-onnx/csrc/lfr.cc
 //
-// Copyright (c)  2026  Xiaomi Corporation
+// Copyright (c)  2026  zhifu gao
 
 #include "sherpa-onnx/csrc/lfr.h"
 

--- a/sherpa-onnx/csrc/lfr.cc
+++ b/sherpa-onnx/csrc/lfr.cc
@@ -1,0 +1,46 @@
+// sherpa-onnx/csrc/lfr.cc
+//
+// Copyright (c)  2026  Xiaomi Corporation
+
+#include "sherpa-onnx/csrc/lfr.h"
+
+#include <algorithm>
+#include <cassert>
+#include <vector>
+
+namespace sherpa_onnx {
+
+std::vector<float> ApplyLfr(const std::vector<float> &input,
+                            int32_t input_dim, int32_t window_size,
+                            int32_t window_shift) {
+  assert(input_dim > 0);
+  assert(window_size > 0);
+  assert(window_shift > 0);
+  assert(input.size() % input_dim == 0);
+
+  if (input.empty()) {
+    return {};
+  }
+
+  int32_t input_frames = static_cast<int32_t>(input.size()) / input_dim;
+  int32_t output_frames = (input_frames + window_shift - 1) / window_shift;
+  int32_t output_dim = input_dim * window_size;
+  std::vector<float> output(output_frames * output_dim);
+
+  float *dst = output.data();
+  for (int32_t i = 0; i != output_frames; ++i) {
+    int32_t first_input_frame =
+        i * window_shift - (window_size - 1) / 2;
+    for (int32_t j = 0; j != window_size; ++j) {
+      int32_t input_frame =
+          std::clamp(first_input_frame + j, 0, input_frames - 1);
+      const float *src = input.data() + input_frame * input_dim;
+      std::copy(src, src + input_dim, dst);
+      dst += input_dim;
+    }
+  }
+
+  return output;
+}
+
+}  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/lfr.h
+++ b/sherpa-onnx/csrc/lfr.h
@@ -1,6 +1,6 @@
 // sherpa-onnx/csrc/lfr.h
 //
-// Copyright (c)  2026  Xiaomi Corporation
+// Copyright (c)  2026  zhifu gao
 
 #ifndef SHERPA_ONNX_CSRC_LFR_H_
 #define SHERPA_ONNX_CSRC_LFR_H_

--- a/sherpa-onnx/csrc/lfr.h
+++ b/sherpa-onnx/csrc/lfr.h
@@ -1,0 +1,33 @@
+// sherpa-onnx/csrc/lfr.h
+//
+// Copyright (c)  2026  Xiaomi Corporation
+
+#ifndef SHERPA_ONNX_CSRC_LFR_H_
+#define SHERPA_ONNX_CSRC_LFR_H_
+
+#include <cstdint>
+#include <vector>
+
+namespace sherpa_onnx {
+
+/** Stack input frames for low frame rate (LFR) processing.
+ *
+ * The first frame is repeated on the left and the last frame is repeated on
+ * the right so every output window is complete. The result contains
+ * ceil(num_frames / window_shift) output frames.
+ *
+ * @param input Flattened input with shape (num_frames, input_dim).
+ * @param input_dim Feature dimension of one input frame.
+ * @param window_size Number of input frames stacked into each output frame.
+ * @param window_shift Number of input frames between adjacent output frames.
+ *
+ * @return Flattened output with shape
+ *         (num_output_frames, input_dim * window_size).
+ */
+std::vector<float> ApplyLfr(const std::vector<float> &input,
+                            int32_t input_dim, int32_t window_size,
+                            int32_t window_shift);
+
+}  // namespace sherpa_onnx
+
+#endif  // SHERPA_ONNX_CSRC_LFR_H_

--- a/sherpa-onnx/csrc/lfr.h
+++ b/sherpa-onnx/csrc/lfr.h
@@ -28,6 +28,24 @@ std::vector<float> ApplyLfr(const std::vector<float> &input,
                             int32_t input_dim, int32_t window_size,
                             int32_t window_shift);
 
+/** Apply LFR and resize it for a model with a fixed frame dimension.
+ *
+ * The LFR result is truncated when it exceeds output_frames and zero-padded
+ * when it is shorter. Empty input remains empty so callers can skip inference.
+ *
+ * @param input Flattened input with shape (num_frames, input_dim).
+ * @param input_dim Feature dimension of one input frame.
+ * @param window_size Number of input frames stacked into each output frame.
+ * @param window_shift Number of input frames between adjacent output frames.
+ * @param output_frames Required output frame dimension of the model.
+ *
+ * @return Flattened output with shape
+ *         (output_frames, input_dim * window_size), or empty for empty input.
+ */
+std::vector<float> ApplyLfrForFixedShape(
+    const std::vector<float> &input, int32_t input_dim, int32_t window_size,
+    int32_t window_shift, int32_t output_frames);
+
 }  // namespace sherpa_onnx
 
 #endif  // SHERPA_ONNX_CSRC_LFR_H_

--- a/sherpa-onnx/csrc/offline-recognizer-paraformer-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-paraformer-impl.h
@@ -12,8 +12,9 @@
 #include <vector>
 
 #include "Eigen/Dense"
-#include "sherpa-onnx/csrc/offline-model-config.h"
+#include "sherpa-onnx/csrc/lfr.h"
 #include "sherpa-onnx/csrc/macros.h"
+#include "sherpa-onnx/csrc/offline-model-config.h"
 #include "sherpa-onnx/csrc/offline-paraformer-decoder.h"
 #include "sherpa-onnx/csrc/offline-paraformer-greedy-search-decoder.h"
 #include "sherpa-onnx/csrc/offline-paraformer-model.h"
@@ -217,28 +218,8 @@ class OfflineRecognizerParaformerImpl : public OfflineRecognizerImpl {
   }
 
   std::vector<float> ApplyLFR(const std::vector<float> &in) const {
-    int32_t lfr_window_size = model_->LfrWindowSize();
-    int32_t lfr_window_shift = model_->LfrWindowShift();
-    int32_t in_feat_dim = config_.feat_config.feature_dim;
-
-    int32_t in_num_frames = in.size() / in_feat_dim;
-    int32_t out_num_frames =
-        (in_num_frames - lfr_window_size) / lfr_window_shift + 1;
-    int32_t out_feat_dim = in_feat_dim * lfr_window_size;
-
-    std::vector<float> out(out_num_frames * out_feat_dim);
-
-    const float *p_in = in.data();
-    float *p_out = out.data();
-
-    for (int32_t i = 0; i != out_num_frames; ++i) {
-      std::copy(p_in, p_in + out_feat_dim, p_out);
-
-      p_out += out_feat_dim;
-      p_in += lfr_window_shift * in_feat_dim;
-    }
-
-    return out;
+    return ApplyLfr(in, config_.feat_config.feature_dim,
+                    model_->LfrWindowSize(), model_->LfrWindowShift());
   }
 
   void ApplyCMVN(std::vector<float> *v) const {

--- a/sherpa-onnx/csrc/offline-recognizer-sense-voice-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-sense-voice-impl.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "Eigen/Dense"
+#include "sherpa-onnx/csrc/lfr.h"
 #include "sherpa-onnx/csrc/macros.h"
 #include "sherpa-onnx/csrc/offline-ctc-greedy-search-decoder.h"
 #include "sherpa-onnx/csrc/offline-model-config.h"
@@ -146,7 +147,8 @@ class OfflineRecognizerSenseVoiceImpl : public OfflineRecognizerImpl {
     for (int32_t i = 0; i != n; ++i) {
       std::vector<float> f = ss[i]->GetFrames();
 
-      f = ApplyLFR(f);
+      f = ApplyLfr(f, config_.feat_config.feature_dim, meta_data.window_size,
+                   meta_data.window_shift);
       ApplyCMVN(&f);
 
       int32_t num_frames = f.size() / feat_dim;
@@ -191,7 +193,8 @@ class OfflineRecognizerSenseVoiceImpl : public OfflineRecognizerImpl {
     std::vector<int32_t> language_array(n);
     std::fill(language_array.begin(), language_array.end(), language);
 
-    // Per-stream use_itn override via OfflineStream::SetOption("use_itn", "1"|"0").
+    // Per-stream use_itn override via
+    // OfflineStream::SetOption("use_itn", "1"|"0").
     // Falls back to model_config.sense_voice.use_itn when the option is absent.
     int32_t default_use_itn = config_.model_config.sense_voice.use_itn;
     std::vector<int32_t> text_norm_array(n);
@@ -256,7 +259,8 @@ class OfflineRecognizerSenseVoiceImpl : public OfflineRecognizerImpl {
 
     int32_t feat_dim = config_.feat_config.feature_dim * meta_data.window_size;
     std::vector<float> f = s->GetFrames();
-    f = ApplyLFR(f);
+    f = ApplyLfr(f, config_.feat_config.feature_dim, meta_data.window_size,
+                 meta_data.window_shift);
 
     int32_t num_frames = f.size() / feat_dim;
     std::array<int64_t, 3> shape = {1, num_frames, feat_dim};
@@ -298,7 +302,8 @@ class OfflineRecognizerSenseVoiceImpl : public OfflineRecognizerImpl {
 
     int32_t feat_dim = config_.feat_config.feature_dim * meta_data.window_size;
     std::vector<float> f = s->GetFrames();
-    f = ApplyLFR(f);
+    f = ApplyLfr(f, config_.feat_config.feature_dim, meta_data.window_size,
+                 meta_data.window_shift);
     ApplyCMVN(&f);
     int32_t num_frames = f.size() / feat_dim;
     std::array<int64_t, 3> shape = {1, num_frames, feat_dim};
@@ -322,7 +327,8 @@ class OfflineRecognizerSenseVoiceImpl : public OfflineRecognizerImpl {
                        config_.model_config.sense_voice.language.c_str());
     }
 
-    // Per-stream use_itn override via OfflineStream::SetOption("use_itn", "1"|"0").
+    // Per-stream use_itn override via
+    // OfflineStream::SetOption("use_itn", "1"|"0").
     // Falls back to model_config.sense_voice.use_itn when the option is absent.
     int32_t use_itn =
         s->GetOptionInt("use_itn", config_.model_config.sense_voice.use_itn);
@@ -379,33 +385,6 @@ class OfflineRecognizerSenseVoiceImpl : public OfflineRecognizerImpl {
     config_.feat_config.window_type = "hamming";
     config_.feat_config.high_freq = 0;
     config_.feat_config.snip_edges = true;
-  }
-
-  std::vector<float> ApplyLFR(const std::vector<float> &in) const {
-    const auto &meta_data = model_->GetModelMetadata();
-
-    int32_t lfr_window_size = meta_data.window_size;
-    int32_t lfr_window_shift = meta_data.window_shift;
-    int32_t in_feat_dim = config_.feat_config.feature_dim;
-
-    int32_t in_num_frames = in.size() / in_feat_dim;
-    int32_t out_num_frames =
-        (in_num_frames - lfr_window_size) / lfr_window_shift + 1;
-    int32_t out_feat_dim = in_feat_dim * lfr_window_size;
-
-    std::vector<float> out(out_num_frames * out_feat_dim);
-
-    const float *p_in = in.data();
-    float *p_out = out.data();
-
-    for (int32_t i = 0; i != out_num_frames; ++i) {
-      std::copy(p_in, p_in + out_feat_dim, p_out);
-
-      p_out += out_feat_dim;
-      p_in += lfr_window_shift * in_feat_dim;
-    }
-
-    return out;
   }
 
   void ApplyCMVN(std::vector<float> *v) const {

--- a/sherpa-onnx/csrc/qnn/offline-paraformer-model-qnn.cc
+++ b/sherpa-onnx/csrc/qnn/offline-paraformer-model-qnn.cc
@@ -22,6 +22,7 @@
 #endif
 
 #include "sherpa-onnx/csrc/file-utils.h"
+#include "sherpa-onnx/csrc/lfr.h"
 #include "sherpa-onnx/csrc/math.h"
 #include "sherpa-onnx/csrc/qnn/macros.h"
 #include "sherpa-onnx/csrc/qnn/qnn-backend.h"
@@ -175,46 +176,9 @@ class OfflineParaformerModelQnn::Impl {
     return decoder_model_->GetOutputTensorData("decoder_out");
   }
 
-  std::vector<float> ApplyLFR(std::vector<float> in) const {
-    int32_t lfr_window_size = 7;
-    int32_t lfr_window_shift = 6;
-    int32_t in_feat_dim = 80;
-
-    int32_t in_num_frames = in.size() / in_feat_dim;
-    if (in_num_frames < lfr_window_size) {
-      return {};
-    }
-
-    int32_t out_num_frames =
-        (in_num_frames - lfr_window_size) / lfr_window_shift + 1;
-
-    if (out_num_frames > num_input_frames_) {
-      SHERPA_ONNX_LOGE(
-          "Number of input frames %d is too large. Truncate it to %d frames.",
-          out_num_frames, num_input_frames_);
-
-      SHERPA_ONNX_LOGE(
-          "Recognition result may be truncated/incomplete. Please select a "
-          "model accepting longer audios.");
-
-      out_num_frames = num_input_frames_;
-    }
-
-    int32_t out_feat_dim = in_feat_dim * lfr_window_size;
-
-    std::vector<float> out(num_input_frames_ * out_feat_dim);
-
-    const float *p_in = in.data();
-    float *p_out = out.data();
-
-    for (int32_t i = 0; i != out_num_frames; ++i) {
-      std::copy(p_in, p_in + out_feat_dim, p_out);
-
-      p_out += out_feat_dim;
-      p_in += lfr_window_shift * in_feat_dim;
-    }
-
-    return out;
+  std::vector<float> ApplyLFR(const std::vector<float> &in) const {
+    return ApplyLfrForFixedShape(in, /*input_dim=*/80, /*window_size=*/7,
+                                 /*window_shift=*/6, num_input_frames_);
   }
 
   bool InitEncoder(const std::string &lib_filename,

--- a/sherpa-onnx/csrc/qnn/offline-sense-voice-model-qnn.cc
+++ b/sherpa-onnx/csrc/qnn/offline-sense-voice-model-qnn.cc
@@ -22,6 +22,7 @@
 #endif
 
 #include "sherpa-onnx/csrc/file-utils.h"
+#include "sherpa-onnx/csrc/lfr.h"
 #include "sherpa-onnx/csrc/qnn/macros.h"
 #include "sherpa-onnx/csrc/qnn/qnn-backend.h"
 #include "sherpa-onnx/csrc/qnn/qnn-model.h"
@@ -204,48 +205,10 @@ class OfflineSenseVoiceModelQnn::Impl {
     expected_num_frames_ = x_shape[1];
   }
 
-  std::vector<float> ApplyLFR(std::vector<float> in) const {
-    int32_t lfr_window_size = meta_data_.window_size;
-    int32_t lfr_window_shift = meta_data_.window_shift;
-    int32_t in_feat_dim = 80;
-
-    int32_t in_num_frames = in.size() / in_feat_dim;
-
-    if (in_num_frames < lfr_window_size) {
-      return {};
-    }
-
-    int32_t out_num_frames =
-        (in_num_frames - lfr_window_size) / lfr_window_shift + 1;
-
-    if (out_num_frames > expected_num_frames_) {
-      SHERPA_ONNX_LOGE(
-          "Number of input frames %d is too large. Truncate it to %d frames.",
-          out_num_frames, expected_num_frames_);
-
-      SHERPA_ONNX_LOGE(
-          "Recognition result may be truncated/incomplete. Please select a "
-          "model accepting longer audios.");
-
-      out_num_frames = expected_num_frames_;
-    }
-
-    int32_t out_feat_dim = in_feat_dim * lfr_window_size;
-
-    // if out_num_frames < expected_num_frames_, it uses 0 padding
-    std::vector<float> out(expected_num_frames_ * out_feat_dim, 0);
-
-    const float *p_in = in.data();
-    float *p_out = out.data();
-
-    for (int32_t i = 0; i != out_num_frames; ++i) {
-      std::copy(p_in, p_in + out_feat_dim, p_out);
-
-      p_out += out_feat_dim;
-      p_in += lfr_window_shift * in_feat_dim;
-    }
-
-    return out;
+  std::vector<float> ApplyLFR(const std::vector<float> &in) const {
+    return ApplyLfrForFixedShape(
+        in, /*input_dim=*/80, meta_data_.window_size, meta_data_.window_shift,
+        expected_num_frames_);
   }
 
  private:

--- a/sherpa-onnx/csrc/rknn/offline-paraformer-model-rknn.cc
+++ b/sherpa-onnx/csrc/rknn/offline-paraformer-model-rknn.cc
@@ -21,6 +21,7 @@
 #endif
 
 #include "sherpa-onnx/csrc/file-utils.h"
+#include "sherpa-onnx/csrc/lfr.h"
 #include "sherpa-onnx/csrc/math.h"
 #include "sherpa-onnx/csrc/rknn/context-blocking-queue-rknn.h"
 #include "sherpa-onnx/csrc/rknn/macros.h"
@@ -291,46 +292,9 @@ class OfflineParaformerModelRknn::Impl {
     }
   }
 
-  std::vector<float> ApplyLFR(std::vector<float> in) const {
-    int32_t lfr_window_size = 7;
-    int32_t lfr_window_shift = 6;
-    int32_t in_feat_dim = 80;
-
-    int32_t in_num_frames = in.size() / in_feat_dim;
-    if (in_num_frames < lfr_window_size) {
-      return {};
-    }
-
-    int32_t out_num_frames =
-        (in_num_frames - lfr_window_size) / lfr_window_shift + 1;
-
-    if (out_num_frames > num_input_frames_) {
-      SHERPA_ONNX_LOGE(
-          "Number of input frames %d is too large. Truncate it to %d frames.",
-          out_num_frames, num_input_frames_);
-
-      SHERPA_ONNX_LOGE(
-          "Recognition result may be truncated/incomplete. Please select a "
-          "model accepting longer audios.");
-
-      out_num_frames = num_input_frames_;
-    }
-
-    int32_t out_feat_dim = in_feat_dim * lfr_window_size;
-
-    std::vector<float> out(num_input_frames_ * out_feat_dim);
-
-    const float *p_in = in.data();
-    float *p_out = out.data();
-
-    for (int32_t i = 0; i != out_num_frames; ++i) {
-      std::copy(p_in, p_in + out_feat_dim, p_out);
-
-      p_out += out_feat_dim;
-      p_in += lfr_window_shift * in_feat_dim;
-    }
-
-    return out;
+  std::vector<float> ApplyLFR(const std::vector<float> &in) const {
+    return ApplyLfrForFixedShape(in, /*input_dim=*/80, /*window_size=*/7,
+                                 /*window_shift=*/6, num_input_frames_);
   }
 
   void PostInit() {

--- a/sherpa-onnx/csrc/rknn/offline-sense-voice-model-rknn.cc
+++ b/sherpa-onnx/csrc/rknn/offline-sense-voice-model-rknn.cc
@@ -20,6 +20,7 @@
 #endif
 
 #include "sherpa-onnx/csrc/file-utils.h"
+#include "sherpa-onnx/csrc/lfr.h"
 #include "sherpa-onnx/csrc/rknn/context-blocking-queue-rknn.h"
 #include "sherpa-onnx/csrc/rknn/macros.h"
 #include "sherpa-onnx/csrc/rknn/utils.h"
@@ -158,47 +159,10 @@ class OfflineSenseVoiceModelRknn::Impl {
     num_input_frames_ = input_attrs_[0].dims[1];
   }
 
-  std::vector<float> ApplyLFR(std::vector<float> in) const {
-    int32_t lfr_window_size = meta_data_.window_size;
-    int32_t lfr_window_shift = meta_data_.window_shift;
-    int32_t in_feat_dim = 80;
-
-    int32_t in_num_frames = in.size() / in_feat_dim;
-
-    if (in_num_frames < lfr_window_size) {
-      return {};
-    }
-
-    int32_t out_num_frames =
-        (in_num_frames - lfr_window_size) / lfr_window_shift + 1;
-
-    if (out_num_frames > num_input_frames_) {
-      SHERPA_ONNX_LOGE(
-          "Number of input frames %d is too large. Truncate it to %d frames.",
-          out_num_frames, num_input_frames_);
-
-      SHERPA_ONNX_LOGE(
-          "Recognition result may be truncated/incomplete. Please select a "
-          "model accepting longer audios.");
-
-      out_num_frames = num_input_frames_;
-    }
-
-    int32_t out_feat_dim = in_feat_dim * lfr_window_size;
-
-    std::vector<float> out(num_input_frames_ * out_feat_dim);
-
-    const float *p_in = in.data();
-    float *p_out = out.data();
-
-    for (int32_t i = 0; i != out_num_frames; ++i) {
-      std::copy(p_in, p_in + out_feat_dim, p_out);
-
-      p_out += out_feat_dim;
-      p_in += lfr_window_shift * in_feat_dim;
-    }
-
-    return out;
+  std::vector<float> ApplyLFR(const std::vector<float> &in) const {
+    return ApplyLfrForFixedShape(
+        in, /*input_dim=*/80, meta_data_.window_size, meta_data_.window_shift,
+        num_input_frames_);
   }
 
   void PostInit() {


### PR DESCRIPTION
## Summary

- align standard and NPU Paraformer/SenseVoice LFR windows with the FunASR
  frontend
- repeat the first frame on the left, keep `ceil(T / window_shift)` outputs, and repeat the final frame to complete the last window
- move the transform into a unit-tested helper with checked size arithmetic

## Problem

The current implementation only keeps complete windows starting at input frame 0:

```text
output_frames = (input_frames - window_size) / window_shift + 1
```

For the common `window_size=7`, `window_shift=6` setup, this differs from FunASR in both alignment and output length. It drops the tail, returns only one output for seven input frames instead of two, and can read past the input for some utterances shorter than one window because signed integer division still produces one output frame.

The behavior difference was independently reported in [TigreGotico/onnx-asr#21](https://github.com/TigreGotico/onnx-asr/issues/21): the sherpa and FunASR variants produced different transcripts, while native FunASR agreed with the padded variant.

## Scope

This change covers the standard offline Paraformer and ONNX SenseVoice
recognizers. At the maintainer's request, the SenseVoice single-stream,
batched, and FunASR-Nano compatibility entry points now all delegate to the
same tested LFR helper instead of retaining a second unpadded implementation.

It also updates every existing NPU implementation for these models:

- RKNN and QNN: Paraformer and SenseVoice
- AXCL and AXERA: SenseVoice (there is no Paraformer implementation in these
  folders)
- Ascend: Paraformer and SenseVoice

Fixed-shape RKNN/QNN/AXCL/AXERA models use the shared helper and then truncate
or zero-pad to the model's input frame count. Dynamic-shape Ascend models use
the same helper and retain their maximum-duration truncation. Online
Paraformer keeps its separate streaming buffer path.

## Validation

- regression test was observed failing against the old implementation for boundary values and output counts
- `./scripts/check_style_cpplint.sh 1`
- static and shared Release builds
- `ctest --test-dir build-lfr --output-on-failure -j 8`: 19/19 passed
- focused Release LFR suite: 9/9 passed
- focused LFR suite under GCC ASAN + UBSAN: 9/9 passed
- checked `size_t` output allocation and index arithmetic, including invalid
  fixed shapes and oversized dimensions
- bundled `sherpa-onnx-paraformer-zh-small-2024-03-09` sample produced the same transcript before and after the fix
- bundled SenseVoice five-language batch completed successfully; Chinese and
  Cantonese stayed unchanged, and Korean word spacing improved
- 30 ms and 80 ms SenseVoice inputs completed without an out-of-bounds access,
  invalid tensor shape, or crash

The local validation host does not have the vendor NPU SDKs, so
backend-specific linking and device runtime remain with the SDK-enabled CI and
device environments.

The bundled INT8 SenseVoice model is sensitive to frontend and batch shape:
with the corrected alignment, the single English sample's final token changes
from `gold` to `code`, while the same sample in the five-file batch remains
`gold`. I reproduced this separately with the ONNX model across
`kaldi-native-fbank` and torchaudio features. The shared helper's frame count,
left context, and right padding match FunASR's `apply_lfr`; the previous
transcript came from the old, differently aligned windows.

The commit is SSH-signed and includes a DCO sign-off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added low-frame-rate feature processing with configurable context windows and frame shifts.
  * Added edge padding to preserve complete windows at input boundaries.
  * Added fixed-size output support with zero-padding or truncation.
  * Applied consistent frame processing across supported recognition workflows.

* **Bug Fixes**
  * Improved handling of empty and single-frame inputs.
  * Ensured consistent output frame counts and feature dimensions.
  * Added validation for invalid dimensions, parameters, and input sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
