### PR TITLE
docs: add qwen-audio-agent to projects using sherpa-onnx

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,15 @@ detection, streaming and offline speech recognition, and text-to-speech.
 Speech engines and models are selected through per-companion configuration,
 making it easy to match supported sherpa-onnx models to different hardware.
 
+### [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent)
+
+> A realtime full-duplex voice runtime for AI coding agents
+> (Claude Code, Codex, OpenCode, and other ACP agents).
+> It uses sherpa-onnx keyword spotting with the 3M-parameter
+> zh-en transducer model to implement a local voice wake word:
+> the app sleeps on idle but keeps the microphone open,
+> and the wake phrase brings the session back with no cloud calls.
+
 [silero-vad]: https://github.com/snakers4/silero-vad
 [Raspberry Pi]: https://www.raspberrypi.com/
 [RV1126]: https://www.rock-chips.com/uploads/pdf/2022.8.26/191/RV1126%20Brief%20Datasheet.pdf


### PR DESCRIPTION
Adds qwen-audio-agent to the **Projects using sherpa-onnx** section.

qwen-audio-agent uses sherpa-onnx keyword spotting (the 3M-parameter zh-en transducer KWS model, downloaded from the official sherpa-onnx release with SHA256 verification) to implement a fully local voice wake word for a realtime voice runtime that drives AI coding agents over ACP. The wake-word detector runs on CPU while the app is sleeping, with no cloud calls.

Disclosure: I am a maintainer of this project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the `qwen-audio-agent` project.
  * Described real-time, full-duplex voice interaction for AI coding agents.
  * Documented local Chinese-English wake-word detection and idle microphone behavior without cloud calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->