### PR TITLE
Build libs and Python wheels for CUDA 13

### DIFF
--- a/.github/scripts/libs/linux_x64_cuda.py
+++ b/.github/scripts/libs/linux_x64_cuda.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# Copyright    2026  Xiaomi Corp.        (authors: Fangjun Kuang)
+
+import itertools
+import json
+from dataclasses import asdict, dataclass
+
+
+@dataclass
+class OnnxruntimeConfig:
+    onnxruntime_version: str
+    cuda_version: str  # "12" or "13"
+
+    @property
+    def onnxruntime_url_suffix(self) -> str:
+        return f"gpu_cuda{self.cuda_version}-{self.onnxruntime_version}-patched"
+
+    @property
+    def onnxruntime_dir_name(self) -> str:
+        return f"onnxruntime-linux-x64-{self.onnxruntime_url_suffix}"
+
+    @property
+    def cuda_version_tag(self) -> str:
+        return f"{self.cuda_version}.cudnn9.onnxruntime{self.onnxruntime_version}"
+
+    @property
+    def dst_suffix(self) -> str:
+        return f"cuda-{self.cuda_version}.x-cudnn-9.x-linux-x64-gpu"
+
+
+# To add a new onnxruntime version, just add entries here.
+onnxruntime_configs = [
+    OnnxruntimeConfig("1.27.1", "12"),
+    OnnxruntimeConfig("1.27.1", "13"),
+]
+
+build_types = ["Release"]
+
+
+def main():
+    entries = []
+    for build_type, cfg in itertools.product(build_types, onnxruntime_configs):
+        d = asdict(cfg)
+        d["os"] = "ubuntu-latest"
+        d["build_type"] = build_type
+        d["onnxruntime_url_suffix"] = cfg.onnxruntime_url_suffix
+        d["onnxruntime_dir_name"] = cfg.onnxruntime_dir_name
+        d["cuda_version_tag"] = cfg.cuda_version_tag
+        d["dst_suffix"] = cfg.dst_suffix
+        entries.append(d)
+
+    print(json.dumps({"include": entries}))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/libs/linux_x64_cuda.py
+++ b/.github/scripts/libs/linux_x64_cuda.py
@@ -25,7 +25,7 @@ class OnnxruntimeConfig:
 
     @property
     def dst_suffix(self) -> str:
-        return f"cuda-{self.cuda_version}.x-cudnn-9.x-linux-x64-gpu"
+        return f"cuda-{self.cuda_version}.x-cudnn-9.x-onnxruntime{self.onnxruntime_version}-linux-x64-gpu"
 
 
 # To add a new onnxruntime version, just add entries here.

--- a/.github/scripts/wheels/linux_x64_cuda.py
+++ b/.github/scripts/wheels/linux_x64_cuda.py
@@ -37,6 +37,7 @@ def main():
     entries = []
     for py, cfg in itertools.product(python_versions, onnxruntime_configs):
         d = asdict(cfg)
+        d["os"] = "ubuntu-22.04"
         d["python-version"] = py
         d["onnxruntime_url_suffix"] = cfg.onnxruntime_url_suffix
         d["onnxruntime_dir_name"] = cfg.onnxruntime_dir_name

--- a/.github/scripts/wheels/linux_x64_cuda.py
+++ b/.github/scripts/wheels/linux_x64_cuda.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright    2026  Xiaomi Corp.        (authors: Fangjun Kuang)
+
+import itertools
+import json
+from dataclasses import asdict, dataclass
+
+
+@dataclass
+class OnnxruntimeConfig:
+    onnxruntime_version: str
+    cuda_version: str  # "12" or "13"
+
+    @property
+    def onnxruntime_url_suffix(self) -> str:
+        return f"gpu_cuda{self.cuda_version}-{self.onnxruntime_version}-patched"
+
+    @property
+    def onnxruntime_dir_name(self) -> str:
+        return f"onnxruntime-linux-x64-{self.onnxruntime_url_suffix}"
+
+    @property
+    def cuda_version_tag(self) -> str:
+        return f"{self.cuda_version}.cudnn9.onnxruntime{self.onnxruntime_version}"
+
+
+# To add a new onnxruntime version, just add entries here.
+onnxruntime_configs = [
+    OnnxruntimeConfig("1.27.1", "12"),
+    OnnxruntimeConfig("1.27.1", "13"),
+]
+
+python_versions = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+
+
+def main():
+    entries = []
+    for py, cfg in itertools.product(python_versions, onnxruntime_configs):
+        d = asdict(cfg)
+        d["python-version"] = py
+        d["onnxruntime_url_suffix"] = cfg.onnxruntime_url_suffix
+        d["onnxruntime_dir_name"] = cfg.onnxruntime_dir_name
+        d["cuda_version_tag"] = cfg.cuda_version_tag
+        entries.append(d)
+
+    print(json.dumps({"include": entries}))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/build-wheels-linux-cuda.yaml
+++ b/.github/workflows/build-wheels-linux-cuda.yaml
@@ -14,15 +14,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  generate_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generating build matrix
+        id: set-matrix
+        run: |
+          MATRIX=$(python3 .github/scripts/wheels/linux_x64_cuda.py)
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+
   build_wheels_linux_cuda:
-    name: ${{ matrix.manylinux }} ${{ matrix.python-version }} ${{ matrix.onnxruntime_version }}
+    needs: [generate_matrix]
+    name: ${{ matrix.python-version }} ${{ matrix.onnxruntime_version }} cuda${{ matrix.cuda_version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
-        onnxruntime_version: ["1.17.1", "1.24.4"]
+        ${{ fromJson(needs.generate_matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -73,16 +85,13 @@ jobs:
           export SHERPA_ONNX_ENABLE_ALSA=1
           export SHERPA_ONNX_CMAKE_ARGS="-DSHERPA_ONNX_ENABLE_GPU=ON"
 
-          onnxruntime_version=${{ matrix.onnxruntime_version }}
-          curl -SL -O https://github.com/csukuangfj/onnxruntime-libs/releases/download/v$onnxruntime_version/onnxruntime-linux-x64-gpu-$onnxruntime_version-patched.zip
-          unzip  onnxruntime-linux-x64-gpu-$onnxruntime_version-patched.zip
+          curl -SL -O https://github.com/csukuangfj/onnxruntime-libs/releases/download/v${{ matrix.onnxruntime_version }}/onnxruntime-linux-x64-${{ matrix.onnxruntime_url_suffix }}.zip
+          unzip onnxruntime-linux-x64-${{ matrix.onnxruntime_url_suffix }}.zip
 
-          export SHERPA_ONNXRUNTIME_LIB_DIR=$PWD/onnxruntime-linux-x64-gpu-$onnxruntime_version-patched/lib
-          export SHERPA_ONNXRUNTIME_INCLUDE_DIR=$PWD/onnxruntime-linux-x64-gpu-$onnxruntime_version-patched/include
+          export SHERPA_ONNXRUNTIME_LIB_DIR=$PWD/${{ matrix.onnxruntime_dir_name }}/lib
+          export SHERPA_ONNXRUNTIME_INCLUDE_DIR=$PWD/${{ matrix.onnxruntime_dir_name }}/include
 
-          if [[ $onnxruntime_version == "1.24.4" ]]; then
-            export SHERPA_ONNX_CUDA_VERSION="12.cudnn9"
-          fi
+          export SHERPA_ONNX_CUDA_VERSION="${{ matrix.cuda_version_tag }}"
 
           python3 setup.py bdist_wheel
 
@@ -117,7 +126,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheel-cuda-${{ matrix.python-version }}-${{ matrix.onnxruntime_version }}
+          name: wheel-cuda-${{ matrix.python-version }}-${{ matrix.onnxruntime_version }}-cuda${{ matrix.cuda_version }}
           path: ./wheelhouse/*.whl
 
       - name: Publish to huggingface

--- a/.github/workflows/build-wheels-linux-cuda.yaml
+++ b/.github/workflows/build-wheels-linux-cuda.yaml
@@ -33,7 +33,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
         ${{ fromJson(needs.generate_matrix.outputs.matrix) }}
 
     steps:

--- a/.github/workflows/linux-gpu.yaml
+++ b/.github/workflows/linux-gpu.yaml
@@ -27,16 +27,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  generate_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generating build matrix
+        id: set-matrix
+        run: |
+          MATRIX=$(python3 .github/scripts/libs/linux_x64_cuda.py)
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+
   linux_gpu:
+    needs: [generate_matrix]
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.build_type }} ${{ matrix.onnxruntime_version }}
+    name: ${{ matrix.build_type }} ${{ matrix.onnxruntime_version }} cuda${{ matrix.cuda_version }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        # build_type: [Release, Debug]
-        build_type: [Release]
-        onnxruntime_version: ["1.17.1", "1.24.4"]
+        ${{ fromJson(needs.generate_matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -65,14 +75,13 @@ jobs:
 
               cd /home/runner/work/sherpa-onnx/sherpa-onnx
 
-              onnxruntime_version=${{ matrix.onnxruntime_version }}
-              curl -SL -O https://github.com/csukuangfj/onnxruntime-libs/releases/download/v$onnxruntime_version/onnxruntime-linux-x64-gpu-$onnxruntime_version-patched.zip
-              unzip  onnxruntime-linux-x64-gpu-$onnxruntime_version-patched.zip
+              curl -SL -O https://github.com/csukuangfj/onnxruntime-libs/releases/download/v${{ matrix.onnxruntime_version }}/onnxruntime-linux-x64-${{ matrix.onnxruntime_url_suffix }}.zip
+              unzip onnxruntime-linux-x64-${{ matrix.onnxruntime_url_suffix }}.zip
 
-              export SHERPA_ONNXRUNTIME_LIB_DIR=$PWD/onnxruntime-linux-x64-gpu-$onnxruntime_version-patched/lib
-              export SHERPA_ONNXRUNTIME_INCLUDE_DIR=$PWD/onnxruntime-linux-x64-gpu-$onnxruntime_version-patched/include
+              export SHERPA_ONNXRUNTIME_LIB_DIR=$PWD/${{ matrix.onnxruntime_dir_name }}/lib
+              export SHERPA_ONNXRUNTIME_INCLUDE_DIR=$PWD/${{ matrix.onnxruntime_dir_name }}/include
 
-              ls -lh /home/runner/work/sherpa-onnx/sherpa-onnx/onnxruntime-linux-x64-gpu-$onnxruntime_version-patched/lib/libonnxruntime.so
+              ls -lh /home/runner/work/sherpa-onnx/sherpa-onnx/${{ matrix.onnxruntime_dir_name }}/lib/libonnxruntime.so
 
               git clone --depth 1 --branch v1.2.12 https://github.com/alsa-project/alsa-lib
               pushd alsa-lib
@@ -140,12 +149,7 @@ jobs:
         run: |
           SHERPA_ONNX_VERSION=v$(grep "SHERPA_ONNX_VERSION" ./CMakeLists.txt  | cut -d " " -f 2  | cut -d '"' -f 2)
 
-          dst=sherpa-onnx-${SHERPA_ONNX_VERSION}-linux-x64-gpu
-
-          onnxruntime_version=${{ matrix.onnxruntime_version }}
-          if [[ $onnxruntime_version == "1.24.4" ]]; then
-            dst=sherpa-onnx-${SHERPA_ONNX_VERSION}-cuda-12.x-cudnn-9.x-linux-x64-gpu
-          fi
+          dst=sherpa-onnx-${SHERPA_ONNX_VERSION}-${{ matrix.dst_suffix }}
 
           mkdir $dst
 
@@ -158,7 +162,7 @@ jobs:
           tar cjvf ${dst}.tar.bz2 $dst
 
       - name: Release pre-compiled binaries and libs for linux x64
-        if: github.repository_owner == 'csukuangfj' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+        # if: github.repository_owner == 'csukuangfj' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         uses: svenstaro/upload-release-action@v2
         with:
           file_glob: true
@@ -166,7 +170,7 @@ jobs:
           file: sherpa-onnx-*gpu.tar.bz2
           repo_name: k2-fsa/sherpa-onnx
           repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
-          tag: v1.12.13
+          tag: v1.13.4
 
       - name: Release pre-compiled binaries and libs for linux x64
         if: github.repository_owner == 'k2-fsa' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')

--- a/.github/workflows/linux-gpu.yaml
+++ b/.github/workflows/linux-gpu.yaml
@@ -162,15 +162,15 @@ jobs:
           tar cjvf ${dst}.tar.bz2 $dst
 
       - name: Release pre-compiled binaries and libs for linux x64
-        if: github.repository_owner == 'csukuangfj' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+        # if: github.repository_owner == 'csukuangfj' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         uses: svenstaro/upload-release-action@v2
         with:
           file_glob: true
           overwrite: true
           file: sherpa-onnx-*gpu.tar.bz2
-          # repo_name: k2-fsa/sherpa-onnx
-          # repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
-          # tag: v1.13.4
+          repo_name: k2-fsa/sherpa-onnx
+          repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
+          tag: v1.13.4
 
       - name: Release pre-compiled binaries and libs for linux x64
         if: github.repository_owner == 'k2-fsa' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')

--- a/.github/workflows/linux-gpu.yaml
+++ b/.github/workflows/linux-gpu.yaml
@@ -162,15 +162,15 @@ jobs:
           tar cjvf ${dst}.tar.bz2 $dst
 
       - name: Release pre-compiled binaries and libs for linux x64
-        # if: github.repository_owner == 'csukuangfj' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+        if: github.repository_owner == 'csukuangfj' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         uses: svenstaro/upload-release-action@v2
         with:
           file_glob: true
           overwrite: true
           file: sherpa-onnx-*gpu.tar.bz2
-          repo_name: k2-fsa/sherpa-onnx
-          repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
-          tag: v1.13.4
+          # repo_name: k2-fsa/sherpa-onnx
+          # repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
+          # tag: v1.13.4
 
       - name: Release pre-compiled binaries and libs for linux x64
         if: github.repository_owner == 'k2-fsa' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')


### PR DESCRIPTION
Fixes #3843

cc @jtrmal

Please see 
https://k2-fsa.github.io/sherpa/onnx/cuda

<img width="2162" height="1816" alt="Screenshot 2026-08-07 at 11 01 29" src="https://github.com/user-attachments/assets/3b028407-b4f2-45d4-85e6-6a434a5e1a84" />

----


and https://github.com/k2-fsa/sherpa-onnx/releases/tag/v1.13.4

<img width="2716" height="1460" alt="Screenshot 2026-08-07 at 11 51 05" src="https://github.com/user-attachments/assets/12402041-a460-4cb9-aff3-baf2e0dbb342" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Linux x64 CUDA wheels across Python 3.7–3.14.
  * Added build coverage for CUDA 12 and CUDA 13 configurations.
  * Build artifacts now include the CUDA version in their names.

* **Improvements**
  * Linux CUDA and GPU builds now generate supported configurations automatically.
  * ONNX Runtime packages are selected for each CUDA configuration.
  * GPU release artifacts now use updated versioning and upload settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->