### PR TITLE
Add CI for Flutter punctuation examples

### DIFF
--- a/.github/workflows/test-flutter-package.yaml
+++ b/.github/workflows/test-flutter-package.yaml
@@ -3,11 +3,7 @@ name: test-flutter-package
 on:
   push:
     branches:
-      - dart-xcframework-2
-
-  schedule:
-    # nightly build at 16:50 UTC time every day
-    - cron: "50 16 * * *"
+      - flutter-ci
 
   workflow_dispatch:
 
@@ -302,8 +298,12 @@ jobs:
 
   android:
     if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
-    name: Android
+    name: Android (${{ matrix.abi }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        abi: [arm64-v8a, armeabi-v7a, x86_64, x86]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -341,15 +341,15 @@ jobs:
         run: |
           cd flutter-examples/hello_world
           flutter pub get
-          flutter build apk
+          flutter build apk --split-per-abi --target-platform android-${{ matrix.abi }}
 
           ls -lh build/app/outputs/flutter-apk/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: hello-world-pkg-android
-          path: flutter-examples/hello_world/build/app/outputs/flutter-apk/app-release.apk
+          name: hello-world-pkg-android-${{ matrix.abi }}
+          path: flutter-examples/hello_world/build/app/outputs/flutter-apk/
 
   web:
     if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'

--- a/.github/workflows/test-flutter-package.yaml
+++ b/.github/workflows/test-flutter-package.yaml
@@ -3,7 +3,7 @@ name: test-flutter-package
 on:
   push:
     branches:
-      - flutter-ci
+      - flutter-ci-2
 
   workflow_dispatch:
 
@@ -410,12 +410,12 @@ jobs:
         shell: bash
         run: |
           cd flutter-examples/hello_world/build/
-          mv web hello-world-pkg-web
-          zip -r hello-world-pkg-web.zip hello-world-pkg-web/
-          ls -lh hello-world-pkg-web.zip
+          mv web flutter-hello-world-pkg-web
+          zip -r flutter-hello-world-pkg-web.zip flutter-hello-world-pkg-web/
+          ls -lh flutter-hello-world-pkg-web.zip
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: hello-world-pkg-web
-          path: flutter-examples/hello_world/build/hello-world-pkg-web.zip
+          name: flutter-hello-world-pkg-web
+          path: flutter-examples/hello_world/build/flutter-hello-world-pkg-web.zip

--- a/.github/workflows/test-flutter-punct.yaml
+++ b/.github/workflows/test-flutter-punct.yaml
@@ -77,13 +77,6 @@ jobs:
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
-      - name: Use local sherpa_onnx_web
-        shell: bash
-        run: |
-          cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_web: ^1.13.4|  # sherpa_onnx_web: ^1.13.4\n  sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
-          rm -f pubspec.yaml.bak
-          cat pubspec.yaml
 
       - name: Download model
         shell: bash
@@ -110,8 +103,9 @@ jobs:
           sed -i.bak 's|sherpa_onnx: ^1.13.4|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
-          flutter pub get
           flutter config --no-enable-swift-package-manager
+          flutter pub get
+          cd macos && pod install && cd ..
           flutter build macos
 
           ls -lh build/macos/Build/Products/Release/
@@ -211,13 +205,6 @@ jobs:
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
-      - name: Use local sherpa_onnx_web
-        shell: bash
-        run: |
-          cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_web: ^1.13.4|  # sherpa_onnx_web: ^1.13.4\n  sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
-          rm -f pubspec.yaml.bak
-          cat pubspec.yaml
 
       - name: Download model
         shell: bash
@@ -343,13 +330,6 @@ jobs:
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
-      - name: Use local sherpa_onnx_web
-        shell: bash
-        run: |
-          cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_web: ^1.13.4|  # sherpa_onnx_web: ^1.13.4\n  sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
-          rm -f pubspec.yaml.bak
-          cat pubspec.yaml
 
       - name: Download model
         shell: bash
@@ -455,13 +435,6 @@ jobs:
           cd ..
           ./generate-asset-list.py
 
-      - name: Use local sherpa_onnx_web
-        shell: bash
-        run: |
-          cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_web: ^1.13.4|  # sherpa_onnx_web: ^1.13.4\n  sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
-          rm -f pubspec.yaml.bak
-          cat pubspec.yaml
 
       - name: Build Flutter web app
         shell: bash

--- a/.github/workflows/test-flutter-punct.yaml
+++ b/.github/workflows/test-flutter-punct.yaml
@@ -4,12 +4,7 @@ on:
   push:
     branches:
       - master
-      - flutter-ci
-    paths:
-      - '.github/workflows/test-flutter-punct.yaml'
-      - 'flutter-examples/online-punctuation/**'
-      - 'flutter-examples/offline-punctuation/**'
-      - 'flutter/**'
+      - flutter-ci-2
 
   workflow_dispatch:
 
@@ -77,18 +72,25 @@ jobs:
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
+      - name: Remove sherpa_onnx_web dependency
+        shell: bash
+        run: |
+          cd flutter/sherpa_onnx
+          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: ^1.13.4|' pubspec.yaml
+          rm -f pubspec.yaml.bak
+
 
       - name: Download model
         shell: bash
         run: |
           cd flutter-examples/${{ matrix.demo }}/assets
           if [ "${{ matrix.demo }}" = "online-punctuation" ]; then
-            wget -q https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
+            curl -sSL -o sherpa-onnx-online-punct-en-2024-08-06.tar.bz2 https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
             tar xf sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
             rm sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
             rm sherpa-onnx-online-punct-en-2024-08-06/model.onnx
           else
-            wget -q https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
+            curl -sSL -o sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2 https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
             tar xf sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
             rm sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
           fi
@@ -114,16 +116,18 @@ jobs:
         shell: bash
         run: |
           cd flutter-examples/${{ matrix.demo }}/build/macos/Build/Products/Release/
-          mkdir -p ${{ matrix.demo }}
-          mv ${{ matrix.demo }}.app ${{ matrix.demo }}/
-          zip -r ${{ matrix.demo }}-macos.zip ${{ matrix.demo }}/
-          ls -lh ${{ matrix.demo }}-macos.zip
+          # Flutter converts hyphens to underscores in the app name.
+          app_name=$(echo ${{ matrix.demo }} | tr '-' '_')
+          mkdir -p flutter-${{ matrix.demo }}
+          mv ${app_name}.app flutter-${{ matrix.demo }}/
+          zip -r flutter-${{ matrix.demo }}-macos.zip flutter-${{ matrix.demo }}/
+          ls -lh flutter-${{ matrix.demo }}-macos.zip
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.demo }}-macos
-          path: flutter-examples/${{ matrix.demo }}/build/macos/Build/Products/Release/${{ matrix.demo }}-macos.zip
+          name: flutter-${{ matrix.demo }}-macos
+          path: flutter-examples/${{ matrix.demo }}/build/macos/Build/Products/Release/flutter-${{ matrix.demo }}-macos.zip
 
   linux:
     name: Linux (${{ matrix.demo }})
@@ -205,18 +209,25 @@ jobs:
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
+      - name: Remove sherpa_onnx_web dependency
+        shell: bash
+        run: |
+          cd flutter/sherpa_onnx
+          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: ^1.13.4|' pubspec.yaml
+          rm -f pubspec.yaml.bak
+
 
       - name: Download model
         shell: bash
         run: |
           cd flutter-examples/${{ matrix.demo }}/assets
           if [ "${{ matrix.demo }}" = "online-punctuation" ]; then
-            wget -q https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
+            curl -sSL -o sherpa-onnx-online-punct-en-2024-08-06.tar.bz2 https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
             tar xf sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
             rm sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
             rm sherpa-onnx-online-punct-en-2024-08-06/model.onnx
           else
-            wget -q https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
+            curl -sSL -o sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2 https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
             tar xf sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
             rm sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
           fi
@@ -239,8 +250,113 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.demo }}-linux
+          name: flutter-${{ matrix.demo }}-linux-x64
           path: flutter-examples/${{ matrix.demo }}/build/linux/*/release/bundle/
+
+  windows:
+    name: Windows (${{ matrix.demo }})
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        demo: [online-punctuation, offline-punctuation]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update version
+        shell: bash
+        run: |
+          ./new-release.sh
+          git diff .
+
+      - name: Setup Flutter SDK
+        uses: flutter-actions/setup-flutter@v4
+        with:
+          channel: stable
+          version: latest
+
+      - name: Display flutter info
+        shell: bash
+        run: |
+          which flutter
+          which dart
+          flutter --version
+          dart --version
+          flutter doctor
+
+      - name: Build sherpa-onnx from source
+        shell: bash
+        run: |
+          mkdir build
+          cd build
+          cmake \
+            -DBUILD_SHARED_LIBS=ON \
+            -DSHERPA_ONNX_ENABLE_PORTAUDIO=OFF \
+            -DSHERPA_ONNX_ENABLE_WEBSOCKET=OFF \
+            -DBUILD_ESPEAK_NG_EXE=OFF \
+            -DSHERPA_ONNX_ENABLE_BINARY=OFF \
+            -DCMAKE_INSTALL_PREFIX=./install \
+            ..
+          cmake --build . --target install --config Release
+
+      - name: Copy libs
+        shell: bash
+        run: |
+          cp -fv build/install/lib/*.dll ./flutter/sherpa_onnx_windows/windows/
+          ls -lh ./flutter/sherpa_onnx_windows/windows/
+
+      - name: Use local sherpa_onnx_windows
+        shell: bash
+        run: |
+          cd flutter/sherpa_onnx
+          sed -i.bak 's|  sherpa_onnx_windows: ^1.13.4|  # sherpa_onnx_windows: ^1.13.4\n  sherpa_onnx_windows:\n    path: ../sherpa_onnx_windows|' pubspec.yaml
+          rm -f pubspec.yaml.bak
+          cat pubspec.yaml
+
+      - name: Remove sherpa_onnx_web dependency
+        shell: bash
+        run: |
+          cd flutter/sherpa_onnx
+          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: ^1.13.4|' pubspec.yaml
+          rm -f pubspec.yaml.bak
+
+      - name: Download model
+        shell: bash
+        run: |
+          cd flutter-examples/${{ matrix.demo }}/assets
+          if [ "${{ matrix.demo }}" = "online-punctuation" ]; then
+            curl -sSL -o sherpa-onnx-online-punct-en-2024-08-06.tar.bz2 https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
+            tar xf sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
+            rm sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
+            rm sherpa-onnx-online-punct-en-2024-08-06/model.onnx
+          else
+            curl -sSL -o sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2 https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
+            tar xf sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
+            rm sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
+          fi
+          cd ..
+          ./generate-asset-list.py
+
+      - name: Build Flutter app
+        shell: bash
+        run: |
+          cd flutter-examples/${{ matrix.demo }}
+
+          sed -i.bak 's|sherpa_onnx: ^1.13.4|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          rm -f pubspec.yaml.bak
+
+          flutter pub get
+          flutter build windows
+
+          ls -lh build/windows/x64/runner/Release/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: flutter-${{ matrix.demo }}-win-x64
+          path: flutter-examples/${{ matrix.demo }}/build/windows/x64/runner/Release/
 
   android:
     name: Android (${{ matrix.demo }}, ${{ matrix.abi }})
@@ -336,12 +452,12 @@ jobs:
         run: |
           cd flutter-examples/${{ matrix.demo }}/assets
           if [ "${{ matrix.demo }}" = "online-punctuation" ]; then
-            wget -q https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
+            curl -sSL -o sherpa-onnx-online-punct-en-2024-08-06.tar.bz2 https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
             tar xf sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
             rm sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
             rm sherpa-onnx-online-punct-en-2024-08-06/model.onnx
           else
-            wget -q https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
+            curl -sSL -o sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2 https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
             tar xf sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
             rm sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
           fi
@@ -361,11 +477,18 @@ jobs:
 
           ls -lh build/app/outputs/flutter-apk/
 
+      - name: Rename APK
+        shell: bash
+        run: |
+          cd flutter-examples/${{ matrix.demo }}/build/app/outputs/flutter-apk/
+          mv app-*-release.apk flutter-${{ matrix.demo }}-${{ matrix.abi }}.apk
+          ls -lh *.apk
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.demo }}-android-${{ matrix.abi }}
-          path: flutter-examples/${{ matrix.demo }}/build/app/outputs/flutter-apk/
+          name: flutter-${{ matrix.demo }}-android-${{ matrix.abi }}
+          path: flutter-examples/${{ matrix.demo }}/build/app/outputs/flutter-apk/flutter-${{ matrix.demo }}-${{ matrix.abi }}.apk
 
   web:
     name: Web (${{ matrix.demo }})
@@ -408,9 +531,6 @@ jobs:
       - name: Build WASM module
         shell: bash
         run: |
-          export CMAKE_CXX_COMPILER_LAUNCHER=ccache
-          export CMAKE_C_COMPILER_LAUNCHER=ccache
-          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           ./build-wasm-simd-web.sh
 
       - name: Copy WASM assets to web plugin
@@ -423,12 +543,12 @@ jobs:
         run: |
           cd flutter-examples/${{ matrix.demo }}/assets
           if [ "${{ matrix.demo }}" = "online-punctuation" ]; then
-            wget -q https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
+            curl -sSL -o sherpa-onnx-online-punct-en-2024-08-06.tar.bz2 https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
             tar xf sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
             rm sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
             rm sherpa-onnx-online-punct-en-2024-08-06/model.onnx
           else
-            wget -q https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
+            curl -sSL -o sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2 https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
             tar xf sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
             rm sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
           fi
@@ -453,12 +573,12 @@ jobs:
         shell: bash
         run: |
           cd flutter-examples/${{ matrix.demo }}/build/
-          mv web ${{ matrix.demo }}
-          zip -r ${{ matrix.demo }}.zip ${{ matrix.demo }}/
-          ls -lh ${{ matrix.demo }}.zip
+          mv web flutter-${{ matrix.demo }}
+          zip -r flutter-${{ matrix.demo }}.zip flutter-${{ matrix.demo }}/
+          ls -lh flutter-${{ matrix.demo }}.zip
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.demo }}-web
-          path: flutter-examples/${{ matrix.demo }}/build/${{ matrix.demo }}.zip
+          name: flutter-${{ matrix.demo }}-web
+          path: flutter-examples/${{ matrix.demo }}/build/flutter-${{ matrix.demo }}.zip

--- a/.github/workflows/test-flutter-punct.yaml
+++ b/.github/workflows/test-flutter-punct.yaml
@@ -1,0 +1,491 @@
+name: test-flutter-punct
+
+on:
+  push:
+    branches:
+      - master
+      - flutter-ci
+    paths:
+      - '.github/workflows/test-flutter-punct.yaml'
+      - 'flutter-examples/online-punctuation/**'
+      - 'flutter-examples/offline-punctuation/**'
+      - 'flutter/**'
+
+  workflow_dispatch:
+
+concurrency:
+  group: test-flutter-punct-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  macos:
+    name: macOS (${{ matrix.demo }})
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        demo: [online-punctuation, offline-punctuation]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update version
+        shell: bash
+        run: |
+          ./new-release.sh
+          git diff .
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: macos-flutter-punct-${{ matrix.demo }}
+
+      - name: Setup Flutter SDK
+        uses: flutter-actions/setup-flutter@v4
+        with:
+          channel: stable
+          version: 3.44.8
+
+      - name: Display flutter info
+        shell: bash
+        run: |
+          which flutter
+          which dart
+          flutter --version
+          dart --version
+          flutter doctor
+
+      - name: Build xcframework from source
+        shell: bash
+        run: |
+          export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          ./build-macos-shared-sherpa-with-static-onnxruntime.sh
+
+      - name: Copy xcframework
+        shell: bash
+        run: |
+          cp -av build-macos-shared-sherpa-with-static-onnxruntime/sherpa-onnx.xcframework flutter/sherpa_onnx_macos/macos/sherpa_onnx_macos/SherpaOnnxC.xcframework
+          ls -lh flutter/sherpa_onnx_macos/macos/sherpa_onnx_macos/SherpaOnnxC.xcframework/
+
+      - name: Use local sherpa_onnx_macos
+        shell: bash
+        run: |
+          cd flutter/sherpa_onnx
+          sed -i.bak 's|  sherpa_onnx_macos: ^1.13.4|  # sherpa_onnx_macos: ^1.13.4\n  sherpa_onnx_macos:\n    path: ../sherpa_onnx_macos|' pubspec.yaml
+          rm -f pubspec.yaml.bak
+          cat pubspec.yaml
+
+      - name: Use local sherpa_onnx_web
+        shell: bash
+        run: |
+          cd flutter/sherpa_onnx
+          sed -i.bak 's|  sherpa_onnx_web: ^1.13.4|  # sherpa_onnx_web: ^1.13.4\n  sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
+          rm -f pubspec.yaml.bak
+          cat pubspec.yaml
+
+      - name: Download model
+        shell: bash
+        run: |
+          cd flutter-examples/${{ matrix.demo }}/assets
+          if [ "${{ matrix.demo }}" = "online-punctuation" ]; then
+            wget -q https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
+            tar xf sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
+            rm sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
+            rm sherpa-onnx-online-punct-en-2024-08-06/model.onnx
+          else
+            wget -q https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
+            tar xf sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
+            rm sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
+          fi
+          cd ..
+          ./generate-asset-list.py
+
+      - name: Build Flutter app
+        shell: bash
+        run: |
+          cd flutter-examples/${{ matrix.demo }}
+
+          sed -i.bak 's|sherpa_onnx: ^1.13.4|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          rm -f pubspec.yaml.bak
+
+          flutter pub get
+          flutter config --no-enable-swift-package-manager
+          flutter build macos
+
+          ls -lh build/macos/Build/Products/Release/
+
+      - name: Zip app
+        shell: bash
+        run: |
+          cd flutter-examples/${{ matrix.demo }}/build/macos/Build/Products/Release/
+          mkdir -p ${{ matrix.demo }}
+          mv ${{ matrix.demo }}.app ${{ matrix.demo }}/
+          zip -r ${{ matrix.demo }}-macos.zip ${{ matrix.demo }}/
+          ls -lh ${{ matrix.demo }}-macos.zip
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.demo }}-macos
+          path: flutter-examples/${{ matrix.demo }}/build/macos/Build/Products/Release/${{ matrix.demo }}-macos.zip
+
+  linux:
+    name: Linux (${{ matrix.demo }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        demo: [online-punctuation, offline-punctuation]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update version
+        shell: bash
+        run: |
+          ./new-release.sh
+          git diff .
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: linux-flutter-punct-${{ matrix.demo }}
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev
+
+      - name: Setup Flutter SDK
+        uses: flutter-actions/setup-flutter@v4
+        with:
+          channel: stable
+          version: latest
+
+      - name: Display flutter info
+        shell: bash
+        run: |
+          which flutter
+          which dart
+          flutter --version
+          dart --version
+          flutter doctor
+
+      - name: Build sherpa-onnx from source
+        shell: bash
+        run: |
+          export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          mkdir build
+          cd build
+          cmake \
+            -DBUILD_SHARED_LIBS=ON \
+            -DSHERPA_ONNX_ENABLE_PORTAUDIO=OFF \
+            -DSHERPA_ONNX_ENABLE_WEBSOCKET=OFF \
+            -DBUILD_ESPEAK_NG_EXE=OFF \
+            -DSHERPA_ONNX_ENABLE_BINARY=OFF \
+            -DCMAKE_INSTALL_PREFIX=./install \
+            ..
+          cmake --build . --target install --config Release
+
+      - name: Copy libs
+        shell: bash
+        run: |
+          if [[ $(uname -m) == "aarch64" ]]; then
+            arch=aarch64
+          else
+            arch=x64
+          fi
+          cp -fv build/install/lib/lib* ./flutter/sherpa_onnx_linux/linux/$arch
+          ls -lh ./flutter/sherpa_onnx_linux/linux/$arch
+
+      - name: Use local sherpa_onnx_linux
+        shell: bash
+        run: |
+          cd flutter/sherpa_onnx
+          sed -i.bak 's|  sherpa_onnx_linux: ^1.13.4|  # sherpa_onnx_linux: ^1.13.4\n  sherpa_onnx_linux:\n    path: ../sherpa_onnx_linux|' pubspec.yaml
+          rm -f pubspec.yaml.bak
+          cat pubspec.yaml
+
+      - name: Use local sherpa_onnx_web
+        shell: bash
+        run: |
+          cd flutter/sherpa_onnx
+          sed -i.bak 's|  sherpa_onnx_web: ^1.13.4|  # sherpa_onnx_web: ^1.13.4\n  sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
+          rm -f pubspec.yaml.bak
+          cat pubspec.yaml
+
+      - name: Download model
+        shell: bash
+        run: |
+          cd flutter-examples/${{ matrix.demo }}/assets
+          if [ "${{ matrix.demo }}" = "online-punctuation" ]; then
+            wget -q https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
+            tar xf sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
+            rm sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
+            rm sherpa-onnx-online-punct-en-2024-08-06/model.onnx
+          else
+            wget -q https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
+            tar xf sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
+            rm sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
+          fi
+          cd ..
+          ./generate-asset-list.py
+
+      - name: Build Flutter app
+        shell: bash
+        run: |
+          cd flutter-examples/${{ matrix.demo }}
+
+          sed -i.bak 's|sherpa_onnx: ^1.13.4|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          rm -f pubspec.yaml.bak
+
+          flutter pub get
+          flutter build linux
+
+          ls -lh build/linux/*/release/bundle/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.demo }}-linux
+          path: flutter-examples/${{ matrix.demo }}/build/linux/*/release/bundle/
+
+  android:
+    name: Android (${{ matrix.demo }}, ${{ matrix.abi }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        demo: [online-punctuation, offline-punctuation]
+        abi: [arm64-v8a, armeabi-v7a, x86_64]
+        include:
+          - abi: arm64-v8a
+            target_platform: android-arm64
+            build_script: build-android-arm64-v8a.sh
+            build_dir: build-android-arm64-v8a
+            plugin: sherpa_onnx_android_arm64
+            plugin_key: sherpa_onnx_android_arm64
+          - abi: armeabi-v7a
+            target_platform: android-arm
+            build_script: build-android-armv7-eabi.sh
+            build_dir: build-android-armv7-eabi
+            plugin: sherpa_onnx_android_armeabi
+            plugin_key: sherpa_onnx_android_armeabi
+          - abi: x86_64
+            target_platform: android-x64
+            build_script: build-android-x86-64.sh
+            build_dir: build-android-x86-64
+            plugin: sherpa_onnx_android_x86_64
+            plugin_key: sherpa_onnx_android_x86_64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update version
+        shell: bash
+        run: |
+          ./new-release.sh
+          git diff .
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: android-flutter-punct-${{ matrix.demo }}-${{ matrix.abi }}
+
+      - name: Setup Flutter SDK
+        uses: flutter-actions/setup-flutter@v4
+        with:
+          channel: stable
+          version: latest
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Display flutter info
+        shell: bash
+        run: |
+          which flutter
+          which dart
+          flutter --version
+          dart --version
+          flutter doctor
+
+      - name: Build ${{ matrix.abi }} from source
+        shell: bash
+        run: |
+          export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          export SHERPA_ONNX_ENABLE_C_API=ON
+          export SHERPA_ONNX_ENABLE_JNI=OFF
+          export SHERPA_ONNX_ENABLE_BINARY=OFF
+          ./${{ matrix.build_script }}
+
+      - name: Copy libs
+        shell: bash
+        run: |
+          cp -fv ${{ matrix.build_dir }}/install/lib/lib*.so flutter/${{ matrix.plugin }}/android/src/main/jniLibs/${{ matrix.abi }}/
+          ls -lh flutter/${{ matrix.plugin }}/android/src/main/jniLibs/${{ matrix.abi }}/
+
+      - name: Use local ${{ matrix.plugin }}
+        shell: bash
+        run: |
+          cd flutter/sherpa_onnx
+          sed -i.bak 's|  ${{ matrix.plugin_key }}: ^1.13.4|  # ${{ matrix.plugin_key }}: ^1.13.4\n  ${{ matrix.plugin_key }}:\n    path: ../${{ matrix.plugin }}|' pubspec.yaml
+          rm -f pubspec.yaml.bak
+          cat pubspec.yaml
+
+      - name: Use local sherpa_onnx_web
+        shell: bash
+        run: |
+          cd flutter/sherpa_onnx
+          sed -i.bak 's|  sherpa_onnx_web: ^1.13.4|  # sherpa_onnx_web: ^1.13.4\n  sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
+          rm -f pubspec.yaml.bak
+          cat pubspec.yaml
+
+      - name: Download model
+        shell: bash
+        run: |
+          cd flutter-examples/${{ matrix.demo }}/assets
+          if [ "${{ matrix.demo }}" = "online-punctuation" ]; then
+            wget -q https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
+            tar xf sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
+            rm sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
+            rm sherpa-onnx-online-punct-en-2024-08-06/model.onnx
+          else
+            wget -q https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
+            tar xf sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
+            rm sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
+          fi
+          cd ..
+          ./generate-asset-list.py
+
+      - name: Build Flutter APK
+        shell: bash
+        run: |
+          cd flutter-examples/${{ matrix.demo }}
+
+          sed -i.bak 's|sherpa_onnx: ^1.13.4|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          rm -f pubspec.yaml.bak
+
+          flutter pub get
+          flutter build apk --split-per-abi --target-platform ${{ matrix.target_platform }}
+
+          ls -lh build/app/outputs/flutter-apk/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.demo }}-android-${{ matrix.abi }}
+          path: flutter-examples/${{ matrix.demo }}/build/app/outputs/flutter-apk/
+
+  web:
+    name: Web (${{ matrix.demo }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        demo: [online-punctuation, offline-punctuation]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update version
+        shell: bash
+        run: |
+          ./new-release.sh
+          git diff .
+
+      - name: Install Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 4.0.23
+
+      - name: Setup Flutter SDK
+        uses: flutter-actions/setup-flutter@v4
+        with:
+          channel: stable
+          version: latest
+
+      - name: Display flutter info
+        shell: bash
+        run: |
+          which flutter
+          which dart
+          flutter --version
+          dart --version
+          flutter doctor
+
+      - name: Build WASM module
+        shell: bash
+        run: |
+          export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+          export CMAKE_C_COMPILER_LAUNCHER=ccache
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          ./build-wasm-simd-web.sh
+
+      - name: Copy WASM assets to web plugin
+        shell: bash
+        run: |
+          ./build-flutter-web-wasm.sh
+
+      - name: Download model
+        shell: bash
+        run: |
+          cd flutter-examples/${{ matrix.demo }}/assets
+          if [ "${{ matrix.demo }}" = "online-punctuation" ]; then
+            wget -q https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
+            tar xf sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
+            rm sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
+            rm sherpa-onnx-online-punct-en-2024-08-06/model.onnx
+          else
+            wget -q https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
+            tar xf sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
+            rm sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8.tar.bz2
+          fi
+          cd ..
+          ./generate-asset-list.py
+
+      - name: Use local sherpa_onnx_web
+        shell: bash
+        run: |
+          cd flutter/sherpa_onnx
+          sed -i.bak 's|  sherpa_onnx_web: ^1.13.4|  # sherpa_onnx_web: ^1.13.4\n  sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
+          rm -f pubspec.yaml.bak
+          cat pubspec.yaml
+
+      - name: Build Flutter web app
+        shell: bash
+        run: |
+          cd flutter-examples/${{ matrix.demo }}
+
+          sed -i.bak 's|sherpa_onnx: ^1.13.4|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          rm -f pubspec.yaml.bak
+
+          flutter pub get
+          flutter build web
+
+          ls -lh build/web/
+
+      - name: Zip web app
+        shell: bash
+        run: |
+          cd flutter-examples/${{ matrix.demo }}/build/
+          mv web ${{ matrix.demo }}
+          zip -r ${{ matrix.demo }}.zip ${{ matrix.demo }}/
+          ls -lh ${{ matrix.demo }}.zip
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.demo }}-web
+          path: flutter-examples/${{ matrix.demo }}/build/${{ matrix.demo }}.zip

--- a/.github/workflows/test-flutter.yaml
+++ b/.github/workflows/test-flutter.yaml
@@ -90,14 +90,16 @@ jobs:
         shell: bash
         run: |
           cd flutter-examples/hello_world/build/macos/Build/Products/Release/
-          zip -r hello-world-macos-cocoapods.zip hello_world.app
-          ls -lh hello-world-macos-cocoapods.zip
+          mkdir -p flutter-hello-world-macos-cocoapods
+          mv hello_world.app flutter-hello-world-macos-cocoapods/
+          zip -r flutter-hello-world-macos-cocoapods.zip flutter-hello-world-macos-cocoapods/
+          ls -lh flutter-hello-world-macos-cocoapods.zip
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: hello-world-macos-cocoapods
-          path: flutter-examples/hello_world/build/macos/Build/Products/Release/hello-world-macos-cocoapods.zip
+          name: flutter-hello-world-macos-cocoapods
+          path: flutter-examples/hello_world/build/macos/Build/Products/Release/flutter-hello-world-macos-cocoapods.zip
 
   macos_spm:
     name: macOS (SPM)
@@ -172,14 +174,16 @@ jobs:
         shell: bash
         run: |
           cd flutter-examples/hello_world/build/macos/Build/Products/Release/
-          zip -r hello-world-macos-spm.zip hello_world.app
-          ls -lh hello-world-macos-spm.zip
+          mkdir -p flutter-hello-world-macos-spm
+          mv hello_world.app flutter-hello-world-macos-spm/
+          zip -r flutter-hello-world-macos-spm.zip flutter-hello-world-macos-spm/
+          ls -lh flutter-hello-world-macos-spm.zip
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: hello-world-macos-spm
-          path: flutter-examples/hello_world/build/macos/Build/Products/Release/hello-world-macos-spm.zip
+          name: flutter-hello-world-macos-spm
+          path: flutter-examples/hello_world/build/macos/Build/Products/Release/flutter-hello-world-macos-spm.zip
 
   ios_cocoapods:
     name: iOS (CocoaPods)
@@ -516,25 +520,23 @@ jobs:
       matrix:
         include:
           - abi: arm64-v8a
+            target_platform: android-arm64
             build_script: build-android-arm64-v8a.sh
             build_dir: build-android-arm64-v8a
             plugin: sherpa_onnx_android_arm64
             plugin_key: sherpa_onnx_android_arm64
           - abi: armeabi-v7a
+            target_platform: android-arm
             build_script: build-android-armv7-eabi.sh
             build_dir: build-android-armv7-eabi
             plugin: sherpa_onnx_android_armeabi
             plugin_key: sherpa_onnx_android_armeabi
           - abi: x86_64
+            target_platform: android-x64
             build_script: build-android-x86-64.sh
             build_dir: build-android-x86-64
             plugin: sherpa_onnx_android_x86_64
             plugin_key: sherpa_onnx_android_x86_64
-          - abi: x86
-            build_script: build-android-x86.sh
-            build_dir: build-android-x86
-            plugin: sherpa_onnx_android_x86
-            plugin_key: sherpa_onnx_android_x86
     steps:
       - uses: actions/checkout@v4
         with:
@@ -605,7 +607,7 @@ jobs:
           rm -f pubspec.yaml.bak
 
           flutter pub get
-          flutter build apk --split-per-abi --target-platform android-${{ matrix.abi }}
+          flutter build apk --split-per-abi --target-platform ${{ matrix.target_platform }}
 
           ls -lh build/app/outputs/flutter-apk/
 
@@ -684,12 +686,12 @@ jobs:
         shell: bash
         run: |
           cd flutter-examples/hello_world/build/
-          mv web hello-world-web
-          zip -r hello-world-web.zip hello-world-web/
-          ls -lh hello-world-web.zip
+          mv web flutter-hello-world-web
+          zip -r flutter-hello-world-web.zip flutter-hello-world-web/
+          ls -lh flutter-hello-world-web.zip
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: hello-world-web
-          path: flutter-examples/hello_world/build/hello-world-web.zip
+          name: flutter-hello-world-web
+          path: flutter-examples/hello_world/build/flutter-hello-world-web.zip

--- a/.github/workflows/test-flutter.yaml
+++ b/.github/workflows/test-flutter.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - dart-xcframework
+      - flutter-ci
     paths:
       - '.github/workflows/test-flutter.yaml'
       - 'flutter-examples/hello_world/**'
@@ -509,8 +509,32 @@ jobs:
           path: flutter-examples/hello_world/build/windows/x64/runner/Release/
 
   android:
-    name: Android
+    name: Android (${{ matrix.abi }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - abi: arm64-v8a
+            build_script: build-android-arm64-v8a.sh
+            build_dir: build-android-arm64-v8a
+            plugin: sherpa_onnx_android_arm64
+            plugin_key: sherpa_onnx_android_arm64
+          - abi: armeabi-v7a
+            build_script: build-android-armv7-eabi.sh
+            build_dir: build-android-armv7-eabi
+            plugin: sherpa_onnx_android_armeabi
+            plugin_key: sherpa_onnx_android_armeabi
+          - abi: x86_64
+            build_script: build-android-x86-64.sh
+            build_dir: build-android-x86-64
+            plugin: sherpa_onnx_android_x86_64
+            plugin_key: sherpa_onnx_android_x86_64
+          - abi: x86
+            build_script: build-android-x86.sh
+            build_dir: build-android-x86
+            plugin: sherpa_onnx_android_x86
+            plugin_key: sherpa_onnx_android_x86
     steps:
       - uses: actions/checkout@v4
         with:
@@ -525,7 +549,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: android-flutter
+          key: android-flutter-${{ matrix.abi }}
 
       - name: Setup Flutter SDK
         uses: flutter-actions/setup-flutter@v4
@@ -548,7 +572,7 @@ jobs:
           dart --version
           flutter doctor
 
-      - name: Build android-arm64-v8a from source
+      - name: Build ${{ matrix.abi }} from source
         shell: bash
         run: |
           export CMAKE_CXX_COMPILER_LAUNCHER=ccache
@@ -556,19 +580,19 @@ jobs:
           export SHERPA_ONNX_ENABLE_C_API=ON
           export SHERPA_ONNX_ENABLE_JNI=OFF
           export SHERPA_ONNX_ENABLE_BINARY=OFF
-          ./build-android-arm64-v8a.sh
+          ./${{ matrix.build_script }}
 
       - name: Copy libs
         shell: bash
         run: |
-          cp -fv build-android-arm64-v8a/install/lib/lib*.so flutter/sherpa_onnx_android_arm64/android/src/main/jniLibs/arm64-v8a/
-          ls -lh flutter/sherpa_onnx_android_arm64/android/src/main/jniLibs/arm64-v8a/
+          cp -fv ${{ matrix.build_dir }}/install/lib/lib*.so flutter/${{ matrix.plugin }}/android/src/main/jniLibs/${{ matrix.abi }}/
+          ls -lh flutter/${{ matrix.plugin }}/android/src/main/jniLibs/${{ matrix.abi }}/
 
-      - name: Use local sherpa_onnx_android_arm64
+      - name: Use local ${{ matrix.plugin }}
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_android_arm64: ^1.13.4|  # sherpa_onnx_android_arm64: ^1.13.4\n  sherpa_onnx_android_arm64:\n    path: ../sherpa_onnx_android_arm64|' pubspec.yaml
+          sed -i.bak 's|  ${{ matrix.plugin_key }}: ^1.13.4|  # ${{ matrix.plugin_key }}: ^1.13.4\n  ${{ matrix.plugin_key }}:\n    path: ../${{ matrix.plugin }}|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -581,15 +605,15 @@ jobs:
           rm -f pubspec.yaml.bak
 
           flutter pub get
-          flutter build apk
+          flutter build apk --split-per-abi --target-platform android-${{ matrix.abi }}
 
           ls -lh build/app/outputs/flutter-apk/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: hello-world-android
-          path: flutter-examples/hello_world/build/app/outputs/flutter-apk/app-release.apk
+          name: hello-world-android-${{ matrix.abi }}
+          path: flutter-examples/hello_world/build/app/outputs/flutter-apk/
 
   web:
     name: Web

--- a/.github/workflows/test-flutter.yaml
+++ b/.github/workflows/test-flutter.yaml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - master
-      - flutter-ci
-    paths:
-      - '.github/workflows/test-flutter.yaml'
-      - 'flutter-examples/hello_world/**'
-      - 'flutter/**'
 
   workflow_dispatch:
 
@@ -434,7 +429,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: hello-world-linux-${{ matrix.os }}
+          name: flutter-hello-world-linux-x64
           path: flutter-examples/hello_world/build/linux/*/release/bundle/
 
   windows:
@@ -511,7 +506,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: hello-world-windows
+          name: flutter-hello-world-win-x64
           path: flutter-examples/hello_world/build/windows/x64/runner/Release/
 
   android:
@@ -613,11 +608,18 @@ jobs:
 
           ls -lh build/app/outputs/flutter-apk/
 
+      - name: Rename APK
+        shell: bash
+        run: |
+          cd flutter-examples/hello_world/build/app/outputs/flutter-apk/
+          mv app-*-release.apk flutter-hello-world-${{ matrix.abi }}.apk
+          ls -lh *.apk
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: hello-world-android-${{ matrix.abi }}
-          path: flutter-examples/hello_world/build/app/outputs/flutter-apk/
+          name: flutter-hello-world-android-${{ matrix.abi }}
+          path: flutter-examples/hello_world/build/app/outputs/flutter-apk/flutter-hello-world-${{ matrix.abi }}.apk
 
   web:
     name: Web

--- a/.github/workflows/test-flutter.yaml
+++ b/.github/workflows/test-flutter.yaml
@@ -80,8 +80,9 @@ jobs:
           sed -i.bak 's|sherpa_onnx: ^1.13.4|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
-          flutter pub get
           flutter config --no-enable-swift-package-manager
+          flutter pub get
+          cd macos && pod install && cd ..
           flutter build macos
 
           ls -lh build/macos/Build/Products/Release/
@@ -248,8 +249,9 @@ jobs:
           sed -i.bak 's|sherpa_onnx: ^1.13.4|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
-          flutter pub get
           flutter config --no-enable-swift-package-manager
+          flutter pub get
+          cd ios && pod install && cd ..
           flutter build ios --no-codesign
 
           ls -lh build/ios/iphoneos/

--- a/cmake/simple-sentencepiece.cmake
+++ b/cmake/simple-sentencepiece.cmake
@@ -83,6 +83,12 @@ class ThreadPool {
     set(BUILD_SHARED_LIBS OFF)
   endif()
 
+  # Skip the C++14 compiler check for WASM (Emscripten supports it but the
+  # CMake test may fail depending on flags).
+  if(SHERPA_ONNX_ENABLE_WASM)
+    set(SBPE_COMPILER_SUPPORTS_CXX14 ON CACHE BOOL "" FORCE)
+  endif()
+
   add_subdirectory(${simple-sentencepiece_SOURCE_DIR} ${simple-sentencepiece_BINARY_DIR} EXCLUDE_FROM_ALL)
 
   if(TARGET ssentencepiece_core AND (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))

--- a/cmake/simple-sentencepiece.cmake
+++ b/cmake/simple-sentencepiece.cmake
@@ -55,18 +55,16 @@ function(download_simple_sentencepiece)
 #include <functional>
 #include <future>
 #include <memory>
-#include <type_traits>
-#include <utility>
-#include <vector>
 
 class ThreadPool {
  public:
   ThreadPool(size_t) {}
+  // C++14 compatible: use auto return type with decltype.
   template<class F, class... Args>
-  std::future<std::invoke_result_t<F, Args...>>
-  enqueue(F&& f, Args&&... args) {
+  auto enqueue(F&& f, Args&&... args)
+      -> std::future<decltype(f(args...))> {
     // Run synchronously — no threading in WASM.
-    using return_type = std::invoke_result_t<F, Args...>;
+    using return_type = decltype(f(args...));
     auto task = std::make_shared<std::packaged_task<return_type()>>(
         std::bind(std::forward<F>(f), std::forward<Args>(args)...));
     std::future<return_type> res = task->get_future();

--- a/flutter-examples/offline-punctuation/pubspec.yaml
+++ b/flutter-examples/offline-punctuation/pubspec.yaml
@@ -17,8 +17,9 @@ dependencies:
   cupertino_icons: ^1.0.6
   path_provider: ^2.1.3
   path: ^1.9.0
-  sherpa_onnx:
-    path: ../../flutter/sherpa_onnx
+  sherpa_onnx: 1.13.4
+  # sherpa_onnx:
+  #   path: ../../flutter/sherpa_onnx
   url_launcher: 6.2.6
   url_launcher_linux: 3.1.0
 

--- a/flutter-examples/offline-punctuation/pubspec.yaml
+++ b/flutter-examples/offline-punctuation/pubspec.yaml
@@ -19,8 +19,6 @@ dependencies:
   path: ^1.9.0
   sherpa_onnx:
     path: ../../flutter/sherpa_onnx
-  sherpa_onnx_web:
-    path: ../../flutter/sherpa_onnx_web
   url_launcher: 6.2.6
   url_launcher_linux: 3.1.0
 

--- a/flutter-examples/online-punctuation/pubspec.yaml
+++ b/flutter-examples/online-punctuation/pubspec.yaml
@@ -17,8 +17,9 @@ dependencies:
   cupertino_icons: ^1.0.6
   path_provider: ^2.1.3
   path: ^1.9.0
-  sherpa_onnx:
-    path: ../../flutter/sherpa_onnx
+  sherpa_onnx: 1.13.4
+  # sherpa_onnx:
+  #   path: ../../flutter/sherpa_onnx
   url_launcher: 6.2.6
   url_launcher_linux: 3.1.0
 

--- a/flutter-examples/online-punctuation/pubspec.yaml
+++ b/flutter-examples/online-punctuation/pubspec.yaml
@@ -19,8 +19,6 @@ dependencies:
   path: ^1.9.0
   sherpa_onnx:
     path: ../../flutter/sherpa_onnx
-  sherpa_onnx_web:
-    path: ../../flutter/sherpa_onnx_web
   url_launcher: 6.2.6
   url_launcher_linux: 3.1.0
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated packaging for Flutter punctuation demos across macOS, Linux, Windows, Android, and Web.
  * Added Android builds for multiple device architectures with architecture-specific downloadable packages.
  * Added split APK generation and platform-specific artifact packaging.

* **Bug Fixes**
  * Improved WebAssembly compatibility for supported builds.

* **Chores**
  * Updated punctuation examples to use the published `sherpa_onnx` 1.13.4 package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->