### PR TITLE
Add emotion_id input to offline VITS TTS

### DIFF
--- a/sherpa-onnx/csrc/offline-tts-vits-impl.h
+++ b/sherpa-onnx/csrc/offline-tts-vits-impl.h
@@ -148,7 +148,9 @@ class OfflineTtsVitsImpl : public OfflineTtsImpl {
   //   - silence_scale: Scale applied to pauses in the generated audio
   //
   // Supported extra options in config.extra:
-  //   - None
+  //   - emotion_id: Emotion index for multi-emotion models (default: 0).
+  //     Only used if the model exposes num_emotions > 0 metadata and
+  //     an "emotion_id" input tensor.
   GeneratedAudio Generate(
       const std::string &_text, const GenerationConfig &gen_config,
       GeneratedAudioCallback callback = nullptr) const override {
@@ -157,6 +159,7 @@ class OfflineTtsVitsImpl : public OfflineTtsImpl {
     }
 
     int64_t sid = gen_config.sid;
+    int64_t emotion_id = gen_config.GetExtraInt("emotion_id", 0);
     float speed = gen_config.speed;
     if (speed <= 0) {
       SHERPA_ONNX_LOGE("Speed must be > 0. Given: %f", speed);
@@ -193,6 +196,42 @@ class OfflineTtsVitsImpl : public OfflineTtsImpl {
           num_speakers, 0, num_speakers - 1, static_cast<int32_t>(sid));
 #endif
       sid = 0;
+    }
+
+    int32_t num_emotions = meta_data.num_emotions;
+
+    if (num_emotions == 0 && emotion_id != 0) {
+#if __OHOS__
+      SHERPA_ONNX_LOGE(
+          "This model does not support emotion selection. Given emotion_id: "
+          "%{public}d. emotion_id is ignored",
+          static_cast<int32_t>(emotion_id));
+#else
+      SHERPA_ONNX_LOGE(
+          "This model does not support emotion selection. Given emotion_id: "
+          "%d. emotion_id is ignored",
+          static_cast<int32_t>(emotion_id));
+#endif
+      emotion_id = 0;
+    }
+
+    if (num_emotions != 0 &&
+        (emotion_id >= num_emotions || emotion_id < 0)) {
+#if __OHOS__
+      SHERPA_ONNX_LOGE(
+          "This model contains only %{public}d emotions. emotion_id should be "
+          "in the range [%{public}d, %{public}d]. Given: %{public}d. Use "
+          "emotion_id=0",
+          num_emotions, 0, num_emotions - 1,
+          static_cast<int32_t>(emotion_id));
+#else
+      SHERPA_ONNX_LOGE(
+          "This model contains only %d emotions. emotion_id should be in the "
+          "range [%d, %d]. Given: %d. Use emotion_id=0",
+          num_emotions, 0, num_emotions - 1,
+          static_cast<int32_t>(emotion_id));
+#endif
+      emotion_id = 0;
     }
 
     std::string text = _text;
@@ -257,7 +296,8 @@ class OfflineTtsVitsImpl : public OfflineTtsImpl {
     int32_t x_size = static_cast<int32_t>(x.size());
 
     if (config_.max_num_sentences <= 0 || x_size <= config_.max_num_sentences) {
-      auto ans = Process(x, tones, sid, speed, gen_config.silence_scale);
+      auto ans = Process(x, tones, sid, speed, gen_config.silence_scale,
+                         emotion_id);
       if (callback) {
         callback(ans.samples.data(), ans.samples.size(), 1.0);
       }
@@ -306,7 +346,8 @@ class OfflineTtsVitsImpl : public OfflineTtsImpl {
       }
 
       auto audio =
-          Process(batch_x, batch_tones, sid, speed, gen_config.silence_scale);
+          Process(batch_x, batch_tones, sid, speed, gen_config.silence_scale,
+                  emotion_id);
       ans.sample_rate = audio.sample_rate;
       ans.samples.insert(ans.samples.end(), audio.samples.begin(),
                          audio.samples.end());
@@ -332,7 +373,8 @@ class OfflineTtsVitsImpl : public OfflineTtsImpl {
 
     if (!batch_x.empty()) {
       auto audio =
-          Process(batch_x, batch_tones, sid, speed, gen_config.silence_scale);
+          Process(batch_x, batch_tones, sid, speed, gen_config.silence_scale,
+                  emotion_id);
       ans.sample_rate = audio.sample_rate;
       ans.samples.insert(ans.samples.end(), audio.samples.begin(),
                          audio.samples.end());
@@ -437,7 +479,8 @@ class OfflineTtsVitsImpl : public OfflineTtsImpl {
 
   GeneratedAudio Process(const std::vector<std::vector<int64_t>> &tokens,
                          const std::vector<std::vector<int64_t>> &tones,
-                         int32_t sid, float speed, float silence_scale) const {
+                         int32_t sid, float speed, float silence_scale,
+                         int64_t emotion_id = 0) const {
     int32_t num_tokens = 0;
     for (const auto &k : tokens) {
       num_tokens += k.size();
@@ -473,7 +516,7 @@ class OfflineTtsVitsImpl : public OfflineTtsImpl {
 
     Ort::Value audio{nullptr};
     if (tones.empty()) {
-      audio = model_->Run(std::move(x_tensor), sid, speed);
+      audio = model_->Run(std::move(x_tensor), sid, speed, emotion_id);
     } else {
       audio =
           model_->Run(std::move(x_tensor), std::move(tones_tensor), sid, speed);

--- a/sherpa-onnx/csrc/offline-tts-vits-model-meta-data.h
+++ b/sherpa-onnx/csrc/offline-tts-vits-model-meta-data.h
@@ -17,6 +17,7 @@ struct OfflineTtsVitsModelMetaData {
   int32_t sample_rate = 0;
   int32_t add_blank = 0;
   int32_t num_speakers = 0;
+  int32_t num_emotions = 0;
 
   bool is_piper = false;
   bool is_coqui = false;

--- a/sherpa-onnx/csrc/offline-tts-vits-model.cc
+++ b/sherpa-onnx/csrc/offline-tts-vits-model.cc
@@ -50,14 +50,14 @@ class OfflineTtsVitsModel::Impl {
     Init(buf.data(), buf.size());
   }
 
-  Ort::Value Run(Ort::Value x, int64_t sid, float speed) {
+  Ort::Value Run(Ort::Value x, int64_t sid, float speed, int64_t emotion_id) {
     if (meta_data_.is_piper || meta_data_.is_coqui) {
       return RunVitsPiperOrCoqui(std::move(x), sid, speed);
     } else if (meta_data_.is_inflect) {
       return RunVitsInflect(std::move(x), speed);
     }
 
-    return RunVits(std::move(x), sid, speed);
+    return RunVits(std::move(x), sid, speed, emotion_id);
   }
 
   Ort::Value Run(Ort::Value x, Ort::Value tones, int64_t sid, float speed) {
@@ -174,6 +174,8 @@ class OfflineTtsVitsModel::Impl {
                                             0);
     SHERPA_ONNX_READ_META_DATA_WITH_DEFAULT(meta_data_.version, "version", 0);
     SHERPA_ONNX_READ_META_DATA(meta_data_.num_speakers, "n_speakers");
+    SHERPA_ONNX_READ_META_DATA_WITH_DEFAULT(meta_data_.num_emotions,
+                                            "num_emotions", 0);
     SHERPA_ONNX_READ_META_DATA_STR_WITH_DEFAULT(meta_data_.punctuations,
                                                 "punctuation", "");
     SHERPA_ONNX_READ_META_DATA_STR(meta_data_.language, "language");
@@ -334,7 +336,8 @@ class OfflineTtsVitsModel::Impl {
     return std::move(out[0]);
   }
 
-  Ort::Value RunVits(Ort::Value x, int64_t sid, float speed) {
+  Ort::Value RunVits(Ort::Value x, int64_t sid, float speed,
+                     int64_t emotion_id) {
     auto memory_info =
         Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeDefault);
 
@@ -372,17 +375,25 @@ class OfflineTtsVitsModel::Impl {
     Ort::Value sid_tensor =
         Ort::Value::CreateTensor(memory_info, &sid, 1, &scale_shape, 1);
 
+    Ort::Value emotion_tensor = Ort::Value::CreateTensor(
+        memory_info, &emotion_id, 1, &scale_shape, 1);
+
     std::vector<Ort::Value> inputs;
-    inputs.reserve(6);
+    inputs.reserve(7);
     inputs.push_back(std::move(x));
     inputs.push_back(std::move(x_length));
     inputs.push_back(std::move(noise_scale_tensor));
     inputs.push_back(std::move(length_scale_tensor));
     inputs.push_back(std::move(noise_scale_w_tensor));
 
-    if (input_names_.size() == 6 &&
-        (input_names_.back() == "sid" || input_names_.back() == "speaker")) {
+    if (input_names_.size() >= 6 &&
+        (input_names_[5] == "sid" || input_names_[5] == "speaker")) {
       inputs.push_back(std::move(sid_tensor));
+    }
+
+    if (meta_data_.num_emotions > 0 && input_names_.size() >= 7 &&
+        (input_names_[6] == "emotion_id" || input_names_[6] == "emotion")) {
+      inputs.push_back(std::move(emotion_tensor));
     }
 
     auto out =
@@ -420,8 +431,9 @@ OfflineTtsVitsModel::OfflineTtsVitsModel(Manager *mgr,
 OfflineTtsVitsModel::~OfflineTtsVitsModel() = default;
 
 Ort::Value OfflineTtsVitsModel::Run(Ort::Value x, int64_t sid /*=0*/,
-                                    float speed /*= 1.0*/) {
-  return impl_->Run(std::move(x), sid, speed);
+                                    float speed /*= 1.0*/,
+                                    int64_t emotion_id /*= 0*/) {
+  return impl_->Run(std::move(x), sid, speed, emotion_id);
 }
 
 Ort::Value OfflineTtsVitsModel::Run(Ort::Value x, Ort::Value tones,

--- a/sherpa-onnx/csrc/offline-tts-vits-model.h
+++ b/sherpa-onnx/csrc/offline-tts-vits-model.h
@@ -26,14 +26,18 @@ class OfflineTtsVitsModel {
   /** Run the model.
    *
    * @param x A int64 tensor of shape (1, num_tokens)
-  // @param sid Speaker ID. Used only for multi-speaker models, e.g., models
-  //            trained using the VCTK dataset. It is not used for
-  //            single-speaker models, e.g., models trained using the ljspeech
-  //            dataset.
+   * @param sid Speaker ID. Used only for multi-speaker models, e.g., models
+   *            trained using the VCTK dataset. It is not used for
+   *            single-speaker models, e.g., models trained using the ljspeech
+   *            dataset.
+   * @param emotion_id Emotion ID. Used only for multi-emotion VITS models
+   *            whose ONNX file exposes an extra emotion_id input tensor
+   *            (num_emotions > 0 in the model metadata).
    * @return Return a float32 tensor containing audio samples. You can flatten
    *         it to a 1-D tensor.
    */
-  Ort::Value Run(Ort::Value x, int64_t sid = 0, float speed = 1.0);
+  Ort::Value Run(Ort::Value x, int64_t sid = 0, float speed = 1.0,
+                 int64_t emotion_id = 0);
 
   // This is for MeloTTS
   Ort::Value Run(Ort::Value x, Ort::Value tones, int64_t sid = 0,

--- a/sherpa-onnx/csrc/sherpa-onnx-offline-tts.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-offline-tts.cc
@@ -103,6 +103,7 @@ or details.
   sherpa_onnx::ParseOptions po(kUsageMessage);
   std::string output_filename = "./generated.wav";
   int32_t sid = 0;
+  int32_t emotion_id = -1;
 
   std::string reference_audio;
   po.Register(
@@ -135,6 +136,10 @@ or details.
               "Speaker ID. Used only for multi-speaker models, e.g., models "
               "trained using the VCTK dataset. Not used for single-speaker "
               "models, e.g., models trained using the LJSpeech dataset");
+
+  po.Register("emotion-id", &emotion_id,
+              "Emotion ID. Used only for models that support emotion "
+              "selection. Ignored otherwise.");
 
   po.Register("speed", &gen_config.speed,
               "Speech speed. Larger=faster. Used by Supertonic, VITS, etc. "
@@ -179,6 +184,10 @@ or details.
                          !config.model.zipvoice.decoder.empty();
 
   gen_config.sid = sid;
+
+  if (emotion_id >= 0) {
+    gen_config.extra["emotion_id"] = std::to_string(emotion_id);
+  }
 
   if (is_supertonic_tts && !lang.empty()) {
     gen_config.extra["lang"] = lang;


### PR DESCRIPTION
### Motivation
There are several TTS models that offer emotion selection. However, the current input shape for offline TTS is:
```
x, x_length, noise_scale, length_scale, noise_scale_w, sid
```
Note that there is no emotion input tensor parameter available. This forces the user who wants to use multi-emotion models, such as [`ai4bharat/vits_rasa_13`](https://huggingface.co/ai4bharat/vits_rasa_13), to export the model with a baked emotion (i.e. the emotion is immutable after the export).

So, to fully take advantage of the multi-emotion models, we would want to export it as intended: with the emotion being an input tensor of its own, namely `emotion_id`.

As of 6897144f087712d0972648fb9ece6ca211b5ee41, if we export it with the `emotion_id` input tensor, and attempt to do TTS with `sherpa-onnx-offline-tts`, we would see the following error:
```bash
... [with T = onnxruntime::Tensor] Missing Input: emotion_id
```

This PR adds `emotion_id` as the optional 7th input tensor to offline VITS TTS to allow for emotion selection. This feature is only enabled when the model's metadata has `num_emotions > 0` and the `ONNX` export has the `emotion_id` input tensor. That is to say that it's completely ignored, if either condition is not met.

Notes:
- Bindings: C++ API, C API
- New `sherpa-onnx-offline-tts` CLI flag: `--emotion-id`
- Resolves #2700. 

### Example Usage

Here is an example of how we vary the emotion using [sherpa-onnx-vits-rasa-13](https://huggingface.co/MatiasLin/sherpa-onnx-vits-rasa-13) (my published `ONNX` export of [ai4bharat/vits_rasa_13](https://huggingface.co/ai4bharat/vits_rasa_13))
```bash
curl -SL -O https://huggingface.co/MatiasLin/sherpa-onnx-vits-rasa-13/resolve/main/model.onnx
curl -SL -O https://huggingface.co/MatiasLin/sherpa-onnx-vits-rasa-13/resolve/main/tokens.txt

sherpa-onnx-offline-tts \
  --vits-model=./model.onnx \
  --vits-tokens=./tokens.txt \
  --sid=0 \
  --emotion-id=0 \
  --output-filename=./rasa_emotion_id_0.wav \
  "வணககம, நஙகள எபபடி இருககிறரகள"

sherpa-onnx-offline-tts \
  --vits-model=./model.onnx \
  --vits-tokens=./tokens.txt \
  --sid=0 \
  --emotion-id=1 \
  --output-filename=./rasa_emotion_id_1.wav \
  "வணககம, நஙகள எபபடி இருககிறரகள"
```
Here is a sample output with only the `emotion_id` varying:
- [rasa_emotion_id_0.wav](https://github.com/user-attachments/files/30837203/rasa_emotion_id_0.wav)
- [rasa_emotion_id_1.wav](https://github.com/user-attachments/files/30837204/rasa_emotion_id_1.wav)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added emotion selection for multi-emotion VITS text-to-speech models.
  - Added an `--emotion-id` command-line option.
  - Emotion settings now work with both single and batched synthesis.
- **Bug Fixes**
  - Unsupported or out-of-range emotion IDs safely fall back to the default emotion with diagnostic logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->