### PR TITLE
Use onnxruntime 1.27.1 for Linux aarch64 and Android

### DIFF
--- a/build-android-arm64-v8a.sh
+++ b/build-android-arm64-v8a.sh
@@ -90,7 +90,7 @@ fi
 
 echo "ANDROID_NDK: $ANDROID_NDK"
 sleep 1
-onnxruntime_version=${SHERPA_ONNX_ONNXRUNTIME_VERSION:-1.27.0}
+onnxruntime_version=${SHERPA_ONNX_ONNXRUNTIME_VERSION:-1.27.1}
 
 if [ -n "${SHERPA_ONNXRUNTIME_LIB_DIR:-}" ] && [ -n "${SHERPA_ONNXRUNTIME_INCLUDE_DIR:-}" ]; then
   echo "Using externally provided ONNX Runtime"

--- a/build-android-armv7-eabi.sh
+++ b/build-android-armv7-eabi.sh
@@ -91,7 +91,7 @@ fi
 echo "ANDROID_NDK: $ANDROID_NDK"
 sleep 1
 
-onnxruntime_version=${SHERPA_ONNX_ONNXRUNTIME_VERSION:-1.27.0}
+onnxruntime_version=${SHERPA_ONNX_ONNXRUNTIME_VERSION:-1.27.1}
 
 if [ -n "${SHERPA_ONNXRUNTIME_LIB_DIR:-}" ] && [ -n "${SHERPA_ONNXRUNTIME_INCLUDE_DIR:-}" ]; then
   echo "Using externally provided ONNX Runtime"

--- a/build-android-x86-64.sh
+++ b/build-android-x86-64.sh
@@ -91,7 +91,7 @@ fi
 echo "ANDROID_NDK: $ANDROID_NDK"
 sleep 1
 
-onnxruntime_version=${SHERPA_ONNX_ONNXRUNTIME_VERSION:-1.27.0}
+onnxruntime_version=${SHERPA_ONNX_ONNXRUNTIME_VERSION:-1.27.1}
 
 if [ -n "${SHERPA_ONNXRUNTIME_LIB_DIR:-}" ] && [ -n "${SHERPA_ONNXRUNTIME_INCLUDE_DIR:-}" ]; then
   echo "Using externally provided ONNX Runtime"

--- a/build-android-x86.sh
+++ b/build-android-x86.sh
@@ -71,7 +71,7 @@ fi
 echo "ANDROID_NDK: $ANDROID_NDK"
 sleep 1
 
-onnxruntime_version=${SHERPA_ONNX_ONNXRUNTIME_VERSION:-1.27.0}
+onnxruntime_version=${SHERPA_ONNX_ONNXRUNTIME_VERSION:-1.27.1}
 
 if [ -n "${SHERPA_ONNXRUNTIME_LIB_DIR:-}" ] && [ -n "${SHERPA_ONNXRUNTIME_INCLUDE_DIR:-}" ]; then
   echo "Using externally provided ONNX Runtime"

--- a/cmake/onnxruntime-linux-aarch64-static.cmake
+++ b/cmake/onnxruntime-linux-aarch64-static.cmake
@@ -14,19 +14,19 @@ if(BUILD_SHARED_LIBS)
   message(FATAL_ERROR "This file is for building static libraries. BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 endif()
 
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.27.0/onnxruntime-linux-aarch64-static_lib-1.27.0-glibc2_17.zip")
-set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj2/onnxruntime-libs/resolve/main/1.27.0/onnxruntime-linux-aarch64-static_lib-1.27.0-glibc2_17.zip")
-set(onnxruntime_HASH "SHA256=58a1009cb4daea0eee79633e043050e433173fc0dca0d9f8c597874301a3e16a")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.27.1/onnxruntime-linux-aarch64-static_lib-1.27.1-glibc2_17.zip")
+set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj2/onnxruntime-libs/resolve/main/1.27.1/onnxruntime-linux-aarch64-static_lib-1.27.1-glibc2_17.zip")
+set(onnxruntime_HASH "SHA256=051131cfe80d07257631311f0b1f726b7302e85e1c7e2176cb84e461eea1fe27")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-linux-aarch64-static_lib-1.27.0-glibc2_17.zip
-  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-aarch64-static_lib-1.27.0-glibc2_17.zip
-  ${CMAKE_BINARY_DIR}/onnxruntime-linux-aarch64-static_lib-1.27.0-glibc2_17.zip
-  /tmp/onnxruntime-linux-aarch64-static_lib-1.27.0-glibc2_17.zip
-  /star-fj/fangjun/download/github/onnxruntime-linux-aarch64-static_lib-1.27.0-glibc2_17.zip
+  $ENV{HOME}/Downloads/onnxruntime-linux-aarch64-static_lib-1.27.1-glibc2_17.zip
+  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-aarch64-static_lib-1.27.1-glibc2_17.zip
+  ${CMAKE_BINARY_DIR}/onnxruntime-linux-aarch64-static_lib-1.27.1-glibc2_17.zip
+  /tmp/onnxruntime-linux-aarch64-static_lib-1.27.1-glibc2_17.zip
+  /star-fj/fangjun/download/github/onnxruntime-linux-aarch64-static_lib-1.27.1-glibc2_17.zip
 )
 
 foreach(f IN LISTS possible_file_locations)

--- a/cmake/onnxruntime-linux-aarch64.cmake
+++ b/cmake/onnxruntime-linux-aarch64.cmake
@@ -14,19 +14,19 @@ if(NOT BUILD_SHARED_LIBS)
   message(FATAL_ERROR "This file is for building shared libraries. BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 endif()
 
-set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.27.0/onnxruntime-linux-aarch64-glibc2_17-Release-1.27.0.zip")
-set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj2/onnxruntime-libs/resolve/main/1.27.0/onnxruntime-linux-aarch64-glibc2_17-Release-1.27.0.zip")
-set(onnxruntime_HASH "SHA256=06e6dbe506fae40d8d735cf22378f7009bfe662cfffca76cb1d8ecea18a63826")
+set(onnxruntime_URL  "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.27.1/onnxruntime-linux-aarch64-glibc2_17-Release-1.27.1.zip")
+set(onnxruntime_URL2 "https://hf-mirror.com/csukuangfj2/onnxruntime-libs/resolve/main/1.27.1/onnxruntime-linux-aarch64-glibc2_17-Release-1.27.1.zip")
+set(onnxruntime_HASH "SHA256=7c0dc460a78745792ee3c339f2369549a1396d60e79cef0b6616e3948205bda6")
 
 # If you don't have access to the Internet,
 # please download onnxruntime to one of the following locations.
 # You can add more if you want.
 set(possible_file_locations
-  $ENV{HOME}/Downloads/onnxruntime-linux-aarch64-glibc2_17-Release-1.27.0.zip
-  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-aarch64-glibc2_17-Release-1.27.0.zip
-  ${CMAKE_BINARY_DIR}/onnxruntime-linux-aarch64-glibc2_17-Release-1.27.0.zip
-  /tmp/onnxruntime-linux-aarch64-glibc2_17-Release-1.27.0.zip
-  /star-fj/fangjun/download/github/onnxruntime-linux-aarch64-glibc2_17-Release-1.27.0.zip
+  $ENV{HOME}/Downloads/onnxruntime-linux-aarch64-glibc2_17-Release-1.27.1.zip
+  ${CMAKE_SOURCE_DIR}/onnxruntime-linux-aarch64-glibc2_17-Release-1.27.1.zip
+  ${CMAKE_BINARY_DIR}/onnxruntime-linux-aarch64-glibc2_17-Release-1.27.1.zip
+  /tmp/onnxruntime-linux-aarch64-glibc2_17-Release-1.27.1.zip
+  /star-fj/fangjun/download/github/onnxruntime-linux-aarch64-glibc2_17-Release-1.27.1.zip
 )
 
 foreach(f IN LISTS possible_file_locations)


### PR DESCRIPTION
### Problem

On arm64 CPUs that implement `FEAT_SME`, onnxruntime 1.27.0 computes the wrong result for the Conv nodes in the zipformer2 frontend, so streaming zipformer ASR and `KeywordSpotter` return garbage or nothing at all, with no error message. That is #3791 and #3776.

macOS moved to 1.27.1 in #3831 and WASM in #3836, but `cmake/onnxruntime-linux-aarch64{,-static}.cmake` and the four `build-android-*.sh` scripts are still on 1.27.0.

### Root cause

1.27.0's route gate `MlasConvSupportsSymmetricChannelsLast2DFloatKernel` only required begin padding to equal end padding per axis, so `pads=[0,1,0,1]` was admitted into the KleidiAI SME kernel, whose LHS indirection table uses one scalar padding for both axes. Fixed upstream by microsoft/onnxruntime#28571, first shipped in 1.27.1. The full analysis is @kecoco16's, in #3791.

That kernel is compiled into the aarch64 archives this repo pins, not just the macOS ones:

```
# onnxruntime-linux-aarch64-glibc2_17-Release-1.27.0.zip
$ strings lib/libonnxruntime.so | grep -c ConvolveSme
2
# onnxruntime-android-1.27.0.zip
$ strings jni/arm64-v8a/libonnxruntime.so | grep -c ConvolveSme
2
```

### Fix

Bump the two Linux aarch64 cmake files and the default `onnxruntime_version` in the Android build scripts to 1.27.1. All four Android scripts extract from the same `onnxruntime-android-<version>.zip`, so they move together.

The Windows and x86_64 pins are deliberately left on 1.27.0. KleidiAI is aarch64 only, so x86_64 cannot hit this, and the Windows cmake files pin eight per-configuration SHA256s each which I have no way to check against a real build.

### Verification

Apple M4 Pro, `hw.optional.arm.FEAT_SME: 1`. master at 634265c built with `BUILD_SHARED_LIBS=ON`, then only `libonnxruntime.dylib` swapped between the two runs:

```
$ sherpa-onnx-keyword-spotter --keywords-file=.../test_keywords.txt .../test_wavs/3.wav
onnxruntime version : 1.27.0
Audio duration: 8.030 s
                                <- nothing

onnxruntime version : 1.27.1
Audio duration: 8.030 s
{"start_time":0.00, "keyword": "文森特卡索", "timestamps": [0.32, ...], "tokens":["w", "én", ...]}
{"start_time":0.00, "keyword": "法国", "timestamps": [2.32, 2.40, 2.60, 2.64], "tokens":["f", "ǎ", "g", "uó"]}
```

Both edited cmake files were run through `FetchContent` on their own; each downloads and passes its hash check. Changing one hex digit of the new hash makes cmake report `Hash mismatch, removing...`, so the check is live. The GitHub and hf-mirror copies of both archives have the same SHA256 as the ones written into the diff, and the same commands reproduce the 1.27.0 hashes that are already in the repo.

`onnxruntime-android-1.27.1.zip` contains all four `jni/<abi>/libonnxruntime.so` the scripts expect.

I have no arm64 Linux or Android hardware here, so what I verified there is that the archives are the right ones, not that a full build passes.

Refs #3791, #3776


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled ONNX Runtime version to 1.27.1 for Android and Linux aarch64 builds.
  * Updated download sources, checksums, and fallback package references to match the new version.
  * Existing environment-based version overrides remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->