### PR TITLE
kotlin-api: validate native ptr after creation

### DIFF
--- a/sherpa-onnx/kotlin-api/AudioTagging.kt
+++ b/sherpa-onnx/kotlin-api/AudioTagging.kt
@@ -38,7 +38,9 @@ class AudioTagging(
         } else {
             newFromFile(config)
         }
-    }
+        require(ptr != 0L) {
+            "Invalid AudioTaggingConfig: failed to create native AudioTagging"
+        }
 
     protected fun finalize() {
         if (ptr != 0L) {

--- a/sherpa-onnx/kotlin-api/KeywordSpotter.kt
+++ b/sherpa-onnx/kotlin-api/KeywordSpotter.kt
@@ -38,7 +38,9 @@ class KeywordSpotter(
         } else {
             newFromFile(config)
         }
-    }
+        require(ptr != 0L) {
+            "Invalid KeywordSpotterConfig: failed to create native KeywordSpotter"
+        }
 
     protected fun finalize() {
         if (ptr != 0L) {

--- a/sherpa-onnx/kotlin-api/OfflinePunctuation.kt
+++ b/sherpa-onnx/kotlin-api/OfflinePunctuation.kt
@@ -26,7 +26,9 @@ class OfflinePunctuation(
         } else {
             newFromFile(config)
         }
-    }
+        require(ptr != 0L) {
+            "Invalid OfflinePunctuationConfig: failed to create native OfflinePunctuation"
+        }
 
     protected fun finalize() {
         if (ptr != 0L) {

--- a/sherpa-onnx/kotlin-api/OfflineRecognizer.kt
+++ b/sherpa-onnx/kotlin-api/OfflineRecognizer.kt
@@ -189,7 +189,9 @@ class OfflineRecognizer(
         } else {
             newFromFile(config)
         }
-    }
+        require(ptr != 0L) {
+            "Invalid OfflineRecognizerConfig: failed to create native OfflineRecognizer"
+        }
 
     protected fun finalize() {
         if (ptr != 0L) {

--- a/sherpa-onnx/kotlin-api/OfflineSpeakerDiarization.kt
+++ b/sherpa-onnx/kotlin-api/OfflineSpeakerDiarization.kt
@@ -44,7 +44,9 @@ class OfflineSpeakerDiarization(
         } else {
             newFromFile(config)
         }
-    }
+        require(ptr != 0L) {
+            "Invalid OfflineSpeakerDiarizationConfig: failed to create native OfflineSpeakerDiarization"
+        }
 
     protected fun finalize() {
         if (ptr != 0L) {

--- a/sherpa-onnx/kotlin-api/OfflineSpeechDenoiser.kt
+++ b/sherpa-onnx/kotlin-api/OfflineSpeechDenoiser.kt
@@ -34,7 +34,9 @@ class OfflineSpeechDenoiser(
         } else {
             newFromFile(config)
         }
-    }
+        require(ptr != 0L) {
+            "Invalid OfflineSpeechDenoiserConfig: failed to create native OfflineSpeechDenoiser"
+        }
 
     protected fun finalize() {
         if (ptr != 0L) {

--- a/sherpa-onnx/kotlin-api/OfflineStream.kt
+++ b/sherpa-onnx/kotlin-api/OfflineStream.kt
@@ -1,6 +1,10 @@
 package com.k2fsa.sherpa.onnx
 
 class OfflineStream(var ptr: Long) {
+    init {
+        require(ptr != 0L) { "Failed to create native OfflineStream" }
+    }
+
     fun acceptWaveform(samples: FloatArray, sampleRate: Int) =
         acceptWaveform(ptr, samples, sampleRate)
 

--- a/sherpa-onnx/kotlin-api/OnlinePunctuation.kt
+++ b/sherpa-onnx/kotlin-api/OnlinePunctuation.kt
@@ -27,7 +27,9 @@ class OnlinePunctuation(
         } else {
             newFromFile(config)
         }
-    }
+        require(ptr != 0L) {
+            "Invalid OnlinePunctuationConfig: failed to create native OnlinePunctuation"
+        }
 
     protected fun finalize() {
         if (ptr != 0L) {

--- a/sherpa-onnx/kotlin-api/OnlineRecognizer.kt
+++ b/sherpa-onnx/kotlin-api/OnlineRecognizer.kt
@@ -100,7 +100,9 @@ class OnlineRecognizer(
         } else {
             newFromFile(config)
         }
-    }
+        require(ptr != 0L) {
+            "Invalid OnlineRecognizerConfig: failed to create native OnlineRecognizer"
+        }
 
     protected fun finalize() {
         if (ptr != 0L) {

--- a/sherpa-onnx/kotlin-api/OnlineSpeechDenoiser.kt
+++ b/sherpa-onnx/kotlin-api/OnlineSpeechDenoiser.kt
@@ -18,7 +18,9 @@ class OnlineSpeechDenoiser(
         } else {
             newFromFile(config)
         }
-    }
+        require(ptr != 0L) {
+            "Invalid OnlineSpeechDenoiserConfig: failed to create native OnlineSpeechDenoiser"
+        }
 
     protected fun finalize() {
         if (ptr != 0L) {

--- a/sherpa-onnx/kotlin-api/OnlineStream.kt
+++ b/sherpa-onnx/kotlin-api/OnlineStream.kt
@@ -1,6 +1,10 @@
 package com.k2fsa.sherpa.onnx
 
 class OnlineStream(var ptr: Long = 0) {
+    init {
+        require(ptr != 0L) { "Failed to create native OnlineStream" }
+    }
+
     fun acceptWaveform(samples: FloatArray, sampleRate: Int) =
         acceptWaveform(ptr, samples, sampleRate)
 

--- a/sherpa-onnx/kotlin-api/Speaker.kt
+++ b/sherpa-onnx/kotlin-api/Speaker.kt
@@ -15,7 +15,9 @@ class SpeakerEmbeddingExtractor(
         } else {
             newFromFile(config)
         }
-    }
+        require(ptr != 0L) {
+            "Invalid SpeakerEmbeddingExtractorConfig: failed to create native SpeakerEmbeddingExtractor"
+        }
 
     protected fun finalize() {
         if (ptr != 0L) {
@@ -66,6 +68,7 @@ class SpeakerEmbeddingManager(val dim: Int) {
 
     init {
         ptr = create(dim)
+        require(ptr != 0L) { "Failed to create native SpeakerEmbeddingManager" }
     }
 
     protected fun finalize() {

--- a/sherpa-onnx/kotlin-api/SpokenLanguageIdentification.kt
+++ b/sherpa-onnx/kotlin-api/SpokenLanguageIdentification.kt
@@ -27,7 +27,9 @@ class SpokenLanguageIdentification(
         } else {
             newFromFile(config)
         }
-    }
+        require(ptr != 0L) {
+            "Invalid SpokenLanguageIdentificationConfig: failed to create native SpokenLanguageIdentification"
+        }
 
     protected fun finalize() {
         if (ptr != 0L) {

--- a/sherpa-onnx/kotlin-api/Tts.kt
+++ b/sherpa-onnx/kotlin-api/Tts.kt
@@ -150,7 +150,9 @@ class OfflineTts(
         } else {
             newFromFile(config)
         }
-    }
+        require(ptr != 0L) {
+            "Invalid OfflineTtsConfig: failed to create native OfflineTts"
+        }
 
     fun sampleRate() = getSampleRate(ptr)
 
@@ -201,8 +203,10 @@ class OfflineTts(
             } else {
                 newFromFile(config)
             }
+            require(ptr != 0L) {
+                "Invalid OfflineTtsConfig: failed to create native OfflineTts"
+            }
         }
-    }
 
     fun free() {
         if (ptr != 0L) {

--- a/sherpa-onnx/kotlin-api/Vad.kt
+++ b/sherpa-onnx/kotlin-api/Vad.kt
@@ -44,7 +44,9 @@ class Vad(
         } else {
             ptr = newFromFile(config)
         }
-    }
+        require(ptr != 0L) {
+            "Invalid VadConfig: failed to create native Vad"
+        }
 
     protected fun finalize() {
         if (ptr != 0L) {


### PR DESCRIPTION
Config-invalid (e.g. missing model files) makes native factory return null; first method call then SIGSEGVs. require(ptr != 0L) in all binding classes and streams, mirroring Java binding and Dart PR #3329.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved initialization error handling across Kotlin audio, speech, recognition, punctuation, denoising, speaker, language identification, text-to-speech, and voice activity detection components.
  - Invalid configurations now fail immediately with a clear `IllegalArgumentException` instead of allowing unusable objects to be created.
  - Stream and text-to-speech initialization now consistently detect creation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->