### PR TITLE
Fix float32 catastrophic cancellation in NemoNormalizePerFeature

### DIFF
--- a/sherpa-onnx/csrc/math-test.cc
+++ b/sherpa-onnx/csrc/math-test.cc
@@ -4,6 +4,7 @@
 
 #include "sherpa-onnx/csrc/math.h"
 
+#include <cmath>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -134,6 +135,39 @@ TEST(ComputeMeanAndInvStd, Case1) {
   for (int32_t i = 0; i < num_cols; ++i) {
     EXPECT_NEAR(mean[i], expected_mean[i], 1e-6f) << "at index " << i;
     EXPECT_NEAR(inv_std[i], expected_inv_std[i], 1e-6f) << "at index " << i;
+  }
+}
+
+TEST(NemoNormalizePerFeature, NearConstantFeatureStaysBounded) {
+  // A feature pinned at a constant log floor with one slightly-off frame,
+  // as produced by a mel bin with no energy. E[x^2] - E[x]^2 cancels to 0
+  // in float32 here, which used to normalize the off-floor frame to
+  // magnitudes in the thousands (7510 with these exact values).
+  int32_t num_frames = 1000;
+  int32_t feature_dim = 2;
+  std::vector<float> x(num_frames * feature_dim);
+  for (int32_t i = 0; i < num_frames; ++i) {
+    x[i * feature_dim] = -15.94f;
+    x[i * feature_dim + 1] = static_cast<float>(i % 7);
+  }
+  x[(num_frames / 2) * feature_dim] = -15.94f + 0.075f;
+
+  NemoNormalizePerFeature(x.data(), num_frames, feature_dim);
+
+  for (int32_t i = 0; i < num_frames; ++i) {
+    EXPECT_LE(std::fabs(x[i * feature_dim]), 100.0f) << "at frame " << i;
+  }
+}
+
+TEST(NemoNormalizePerFeature, ConstantFeatureNormalizesToZero) {
+  int32_t num_frames = 8;
+  int32_t feature_dim = 1;
+  std::vector<float> x(num_frames, 3.5f);
+
+  NemoNormalizePerFeature(x.data(), num_frames, feature_dim);
+
+  for (int32_t i = 0; i < num_frames; ++i) {
+    EXPECT_NEAR(x[i], 0.0f, 1e-6f) << "at frame " << i;
   }
 }
 

--- a/sherpa-onnx/csrc/math.cc
+++ b/sherpa-onnx/csrc/math.cc
@@ -137,8 +137,12 @@ void NemoNormalizePerFeature(float *p, int32_t num_frames,
   Eigen::Map<RowMajorMat> x(p, num_frames, feature_dim);
 
   Eigen::RowVectorXf mean = x.colwise().mean();
+
+  // E[x^2] - E[x]^2 cancels catastrophically in float32 when a feature
+  // stays near a constant value, yielding var == 0 and huge normalized
+  // outliers, so compute the variance from centered values instead.
   Eigen::RowVectorXf var =
-      (x.array().square().colwise().mean() - mean.array().square()).max(0.0f);
+      (x.rowwise() - mean).array().square().colwise().mean();
 
   Eigen::RowVectorXf inv_std = (var.array().sqrt() + 1e-5f).inverse();
 


### PR DESCRIPTION
Fixes #3853.

`NemoNormalizePerFeature` computes per-feature variance as `E[x^2] - (E[x])^2` in float32. For the trigger utterance in #3853, one mel bin sits at the log floor near -15.94, so both terms are about 254.1 and their true difference (about 2.5e-5) is below float32 resolution at that magnitude. The subtraction cancels to exactly 0, `inv_std` becomes `1/(0 + 1e-5) = 1e5`, and that bin's small deviations normalize to +7515 while every other feature stays within +/-17.

That is also why one bad stream empties the whole batch: the padded batch goes through the INT8 encoder in one session, its per-tensor dynamic-quantization scale is computed over the outliers, the quant step grows to about 30, and all real features collapse into a single bucket. The decoder then emits blank for every stream.

The fix computes variance from centered values, `mean((x - mean)^2)`. Same semantics and epsilon, no cancellation. An exactly constant column now normalizes to 0 instead of exploding.

Tests: two new cases in `math-test.cc`. A floor-pinned column with one off-floor frame normalizes to 7510 before the fix and fails the test; with the fix it stays bounded. A constant column normalizes to 0.

End to end with the Parakeet Unified EN 0.6B INT8 model from the issue (LibriSpeech test-clean, trigger = 5142-36600-0000, control = 237-134500-0006):

| Case | v1.13.4 | this PR |
|---|---|---|
| trigger alone | "" | "CHAPTER seven ON THE RACES OF MAN" |
| control alone | correct | correct (unchanged) |
| [trigger, control] batch | both "" | both correct |
| [control, trigger] batch | both "" | both correct |
| max normalized feature (trigger, mel bin at log floor) | +7515 | within normal range |

`ComputeMeanAndInvStd` in the same file uses the same variance form. I can change it to the centered form here too if you want; I kept the diff minimal for now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feature normalization for near-constant inputs, reducing numerical instability.
  * Constant-valued features now normalize reliably to zero.

* **Tests**
  * Added coverage for near-constant and constant feature normalization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->