### PR TITLE
Expose N-best hypotheses from offline transducer modified beam search

### DIFF
--- a/python-api-examples/offline-decode-files.py
+++ b/python-api-examples/offline-decode-files.py
@@ -44,6 +44,8 @@ file(s) with a non-streaming model.
       --joiner=/path/to/joiner.onnx \
       --num-threads=2 \
       --decoding-method=modified_beam_search \
+      --max-active-paths=8 \
+      --num-return-paths=3 \
       --debug=false \
       --sample-rate=16000 \
       --feature-dim=80 \
@@ -290,6 +292,20 @@ def get_args():
     )
 
     parser.add_argument(
+        "--max-active-paths",
+        type=int,
+        default=4,
+        help="Number of active paths kept by modified beam search",
+    )
+
+    parser.add_argument(
+        "--num-return-paths",
+        type=int,
+        default=1,
+        help="Number of final modified beam search hypotheses to return",
+    )
+
+    parser.add_argument(
         "--lm",
         metavar="file",
         type=str,
@@ -421,6 +437,8 @@ def main():
             lodr_fst=args.lodr_fst,
             lodr_scale=args.lodr_scale,
             decoding_method=args.decoding_method,
+            max_active_paths=args.max_active_paths,
+            num_return_paths=args.num_return_paths,
             hotwords_file=args.hotwords_file,
             hotwords_score=args.hotwords_score,
             modeling_unit=args.modeling_unit,
@@ -527,18 +545,23 @@ def main():
         streams.append(s)
 
     recognizer.decode_streams(streams)
-    results = [s.result.text for s in streams]
     end_time = time.time()
     print("Done!")
 
-    for wave_filename, result in zip(args.sound_files, results):
-        print(f"{wave_filename}\n{result}")
+    for wave_filename, stream in zip(args.sound_files, streams):
+        print(f"{wave_filename}\n{stream.result.text}")
+        if len(stream.result.hypotheses) > 1:
+            for i, hypothesis in enumerate(stream.result.hypotheses, start=1):
+                print(f"  {i}: score={hypothesis.score:.6f} {hypothesis.text}")
         print("-" * 10)
 
     elapsed_seconds = end_time - start_time
     rtf = elapsed_seconds / total_duration
     print(f"num_threads: {args.num_threads}")
     print(f"decoding_method: {args.decoding_method}")
+    if args.decoding_method == "modified_beam_search":
+        print(f"max_active_paths: {args.max_active_paths}")
+        print(f"num_return_paths: {args.num_return_paths}")
     print(f"Wave duration: {total_duration:.3f} s")
     print(f"Elapsed time: {elapsed_seconds:.3f} s")
     print(

--- a/python-api-examples/offline-decode-files.py
+++ b/python-api-examples/offline-decode-files.py
@@ -548,7 +548,8 @@ def main():
     end_time = time.time()
     print("Done!")
 
-    for wave_filename, stream in zip(args.sound_files, streams):
+    for stream_index, wave_filename in enumerate(args.sound_files):
+        stream = streams[stream_index]
         print(f"{wave_filename}\n{stream.result.text}")
         if len(stream.result.hypotheses) > 1:
             for i, hypothesis in enumerate(stream.result.hypotheses, start=1):

--- a/sherpa-onnx/csrc/CMakeLists.txt
+++ b/sherpa-onnx/csrc/CMakeLists.txt
@@ -830,6 +830,7 @@ if(SHERPA_ONNX_ENABLE_TESTS)
     context-graph-test.cc
     lfr-test.cc
     math-test.cc
+    offline-stream-test.cc
     offline-whisper-timestamp-rules-test.cc
     packed-sequence-test.cc
     pad-sequence-test.cc

--- a/sherpa-onnx/csrc/offline-recognizer-transducer-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-transducer-impl.h
@@ -31,13 +31,13 @@
 
 namespace sherpa_onnx {
 
-static OfflineRecognitionResult Convert(
-    const OfflineTransducerDecoderResult &src, const SymbolTable &sym_table,
-    int32_t frame_shift_ms, int32_t subsampling_factor) {
-  OfflineRecognitionResult r;
-  r.tokens.reserve(src.tokens.size());
-  r.timestamps.reserve(src.timestamps.size());
-  r.durations.reserve(src.durations.size());
+template <typename Source, typename Destination>
+static void ConvertTransducerHypothesis(
+    const Source &src, const SymbolTable &sym_table, int32_t frame_shift_ms,
+    int32_t subsampling_factor, Destination *dest) {
+  dest->tokens.reserve(src.tokens.size());
+  dest->timestamps.reserve(src.timestamps.size());
+  dest->durations.reserve(src.durations.size());
 
   std::string text;
   for (auto i : src.tokens) {
@@ -54,29 +54,41 @@ static OfflineRecognitionResult Convert(
       sym = os.str();
     }
 
-    r.tokens.push_back(std::move(sym));
+    dest->tokens.push_back(std::move(sym));
   }
   if (sym_table.IsByteBpe()) {
     text = sym_table.DecodeByteBpe(text);
   }
 
-  text = RemoveSpaceBetweenCjk(text);
-
-  r.text = std::move(text);
+  dest->text = RemoveSpaceBetweenCjk(text);
 
   float frame_shift_s = frame_shift_ms / 1000. * subsampling_factor;
   for (auto t : src.timestamps) {
-    float time = frame_shift_s * t;
-    r.timestamps.push_back(time);
+    dest->timestamps.push_back(frame_shift_s * t);
   }
 
-  // Copy durations (if present)
   for (auto d : src.durations) {
-    r.durations.push_back(d * frame_shift_s);
+    dest->durations.push_back(d * frame_shift_s);
   }
 
-  // Copy token log probabilities (confidence scores)
-  r.ys_log_probs = src.ys_log_probs;
+  dest->ys_log_probs = src.ys_log_probs;
+}
+
+static OfflineRecognitionResult Convert(
+    const OfflineTransducerDecoderResult &src, const SymbolTable &sym_table,
+    int32_t frame_shift_ms, int32_t subsampling_factor) {
+  OfflineRecognitionResult r;
+  ConvertTransducerHypothesis(src, sym_table, frame_shift_ms,
+                              subsampling_factor, &r);
+
+  r.hypotheses.reserve(src.hypotheses.size());
+  for (const auto &src_hyp : src.hypotheses) {
+    OfflineRecognitionHypothesis hyp;
+    ConvertTransducerHypothesis(src_hyp, sym_table, frame_shift_ms,
+                                subsampling_factor, &hyp);
+    hyp.score = src_hyp.score;
+    r.hypotheses.push_back(std::move(hyp));
+  }
 
   return r;
 }
@@ -112,7 +124,8 @@ class OfflineRecognizerTransducerImpl : public OfflineRecognizerImpl {
 
       decoder_ = std::make_unique<OfflineTransducerModifiedBeamSearchDecoder>(
           model_.get(), lm_.get(), config_.max_active_paths,
-          config_.lm_config.scale, unk_id_, config_.blank_penalty);
+          config_.lm_config.scale, unk_id_, config_.blank_penalty,
+          config_.num_return_paths);
     } else {
       SHERPA_ONNX_LOGE("Unsupported decoding method: %s",
                        config_.decoding_method.c_str());
@@ -152,7 +165,8 @@ class OfflineRecognizerTransducerImpl : public OfflineRecognizerImpl {
 
       decoder_ = std::make_unique<OfflineTransducerModifiedBeamSearchDecoder>(
           model_.get(), lm_.get(), config_.max_active_paths,
-          config_.lm_config.scale, unk_id_, config_.blank_penalty);
+          config_.lm_config.scale, unk_id_, config_.blank_penalty,
+          config_.num_return_paths);
     } else {
       SHERPA_ONNX_LOGE("Unsupported decoding method: %s",
                        config_.decoding_method.c_str());
@@ -252,6 +266,10 @@ class OfflineRecognizerTransducerImpl : public OfflineRecognizerImpl {
                        model_->SubsamplingFactor());
       r.text = ApplyInverseTextNormalization(std::move(r.text));
       r.text = ApplyHomophoneReplacer(std::move(r.text));
+      for (auto &hyp : r.hypotheses) {
+        hyp.text = ApplyInverseTextNormalization(std::move(hyp.text));
+        hyp.text = ApplyHomophoneReplacer(std::move(hyp.text));
+      }
 
       ss[i]->SetResult(r);
     }

--- a/sherpa-onnx/csrc/offline-recognizer-transducer-nemo-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-transducer-nemo-impl.h
@@ -65,7 +65,8 @@ class OfflineRecognizerTransducerNeMoImpl : public OfflineRecognizerImpl {
       decoder_ =
           std::make_unique<OfflineTransducerModifiedBeamSearchNeMoDecoder>(
               model_.get(), config_.max_active_paths, unk_id_,
-              config_.blank_penalty, model_->IsTDT(), config_.hotwords_score);
+              config_.blank_penalty, model_->IsTDT(), config_.hotwords_score,
+              config_.num_return_paths);
     } else {
       SHERPA_ONNX_LOGE("Unsupported decoding method: %s",
                        config_.decoding_method.c_str());
@@ -105,7 +106,8 @@ class OfflineRecognizerTransducerNeMoImpl : public OfflineRecognizerImpl {
       decoder_ =
           std::make_unique<OfflineTransducerModifiedBeamSearchNeMoDecoder>(
               model_.get(), config_.max_active_paths, unk_id_,
-              config_.blank_penalty, model_->IsTDT(), config_.hotwords_score);
+              config_.blank_penalty, model_->IsTDT(), config_.hotwords_score,
+              config_.num_return_paths);
     } else {
       SHERPA_ONNX_LOGE("Unsupported decoding method: %s",
                        config_.decoding_method.c_str());
@@ -217,6 +219,15 @@ class OfflineRecognizerTransducerNeMoImpl : public OfflineRecognizerImpl {
 
       r.text = ApplyInverseTextNormalization(std::move(r.text));
       r.text = ApplyHomophoneReplacer(std::move(r.text));
+      for (auto &hyp : r.hypotheses) {
+        // Keep N-best text preprocessing consistent with the 1-best result.
+        if (!hyp.text.empty() && hyp.text.front() == ' ') {
+          hyp.text.erase(0, 1);
+        }
+
+        hyp.text = ApplyInverseTextNormalization(std::move(hyp.text));
+        hyp.text = ApplyHomophoneReplacer(std::move(hyp.text));
+      }
 
       ss[i]->SetResult(r);
     }

--- a/sherpa-onnx/csrc/offline-recognizer.cc
+++ b/sherpa-onnx/csrc/offline-recognizer.cc
@@ -41,6 +41,11 @@ void OfflineRecognizerConfig::Register(ParseOptions *po) {
   po->Register("max-active-paths", &max_active_paths,
                "Used only when decoding_method is modified_beam_search");
 
+  po->Register(
+      "num-return-paths", &num_return_paths,
+      "Number of final hypotheses to return. Used only when decoding_method "
+      "is modified_beam_search");
+
   po->Register("blank-penalty", &blank_penalty,
                "The penalty applied on blank symbol during decoding. "
                "Note: It is a positive value. "
@@ -70,15 +75,30 @@ void OfflineRecognizerConfig::Register(ParseOptions *po) {
 }
 
 bool OfflineRecognizerConfig::Validate() const {
-  if (decoding_method == "modified_beam_search" && !lm_config.model.empty()) {
+  if (decoding_method == "modified_beam_search") {
     if (max_active_paths <= 0) {
-      SHERPA_ONNX_LOGE("max_active_paths is less than 0! Given: %d",
+      SHERPA_ONNX_LOGE("max_active_paths must be greater than 0! Given: %d",
                        max_active_paths);
       return false;
     }
-    if (!lm_config.Validate()) {
+
+    if (num_return_paths <= 0 || num_return_paths > max_active_paths) {
+      SHERPA_ONNX_LOGE(
+          "num_return_paths must be in the range [1, max_active_paths]. "
+          "Given: %d. max_active_paths: %d",
+          num_return_paths, max_active_paths);
       return false;
     }
+
+    if (!lm_config.model.empty() && !lm_config.Validate()) {
+      return false;
+    }
+  } else if (num_return_paths != 1) {
+    SHERPA_ONNX_LOGE(
+        "num_return_paths is supported only when decoding_method is "
+        "modified_beam_search. Given decoding_method: '%s'",
+        decoding_method.c_str());
+    return false;
   }
 
   if (!hotwords_file.empty() && decoding_method != "modified_beam_search") {
@@ -141,6 +161,7 @@ std::string OfflineRecognizerConfig::ToString() const {
 
   os << "decoding_method=\"" << decoding_method << "\", ";
   os << "max_active_paths=" << max_active_paths << ", ";
+  os << "num_return_paths=" << num_return_paths << ", ";
   os << "hotwords_file=\"" << hotwords_file << "\", ";
   os << "hotwords_score=" << hotwords_score << ", ";
   os << "blank_penalty=" << blank_penalty << ", ";
@@ -176,6 +197,9 @@ void OfflineRecognizer::DecodeStreams(OfflineStream **ss, int32_t n) const {
   for (int32_t i = 0; i < n; ++i) {
     auto r = ss[i]->GetResult();
     r.text = RemoveLeadingSpaces(r.text);
+    for (auto &hyp : r.hypotheses) {
+      hyp.text = RemoveLeadingSpaces(hyp.text);
+    }
     ss[i]->SetResult(r);
   }
 }

--- a/sherpa-onnx/csrc/offline-recognizer.h
+++ b/sherpa-onnx/csrc/offline-recognizer.h
@@ -30,6 +30,7 @@ struct OfflineRecognizerConfig {
 
   std::string decoding_method = "greedy_search";
   int32_t max_active_paths = 4;
+  int32_t num_return_paths = 1;
 
   std::string hotwords_file;
   float hotwords_score = 1.5;
@@ -43,9 +44,6 @@ struct OfflineRecognizerConfig {
   std::string rule_fars;
   HomophoneReplacerConfig hr;
 
-  // only greedy_search is implemented
-  // TODO(fangjun): Implement modified_beam_search
-
   OfflineRecognizerConfig() = default;
   OfflineRecognizerConfig(
       const FeatureExtractorConfig &feat_config,
@@ -54,13 +52,15 @@ struct OfflineRecognizerConfig {
       const std::string &decoding_method, int32_t max_active_paths,
       const std::string &hotwords_file, float hotwords_score,
       float blank_penalty, const std::string &rule_fsts,
-      const std::string &rule_fars, const HomophoneReplacerConfig &hr)
+      const std::string &rule_fars, const HomophoneReplacerConfig &hr,
+      int32_t num_return_paths = 1)
       : feat_config(feat_config),
         model_config(model_config),
         lm_config(lm_config),
         ctc_fst_decoder_config(ctc_fst_decoder_config),
         decoding_method(decoding_method),
         max_active_paths(max_active_paths),
+        num_return_paths(num_return_paths),
         hotwords_file(hotwords_file),
         hotwords_score(hotwords_score),
         blank_penalty(blank_penalty),

--- a/sherpa-onnx/csrc/offline-stream-test.cc
+++ b/sherpa-onnx/csrc/offline-stream-test.cc
@@ -1,0 +1,48 @@
+// sherpa-onnx/csrc/offline-stream-test.cc
+//
+// Copyright (c)  2026  mitsu-h
+
+#include "sherpa-onnx/csrc/offline-stream.h"
+
+#include <string>
+
+#include "gtest/gtest.h"
+
+namespace sherpa_onnx {
+
+TEST(OfflineRecognitionResult, SerializesNBestHypotheses) {
+  OfflineRecognitionResult result;
+  result.text = "top one";
+  result.tokens = {"top", " one"};
+
+  OfflineRecognitionHypothesis first;
+  first.text = "top one";
+  first.tokens = {"top", " one"};
+  first.timestamps = {0.0f, 0.4f};
+  first.ys_log_probs = {-0.1f, -0.2f};
+  first.score = -0.15;
+
+  OfflineRecognitionHypothesis second;
+  second.text = "top won";
+  second.tokens = {"top", " won"};
+  second.timestamps = {0.0f, 0.4f};
+  second.ys_log_probs = {-0.1f, -0.3f};
+  second.score = -0.2;
+
+  result.hypotheses = {first, second};
+
+  std::string json = result.AsJsonString();
+  EXPECT_NE(json.find("\"hypotheses\": [{"), std::string::npos);
+  EXPECT_NE(json.find("\"text\": \"top one\""), std::string::npos);
+  EXPECT_NE(json.find("\"text\": \"top won\""), std::string::npos);
+  EXPECT_NE(json.find("\"score\": -0.150000"), std::string::npos);
+  EXPECT_NE(json.find("\"score\": -0.200000"), std::string::npos);
+}
+
+TEST(OfflineRecognitionResult, SerializesEmptyHypothesisList) {
+  OfflineRecognitionResult result;
+  std::string json = result.AsJsonString();
+  EXPECT_NE(json.find("\"hypotheses\": []"), std::string::npos);
+}
+
+}  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/offline-stream.cc
+++ b/sherpa-onnx/csrc/offline-stream.cc
@@ -474,6 +474,59 @@ std::string OfflineRecognitionResult::AsJsonString() const {
   }
   os << "]";
 
+  os << ", \"hypotheses\": [";
+  std::string hyp_sep;
+  for (const auto &hyp : hypotheses) {
+    os << hyp_sep << "{";
+    os << "\"text\": " << std::quoted(hyp.text) << ", ";
+
+    os << "\"timestamps\": [";
+    sep = "";
+    for (auto t : hyp.timestamps) {
+      os << sep << std::fixed << std::setprecision(2) << t;
+      sep = ", ";
+    }
+    os << "], ";
+
+    os << "\"durations\": [";
+    sep = "";
+    for (auto d : hyp.durations) {
+      os << sep << std::fixed << std::setprecision(2) << d;
+      sep = ", ";
+    }
+    os << "], ";
+
+    os << "\"tokens\": [";
+    sep = "";
+    for (const auto &token : hyp.tokens) {
+      if (token.size() == 1 && static_cast<uint8_t>(token[0]) > 0x7f) {
+        const uint8_t *p =
+            reinterpret_cast<const uint8_t *>(token.c_str());
+        os << sep << "\""
+           << "<0x" << std::hex << std::uppercase
+           << static_cast<uint32_t>(p[0]) << ">"
+           << "\"";
+        os.flags(oldFlags);
+      } else {
+        os << sep << std::quoted(token);
+      }
+      sep = ", ";
+    }
+    os << "], ";
+
+    os << "\"ys_log_probs\": [";
+    sep = "";
+    for (auto p : hyp.ys_log_probs) {
+      os << sep << std::fixed << std::setprecision(6) << p;
+      sep = ", ";
+    }
+    os << "], ";
+    os << "\"score\": " << std::fixed << std::setprecision(6) << hyp.score;
+    os << "}";
+    hyp_sep = ", ";
+  }
+  os << "]";
+
   // Add segment-level data if present (from Whisper timestamp token mode)
   if (!segment_timestamps.empty()) {
     os << ", ";

--- a/sherpa-onnx/csrc/offline-stream.h
+++ b/sherpa-onnx/csrc/offline-stream.h
@@ -16,6 +16,23 @@
 
 namespace sherpa_onnx {
 
+struct OfflineRecognitionHypothesis {
+  std::string text;
+
+  std::vector<std::string> tokens;
+
+  std::vector<float> timestamps;
+
+  std::vector<float> durations;
+
+  std::vector<float> ys_log_probs;
+
+  /// The decoder score used to rank this hypothesis. It is the
+  /// length-normalized total log probability for the regular transducer
+  /// decoder and the accumulated log probability for the NeMo decoder.
+  double score = 0;
+};
+
 struct OfflineRecognitionResult {
   // Recognition results.
   // For English, it consists of space separated words.
@@ -54,6 +71,10 @@ struct OfflineRecognitionResult {
   std::vector<float> segment_timestamps;   // start time of each segment
   std::vector<float> segment_durations;    // duration of each segment
   std::vector<std::string> segment_texts;  // text of each segment
+
+  /// N-best hypotheses in descending score order. It is populated only by
+  /// modified beam search and includes the 1-best hypothesis as the first item.
+  std::vector<OfflineRecognitionHypothesis> hypotheses;
 
   std::string AsJsonString() const;
 };

--- a/sherpa-onnx/csrc/offline-transducer-decoder.h
+++ b/sherpa-onnx/csrc/offline-transducer-decoder.h
@@ -12,6 +12,28 @@
 
 namespace sherpa_onnx {
 
+struct OfflineTransducerDecoderHypothesis {
+  /// The decoded token IDs
+  std::vector<int64_t> tokens;
+
+  /// timestamps[i] contains the output frame index where tokens[i] is decoded.
+  /// Note: The index is after subsampling
+  std::vector<int32_t> timestamps;
+
+  /// durations[i] contains the duration for tokens[i] in output frames
+  /// (post-subsampling). It is converted to seconds by higher layers
+  /// (e.g., Convert() in offline-recognizer-transducer-impl.h).
+  std::vector<float> durations;
+
+  /// ys_log_probs[i] contains the log probability (confidence) for tokens[i].
+  std::vector<float> ys_log_probs;
+
+  /// The decoder score used to rank this hypothesis. It is the
+  /// length-normalized total log probability for the regular transducer
+  /// decoder and the accumulated log probability for the NeMo decoder.
+  double score = 0;
+};
+
 struct OfflineTransducerDecoderResult {
   /// The decoded token IDs
   std::vector<int64_t> tokens;
@@ -27,6 +49,10 @@ struct OfflineTransducerDecoderResult {
 
   /// ys_log_probs[i] contains the log probability (confidence) for tokens[i].
   std::vector<float> ys_log_probs;
+
+  /// N-best hypotheses in descending score order. It is populated only by
+  /// modified beam search and includes the 1-best hypothesis as the first item.
+  std::vector<OfflineTransducerDecoderHypothesis> hypotheses;
 };
 
 class OfflineTransducerDecoder {

--- a/sherpa-onnx/csrc/offline-transducer-modified-beam-search-decoder.cc
+++ b/sherpa-onnx/csrc/offline-transducer-modified-beam-search-decoder.cc
@@ -183,14 +183,28 @@ OfflineTransducerModifiedBeamSearchDecoder::Decode(
 
   std::vector<OfflineTransducerDecoderResult> unsorted_ans(batch_size);
   for (int32_t i = 0; i != batch_size; ++i) {
-    Hypothesis hyp = cur[i].GetMostProbable(true);
+    auto hyps = cur[i].GetTopK(num_return_paths_, true);
 
     auto &r = unsorted_ans[packed_encoder_out.sorted_indexes[i]];
+    r.hypotheses.reserve(hyps.size());
 
-    // strip leading blanks
-    r.tokens = {hyp.ys.begin() + context_size, hyp.ys.end()};
-    r.timestamps = std::move(hyp.timestamps);
-    r.ys_log_probs = std::move(hyp.ys_probs);
+    for (auto &hyp : hyps) {
+      OfflineTransducerDecoderHypothesis h;
+
+      // strip leading blanks
+      h.tokens = {hyp.ys.begin() + context_size, hyp.ys.end()};
+      h.timestamps = std::move(hyp.timestamps);
+      h.ys_log_probs = std::move(hyp.ys_probs);
+      h.score = hyp.TotalLogProb() / hyp.ys.size();
+
+      r.hypotheses.push_back(std::move(h));
+    }
+
+    // Preserve the existing 1-best fields for backward compatibility.
+    const auto &best = r.hypotheses.front();
+    r.tokens = best.tokens;
+    r.timestamps = best.timestamps;
+    r.ys_log_probs = best.ys_log_probs;
   }
 
   return unsorted_ans;

--- a/sherpa-onnx/csrc/offline-transducer-modified-beam-search-decoder.h
+++ b/sherpa-onnx/csrc/offline-transducer-modified-beam-search-decoder.h
@@ -20,13 +20,15 @@ class OfflineTransducerModifiedBeamSearchDecoder
                                              OfflineLM *lm,
                                              int32_t max_active_paths,
                                              float lm_scale, int32_t unk_id,
-                                             float blank_penalty)
+                                             float blank_penalty,
+                                             int32_t num_return_paths)
       : model_(model),
         lm_(lm),
         max_active_paths_(max_active_paths),
         lm_scale_(lm_scale),
         unk_id_(unk_id),
-        blank_penalty_(blank_penalty) {}
+        blank_penalty_(blank_penalty),
+        num_return_paths_(num_return_paths) {}
 
   std::vector<OfflineTransducerDecoderResult> Decode(
       Ort::Value encoder_out, Ort::Value encoder_out_length,
@@ -40,6 +42,7 @@ class OfflineTransducerModifiedBeamSearchDecoder
   float lm_scale_;  // used only when lm_ is not nullptr
   int32_t unk_id_;
   float blank_penalty_;
+  int32_t num_return_paths_;
 };
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/offline-transducer-modified-beam-search-nemo-decoder.cc
+++ b/sherpa-onnx/csrc/offline-transducer-modified-beam-search-nemo-decoder.cc
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <deque>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -392,23 +393,40 @@ OfflineTransducerModifiedBeamSearchNeMoDecoder::Decode(
       }
     }
 
-    // Find best hypothesis
-    auto best_it =
-        std::max_element(cur_hyps.begin(), cur_hyps.end(),
-                         [](const NeMoHypothesis &a, const NeMoHypothesis &b) {
-                           return a.log_prob < b.log_prob;
-                         });
+    std::sort(cur_hyps.begin(), cur_hyps.end(),
+              [](const NeMoHypothesis &a, const NeMoHypothesis &b) {
+                return a.log_prob > b.log_prob;
+              });
 
-    if (best_it != cur_hyps.end()) {
-      // Convert int32_t to int64_t for tokens
-      results[b].tokens.assign(best_it->ys.begin(), best_it->ys.end());
-      results[b].timestamps = best_it->timestamps;
-      results[b].ys_log_probs = best_it->ys_probs;
-      // Convert int32_t durations to float
-      results[b].durations.reserve(best_it->durations.size());
-      for (int32_t d : best_it->durations) {
-        results[b].durations.push_back(static_cast<float>(d));
+    std::set<std::vector<int32_t>> seen;
+    for (const auto &hyp : cur_hyps) {
+      if (!seen.insert(hyp.ys).second) {
+        continue;
       }
+
+      OfflineTransducerDecoderHypothesis h;
+      h.tokens.assign(hyp.ys.begin(), hyp.ys.end());
+      h.timestamps = hyp.timestamps;
+      h.ys_log_probs = hyp.ys_probs;
+      h.score = hyp.log_prob;
+      h.durations.reserve(hyp.durations.size());
+      for (int32_t d : hyp.durations) {
+        h.durations.push_back(static_cast<float>(d));
+      }
+      results[b].hypotheses.push_back(std::move(h));
+
+      if (static_cast<int32_t>(results[b].hypotheses.size()) ==
+          num_return_paths_) {
+        break;
+      }
+    }
+
+    if (!results[b].hypotheses.empty()) {
+      const auto &best = results[b].hypotheses.front();
+      results[b].tokens = best.tokens;
+      results[b].timestamps = best.timestamps;
+      results[b].durations = best.durations;
+      results[b].ys_log_probs = best.ys_log_probs;
     }
   }
 

--- a/sherpa-onnx/csrc/offline-transducer-modified-beam-search-nemo-decoder.h
+++ b/sherpa-onnx/csrc/offline-transducer-modified-beam-search-nemo-decoder.h
@@ -18,13 +18,14 @@ class OfflineTransducerModifiedBeamSearchNeMoDecoder
   OfflineTransducerModifiedBeamSearchNeMoDecoder(
       OfflineTransducerNeMoModel *model, int32_t max_active_paths,
       int32_t unk_id, float blank_penalty, bool is_tdt,
-      float hotwords_score = 0.0f)
+      float hotwords_score, int32_t num_return_paths)
       : model_(model),
         max_active_paths_(max_active_paths),
         unk_id_(unk_id),
         blank_penalty_(blank_penalty),
         is_tdt_(is_tdt),
-        hotwords_score_(hotwords_score) {}
+        hotwords_score_(hotwords_score),
+        num_return_paths_(num_return_paths) {}
 
   std::vector<OfflineTransducerDecoderResult> Decode(
       Ort::Value encoder_out,
@@ -40,6 +41,7 @@ class OfflineTransducerModifiedBeamSearchNeMoDecoder
   float blank_penalty_;
   bool is_tdt_;  // Token-and-Duration Transducer mode
   float hotwords_score_;
+  int32_t num_return_paths_;
 };
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/sherpa-onnx-offline-parallel.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-offline-parallel.cc
@@ -298,6 +298,7 @@ for a list of pre-trained models to download.
   fprintf(stderr, "decoding method: %s\n", config.decoding_method.c_str());
   if (config.decoding_method == "modified_beam_search") {
     fprintf(stderr, "max active paths: %d\n", config.max_active_paths);
+    fprintf(stderr, "num return paths: %d\n", config.num_return_paths);
   }
   fprintf(stderr, "Elapsed seconds: %.3f s\n", total_time);
   float rtf = total_time / total_length;

--- a/sherpa-onnx/csrc/sherpa-onnx-offline.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-offline.cc
@@ -192,6 +192,7 @@ for a list of pre-trained models to download.
   fprintf(stderr, "decoding method: %s\n", config.decoding_method.c_str());
   if (config.decoding_method == "modified_beam_search") {
     fprintf(stderr, "max active paths: %d\n", config.max_active_paths);
+    fprintf(stderr, "num return paths: %d\n", config.num_return_paths);
   }
 
   fprintf(stderr, "Elapsed seconds: %.3f s\n", elapsed_seconds);

--- a/sherpa-onnx/csrc/sherpa-onnx-vad-with-offline-asr.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-vad-with-offline-asr.cc
@@ -249,6 +249,8 @@ for a list of pre-trained models to download.
   fprintf(stderr, "decoding method: %s\n", asr_config.decoding_method.c_str());
   if (asr_config.decoding_method == "modified_beam_search") {
     fprintf(stderr, "max active paths: %d\n", asr_config.max_active_paths);
+    fprintf(stderr, "num return paths: %d\n",
+            asr_config.num_return_paths);
   }
 
   float duration = samples.size() / 16000.;

--- a/sherpa-onnx/python/csrc/offline-recognizer.cc
+++ b/sherpa-onnx/python/csrc/offline-recognizer.cc
@@ -33,6 +33,10 @@ Args:
   max_active_paths:
     Number of active paths for beam search decoding. Only effective when
     ``decoding_method`` is ``modified_beam_search``.
+  num_return_paths:
+    Number of final hypotheses to return. Only effective when
+    ``decoding_method`` is ``modified_beam_search``. It must not exceed
+    ``max_active_paths``.
   hotwords_file:
     Path to a file containing hotwords, one per line.
   hotwords_score:
@@ -113,7 +117,7 @@ static void PybindOfflineRecognizerConfig(py::module *m) {
                     const OfflineLMConfig &, const OfflineCtcFstDecoderConfig &,
                     const std::string &, int32_t, const std::string &, float,
                     float, const std::string &, const std::string &,
-                    const HomophoneReplacerConfig &>(),
+                    const HomophoneReplacerConfig &, int32_t>(),
            py::arg("feat_config") = FeatureExtractorConfig(),
            py::arg("model_config") = OfflineModelConfig(),
            py::arg("lm_config") = OfflineLMConfig(),
@@ -123,6 +127,7 @@ static void PybindOfflineRecognizerConfig(py::module *m) {
            py::arg("hotwords_score") = 1.5, py::arg("blank_penalty") = 0.0,
            py::arg("rule_fsts") = "", py::arg("rule_fars") = "",
            py::arg("hr") = HomophoneReplacerConfig{},
+           py::arg("num_return_paths") = 1,
            kOfflineRecognizerConfigInitDoc)
       .def_readwrite("feat_config", &PyClass::feat_config)
       .def_readwrite("model_config", &PyClass::model_config)
@@ -130,6 +135,7 @@ static void PybindOfflineRecognizerConfig(py::module *m) {
       .def_readwrite("ctc_fst_decoder_config", &PyClass::ctc_fst_decoder_config)
       .def_readwrite("decoding_method", &PyClass::decoding_method)
       .def_readwrite("max_active_paths", &PyClass::max_active_paths)
+      .def_readwrite("num_return_paths", &PyClass::num_return_paths)
       .def_readwrite("hotwords_file", &PyClass::hotwords_file)
       .def_readwrite("hotwords_score", &PyClass::hotwords_score)
       .def_readwrite("blank_penalty", &PyClass::blank_penalty)

--- a/sherpa-onnx/python/csrc/offline-stream.cc
+++ b/sherpa-onnx/python/csrc/offline-stream.cc
@@ -29,6 +29,14 @@ Use the read-only properties to access individual fields of the result
 such as text, tokens, timestamps, etc.
 )doc";
 
+static constexpr const char *kOfflineRecognitionHypothesisDoc = R"doc(
+One hypothesis returned by offline modified beam search.
+
+The score is the decoder score used to rank the hypothesis. It is the
+length-normalized total log probability for the regular transducer decoder and
+the accumulated log probability for the NeMo decoder.
+)doc";
+
 static constexpr const char *kOfflineStreamDoc = R"doc(
 An offline stream is created by an OfflineRecognizer and holds a
 single utterance of audio. Feed audio into it with ``accept_waveform``,
@@ -68,6 +76,28 @@ Return:
   does not exist.
 )doc";
 
+static void PybindOfflineRecognitionHypothesis(py::module *m) {  // NOLINT
+  using PyClass = OfflineRecognitionHypothesis;
+  py::class_<PyClass>(*m, "OfflineRecognitionHypothesis",
+                      kOfflineRecognitionHypothesisDoc)
+      .def_property_readonly(
+          "text",
+          [](const PyClass &self) -> py::str {
+            return py::str(PyUnicode_DecodeUTF8(self.text.c_str(),
+                                                self.text.size(), "ignore"));
+          })
+      .def_property_readonly("tokens",
+        [](const PyClass &self) { return self.tokens; })
+      .def_property_readonly("timestamps",
+        [](const PyClass &self) { return self.timestamps; })
+      .def_property_readonly("durations",
+        [](const PyClass &self) { return self.durations; })
+      .def_property_readonly("ys_log_probs",
+        [](const PyClass &self) { return self.ys_log_probs; })
+      .def_property_readonly("score",
+        [](const PyClass &self) { return self.score; });
+}
+
 static void PybindOfflineRecognitionResult(py::module *m) {  // NOLINT
   using PyClass = OfflineRecognitionResult;
   py::class_<PyClass>(*m, "OfflineRecognitionResult",
@@ -100,10 +130,13 @@ static void PybindOfflineRecognitionResult(py::module *m) {  // NOLINT
       .def_property_readonly("segment_durations",
         [](const PyClass &self) { return self.segment_durations; })
       .def_property_readonly("segment_texts",
-        [](const PyClass &self) { return self.segment_texts; });
+        [](const PyClass &self) { return self.segment_texts; })
+      .def_property_readonly("hypotheses",
+        [](const PyClass &self) { return self.hypotheses; });
 }
 
 void PybindOfflineStream(py::module *m) {
+  PybindOfflineRecognitionHypothesis(m);
   PybindOfflineRecognitionResult(m);
 
   using PyClass = OfflineStream;

--- a/sherpa-onnx/python/sherpa_onnx/offline_recognizer.py
+++ b/sherpa-onnx/python/sherpa_onnx/offline_recognizer.py
@@ -130,6 +130,7 @@ class OfflineRecognizer(object):
         hr_lexicon: str = "",
         lodr_fst: str = "",
         lodr_scale: float = 0.0,
+        num_return_paths: int = 1,
     ):
         """
         Please refer to
@@ -166,6 +167,10 @@ class OfflineRecognizer(object):
           max_active_paths:
             Maximum number of active paths to keep. Used only when
             decoding_method is modified_beam_search.
+          num_return_paths:
+            Number of final hypotheses to return. Used only when
+            decoding_method is modified_beam_search. It must not exceed
+            max_active_paths.
           hotwords_file:
             The file containing hotwords, one words/phrases per line, and for each
             phrase the bpe/cjkchar are separated by a space.
@@ -233,6 +238,21 @@ class OfflineRecognizer(object):
                 f"--lm. Currently given: {decoding_method}"
             )
 
+        if decoding_method == "modified_beam_search" and (
+            num_return_paths < 1 or num_return_paths > max_active_paths
+        ):
+            raise ValueError(
+                "num_return_paths must be in the range "
+                f"[1, max_active_paths]. Given: {num_return_paths}. "
+                f"max_active_paths: {max_active_paths}"
+            )
+
+        if num_return_paths != 1 and decoding_method != "modified_beam_search":
+            raise ValueError(
+                "Please use --decoding-method=modified_beam_search when "
+                f"num_return_paths is not 1. Currently given: {decoding_method}"
+            )
+
         lm_config = OfflineLMConfig(
             model=lm,
             scale=lm_scale,
@@ -248,6 +268,7 @@ class OfflineRecognizer(object):
             lm_config=lm_config,
             decoding_method=decoding_method,
             max_active_paths=max_active_paths,
+            num_return_paths=num_return_paths,
             hotwords_file=hotwords_file,
             hotwords_score=hotwords_score,
             blank_penalty=blank_penalty,

--- a/sherpa-onnx/python/tests/test_offline_recognizer.py
+++ b/sherpa-onnx/python/tests/test_offline_recognizer.py
@@ -48,6 +48,86 @@ def read_wave(wave_filename: str) -> Tuple[np.ndarray, int]:
 
 
 class TestOfflineRecognizer(unittest.TestCase):
+    def test_from_transducer_positional_hotwords_compatibility(self):
+        with self.assertRaisesRegex(ValueError, "hotwords-file"):
+            sherpa_onnx.OfflineRecognizer.from_transducer(
+                "encoder.onnx",
+                "decoder.onnx",
+                "joiner.onnx",
+                "tokens.txt",
+                1,
+                16000,
+                80,
+                0.0,
+                "greedy_search",
+                4,
+                "hotwords.txt",
+            )
+
+    def test_num_return_paths_validation(self):
+        kwargs = {
+            "encoder": "encoder.onnx",
+            "decoder": "decoder.onnx",
+            "joiner": "joiner.onnx",
+            "tokens": "tokens.txt",
+        }
+
+        with self.assertRaisesRegex(ValueError, "range"):
+            sherpa_onnx.OfflineRecognizer.from_transducer(
+                **kwargs,
+                decoding_method="modified_beam_search",
+                max_active_paths=4,
+                num_return_paths=5,
+            )
+
+        with self.assertRaisesRegex(ValueError, "modified_beam_search"):
+            sherpa_onnx.OfflineRecognizer.from_transducer(
+                **kwargs,
+                decoding_method="greedy_search",
+                num_return_paths=2,
+            )
+
+    def test_transducer_modified_beam_search_nbest(self):
+        model_dir = Path(d) / "sherpa-onnx-zipformer-en-2023-04-01"
+        encoder = model_dir / "encoder-epoch-99-avg-1.int8.onnx"
+        decoder = model_dir / "decoder-epoch-99-avg-1.onnx"
+        joiner = model_dir / "joiner-epoch-99-avg-1.int8.onnx"
+        tokens = model_dir / "tokens.txt"
+        wave0 = model_dir / "test_wavs" / "0.wav"
+
+        if not encoder.is_file():
+            print("skipping test_transducer_modified_beam_search_nbest()")
+            return
+
+        recognizer = sherpa_onnx.OfflineRecognizer.from_transducer(
+            encoder=str(encoder),
+            decoder=str(decoder),
+            joiner=str(joiner),
+            tokens=str(tokens),
+            num_threads=1,
+            decoding_method="modified_beam_search",
+            max_active_paths=8,
+            num_return_paths=3,
+            provider="cpu",
+        )
+
+        stream = recognizer.create_stream()
+        samples, sample_rate = read_wave(str(wave0))
+        stream.accept_waveform(sample_rate, samples)
+        recognizer.decode_stream(stream)
+
+        hypotheses = stream.result.hypotheses
+        self.assertGreaterEqual(len(hypotheses), 1)
+        self.assertLessEqual(len(hypotheses), 3)
+        self.assertEqual(stream.result.text, hypotheses[0].text)
+        self.assertEqual(stream.result.tokens, hypotheses[0].tokens)
+        self.assertTrue(
+            all(
+                left.score >= right.score
+                for left, right in zip(hypotheses, hypotheses[1:])
+            )
+        )
+
     def test_transducer_single_file(self):
         for use_int8 in [True, False]:
             if use_int8:

--- a/sherpa-onnx/python/tests/test_offline_recognizer.py
+++ b/sherpa-onnx/python/tests/test_offline_recognizer.py
@@ -123,8 +123,8 @@ class TestOfflineRecognizer(unittest.TestCase):
         self.assertEqual(stream.result.tokens, hypotheses[0].tokens)
         self.assertTrue(
             all(
-                left.score >= right.score
-                for left, right in zip(hypotheses, hypotheses[1:])
+                hypotheses[i - 1].score >= hypotheses[i].score
+                for i in range(1, len(hypotheses))
             )
         )
 


### PR DESCRIPTION
## Summary

- Add `num_return_paths` for offline transducer modified beam search while keeping the existing 1-best result fields.
- Expose ranked hypotheses with text, tokens, timestamps, durations, token log probabilities, and decoder scores through C++ JSON and Python.
- Support both regular and NeMo transducer decoders and update the offline decoding example and CLI output.

## Compatibility

- Keep `num_return_paths=1` as the default.
- Require `1 <= num_return_paths <= max_active_paths`.
- Allow multiple returned paths only with `modified_beam_search`.
- Preserve `result.text`, `result.tokens`, `result.timestamps`, `result.durations`, and `result.ys_log_probs` as the 1-best result.
- Keep the existing positional Python arguments compatible by appending the new option.

## Tests

- Full CMake build
- `./build-nbest/bin/offline-stream-test`
- Python validation and positional-compatibility tests in an isolated uv environment
- `git diff --check`

Closes #3858

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Modified beam search can return multiple ranked recognition hypotheses.
  - Results include hypothesis text, tokens, timing details, log probabilities, and scores.
  - Added `num_return_paths` configuration support to Python and C++ APIs.
  - JSON and Python outputs expose alternative hypotheses.

- **Improvements**
  - Text normalization and homophone processing now apply consistently to all hypotheses.
  - Command-line tools and examples report configured return-path settings.

- **Tests**
  - Added coverage for serialization, validation, compatibility, and ranked n-best results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->