### PR TITLE
Fix float32 catastrophic cancellation in variance computation

### DIFF
--- a/sherpa-onnx/csrc/math.cc
+++ b/sherpa-onnx/csrc/math.cc
@@ -97,9 +97,11 @@ void ComputeMeanAndInvStd(const float *p, int32_t num_rows, int32_t num_cols,
 
   Eigen::RowVectorXf mean_vec = X.colwise().mean();
 
-  Eigen::RowVectorXf mean_sq = X.array().square().colwise().mean();
-
-  Eigen::RowVectorXf var = mean_sq.array() - mean_vec.array().square();
+  // E[x^2] - E[x]^2 cancels catastrophically in float32 when a feature
+  // stays near a constant value, so compute the variance from centered
+  // values instead.
+  Eigen::RowVectorXf var =
+      (X.rowwise() - mean_vec).array().square().colwise().mean();
 
   Eigen::RowVectorXf stddev = var.array().max(0.0f).sqrt();
 

--- a/sherpa-onnx/csrc/offline-omnilingual-asr-ctc-model.cc
+++ b/sherpa-onnx/csrc/offline-omnilingual-asr-ctc-model.cc
@@ -89,7 +89,10 @@ class OfflineOmnilingualAsrCtcModel::Impl {
     // Map the single-row feature vector
     Eigen::Map<Eigen::ArrayXf> x(features, feat_dim);
     float mean = x.mean();
-    float var = (x.square().mean() - mean * mean);
+    // E[x^2] - E[x]^2 cancels catastrophically in float32 when a feature
+    // stays near a constant value, so compute the variance from centered
+    // values instead.
+    float var = (x - mean).square().mean();
     var = std::max(var, 0.0f);
     float inv_stddev = 1.0f / std::sqrt(var + 1e-5f);
 

--- a/sherpa-onnx/csrc/speaker-embedding-extractor-nemo-impl.h
+++ b/sherpa-onnx/csrc/speaker-embedding-extractor-nemo-impl.h
@@ -130,8 +130,10 @@ class SpeakerEmbeddingExtractorNeMoImpl : public SpeakerEmbeddingExtractorImpl {
         p, num_frames, feat_dim);
 
     auto EX = m.colwise().mean();
-    auto EX2 = m.array().pow(2).colwise().sum() / num_frames;
-    auto variance = (EX2 - EX.array().pow(2)).max(1e-5f);
+    // E[x^2] - E[x]^2 cancels catastrophically in float32 when a feature
+    // stays near a constant value, so compute the variance from centered
+    // values instead.
+    auto variance = (m.rowwise() - EX).array().square().colwise().mean();
 
     auto stddev = variance.array().sqrt();
 


### PR DESCRIPTION
See also #3857 

Compute variance from centered values (x - mean)^2 instead of E[x^2] - E[x]^2 in ComputeMeanAndInvStd, Omnilingual ASR CTC normalization, and SpeakerEmbeddingExtractorNeMo NormalizePerFeature.

The subtraction E[x^2] - E[x]^2 cancels catastrophically in float32 when a feature stays near a constant value, yielding var == 0 and huge normalized outliers.

Applies the same fix as PR #3857 (NemoNormalizePerFeature) to all remaining instances of this pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numerical stability when normalizing nearly constant audio features.
  * Reduced potential precision errors in speech recognition and speaker embedding processing.
  * Preserved existing normalization safeguards and behavior for typical inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->