### PR TITLE
Fix using SPM in iOS examples

### DIFF
--- a/.github/workflows/build-xcframework.yaml
+++ b/.github/workflows/build-xcframework.yaml
@@ -314,7 +314,7 @@ jobs:
           cd spm-examples/macOS
 
           # Patch Package.swift to use local package
-          sed -i.bak 's|.package(url: "https://github.com/k2-fsa/sherpa-onnx", exact: "v1.13.5")|.package(path: "../../")|' Package.swift
+          sed -i.bak 's|.package(url: "https://github.com/k2-fsa/sherpa-onnx", exact: "1.13.5")|.package(path: "../../")|' Package.swift
 
           # Patch root Package.swift to use local xcframework paths
           cd ../..
@@ -366,7 +366,7 @@ jobs:
           cd spm-examples/iOS
 
           # Patch Package.swift to use local package
-          sed -i.bak 's|.package(url: "https://github.com/k2-fsa/sherpa-onnx", exact: "v1.13.5")|.package(path: "../../")|' Package.swift
+          sed -i.bak 's|.package(url: "https://github.com/k2-fsa/sherpa-onnx", exact: "1.13.5")|.package(path: "../../")|' Package.swift
 
           echo "=== Package.swift ==="
           cat Package.swift

--- a/.github/workflows/test-spm.yaml
+++ b/.github/workflows/test-spm.yaml
@@ -20,7 +20,7 @@ jobs:
         run: |
           cd spm-examples/macOS
           # Use local package for CI testing
-          sed -i.bak 's|.package(url: "https://github.com/k2-fsa/sherpa-onnx", exact: "v1.13.5")|.package(path: "../../")|' Package.swift
+          sed -i.bak 's|.package(url: "https://github.com/k2-fsa/sherpa-onnx", exact: "1.13.5")|.package(path: "../../")|' Package.swift
           git diff
           cat Package.swift
           rm -rf .build
@@ -60,7 +60,7 @@ jobs:
           cd spm-examples/iOS
 
           # Use local package for CI testing
-          sed -i.bak 's|.package(url: "https://github.com/k2-fsa/sherpa-onnx", exact: "v1.13.5")|.package(path: "../../")|' Package.swift
+          sed -i.bak 's|.package(url: "https://github.com/k2-fsa/sherpa-onnx", exact: "1.13.5")|.package(path: "../../")|' Package.swift
           git diff
           cat Package.swift
 

--- a/ios-swift/SherpaOnnxAsr/SherpaOnnxAsr.xcodeproj/project.pbxproj
+++ b/ios-swift/SherpaOnnxAsr/SherpaOnnxAsr.xcodeproj/project.pbxproj
@@ -592,7 +592,7 @@
 			repositoryURL = "https://github.com/k2-fsa/sherpa-onnx";
 			requirement = {
 				kind = exactVersion;
-				version = v1.13.5;
+				version = 1.13.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios-swiftui/README.md
+++ b/ios-swiftui/README.md
@@ -28,7 +28,7 @@ There are two ways to add sherpa-onnx to your Xcode project:
    ```
 4. Choose your version rule:
    - **Up to Next Major**: e.g. `1.13.0 ..< 2.0.0`
-   - **Exact**: e.g. `1.13.4`
+   - **Exact**: e.g. `1.13.5`
    - **Branch**: e.g. `master`
 5. Click **Add Package**
 6. Select the product you want (`sherpa-onnx` or `sherpa-onnx-shared`) and click **Add Package**

--- a/ios-swiftui/SherpaOnnx2Pass/SherpaOnnx2Pass.xcodeproj/project.pbxproj
+++ b/ios-swiftui/SherpaOnnx2Pass/SherpaOnnx2Pass.xcodeproj/project.pbxproj
@@ -366,7 +366,7 @@
 			repositoryURL = "https://github.com/k2-fsa/sherpa-onnx";
 			requirement = {
 				kind = exactVersion;
-				version = v1.13.5;
+				version = 1.13.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios-swiftui/SherpaOnnxAsr/SherpaOnnxAsr.xcodeproj/project.pbxproj
+++ b/ios-swiftui/SherpaOnnxAsr/SherpaOnnxAsr.xcodeproj/project.pbxproj
@@ -609,7 +609,7 @@
 			repositoryURL = "https://github.com/k2-fsa/sherpa-onnx";
 			requirement = {
 				kind = exactVersion;
-				version = v1.13.5;
+				version = 1.13.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios-swiftui/SherpaOnnxLangID/SherpaOnnxLangID.xcodeproj/project.pbxproj
+++ b/ios-swiftui/SherpaOnnxLangID/SherpaOnnxLangID.xcodeproj/project.pbxproj
@@ -623,7 +623,7 @@
 			repositoryURL = "https://github.com/k2-fsa/sherpa-onnx";
 			requirement = {
 				kind = exactVersion;
-				version = v1.13.5;
+				version = 1.13.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios-swiftui/SherpaOnnxSubtitle/SherpaOnnxSubtitle.xcodeproj/project.pbxproj
+++ b/ios-swiftui/SherpaOnnxSubtitle/SherpaOnnxSubtitle.xcodeproj/project.pbxproj
@@ -412,7 +412,7 @@
 			repositoryURL = "https://github.com/k2-fsa/sherpa-onnx";
 			requirement = {
 				kind = exactVersion;
-				version = v1.13.5;
+				version = 1.13.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios-swiftui/SherpaOnnxTts/SherpaOnnxTts.xcodeproj/project.pbxproj
+++ b/ios-swiftui/SherpaOnnxTts/SherpaOnnxTts.xcodeproj/project.pbxproj
@@ -11,8 +11,8 @@
 		C917B4E72B0EEF3B005245AC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C917B4E62B0EEF3B005245AC /* ContentView.swift */; };
 		C917B4E92B0EEF3C005245AC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C917B4E82B0EEF3C005245AC /* Assets.xcassets */; };
 		C917B4EC2B0EEF3C005245AC /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C917B4EB2B0EEF3C005245AC /* Preview Assets.xcassets */; };
+		C9A4C699302B3BD60004DECB /* sherpa-onnx in Frameworks */ = {isa = PBXBuildFile; productRef = C9A4C698302B3BD60004DECB /* sherpa-onnx */; };
 		C9FE9FE52B0F33CD009F1003 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9FE9FE42B0F33CD009F1003 /* ViewModel.swift */; };
-		C9SP000000000001 /* sherpa-onnx in Frameworks */ = {isa = PBXBuildFile; productRef = C9SP000000000002 /* sherpa-onnx */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -29,7 +29,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C9SP000000000001 /* sherpa-onnx in Frameworks */,
+				C9A4C699302B3BD60004DECB /* sherpa-onnx in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -89,7 +89,7 @@
 			);
 			name = SherpaOnnxTts;
 			packageProductDependencies = (
-				C9SP000000000002 /* sherpa-onnx */,
+				C9A4C698302B3BD60004DECB /* sherpa-onnx */,
 			);
 			productName = SherpaOnnxTts;
 			productReference = C917B4E12B0EEF3B005245AC /* SherpaOnnxTts.app */;
@@ -120,7 +120,7 @@
 			);
 			mainGroup = C917B4D82B0EEF3B005245AC;
 			packageReferences = (
-				C9SP000000000003 /* XCRemoteSwiftPackageReference "sherpa-onnx" */,
+				C9A4C697302B3BD60004DECB /* XCRemoteSwiftPackageReference "sherpa-onnx" */,
 			);
 			productRefGroup = C917B4E22B0EEF3B005245AC /* Products */;
 			projectDirPath = "";
@@ -351,20 +351,20 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		C9SP000000000003 /* XCRemoteSwiftPackageReference "sherpa-onnx" */ = {
+		C9A4C697302B3BD60004DECB /* XCRemoteSwiftPackageReference "sherpa-onnx" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/k2-fsa/sherpa-onnx";
 			requirement = {
 				kind = exactVersion;
-				version = v1.13.5;
+				version = 1.13.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		C9SP000000000002 /* sherpa-onnx */ = {
+		C9A4C698302B3BD60004DECB /* sherpa-onnx */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9SP000000000003 /* XCRemoteSwiftPackageReference "sherpa-onnx" */;
+			package = C9A4C697302B3BD60004DECB /* XCRemoteSwiftPackageReference "sherpa-onnx" */;
 			productName = "sherpa-onnx";
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/spm-examples/iOS/Package.swift
+++ b/spm-examples/iOS/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
   name: "SherpaOnnxExample",
   platforms: [.iOS(.v15)],
   dependencies: [
-    .package(url: "https://github.com/k2-fsa/sherpa-onnx", exact: "v1.13.5"),
+    .package(url: "https://github.com/k2-fsa/sherpa-onnx", exact: "1.13.5"),
   ],
   targets: [
     .executableTarget(

--- a/spm-examples/macOS/Package.swift
+++ b/spm-examples/macOS/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
   name: "SherpaOnnxExample",
   platforms: [.macOS(.v10_15)],
   dependencies: [
-    .package(url: "https://github.com/k2-fsa/sherpa-onnx", exact: "v1.13.5"),
+    .package(url: "https://github.com/k2-fsa/sherpa-onnx", exact: "1.13.5"),
   ],
   targets: [
     .executableTarget(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependency Updates**
  * Updated Apple platform integrations and Swift Package Manager examples to use the exact `sherpa-onnx` version 1.13.5.
  * Standardized version formatting by removing the leading `v` prefix.

* **Documentation**
  * Updated the SwiftUI documentation to reference version 1.13.5.

* **Tests**
  * Updated package validation workflows to correctly test the local dependency at version 1.13.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->