### PR TITLE
Fix CircularBuffer overflow in long-running VAD

### DIFF
--- a/sherpa-onnx/c-api/c-api.h
+++ b/sherpa-onnx/c-api/c-api.h
@@ -2055,7 +2055,7 @@ SherpaOnnxCircularBufferSize(const SherpaOnnxCircularBuffer *buffer);
 /**
  * @brief Return the current head index of the buffer timeline.
  *
- * The value is monotonically non-decreasing until
+ * The value wraps to 0 after reaching INT32_MAX. It is also reset to 0 when
  * SherpaOnnxCircularBufferReset() is called.
  *
  * @param buffer A pointer returned by SherpaOnnxCreateCircularBuffer().

--- a/sherpa-onnx/csrc/circular-buffer-test.cc
+++ b/sherpa-onnx/csrc/circular-buffer-test.cc
@@ -4,6 +4,7 @@
 
 #include "sherpa-onnx/csrc/circular-buffer.h"
 
+#include <limits>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -145,6 +146,46 @@ TEST(CircularBuffer, PushAndPop) {
   EXPECT_EQ(c.size(), 2);
   EXPECT_EQ(c[0], 3000);
   EXPECT_EQ(c[1], 4000);
+}
+
+TEST(CircularBuffer, ResizeWrappedData) {
+  CircularBuffer buffer(4);
+  std::vector<float> a = {0, 1, 2};
+  buffer.Push(a.data(), a.size());
+  buffer.Pop(2);
+
+  a = {3, 4, 5};
+  buffer.Push(a.data(), a.size());
+
+  a = {6, 7};
+  buffer.Push(a.data(), a.size());
+
+  std::vector<float> expected = {2, 3, 4, 5, 6, 7};
+  auto actual = buffer.Get(buffer.Head(), buffer.Size());
+  EXPECT_EQ(actual, expected);
+}
+
+TEST(CircularBuffer, LogicalIndexWrap) {
+  CircularBuffer buffer(4);
+  buffer.head_index_ =
+      static_cast<uint32_t>(std::numeric_limits<int32_t>::max()) - 2;
+
+  std::vector<float> a = {0, 1, 2, 3};
+  buffer.Push(a.data(), a.size());
+
+  EXPECT_EQ(buffer.Head(), std::numeric_limits<int32_t>::max() - 2);
+  EXPECT_EQ(buffer.Tail(), 1);
+  EXPECT_EQ(buffer.Get(buffer.Head(), buffer.Size()), a);
+
+  buffer.Pop(3);
+  EXPECT_EQ(buffer.Head(), 0);
+  EXPECT_EQ(buffer.Tail(), 1);
+  EXPECT_EQ(buffer.Get(0, 1), std::vector<float>({3}));
+
+  a = {4, 5, 6};
+  buffer.Push(a.data(), a.size());
+  EXPECT_EQ(buffer.Get(buffer.Head(), buffer.Size()),
+            std::vector<float>({3, 4, 5, 6}));
 }
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/circular-buffer.cc
+++ b/sherpa-onnx/csrc/circular-buffer.cc
@@ -5,6 +5,7 @@
 #include "sherpa-onnx/csrc/circular-buffer.h"
 
 #include <algorithm>
+#include <limits>
 #include <vector>
 
 #include "sherpa-onnx/csrc/macros.h"
@@ -37,88 +38,71 @@ void CircularBuffer::Resize(int32_t new_capacity) {
   int32_t size = Size();
   if (size == 0) {
     buffer_.resize(new_capacity);
+    begin_ = 0;
     return;
   }
 
   std::vector<float> new_buffer(new_capacity);
-  int32_t start = head_ % capacity;
-  int32_t dest = head_ % new_capacity;
+  int32_t part1_size = std::min(size, capacity - begin_);
+  std::copy(buffer_.begin() + begin_, buffer_.begin() + begin_ + part1_size,
+            new_buffer.begin());
+  std::copy(buffer_.begin(), buffer_.begin() + size - part1_size,
+            new_buffer.begin() + part1_size);
 
-  if (start + size <= capacity) {
-    if (dest + size <= new_capacity) {
-      std::copy(buffer_.begin() + start, buffer_.begin() + start + size,
-                new_buffer.begin() + dest);
-    } else {
-      int32_t part1_size = new_capacity - dest;
-
-      // copy [start, start+part1_size] to new_buffer
-      std::copy(buffer_.begin() + start, buffer_.begin() + start + part1_size,
-                new_buffer.begin() + dest);
-
-      // copy [start+part1_size, start+size] to new_buffer
-      std::copy(buffer_.begin() + start + part1_size,
-                buffer_.begin() + start + size, new_buffer.begin());
-    }
-  } else {
-    int32_t part1_size = capacity - start;
-    int32_t part2_size = size - part1_size;
-
-    // copy [start, start+part1_size] to new_buffer
-    if (dest + part1_size <= new_capacity) {
-      std::copy(buffer_.begin() + start, buffer_.begin() + start + part1_size,
-                new_buffer.begin() + dest);
-    } else {
-      int32_t first_part = new_capacity - dest;
-      std::copy(buffer_.begin() + start, buffer_.begin() + start + first_part,
-                new_buffer.begin() + dest);
-
-      std::copy(buffer_.begin() + start + first_part,
-                buffer_.begin() + start + part1_size, new_buffer.begin());
-    }
-
-    int32_t new_dest = (dest + part1_size) % new_capacity;
-
-    if (new_dest + part2_size <= new_capacity) {
-      std::copy(buffer_.begin(), buffer_.begin() + part2_size,
-                new_buffer.begin() + new_dest);
-    } else {
-      int32_t first_part = new_capacity - new_dest;
-      std::copy(buffer_.begin(), buffer_.begin() + first_part,
-                new_buffer.begin() + new_dest);
-      std::copy(buffer_.begin() + first_part, buffer_.begin() + part2_size,
-                new_buffer.begin());
-    }
-  }
   buffer_.swap(new_buffer);
+  begin_ = 0;
 }
 
 void CircularBuffer::Push(const float *p, int32_t n) {
+  if (n < 0) {
+    SHERPA_ONNX_LOGE("Invalid n: %d", n);
+    return;
+  }
+
+  if (n == 0) {
+    return;
+  }
+
+  if (!p) {
+    SHERPA_ONNX_LOGE("p is NULL");
+    return;
+  }
+
   int32_t capacity = static_cast<int32_t>(buffer_.size());
   int32_t size = Size();
-  if (n + size > capacity) {
-    int32_t new_capacity = std::max(capacity * 2, n + size);
+  int64_t required_size = static_cast<int64_t>(n) + size;
+  if (required_size > std::numeric_limits<int32_t>::max()) {
+    SHERPA_ONNX_LOGE("n + size exceeds INT32_MAX. n: %d, size: %d", n, size);
+    return;
+  }
+
+  if (required_size > capacity) {
+    int32_t new_capacity = static_cast<int32_t>(std::max(
+        std::min(static_cast<int64_t>(capacity) * 2,
+                 static_cast<int64_t>(std::numeric_limits<int32_t>::max())),
+        required_size));
 #if __OHOS__
     SHERPA_ONNX_LOGE(
         "Overflow! n: %{public}d, size: %{public}d, n+size: %{public}d, "
         "capacity: %{public}d. Increase "
         "capacity to: %{public}d. (Original data is copied. No data loss!)",
-        n, size, n + size, capacity, new_capacity);
+        n, size, static_cast<int32_t>(required_size), capacity, new_capacity);
 #else
     SHERPA_ONNX_LOGE(
         "Overflow! n: %d, size: %d, n+size: %d, capacity: %d. Increase "
         "capacity to: %d. (Original data is copied. No data loss!)",
-        n, size, n + size, capacity, new_capacity);
+        n, size, static_cast<int32_t>(required_size), capacity, new_capacity);
 #endif
     Resize(new_capacity);
 
     capacity = new_capacity;
   }
 
-  int32_t start = tail_ % capacity;
+  int32_t start =
+      static_cast<int32_t>((static_cast<int64_t>(begin_) + size_) % capacity);
+  size_ = static_cast<int32_t>(required_size);
 
-  tail_ += n;
-
-  if (start + n < capacity) {
+  if (n <= capacity - start) {
     std::copy(p, p + n, buffer_.begin() + start);
     return;
   }
@@ -130,10 +114,31 @@ void CircularBuffer::Push(const float *p, int32_t n) {
   std::copy(p + part1_size, p + n, buffer_.begin());
 }
 
+int32_t CircularBuffer::GetIndex(int32_t offset) const {
+  if (offset < 0 || offset > size_) {
+    SHERPA_ONNX_LOGE("Invalid offset: %d. size: %d", offset, size_);
+    return Head();
+  }
+
+  uint32_t index = head_index_ + static_cast<uint32_t>(offset);
+  if (index >= kIndexRange) {
+    index -= kIndexRange;
+  }
+
+  return static_cast<int32_t>(index);
+}
+
 std::vector<float> CircularBuffer::Get(int32_t start_index, int32_t n) const {
-  if (start_index < head_ || start_index >= tail_) {
+  uint32_t offset = kIndexRange;
+  if (start_index >= 0) {
+    uint32_t index = static_cast<uint32_t>(start_index);
+    offset = index >= head_index_ ? index - head_index_
+                                  : kIndexRange - head_index_ + index;
+  }
+
+  if (offset >= static_cast<uint32_t>(size_)) {
     SHERPA_ONNX_LOGE("Invalid start_index: %d. head_: %d, tail_: %d",
-                     start_index, head_, tail_);
+                     start_index, Head(), Tail());
     return {};
   }
 
@@ -143,17 +148,17 @@ std::vector<float> CircularBuffer::Get(int32_t start_index, int32_t n) const {
     return {};
   }
 
-  int32_t capacity = static_cast<int32_t>(buffer_.size());
-
-  if (start_index - head_ + n > size) {
+  if (static_cast<uint32_t>(n) > static_cast<uint32_t>(size) - offset) {
     SHERPA_ONNX_LOGE("Invalid start_index: %d and n: %d. head_: %d, size: %d",
-                     start_index, n, head_, size);
+                     start_index, n, Head(), size);
     return {};
   }
 
-  int32_t start = start_index % capacity;
+  int32_t capacity = static_cast<int32_t>(buffer_.size());
+  int32_t start =
+      static_cast<int32_t>((static_cast<int64_t>(begin_) + offset) % capacity);
 
-  if (start + n < capacity) {
+  if (n <= capacity - start) {
     return {buffer_.begin() + start, buffer_.begin() + start + n};
   }
 
@@ -176,7 +181,22 @@ void CircularBuffer::Pop(int32_t n) {
     return;
   }
 
-  head_ += n;
+  if (n == 0) {
+    return;
+  }
+
+  int32_t capacity = static_cast<int32_t>(buffer_.size());
+  begin_ = static_cast<int32_t>((static_cast<int64_t>(begin_) + n) % capacity);
+
+  head_index_ += static_cast<uint32_t>(n);
+  if (head_index_ >= kIndexRange) {
+    head_index_ -= kIndexRange;
+  }
+
+  size_ -= n;
+  if (size_ == 0) {
+    begin_ = 0;
+  }
 }
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/circular-buffer.h
+++ b/sherpa-onnx/csrc/circular-buffer.h
@@ -5,14 +5,14 @@
 #define SHERPA_ONNX_CSRC_CIRCULAR_BUFFER_H_
 
 #include <cstdint>
+#include <limits>
 #include <vector>
 
 namespace sherpa_onnx {
 
 class CircularBuffer {
  public:
-  // Capacity of this buffer. Should be large enough.
-  // If it is full, we just print a message and exit the program.
+  // Initial capacity of this buffer. It grows when needed.
   explicit CircularBuffer(int32_t capacity);
 
   // Push an array
@@ -20,13 +20,17 @@ class CircularBuffer {
   // @param p Pointer to the start address of the array
   // @param n Number of elements in the array
   //
-  // Note: If n + Size() > capacity, we print an error message and exit.
+  // Note: The buffer grows if n + Size() is greater than its capacity.
   void Push(const float *p, int32_t n);
 
-  // @param start_index Should in the range [head_, tail_)
+  // @param start_index Should be in the range [Head(), Tail())
   // @param n Number of elements to get
   // @return Return a vector of size n containing the requested elements
   std::vector<float> Get(int32_t start_index, int32_t n) const;
+
+  // Return the logical index at the given offset from Head().
+  // @param offset Should be in the range [0, Size()]
+  int32_t GetIndex(int32_t offset) const;
 
   // Remove n elements from the buffer
   //
@@ -34,26 +38,35 @@ class CircularBuffer {
   void Pop(int32_t n);
 
   // Number of elements in the buffer.
-  int32_t Size() const { return tail_ - head_; }
+  int32_t Size() const { return size_; }
 
-  // Current position of the head
-  int32_t Head() const { return head_; }
+  // Current logical position of the head.
+  // It wraps to 0 after reaching INT32_MAX.
+  int32_t Head() const { return static_cast<int32_t>(head_index_); }
 
-  // Current position of the tail
-  int32_t Tail() const { return tail_; }
+  // Current logical position of the tail.
+  // It wraps to 0 after reaching INT32_MAX.
+  int32_t Tail() const { return GetIndex(size_); }
 
   void Reset() {
-    head_ = 0;
-    tail_ = 0;
+    begin_ = 0;
+    size_ = 0;
+    head_index_ = 0;
   }
 
   void Resize(int32_t new_capacity);
 
  private:
+  friend class CircularBuffer_LogicalIndexWrap_Test;
+
+  static constexpr uint32_t kIndexRange =
+      static_cast<uint32_t>(std::numeric_limits<int32_t>::max()) + 1;
+
   std::vector<float> buffer_;
 
-  int32_t head_ = 0;  // linear index; always increasing; never wraps around
-  int32_t tail_ = 0;  // linear index, always increasing; never wraps around.
+  int32_t begin_ = 0;  // physical index of the first element
+  int32_t size_ = 0;
+  uint32_t head_index_ = 0;  // logical index; wraps at kIndexRange
 };
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/voice-activity-detector.cc
+++ b/sherpa-onnx/csrc/voice-activity-detector.cc
@@ -92,46 +92,49 @@ class VoiceActivityDetector::Impl {
         p, static_cast<const float *>(last_.data()) + last_.size());
 
     if (is_speech) {
-      if (start_ == -1) {
+      if (start_offset_ == -1) {
         // beginning of speech
-        start_ = std::max(buffer_.Tail() - 2 * model_->WindowSize() -
-                              model_->MinSpeechDurationSamples(),
-                          buffer_.Head());
-        cur_segment_.start = start_;
+        int32_t look_back =
+            2 * model_->WindowSize() + model_->MinSpeechDurationSamples();
+        start_offset_ = std::max(buffer_.Size() - look_back, 0);
+        cur_segment_.start = buffer_.GetIndex(start_offset_);
       }
-      int32_t num_samples = buffer_.Tail() - start_ - 1;
-      cur_segment_.samples = buffer_.Get(start_, num_samples);
+      int32_t num_samples = buffer_.Size() - start_offset_ - 1;
+      cur_segment_.samples = buffer_.Get(cur_segment_.start, num_samples);
     } else {
       // non-speech
 
       cur_segment_.start = -1;
       cur_segment_.samples.clear();
 
-      if (start_ != -1 && buffer_.Size()) {
+      if (start_offset_ != -1 && buffer_.Size()) {
         // end of speech, save the speech segment
-        int32_t end = buffer_.Tail() - model_->MinSilenceDurationSamples();
+        int32_t end_offset =
+            buffer_.Size() - model_->MinSilenceDurationSamples();
+        int32_t start_index = buffer_.GetIndex(start_offset_);
 
-        std::vector<float> s = buffer_.Get(start_, end - start_);
+        std::vector<float> s =
+            buffer_.Get(start_index, end_offset - start_offset_);
         SpeechSegment segment;
 
-        segment.start = start_;
+        segment.start = start_index;
         segment.samples = std::move(s);
 
         segments_.push(std::move(segment));
 
-        buffer_.Pop(end - buffer_.Head());
+        buffer_.Pop(end_offset);
       }
 
-      if (start_ == -1) {
-        int32_t end = buffer_.Tail() - 2 * model_->WindowSize() -
-                      model_->MinSpeechDurationSamples();
-        int32_t n = std::max(0, end - buffer_.Head());
+      if (start_offset_ == -1) {
+        int32_t keep =
+            2 * model_->WindowSize() + model_->MinSpeechDurationSamples();
+        int32_t n = std::max(0, buffer_.Size() - keep);
         if (n > 0) {
           buffer_.Pop(n);
         }
       }
 
-      start_ = -1;
+      start_offset_ = -1;
     }
   }
 
@@ -161,39 +164,40 @@ class VoiceActivityDetector::Impl {
     buffer_.Reset();
     last_.clear();
 
-    start_ = -1;
+    start_offset_ = -1;
 
     cur_segment_.start = -1;
     cur_segment_.samples.clear();
   }
 
   void Flush() {
-    if (start_ == -1 || buffer_.Size() == 0) {
+    if (start_offset_ == -1 || buffer_.Size() == 0) {
       return;
     }
 
-    int32_t end = buffer_.Tail();
-    if (end <= start_) {
+    int32_t end_offset = buffer_.Size();
+    if (end_offset <= start_offset_) {
       return;
     }
 
-    std::vector<float> s = buffer_.Get(start_, end - start_);
+    int32_t start_index = buffer_.GetIndex(start_offset_);
+    std::vector<float> s = buffer_.Get(start_index, end_offset - start_offset_);
 
     SpeechSegment segment;
 
-    segment.start = start_;
+    segment.start = start_index;
     segment.samples = std::move(s);
 
     segments_.push(std::move(segment));
 
-    buffer_.Pop(end - buffer_.Head());
-    start_ = -1;
+    buffer_.Pop(end_offset);
+    start_offset_ = -1;
 
     cur_segment_.start = -1;
     cur_segment_.samples.clear();
   }
 
-  bool IsSpeechDetected() const { return start_ != -1; }
+  bool IsSpeechDetected() const { return start_offset_ != -1; }
 
   SpeechSegment CurrentSpeechSegment() const { return cur_segment_; }
 
@@ -228,7 +232,8 @@ class VoiceActivityDetector::Impl {
   float new_min_silence_duration_s_ = 0.1;
   float new_threshold_ = 0.90;
 
-  int32_t start_ = -1;
+  // Offset from buffer_.Head() to the start of the current speech segment.
+  int32_t start_offset_ = -1;
 };
 
 VoiceActivityDetector::VoiceActivityDetector(


### PR DESCRIPTION
## Summary

- Fix a deterministic signed `int32_t` overflow in the circular buffer used by `VoiceActivityDetector`. At 16 kHz, the accumulated sample index can overflow after about 37 hours, resulting in an invalid buffer index and a possible SIGSEGV.
- Regular short-lived VAD usage is unaffected. The issue was originally reported with TEN VAD in [#3635](https://github.com/k2-fsa/sherpa-onnx/issues/3635), and I encountered the same problem with Silero VAD because both use the shared VAD buffer.
- Keep the existing user-facing APIs backward compatible and add focused regression tests for the overflow boundary.

Fixes [#3635](https://github.com/k2-fsa/sherpa-onnx/issues/3635).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Circular buffers now grow automatically when incoming data exceeds their capacity.
  - Improved support for long-running buffers, including index wraparound at the 32-bit boundary.
  - Voice activity detection continues tracking and extracting speech segments correctly as buffer indices wrap.

- **Bug Fixes**
  - Preserved data ordering during buffer resizing.
  - Improved reliability of speech segment tracking, retrieval, and buffer cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->