### PR TITLE
Expose the pyannote window shift ratio in the C API and language bindings

### DIFF
--- a/android/SherpaOnnxSpeakerDiarization/app/src/main/java/com/k2fsa/sherpa/onnx/speaker/diarization/SpeakerDiarizationObject.kt
+++ b/android/SherpaOnnxSpeakerDiarization/app/src/main/java/com/k2fsa/sherpa/onnx/speaker/diarization/SpeakerDiarizationObject.kt
@@ -48,7 +48,8 @@ object SpeakerDiarizationObject {
             val config = OfflineSpeakerDiarizationConfig(
                 segmentation = OfflineSpeakerSegmentationModelConfig(
                     pyannote = OfflineSpeakerSegmentationPyannoteModelConfig(
-                        segmentationModel
+                        model = segmentationModel,
+                        windowShiftRatio = 0.1f,
                     ),
                     debug = true,
                 ),

--- a/c-api-examples/offline-speaker-diarization-c-api.c
+++ b/c-api-examples/offline-speaker-diarization-c-api.c
@@ -73,6 +73,8 @@ int main() {
   memset(&config, 0, sizeof(config));
 
   config.segmentation.pyannote.model = segmentation_model;
+  // A value of 0 also uses the default of 0.1.
+  config.segmentation.pyannote.window_shift_ratio = 0.1f;
   config.embedding.model = embedding_extractor_model;
 
   // the test wave ./0-four-speakers-zh.wav has 4 speakers, so

--- a/cxx-api-examples/offline-speaker-diarization-cxx-api.cc
+++ b/cxx-api-examples/offline-speaker-diarization-cxx-api.cc
@@ -31,6 +31,7 @@ int32_t main() {
   OfflineSpeakerDiarizationConfig config;
   config.segmentation.pyannote.model =
       "./sherpa-onnx-pyannote-segmentation-3-0/model.onnx";
+  config.segmentation.pyannote.window_shift_ratio = 0.1f;
   config.embedding.model =
       "./3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx";
   config.clustering.num_clusters = 4;

--- a/dart-api-examples/speaker-diarization/bin/speaker-diarization.dart
+++ b/dart-api-examples/speaker-diarization/bin/speaker-diarization.dart
@@ -46,7 +46,7 @@ void main(List<String> arguments) async {
 
   final segmentationConfig = sherpa_onnx.OfflineSpeakerSegmentationModelConfig(
     pyannote: sherpa_onnx.OfflineSpeakerSegmentationPyannoteModelConfig(
-        model: segmentationModel),
+        model: segmentationModel, windowShiftRatio: 0.1),
   );
 
   final embeddingConfig =

--- a/dotnet-examples/offline-speaker-diarization/Program.cs
+++ b/dotnet-examples/offline-speaker-diarization/Program.cs
@@ -41,6 +41,7 @@ class OfflineSpeakerDiarizationDemo
   {
     var config = new OfflineSpeakerDiarizationConfig();
     config.Segmentation.Pyannote.Model = "./sherpa-onnx-pyannote-segmentation-3-0/model.onnx";
+    config.Segmentation.Pyannote.WindowShiftRatio = 0.1f;
     config.Embedding.Model = "./3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx";
 
     // the test wave ./0-four-speakers-zh.wav has 4 speakers, so

--- a/flutter/sherpa_onnx/lib/src/offline_speaker_diarization.dart
+++ b/flutter/sherpa_onnx/lib/src/offline_speaker_diarization.dart
@@ -40,6 +40,8 @@ class OfflineSpeakerDiarization {
 
     c.ref.segmentation.pyannote.model =
         config.segmentation.pyannote.model.toNativeUtf8();
+    c.ref.segmentation.pyannote.windowShiftRatio =
+        config.segmentation.pyannote.windowShiftRatio;
     c.ref.segmentation.numThreads = config.segmentation.numThreads;
     c.ref.segmentation.debug = config.segmentation.debug ? 1 : 0;
     c.ref.segmentation.provider = config.segmentation.provider.toNativeUtf8();

--- a/flutter/sherpa_onnx/lib/src/offline_speaker_diarization_config.dart
+++ b/flutter/sherpa_onnx/lib/src/offline_speaker_diarization_config.dart
@@ -43,25 +43,31 @@ class OfflineSpeakerDiarizationSegment {
 class OfflineSpeakerSegmentationPyannoteModelConfig {
   const OfflineSpeakerSegmentationPyannoteModelConfig({
     this.model = '',
+    this.windowShiftRatio = 0.1,
   });
 
   factory OfflineSpeakerSegmentationPyannoteModelConfig.fromJson(
       Map<String, dynamic> json) {
     return OfflineSpeakerSegmentationPyannoteModelConfig(
       model: json['model'] as String? ?? '',
+      windowShiftRatio:
+          (json['windowShiftRatio'] as num?)?.toDouble() ?? 0.1,
     );
   }
 
   @override
   String toString() {
-    return 'OfflineSpeakerSegmentationPyannoteModelConfig(model: $model)';
+    return 'OfflineSpeakerSegmentationPyannoteModelConfig(model: $model, '
+        'windowShiftRatio: $windowShiftRatio)';
   }
 
   Map<String, dynamic> toJson() => {
         'model': model,
+        'windowShiftRatio': windowShiftRatio,
       };
 
   final String model;
+  final double windowShiftRatio;
 }
 
 /// Segmentation model configuration for speaker diarization.

--- a/flutter/sherpa_onnx/lib/src/sherpa_onnx_bindings.dart
+++ b/flutter/sherpa_onnx/lib/src/sherpa_onnx_bindings.dart
@@ -71,6 +71,9 @@ final class SherpaOnnxOfflineSpeakerDiarizationSegment extends Struct {
 final class SherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig
     extends Struct {
   external Pointer<Utf8> model;
+
+  @Float()
+  external double windowShiftRatio;
 }
 
 final class SherpaOnnxOfflineSpeakerSegmentationModelConfig extends Struct {

--- a/go-api-examples/non-streaming-speaker-diarization/main.go
+++ b/go-api-examples/non-streaming-speaker-diarization/main.go
@@ -38,6 +38,7 @@ func initSpeakerDiarization() *sherpa.OfflineSpeakerDiarization {
 	config := sherpa.OfflineSpeakerDiarizationConfig{}
 
 	config.Segmentation.Pyannote.Model = "./sherpa-onnx-pyannote-segmentation-3-0/model.onnx"
+	config.Segmentation.Pyannote.WindowShiftRatio = 0.1
 	config.Embedding.Model = "./3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx"
 
 	// The test wave file contains 4 speakers, so we use 4 here

--- a/harmony-os/SherpaOnnxHar/sherpa_onnx/src/main/cpp/non-streaming-speaker-diarization.cc
+++ b/harmony-os/SherpaOnnxHar/sherpa_onnx/src/main/cpp/non-streaming-speaker-diarization.cc
@@ -23,6 +23,7 @@ GetOfflineSpeakerSegmentationPyannoteModelConfig(Napi::Object obj) {
 
   Napi::Object o = obj.Get("pyannote").As<Napi::Object>();
   SHERPA_ONNX_ASSIGN_ATTR_STR(model, model);
+  SHERPA_ONNX_ASSIGN_ATTR_FLOAT(window_shift_ratio, windowShiftRatio);
 
   return c;
 }

--- a/harmony-os/SherpaOnnxHar/sherpa_onnx/src/main/ets/components/NonStreamingSpeakerDiarization.ets
+++ b/harmony-os/SherpaOnnxHar/sherpa_onnx/src/main/ets/components/NonStreamingSpeakerDiarization.ets
@@ -10,6 +10,7 @@ import { SpeakerEmbeddingExtractorConfig } from './SpeakerIdentification';
 
 export class OfflineSpeakerSegmentationPyannoteModelConfig {
   public model: string = '';
+  public windowShiftRatio: number = 0.1;
 }
 
 export class OfflineSpeakerSegmentationModelConfig {

--- a/harmony-os/SherpaOnnxSpeakerDiarization/entry/src/main/ets/workers/SpeakerDiarizationWorker.ets
+++ b/harmony-os/SherpaOnnxSpeakerDiarization/entry/src/main/ets/workers/SpeakerDiarizationWorker.ets
@@ -32,6 +32,7 @@ function initOfflineSpeakerDiarization(context: Context): OfflineSpeakerDiarizat
   //
   // Also, please delete unused files to reduce the size of the app
   config.segmentation.pyannote.model = 'sherpa-onnx-pyannote-segmentation-3-0/model.int8.onnx';
+  config.segmentation.pyannote.windowShiftRatio = 0.1;
   config.segmentation.numThreads = 2;
   config.segmentation.debug = true;
 

--- a/java-api-examples/OfflineSpeakerDiarizationDemo.java
+++ b/java-api-examples/OfflineSpeakerDiarizationDemo.java
@@ -39,7 +39,10 @@ public class OfflineSpeakerDiarizationDemo {
     WaveReader reader = new WaveReader(waveFilename);
 
     OfflineSpeakerSegmentationPyannoteModelConfig pyannote =
-        OfflineSpeakerSegmentationPyannoteModelConfig.builder().setModel(segmentationModel).build();
+        OfflineSpeakerSegmentationPyannoteModelConfig.builder()
+            .setModel(segmentationModel)
+            .setWindowShiftRatio(0.1f)
+            .build();
 
     OfflineSpeakerSegmentationModelConfig segmentation =
         OfflineSpeakerSegmentationModelConfig.builder()

--- a/kotlin-api-examples/test_offline_speaker_diarization.kt
+++ b/kotlin-api-examples/test_offline_speaker_diarization.kt
@@ -15,7 +15,10 @@ fun callback(numProcessedChunks: Int, numTotalChunks: Int, arg: Long): Int {
 fun testOfflineSpeakerDiarization() {
   var config = OfflineSpeakerDiarizationConfig(
     segmentation=OfflineSpeakerSegmentationModelConfig(
-      pyannote=OfflineSpeakerSegmentationPyannoteModelConfig("./sherpa-onnx-pyannote-segmentation-3-0/model.onnx"),
+      pyannote=OfflineSpeakerSegmentationPyannoteModelConfig(
+        model="./sherpa-onnx-pyannote-segmentation-3-0/model.onnx",
+        windowShiftRatio=0.1f,
+      ),
     ),
     embedding=SpeakerEmbeddingExtractorConfig(
       model="./3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx",

--- a/nodejs-addon-examples/test_offline_speaker_diarization.js
+++ b/nodejs-addon-examples/test_offline_speaker_diarization.js
@@ -20,6 +20,7 @@ const config = {
   segmentation: {
     pyannote: {
       model: './sherpa-onnx-pyannote-segmentation-3-0/model.onnx',
+      windowShiftRatio: 0.1,
     },
   },
   embedding: {

--- a/nodejs-examples/test-offline-speaker-diarization.js
+++ b/nodejs-examples/test-offline-speaker-diarization.js
@@ -20,6 +20,7 @@ const config = {
   segmentation: {
     pyannote: {
       model: './sherpa-onnx-pyannote-segmentation-3-0/model.onnx',
+      windowShiftRatio: 0.1,
       debug: 1,
     },
   },

--- a/pascal-api-examples/speaker-diarization/main.pas
+++ b/pascal-api-examples/speaker-diarization/main.pas
@@ -62,6 +62,7 @@ begin
   Wave := SherpaOnnxReadWave('./0-four-speakers-zh.wav');
 
   Config.Segmentation.Pyannote.Model := './sherpa-onnx-pyannote-segmentation-3-0/model.onnx';
+  Config.Segmentation.Pyannote.WindowShiftRatio := 0.1;
   Config.Embedding.Model := './3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx';
 
   {

--- a/python-api-examples/offline-speaker-diarization.py
+++ b/python-api-examples/offline-speaker-diarization.py
@@ -73,7 +73,7 @@ def init_speaker_diarization(num_speakers: int = -1, cluster_threshold: float = 
     config = sherpa_onnx.OfflineSpeakerDiarizationConfig(
         segmentation=sherpa_onnx.OfflineSpeakerSegmentationModelConfig(
             pyannote=sherpa_onnx.OfflineSpeakerSegmentationPyannoteModelConfig(
-                model=segmentation_model
+                model=segmentation_model, window_shift_ratio=0.1
             ),
         ),
         embedding=sherpa_onnx.SpeakerEmbeddingExtractorConfig(

--- a/rust-api-examples/examples/offline_speaker_diarization.rs
+++ b/rust-api-examples/examples/offline_speaker_diarization.rs
@@ -9,6 +9,7 @@ fn main() {
         segmentation: OfflineSpeakerSegmentationModelConfig {
             pyannote: OfflineSpeakerSegmentationPyannoteModelConfig {
                 model: Some("./sherpa-onnx-pyannote-segmentation-3-0/model.onnx".into()),
+                window_shift_ratio: 0.1,
             },
             ..Default::default()
         },

--- a/scripts/dotnet/OfflineSpeakerSegmentationPyannoteModelConfig.cs
+++ b/scripts/dotnet/OfflineSpeakerSegmentationPyannoteModelConfig.cs
@@ -11,10 +11,11 @@ namespace SherpaOnnx
         public OfflineSpeakerSegmentationPyannoteModelConfig()
         {
             Model = "";
+            WindowShiftRatio = 0.1f;
         }
 
         [MarshalAs(UnmanagedType.LPStr)]
         public string Model;
+        public float WindowShiftRatio;
     }
 }
-

--- a/scripts/go/sherpa_onnx.go
+++ b/scripts/go/sherpa_onnx.go
@@ -2080,7 +2080,8 @@ func ReadWave(filename string) *Wave {
 // For offline speaker diarization
 // ============================================================
 type OfflineSpeakerSegmentationPyannoteModelConfig struct {
-	Model string
+	Model            string
+	WindowShiftRatio float32
 }
 
 type OfflineSpeakerSegmentationModelConfig struct {
@@ -2116,6 +2117,7 @@ func NewOfflineSpeakerDiarization(config *OfflineSpeakerDiarizationConfig) *Offl
 	c := C.struct_SherpaOnnxOfflineSpeakerDiarizationConfig{}
 	c.segmentation.pyannote.model = C.CString(config.Segmentation.Pyannote.Model)
 	defer C.free(unsafe.Pointer(c.segmentation.pyannote.model))
+	c.segmentation.pyannote.window_shift_ratio = C.float(config.Segmentation.Pyannote.WindowShiftRatio)
 
 	c.segmentation.num_threads = C.int(config.Segmentation.NumThreads)
 

--- a/scripts/node-addon-api/lib/types.js
+++ b/scripts/node-addon-api/lib/types.js
@@ -648,6 +648,7 @@
  * Offline speaker segmentation (pyannote) model config
  * @typedef {Object} OfflineSpeakerSegmentationPyannoteModelConfig
  * @property {string} [model]
+ * @property {number} [windowShiftRatio=0.1]
  */
 
 /**

--- a/sherpa-onnx/c-api/c-api.cc
+++ b/sherpa-onnx/c-api/c-api.cc
@@ -3149,6 +3149,10 @@ GetOfflineSpeakerDiarizationConfig(
 
   sd_config.segmentation.pyannote.model =
       SHERPA_ONNX_OR(config->segmentation.pyannote.model, "");
+  sd_config.segmentation.pyannote.window_shift_ratio =
+      config->segmentation.pyannote.window_shift_ratio <= 0
+          ? 0.1f
+          : config->segmentation.pyannote.window_shift_ratio;
   sd_config.segmentation.num_threads =
       GetNumThreads(config->segmentation.num_threads);
   sd_config.segmentation.debug = config->segmentation.debug;

--- a/sherpa-onnx/c-api/c-api.h
+++ b/sherpa-onnx/c-api/c-api.h
@@ -3836,6 +3836,13 @@ SHERPA_ONNX_API int32_t SherpaOnnxLinearResamplerResampleGetOutputSampleRate(
 typedef struct SherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig {
   /** Segmentation model filename. */
   const char *model;
+  /**
+   * Sliding-window shift as a fraction of the model window size.
+   *
+   * Must be in (0, 1]. Set to 0 (or a negative value) to use the default of
+   * 0.1.
+   */
+  float window_shift_ratio;
 } SherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig;
 
 /**

--- a/sherpa-onnx/c-api/cxx-api.cc
+++ b/sherpa-onnx/c-api/cxx-api.cc
@@ -1464,6 +1464,8 @@ OfflineSpeakerDiarization OfflineSpeakerDiarization::Create(
   memset(&c, 0, sizeof(c));
   c.segmentation.pyannote.model =
       config.segmentation.pyannote.model.c_str();
+  c.segmentation.pyannote.window_shift_ratio =
+      config.segmentation.pyannote.window_shift_ratio;
   c.segmentation.num_threads = config.segmentation.num_threads;
   c.segmentation.debug = config.segmentation.debug;
   c.segmentation.provider = config.segmentation.provider.c_str();

--- a/sherpa-onnx/c-api/cxx-api.h
+++ b/sherpa-onnx/c-api/cxx-api.h
@@ -1912,6 +1912,8 @@ class SHERPA_ONNX_API SpeakerEmbeddingManager
 struct OfflineSpeakerSegmentationPyannoteModelConfig {
   /** Segmentation model filename. */
   std::string model;
+  /** Sliding-window shift as a fraction of the model window size. */
+  float window_shift_ratio = 0.1f;
 };
 
 /** @brief Segmentation model configuration for offline speaker diarization. */

--- a/sherpa-onnx/c-api/docs/speaker-diarization.dox
+++ b/sherpa-onnx/c-api/docs/speaker-diarization.dox
@@ -14,8 +14,9 @@ SherpaOnnxOfflineSpeakerDiarizationConfig config;
 memset(&config, 0, sizeof(config));
 config.segmentation.pyannote.model =
     "./sherpa-onnx-pyannote-segmentation-3-0/model.onnx";
-// Zero uses the default window shift ratio of 0.1. Set a value in (0, 1]
-// to change the sliding-window overlap.
+// Zero uses the default window shift ratio of 0.1. Set a value in (0, 1] to
+// change the sliding-window shift; smaller values mean more overlap and more
+// compute.
 config.segmentation.pyannote.window_shift_ratio = 0.1f;
 config.embedding.model =
     "./3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx";

--- a/sherpa-onnx/c-api/docs/speaker-diarization.dox
+++ b/sherpa-onnx/c-api/docs/speaker-diarization.dox
@@ -14,6 +14,9 @@ SherpaOnnxOfflineSpeakerDiarizationConfig config;
 memset(&config, 0, sizeof(config));
 config.segmentation.pyannote.model =
     "./sherpa-onnx-pyannote-segmentation-3-0/model.onnx";
+// Zero uses the default window shift ratio of 0.1. Set a value in (0, 1]
+// to change the sliding-window overlap.
+config.segmentation.pyannote.window_shift_ratio = 0.1f;
 config.embedding.model =
     "./3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx";
 config.clustering.num_clusters = 4;

--- a/sherpa-onnx/csrc/offline-speaker-segmentation-pyannote-model.cc
+++ b/sherpa-onnx/csrc/offline-speaker-segmentation-pyannote-model.cc
@@ -112,6 +112,11 @@ class OfflineSpeakerSegmentationPyannoteModel::Impl {
       meta_data_.window_shift = static_cast<int32_t>(window_shift);
     }
 
+    if (config_.debug) {
+      SHERPA_ONNX_LOGE("Pyannote window shift: %d samples",
+                       meta_data_.window_shift);
+    }
+
     SHERPA_ONNX_READ_META_DATA(meta_data_.receptive_field_size,
                                "receptive_field_size");
     SHERPA_ONNX_READ_META_DATA(meta_data_.receptive_field_shift,

--- a/sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/OfflineSpeakerSegmentationPyannoteModelConfig.java
+++ b/sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/OfflineSpeakerSegmentationPyannoteModelConfig.java
@@ -4,9 +4,11 @@ package com.k2fsa.sherpa.onnx;
 
 public class OfflineSpeakerSegmentationPyannoteModelConfig {
     private final String model;
+    private final float windowShiftRatio;
 
     private OfflineSpeakerSegmentationPyannoteModelConfig(Builder builder) {
         this.model = builder.model;
+        this.windowShiftRatio = builder.windowShiftRatio;
     }
 
     public static Builder builder() {
@@ -17,8 +19,13 @@ public class OfflineSpeakerSegmentationPyannoteModelConfig {
         return model;
     }
 
+    public float getWindowShiftRatio() {
+        return windowShiftRatio;
+    }
+
     public static class Builder {
         private String model = "";
+        private float windowShiftRatio = 0.1f;
 
         public OfflineSpeakerSegmentationPyannoteModelConfig build() {
             return new OfflineSpeakerSegmentationPyannoteModelConfig(this);
@@ -26,6 +33,11 @@ public class OfflineSpeakerSegmentationPyannoteModelConfig {
 
         public Builder setModel(String model) {
             this.model = model;
+            return this;
+        }
+
+        public Builder setWindowShiftRatio(float value) {
+            this.windowShiftRatio = value;
             return this;
         }
     }

--- a/sherpa-onnx/jni/offline-speaker-diarization.cc
+++ b/sherpa-onnx/jni/offline-speaker-diarization.cc
@@ -33,6 +33,9 @@ static OfflineSpeakerDiarizationConfig GetOfflineSpeakerDiarizationConfig(
 
   SHERPA_ONNX_JNI_READ_STRING(ans.segmentation.pyannote.model, model,
                               pyannote_config_cls, pyannote_config);
+  SHERPA_ONNX_JNI_READ_FLOAT(ans.segmentation.pyannote.window_shift_ratio,
+                             windowShiftRatio, pyannote_config_cls,
+                             pyannote_config);
 
   SHERPA_ONNX_JNI_READ_INT(ans.segmentation.num_threads, numThreads,
                            segmentation_config_cls, segmentation_config);

--- a/sherpa-onnx/kotlin-api/OfflineSpeakerDiarization.kt
+++ b/sherpa-onnx/kotlin-api/OfflineSpeakerDiarization.kt
@@ -4,6 +4,7 @@ import android.content.res.AssetManager
 
 data class OfflineSpeakerSegmentationPyannoteModelConfig(
     var model: String = "",
+    var windowShiftRatio: Float = 0.1f,
 )
 
 data class OfflineSpeakerSegmentationModelConfig(

--- a/sherpa-onnx/pascal-api/sherpa_onnx.pas
+++ b/sherpa-onnx/pascal-api/sherpa_onnx.pas
@@ -657,6 +657,7 @@ type
 
   TSherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig = record
     Model: AnsiString;
+    WindowShiftRatio: Single;
     function ToString: AnsiString;
   end;
 
@@ -1261,6 +1262,7 @@ type
 
   SherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig = record
     Model: PAnsiChar;
+    WindowShiftRatio: cfloat;
   end;
 
   SherpaOnnxOfflineSpeakerSegmentationModelConfig = record
@@ -3227,7 +3229,8 @@ end;
 function TSherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig.ToString: AnsiString;
 begin
   Result := Format('TSherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig(' +
-    'Model := %s)',[Self.Model]);
+    'Model := %s, WindowShiftRatio := %f)',
+    [Self.Model, Self.WindowShiftRatio]);
 end;
 
 function TSherpaOnnxOfflineSpeakerSegmentationModelConfig.ToString: AnsiString;
@@ -3243,6 +3246,7 @@ end;
 
 class operator TSherpaOnnxOfflineSpeakerSegmentationModelConfig.Initialize({$IFDEF FPC}var{$ELSE}out{$ENDIF} Dest: TSherpaOnnxOfflineSpeakerSegmentationModelConfig);
 begin
+  Dest.Pyannote.WindowShiftRatio := 0.1;
   Dest.NumThreads := 1;
   Dest.Debug := False;
   Dest.Provider := 'cpu';
@@ -3311,6 +3315,8 @@ var
 begin
   C := Default(SherpaOnnxOfflineSpeakerDiarizationConfig);
   C.Segmentation.Pyannote.Model := PAnsiChar(Config.Segmentation.Pyannote.Model);
+  C.Segmentation.Pyannote.WindowShiftRatio :=
+    Config.Segmentation.Pyannote.WindowShiftRatio;
   C.Segmentation.NumThreads := Config.Segmentation.NumThreads;
   C.Segmentation.Debug := Ord(Config.Segmentation.Debug);
   C.Segmentation.Provider := PAnsiChar(Config.Segmentation.Provider);

--- a/sherpa-onnx/python/csrc/offline-speaker-diarization.cc
+++ b/sherpa-onnx/python/csrc/offline-speaker-diarization.cc
@@ -51,8 +51,10 @@ static void PybindOfflineSpeakerSegmentationPyannoteModelConfig(py::module *m) {
   using PyClass = OfflineSpeakerSegmentationPyannoteModelConfig;
   py::class_<PyClass>(*m, "OfflineSpeakerSegmentationPyannoteModelConfig")
       .def(py::init<>())
-      .def(py::init<const std::string &>(), py::arg("model"))
+      .def(py::init<const std::string &, float>(), py::arg("model"),
+           py::arg("window_shift_ratio") = 0.1f)
       .def_readwrite("model", &PyClass::model)
+      .def_readwrite("window_shift_ratio", &PyClass::window_shift_ratio)
       .def("__str__", &PyClass::ToString)
       .def("validate", &PyClass::Validate);
 }

--- a/sherpa-onnx/rust/sherpa-onnx-sys/src/offline_speaker_diarization.rs
+++ b/sherpa-onnx/rust/sherpa-onnx-sys/src/offline_speaker_diarization.rs
@@ -8,6 +8,7 @@ use std::os::raw::{c_char, c_float};
 #[derive(Debug, Copy, Clone)]
 pub struct OfflineSpeakerSegmentationPyannoteModelConfig {
     pub model: *const c_char,
+    pub window_shift_ratio: c_float,
 }
 
 #[repr(C)]

--- a/sherpa-onnx/rust/sherpa-onnx/src/offline_speaker_diarization.rs
+++ b/sherpa-onnx/rust/sherpa-onnx/src/offline_speaker_diarization.rs
@@ -8,10 +8,21 @@ use sherpa_onnx_sys as sys;
 use std::ffi::CString;
 use std::slice;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 /// Pyannote segmentation model path.
 pub struct OfflineSpeakerSegmentationPyannoteModelConfig {
     pub model: Option<String>,
+    /// Sliding-window shift as a fraction of the model window size.
+    pub window_shift_ratio: f32,
+}
+
+impl Default for OfflineSpeakerSegmentationPyannoteModelConfig {
+    fn default() -> Self {
+        Self {
+            model: None,
+            window_shift_ratio: 0.1,
+        }
+    }
 }
 
 impl OfflineSpeakerSegmentationPyannoteModelConfig {
@@ -21,6 +32,7 @@ impl OfflineSpeakerSegmentationPyannoteModelConfig {
     ) -> sys::OfflineSpeakerSegmentationPyannoteModelConfig {
         sys::OfflineSpeakerSegmentationPyannoteModelConfig {
             model: to_c_ptr(&self.model, cstrings),
+            window_shift_ratio: self.window_shift_ratio,
         }
     }
 }

--- a/swift-api-examples/SherpaOnnx.swift
+++ b/swift-api-examples/SherpaOnnx.swift
@@ -1757,10 +1757,13 @@ public class SherpaOnnxOnlinePunctuationWrapper {
   }
 }
 
-public func sherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig(model: String)
-  -> SherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig
-{
-  return SherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig(model: toCPointer(model))
+public func sherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig(
+  model: String,
+  windowShiftRatio: Float = 0.1
+) -> SherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig {
+  return SherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig(
+    model: toCPointer(model),
+    window_shift_ratio: windowShiftRatio)
 }
 
 public func sherpaOnnxOfflineSpeakerSegmentationModelConfig(

--- a/swift-api-examples/speaker-diarization.swift
+++ b/swift-api-examples/speaker-diarization.swift
@@ -21,7 +21,9 @@ func run() {
   let numSpeakers = 4
   var config = sherpaOnnxOfflineSpeakerDiarizationConfig(
     segmentation: sherpaOnnxOfflineSpeakerSegmentationModelConfig(
-      pyannote: sherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig(model: segmentationModel)),
+      pyannote: sherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig(
+        model: segmentationModel,
+        windowShiftRatio: 0.1)),
     embedding: sherpaOnnxSpeakerEmbeddingExtractorConfig(model: embeddingExtractorModel),
     clustering: sherpaOnnxFastClusteringConfig(numClusters: numSpeakers)
   )

--- a/wasm/speaker-diarization/sherpa-onnx-speaker-diarization.js
+++ b/wasm/speaker-diarization/sherpa-onnx-speaker-diarization.js
@@ -29,7 +29,7 @@ function initSherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig(
   const n = modelLen;
   const buffer = Module._malloc(n);
 
-  const len = 1 * 4;
+  const len = 2 * 4;
   const ptr = Module._malloc(len);
 
   let offset = 0;
@@ -38,6 +38,10 @@ function initSherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig(
 
   offset = 0;
   Module.setValue(ptr, buffer + offset, 'i8*');
+  offset += 4;
+
+  Module.setValue(
+      ptr + offset, config.windowShiftRatio ?? 0, 'float');
 
   return {
     buffer: buffer,
@@ -50,6 +54,7 @@ function initSherpaOnnxOfflineSpeakerSegmentationModelConfig(config, Module) {
   if (!('pyannote' in config)) {
     config.pyannote = {
       model: '',
+      windowShiftRatio: 0.1,
     };
   }
 
@@ -138,7 +143,7 @@ function initSherpaOnnxFastClusteringConfig(config, Module) {
 function initSherpaOnnxOfflineSpeakerDiarizationConfig(config, Module) {
   if (!('segmentation' in config)) {
     config.segmentation = {
-      pyannote: {model: ''},
+      pyannote: {model: '', windowShiftRatio: 0.1},
       numThreads: 1,
       debug: 0,
       provider: 'cpu',
@@ -277,7 +282,7 @@ class OfflineSpeakerDiarization {
 function createOfflineSpeakerDiarization(Module, myConfig) {
   let config = {
     segmentation: {
-      pyannote: {model: './segmentation.onnx'},
+      pyannote: {model: './segmentation.onnx', windowShiftRatio: 0.1},
       debug: 1,
     },
     embedding: {

--- a/wasm/speaker-diarization/sherpa-onnx-wasm-main-speaker-diarization.cc
+++ b/wasm/speaker-diarization/sherpa-onnx-wasm-main-speaker-diarization.cc
@@ -14,7 +14,7 @@
 extern "C" {
 
 static_assert(sizeof(SherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig) ==
-                  1 * 4,
+                  2 * 4,
               "");
 
 static_assert(
@@ -39,6 +39,8 @@ void MyPrint(const SherpaOnnxOfflineSpeakerDiarizationConfig *sd_config) {
 
   fprintf(stdout, "----------segmentation config----------\n");
   fprintf(stdout, "pyannote model: %s\n", segmentation.pyannote.model);
+  fprintf(stdout, "pyannote window shift ratio: %.3f\n",
+          segmentation.pyannote.window_shift_ratio);
   fprintf(stdout, "num threads: %d\n", segmentation.num_threads);
   fprintf(stdout, "debug: %d\n", segmentation.debug);
   fprintf(stdout, "provider: %s\n", segmentation.provider);


### PR DESCRIPTION
Follow-up to #3769, which added `window_shift_ratio` to the C++ core and the CLI but deliberately left the bindings alone to stay reviewable. This exposes `OfflineSpeakerSegmentationPyannoteModelConfig::window_shift_ratio` through the C and CXX APIs and the language bindings that already surface that config, so the knob is reachable outside the CLI.

The C struct treats `0` and negative values as unset and maps them to `0.1`. C API callers and raw bindings commonly zero-initialize config structs, and passing a zero straight through would fail the native `(0, 1]` validation and break every existing caller. The sentinel lives in one place, the config conversion in `c-api.cc`, and `c-api.h` documents it. NaN is not treated as unset; it still reaches native validation and is rejected. Typed binding defaults are `0.1`.

For the standard `window_size=160000` model the default path still computes a 16000-sample shift. A C API probe returned 16000 samples from a zero-initialized field and 32000 samples at `0.2`. A build of untouched `upstream/master` and a build of this branch produced byte-identical segment output with the ratio unset (same ten segments, same SHA-256).

Two things worth calling out beyond the mechanical binding work. There is a new debug-only log line in `offline-speaker-segmentation-pyannote-model.cc` that reports the computed shift in samples, which is what makes propagation observable from a binding; it is inside the existing `config_.debug` guard and does not change normal output. And the WASM binding's struct packing moves from 4 to 8 bytes with its compile-time layout assertion updated to match. I could not compile that one locally, so it is worth a look in CI.

The benchmark that motivated the core option, for context: a 644 s two-speaker English WAV on macOS arm64, `0.10` at 40 s, `0.15` at 27 s (1.48x), `0.20` at 20 s (2.00x), with 99.89% and 99.93% frame-level label agreement against `0.10`.

| Check | Result |
|---|---|
| Release C++ core, CLI, C API, CXX API, C/CXX examples | Passed |
| Default output vs untouched `upstream/master` | Identical (same 10 segments and SHA-256) |
| C API zero / negative / `0.2` native shift | 16000 / 16000 / 32000 samples |
| JNI shared library | Passed |
| Python build and import | Passed |
| Java compile | Passed (existing deprecation warnings only) |
| Flutter library analyze | Passed |
| Dart example analyze | Passed with existing warnings and info |
| Go wrapper tests and example build | Passed |
| Node typecheck, native addon build, JS syntax | Passed |
| Swift typecheck | Passed |
| Kotlin and Android app | Not compiled locally; Kotlin compiler and API artifact unavailable |
| .NET | Not compiled locally; `dotnet` unavailable |
| Rust | Not compiled locally; Cargo unavailable |
| Pascal | Not compiled locally; FPC unavailable |
| WASM C++ | Not compiled locally; Emscripten unavailable; JS syntax passed |
| HarmonyOS ETS | Not compiled locally; Harmony toolchain unavailable; shared native bridge compiled through Node |

`git diff --check` passes and no generated artifacts are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable Pyannote segmentation window-shift ratio for offline speaker diarization.
  - The setting is available across supported APIs and platforms, with a default value of `0.1`.
  - Values can be adjusted to control segmentation window overlap.

- **Documentation**
  - Updated speaker diarization guidance and examples to demonstrate the new configuration option.

- **Bug Fixes**
  - Improved consistency by ensuring the configured window-shift ratio is applied throughout speaker diarization workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->