### PR TITLE
Avoid bundling the web WASM assets in native Flutter apps

### DIFF
--- a/flutter-examples/hello_world/README.md
+++ b/flutter-examples/hello_world/README.md
@@ -19,7 +19,8 @@ Edit `pubspec.yaml`, replace the `dependencies:` section with:
 dependencies:
   flutter:
     sdk: flutter
-  sherpa_onnx: ^1.13.4
+  sherpa_onnx: ^1.13.5
+  sherpa_onnx_web: ^1.13.5 # Required only when building for web.
 ```
 
 Then run:

--- a/flutter-examples/hello_world/pubspec.yaml
+++ b/flutter-examples/hello_world/pubspec.yaml
@@ -16,6 +16,9 @@ dependencies:
   sherpa_onnx: ^1.13.5
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
+  sherpa_onnx_web: ^1.13.5
+  # sherpa_onnx_web:
+  #   path: ../../flutter/sherpa_onnx_web
 
 dev_dependencies:
   flutter_test:

--- a/flutter-examples/offline-punctuation/pubspec.yaml
+++ b/flutter-examples/offline-punctuation/pubspec.yaml
@@ -20,6 +20,9 @@ dependencies:
   sherpa_onnx: ^1.13.5
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
+  sherpa_onnx_web: ^1.13.5
+  # sherpa_onnx_web:
+  #   path: ../../flutter/sherpa_onnx_web
   url_launcher: 6.2.6
   url_launcher_linux: 3.1.0
 

--- a/flutter-examples/online-punctuation/pubspec.yaml
+++ b/flutter-examples/online-punctuation/pubspec.yaml
@@ -20,6 +20,9 @@ dependencies:
   sherpa_onnx: ^1.13.5
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
+  sherpa_onnx_web: ^1.13.5
+  # sherpa_onnx_web:
+  #   path: ../../flutter/sherpa_onnx_web
   url_launcher: 6.2.6
   url_launcher_linux: 3.1.0
 

--- a/flutter-examples/tts/pubspec.yaml
+++ b/flutter-examples/tts/pubspec.yaml
@@ -22,6 +22,9 @@ dependencies:
   sherpa_onnx: ^1.13.5
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
+  sherpa_onnx_web: ^1.13.5
+  # sherpa_onnx_web:
+  #   path: ../../flutter/sherpa_onnx_web
   url_launcher: 6.2.6
   url_launcher_linux: 3.1.0
   audioplayers: ^5.0.0

--- a/flutter-examples/vad-from-file/pubspec.yaml
+++ b/flutter-examples/vad-from-file/pubspec.yaml
@@ -21,6 +21,9 @@ dependencies:
   sherpa_onnx: ^1.13.5
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
+  sherpa_onnx_web: ^1.13.5
+  # sherpa_onnx_web:
+  #   path: ../../flutter/sherpa_onnx_web
   video_player: ^2.8.0
   ffmpeg_kit_flutter_new: ^4.6.0
   url_launcher: 6.2.6

--- a/flutter-examples/vad-from-microphone/pubspec.yaml
+++ b/flutter-examples/vad-from-microphone/pubspec.yaml
@@ -22,6 +22,9 @@ dependencies:
   sherpa_onnx: ^1.13.5
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
+  sherpa_onnx_web: ^1.13.5
+  # sherpa_onnx_web:
+  #   path: ../../flutter/sherpa_onnx_web
   record: ^6.2.0
   url_launcher: 6.2.6
   url_launcher_linux: 3.1.0

--- a/flutter/sherpa_onnx/lib/sherpa_onnx.dart
+++ b/flutter/sherpa_onnx/lib/sherpa_onnx.dart
@@ -1,13 +1,10 @@
 // Copyright (c)  2024  Xiaomi Corporation
 import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/services.dart' show MethodChannel, MissingPluginException;
 
 // Conditional import: native uses dart:io/dart:ffi, web uses dart:js_interop.
 import 'src/init_native.dart'
     if (dart.library.js_interop) 'src/web/init.dart' as init;
-
-// Conditional import for web WASM loader.
-import 'package:sherpa_onnx_web/sherpa_onnx_web.dart'
-    if (dart.library.io) 'src/init_stub.dart' as web;
 
 /// Dart bindings for the public sherpa-onnx inference APIs.
 ///
@@ -85,6 +82,8 @@ export 'src/wave_reader.dart'
 export 'src/wave_writer.dart'
     if (dart.library.js_interop) 'src/web/wave_writer.dart';
 
+const _webChannel = MethodChannel('sherpa_onnx_web');
+
 String? _path;
 
 /// Initialize the native sherpa-onnx bindings.
@@ -110,7 +109,8 @@ void initBindings([String? p]) {
 
 /// Initialize the sherpa-onnx bindings (works on all platforms including web).
 ///
-/// On web, this loads the WASM module and JS wrappers automatically.
+/// On web, this loads the WASM module and JS wrappers from the
+/// `sherpa_onnx_web` package, which must be a direct dependency of the app.
 /// On native platforms, this behaves the same as [initBindings].
 ///
 /// **Important:** If you use Dart isolates, call `initBindings()` or
@@ -119,7 +119,15 @@ void initBindings([String? p]) {
 Future<void> initBindingsAsync([String? p]) async {
   _path ??= p;
   if (kIsWeb) {
-    await web.SherpaOnnxWeb.loadWasm();
+    try {
+      await _webChannel.invokeMethod<void>('loadWasm');
+    } on MissingPluginException {
+      throw StateError(
+        'sherpa_onnx_web is required to use sherpa_onnx on web. '
+        'Add `sherpa_onnx_web` to your pubspec.yaml, then run '
+        '`flutter pub get`.',
+      );
+    }
     return;
   }
   init.initNativeBindings(_path);

--- a/flutter/sherpa_onnx/lib/src/init_stub.dart
+++ b/flutter/sherpa_onnx/lib/src/init_stub.dart
@@ -1,5 +1,0 @@
-// Native stub for sherpa_onnx_web.
-// On native platforms, SherpaOnnxWeb is not needed.
-class SherpaOnnxWeb {
-  static Future<void> loadWasm() async {}
-}

--- a/flutter/sherpa_onnx/pubspec.yaml
+++ b/flutter/sherpa_onnx/pubspec.yaml
@@ -62,10 +62,6 @@ dependencies:
   # sherpa_onnx_ios:
   #   path: ../sherpa_onnx_ios
 
-  sherpa_onnx_web: ^1.13.5
-  # sherpa_onnx_web:
-  #   path: ../sherpa_onnx_web
-
 dev_dependencies:
   flutter_lints: ^3.0.0
 
@@ -86,6 +82,3 @@ flutter:
 
       windows:
         default_package: sherpa_onnx_windows
-
-      web:
-        default_package: sherpa_onnx_web

--- a/flutter/sherpa_onnx_web/README.md
+++ b/flutter/sherpa_onnx_web/README.md
@@ -2,7 +2,13 @@
 
 This is a sub project of [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx).
 
-You are not expected to use this package directly.
+Flutter web apps using `sherpa_onnx` must add this package as a direct
+dependency:
+
+```yaml
+dependencies:
+  sherpa_onnx: ^1.13.5
+  sherpa_onnx_web: ^1.13.5
+```
 
 Please see the entry point at <https://pub.dev/packages/sherpa_onnx>.
-

--- a/flutter/sherpa_onnx_web/lib/sherpa_onnx_web.dart
+++ b/flutter/sherpa_onnx_web/lib/sherpa_onnx_web.dart
@@ -30,7 +30,23 @@ class SherpaOnnxWeb {
   static bool _initialized = false;
   static Completer<void>? _loadingCompleter;
 
-  static void registerWith(Registrar registrar) {}
+  static void registerWith(Registrar registrar) {
+    final channel = MethodChannel(
+      'sherpa_onnx_web',
+      const StandardMethodCodec(),
+      registrar,
+    );
+    channel.setMethodCallHandler((call) async {
+      if (call.method == 'loadWasm') {
+        await loadWasm();
+        return;
+      }
+      throw MissingPluginException(
+        'No implementation found for method ${call.method} on channel '
+        '${channel.name}',
+      );
+    });
+  }
 
   /// Load the sherpa-onnx WASM module and JS wrappers.
   ///

--- a/flutter/sherpa_onnx_web/pubspec.yaml
+++ b/flutter/sherpa_onnx_web/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
 
 flutter:
   plugin:
+    implements: sherpa_onnx
     platforms:
       web:
         pluginClass: SherpaOnnxWeb


### PR DESCRIPTION
Fixes #3871.

`sherpa_onnx` depends on `sherpa_onnx_web` unconditionally, and Flutter copies package-declared assets regardless of build target, so every native app carries the ~15 MB web WASM payload.

This makes `sherpa_onnx_web` a non-endorsed web implementation. It is removed from `sherpa_onnx`'s dependencies and from its `web: default_package` entry; web apps add it directly. `sherpa_onnx_web` declares `implements: sherpa_onnx`, and its `registerWith` now serves the existing idempotent `loadWasm()` over a method channel that `initBindingsAsync()` invokes on web. A missing package surfaces as a `StateError` naming `sherpa_onnx_web` and the `flutter pub get` step instead of a `MissingPluginException`. The web-capable examples get the explicit dependency.

Native behavior is unchanged: `initBindings()` is untouched, and the non-web branch of `initBindingsAsync()` still calls `initNativeBindings` directly.

I considered a shared Dart hook owned by `sherpa_onnx` instead of a channel, but that needs the web package to depend back on `sherpa_onnx`, or a new platform-interface package. The channel uses the plugin boundary that already exists and keeps the two published packages independent.

One caveat: an app targeting both web and native from a single pubspec still gets the assets in its native builds, since it has to depend on the web package. The saving is for native-only dependency graphs.

Measured on a fresh `flutter create` probe (Flutter 3.44.8, macOS): `flutter_assets` fell from 70,656,531 to 55,571,027 bytes and no longer contains `packages/sherpa_onnx_web`.

Testing:
- `flutter analyze` in `flutter/sherpa_onnx`, and in `sherpa_onnx_web` with the release-generated assets present
- `flutter build bundle` in a fresh native-only app against the patched path dependency
- `flutter build web` for `flutter-examples/hello_world` against both patched packages
- In Chrome: two concurrent `initBindingsAsync()` calls completed, and `getVersion()`, `getGitSha1()`, `getGitDate()` and `getOnnxruntimeVersion()` returned values
- In Chrome without the web package: `initBindingsAsync()` reported that `sherpa_onnx_web` must be added to `pubspec.yaml`

Versioning for the two packages is left to you, since publication order matters here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved Flutter web support for loading the required WebAssembly resources.
  - Flutter web applications can now explicitly integrate the web plugin for runtime initialization.

- **Documentation**
  - Updated setup guidance to require both the core and web packages as direct dependencies.
  - Refreshed Flutter examples and dependency versions to support web builds.

- **Bug Fixes**
  - Added clearer runtime errors when the web plugin is missing or not registered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->