### PR TITLE
Align Qwen3-ASR whisper features to the centered-STFT convention (#3535)

### DIFF
--- a/sherpa-onnx/csrc/offline-recognizer-qwen3-asr-impl.cc
+++ b/sherpa-onnx/csrc/offline-recognizer-qwen3-asr-impl.cc
@@ -339,8 +339,10 @@ bool IsDegenerateRepetition(const std::vector<int64_t> &ids) {
   return true;
 }
 
-// Removes the degenerate tail from ids: every trailing token drawn from the
-// token set of the final kQwen3LoopWindow entries. What remains is the text
+// Removes the degenerate tail from ids: trailing tokens drawn from the token
+// set of the final kQwen3LoopWindow entries, scanning no further back than
+// that window so text decoded before the collapse is never removed even when
+// it ends with a token the loop happens to reuse. What remains is the text
 // decoded before the loop started (possibly nothing).
 void TrimDegenerateTail(std::vector<int64_t> *ids) {
   std::array<int64_t, kQwen3LoopMaxDistinct> distinct{};
@@ -358,8 +360,9 @@ void TrimDegenerateTail(std::vector<int64_t> *ids) {
     }
   }
 
+  const size_t window_start = ids->size() - kQwen3LoopWindow;
   size_t keep = ids->size();
-  while (keep > 0) {
+  while (keep > window_start) {
     bool in_loop_set = false;
     for (int32_t k = 0; k != num_distinct; ++k) {
       if (distinct[k] == (*ids)[keep - 1]) {

--- a/sherpa-onnx/csrc/offline-recognizer-qwen3-asr-impl.cc
+++ b/sherpa-onnx/csrc/offline-recognizer-qwen3-asr-impl.cc
@@ -302,6 +302,79 @@ inline float TensorAbsMax(const Ort::Value &t, int64_t limit) {
   return abs_max;
 }
 
+// Number of trailing tokens to inspect for degenerate repetition, and the
+// maximum number of distinct token ids such a window may contain before the
+// decode is treated as a repetition loop rather than speech. A degenerate
+// greedy decode cycles over two or three token ids until max_new_tokens;
+// real transcriptions -- even of repetitive lyrics -- vary more than that
+// within 64 consecutive tokens.
+constexpr int32_t kQwen3LoopWindow = 64;
+constexpr int32_t kQwen3LoopMaxDistinct = 3;
+
+// Returns true if the last kQwen3LoopWindow entries of ids consist of at
+// most kQwen3LoopMaxDistinct distinct token ids.
+bool IsDegenerateRepetition(const std::vector<int64_t> &ids) {
+  if (static_cast<int32_t>(ids.size()) < kQwen3LoopWindow) {
+    return false;
+  }
+
+  std::array<int64_t, kQwen3LoopMaxDistinct> distinct{};
+  int32_t num_distinct = 0;
+  for (size_t i = ids.size() - kQwen3LoopWindow; i != ids.size(); ++i) {
+    bool seen = false;
+    for (int32_t k = 0; k != num_distinct; ++k) {
+      if (distinct[k] == ids[i]) {
+        seen = true;
+        break;
+      }
+    }
+    if (seen) {
+      continue;
+    }
+    if (num_distinct == kQwen3LoopMaxDistinct) {
+      return false;
+    }
+    distinct[num_distinct++] = ids[i];
+  }
+  return true;
+}
+
+// Removes the degenerate tail from ids: every trailing token drawn from the
+// token set of the final kQwen3LoopWindow entries. What remains is the text
+// decoded before the loop started (possibly nothing).
+void TrimDegenerateTail(std::vector<int64_t> *ids) {
+  std::array<int64_t, kQwen3LoopMaxDistinct> distinct{};
+  int32_t num_distinct = 0;
+  for (size_t i = ids->size() - kQwen3LoopWindow; i != ids->size(); ++i) {
+    bool seen = false;
+    for (int32_t k = 0; k != num_distinct; ++k) {
+      if (distinct[k] == (*ids)[i]) {
+        seen = true;
+        break;
+      }
+    }
+    if (!seen && num_distinct < kQwen3LoopMaxDistinct) {
+      distinct[num_distinct++] = (*ids)[i];
+    }
+  }
+
+  size_t keep = ids->size();
+  while (keep > 0) {
+    bool in_loop_set = false;
+    for (int32_t k = 0; k != num_distinct; ++k) {
+      if (distinct[k] == (*ids)[keep - 1]) {
+        in_loop_set = true;
+        break;
+      }
+    }
+    if (!in_loop_set) {
+      break;
+    }
+    --keep;
+  }
+  ids->resize(keep);
+}
+
 inline void RemoveUtf8ReplacementChars(std::string *s) {
   if (!s || s->empty()) {
     return;
@@ -341,7 +414,13 @@ OfflineRecognizerQwen3ASRImpl::OfflineRecognizerQwen3ASRImpl(
 
 std::unique_ptr<OfflineStream> OfflineRecognizerQwen3ASRImpl::CreateStream()
     const {
-  return std::make_unique<OfflineStream>(WhisperTag{kQwen3MelDim});
+  WhisperTag tag;
+  tag.dim = kQwen3MelDim;
+  // Qwen3-ASR's feature extractor uses a centered STFT; the kaldi-style
+  // half-shift frame offset is enough to make the 1.7B model collapse into
+  // repetition loops on some inputs (k2-fsa/sherpa-onnx#3535).
+  tag.align_to_stft_center = true;
+  return std::make_unique<OfflineStream>(tag);
 }
 
 void OfflineRecognizerQwen3ASRImpl::InitPromptTemplateIds() {
@@ -977,6 +1056,21 @@ OfflineRecognitionResult OfflineRecognizerQwen3ASRImpl::GenerateText(
 
     generated_ids.push_back(next_id);
     ++cur_len;
+
+    if (IsDegenerateRepetition(generated_ids)) {
+      // The decoder has collapsed into cycling over a couple of token ids;
+      // it will not recover under greedy decoding and would only repeat
+      // them until max_new_tokens. Stop, and drop the repetition so the
+      // caller sees the text decoded before the collapse instead of a
+      // window full of one syllable. Seen with the Qwen3-ASR 1.7B model on
+      // some sung inputs; see k2-fsa/sherpa-onnx#3535.
+      SHERPA_ONNX_LOGE(
+          "qwen3-asr: decode collapsed into a repetition loop after %d "
+          "tokens; truncating the repetition",
+          static_cast<int32_t>(generated_ids.size()));
+      TrimDegenerateTail(&generated_ids);
+      break;
+    }
   }
 
   std::vector<int64_t> cleaned_ids = generated_ids;

--- a/sherpa-onnx/csrc/offline-stream.cc
+++ b/sherpa-onnx/csrc/offline-stream.cc
@@ -80,6 +80,18 @@ class OfflineStream::Impl {
 
     whisper_fbank_ = std::make_unique<knf::OnlineWhisperFbank>(whisper_opts);
     config_.sampling_rate = opts_.frame_opts.samp_freq;
+
+    if (tag.align_to_stft_center) {
+      whisper_align_to_stft_center_ = true;
+      // The whisper feature computer uses a 10 ms frame shift; prepending
+      // half a shift of silence moves each kaldi-placed window midpoint
+      // from i * shift + shift / 2 back to i * shift, the centered-STFT
+      // convention. GetFrames() drops the one extra trailing frame this
+      // produces, so the frame count matches floor(num_samples / shift)
+      // exactly as the reference extractor computes it.
+      whisper_center_padding_ =
+          static_cast<int32_t>(opts_.frame_opts.samp_freq * 0.01f) / 2;
+    }
   }
 
   explicit Impl(CEDTag /*tag*/) : is_ced_(true) {
@@ -154,9 +166,7 @@ class OfflineStream::Impl {
                               samples.size());
         mfcc_->InputFinished();
       } else {
-        whisper_fbank_->AcceptWaveform(config_.sampling_rate, samples.data(),
-                                       samples.size());
-        whisper_fbank_->InputFinished();
+        FeedWhisper(samples.data(), samples.size());
       }
 
       return;
@@ -171,9 +181,32 @@ class OfflineStream::Impl {
       mfcc_->AcceptWaveform(sampling_rate, waveform, n);
       mfcc_->InputFinished();
     } else {
-      whisper_fbank_->AcceptWaveform(sampling_rate, waveform, n);
-      whisper_fbank_->InputFinished();
+      FeedWhisper(waveform, n);
     }
+  }
+
+  void FeedWhisper(const float *samples, int32_t n) {
+    if (whisper_center_padding_ > 0 && n > 0) {
+      // Reflect-pad the lead-in the way torch.stft(center=True,
+      // pad_mode="reflect") does: sample -i mirrors sample i (the
+      // boundary sample itself is not repeated). A first chunk shorter
+      // than the padding is zero-padded instead.
+      int32_t pad = whisper_center_padding_;
+      std::vector<float> padded(static_cast<size_t>(pad) + n);
+      if (n > pad) {
+        for (int32_t i = 0; i != pad; ++i) {
+          padded[i] = samples[pad - i];
+        }
+      }
+      std::copy(samples, samples + n, padded.begin() + pad);
+      whisper_fbank_->AcceptWaveform(config_.sampling_rate, padded.data(),
+                                     padded.size());
+      whisper_center_padding_ = 0;  // pad only before the first chunk
+    } else {
+      whisper_fbank_->AcceptWaveform(config_.sampling_rate, samples, n);
+    }
+    whisper_num_samples_ += n;
+    whisper_fbank_->InputFinished();
   }
 
   int32_t FeatureDim() const {
@@ -193,6 +226,19 @@ class OfflineStream::Impl {
                 : mfcc_ ? mfcc_->NumFramesReady()
                         : whisper_fbank_->NumFramesReady();
     assert(n > 0 && "Please first call AcceptWaveform()");
+
+    if (whisper_align_to_stft_center_) {
+      // The half-shift lead-in padding yields extra trailing frames
+      // relative to the centered-STFT frame count of
+      // floor(num_samples / frame_shift); keep exactly that many.
+      int32_t frame_shift =
+          static_cast<int32_t>(opts_.frame_opts.samp_freq * 0.01f);
+      int32_t target = static_cast<int32_t>(whisper_num_samples_ / frame_shift);
+      n = std::min(n, target);
+      if (n <= 0) {
+        return {};
+      }
+    }
 
     int32_t feature_dim = FeatureDim();
 
@@ -311,6 +357,9 @@ class OfflineStream::Impl {
   bool is_ced_ = false;
   bool is_moonshine_ = false;
   bool is_omnilingual_asr_ = false;
+  bool whisper_align_to_stft_center_ = false;
+  int32_t whisper_center_padding_ = 0;
+  int64_t whisper_num_samples_ = 0;
 
   // used only when (is_moonshine_ || is_omnilingual_asr_) == true
   std::vector<float> samples_;

--- a/sherpa-onnx/csrc/offline-stream.h
+++ b/sherpa-onnx/csrc/offline-stream.h
@@ -60,6 +60,17 @@ struct OfflineRecognitionResult {
 
 struct WhisperTag {
   int32_t dim = 80;
+
+  // When true, place each analysis window so that its midpoint is at
+  // i * frame_shift, matching the centered STFT that OpenAI Whisper's
+  // feature extractor uses (torch.stft with center=True). The kaldi-style
+  // placement used otherwise centers frame i at
+  // i * frame_shift + frame_shift / 2, i.e. every frame is half a
+  // frame-shift (5 ms) late relative to the convention the models were
+  // trained on. Models that are robust to the 5 ms offset (e.g. Whisper
+  // itself) keep the historical behavior; Qwen3-ASR is sensitive to it
+  // (see k2-fsa/sherpa-onnx#3535), so its recognizer opts in.
+  bool align_to_stft_center = false;
 };
 
 struct CEDTag {};


### PR DESCRIPTION
Towards #3535 (Qwen3-ASR 1.7B support): the reason a 1.7B export produced with the same recipe as the official 0.6B collapses into repetition loops on some sung inputs is a feature-frontend mismatch in sherpa-onnx, not the model and not the export.

## Root cause

The whisper-style feature frontend (kaldi-native-fbank `WhisperFeatureComputer`, kaldi `snip_edges=false` placement) centers analysis frame `i` at `i * frame_shift + frame_shift / 2`. The reference extractor these models were trained against (`torch.stft` with `center=True`) centers it at `i * frame_shift`. Every sherpa frame is therefore **half a frame shift (5 ms) late**, and the produced log-mel differs from the reference by **0.064 mean absolute error** (features span roughly [-0.67, 1.33]; Pearson 0.977). Shifting the reference analysis by exactly +80 samples reproduces sherpa's features to 1e-5 — the discrepancy is precisely this offset.

Whisper itself is robust to that. Qwen3-ASR 1.7B is not: on reproducible real-world windows (sung vocals, 12–14.6 s, 16 kHz), greedy decode collapses into a 2–3-token repetition loop that runs to `max_new_tokens`, while the official reference implementation (`qwen-asr` pip package, fp32, transformers backend) transcribes the same float samples cleanly.

Evidence that isolates the cause (all measured on the same input samples):

| pipeline | features | result |
|---|---|---|
| official `qwen-asr` fp32 reference | reference | clean (~25–31 tokens) |
| exported ONNX decoder, teacher-forced vs reference model | reference | **bit-exact logits** (max abs diff 0.0000 over all decode steps) |
| ONNX pipeline outside sherpa (export repo's Python inference) | reference | clean |
| sherpa-onnx, prompt verified token-identical to the reference chat template | sherpa (5 ms late) | **loops** (128 tokens, 2–3 distinct), int8 **and** fp32 decoder |
| sherpa-onnx with waveform pre-shifted 80 samples (alignment emulation) | aligned | clean, token-identical to reference |

The true model has healthy top-1/top-2 logit margins (3–14) on these windows; the shifted spectrogram is a large perturbation, not epsilon noise.

## Fix

1. `WhisperTag.align_to_stft_center` (opt-in, default off): reflect-pad half a frame shift of lead-in before the first chunk and keep exactly `floor(num_samples / frame_shift)` frames. This realigns every frame midpoint to the centered-STFT convention; sherpa's features then match the reference extractor to **2e-5 mean absolute error** (only the first frame differs, from the shorter reflect lead-in). Only the Qwen3-ASR recognizer sets the flag, so Whisper-family models keep their historical features bit-for-bit.

2. A degenerate-repetition guard in the Qwen3-ASR generation loop: if the last 64 generated tokens contain ≤3 distinct ids, decoding has collapsed and cannot recover under greedy sampling; stop early and trim the repetition, returning the text decoded before the collapse. A few inputs sit close enough to the loop attractor that int8 quantization noise alone can tip them over even with exact features (measured: one window loops through the untouched export at int8 with reference features while fp32 is clean); this bounds the damage to an honest truncation instead of a window full of one syllable.

## Validation

- Both reproducible loop windows (extracted from a real song's vocal stem via the downstream pipeline that hit this, exact float samples): previously 128 tokens / 2–3 distinct in every configuration; now clean — one decodes token-identically to the fp32 reference at both int8 and fp32, the other returns the pre-collapse text via the guard instead of garbage.
- A second symptom also fixed: without a language hint one failing window used to return an empty result (the model emitted the language prefix then EOS on the shifted features); it now transcribes.
- 0.6B regression on the official artifact's own 15 `test_wavs` against its bundled `transcript.txt`: mean CER 0.2228 (before) → **0.2109** (after); per-file movement in both directions, no loops, no systematic degradation.
- Whisper recognizers, spoken-language-id, and every other `WhisperTag` consumer are unaffected (flag defaults to off).

The deeper home for the alignment would be kaldi-native-fbank's `WhisperFeatureComputer` itself; this PR keeps the change local, opt-in, and shippable without a dependency bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Qwen3-ASR decoding to detect repetitive generation loops, trim redundant output, and stop gracefully.
  * Improved Whisper-compatible transcription timing by aligning audio features with centered short-time analysis windows.
  * Reduced inaccurate trailing audio frames, helping produce cleaner and more reliable transcriptions across streaming input chunks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->