### PR TITLE
Add per-segment confidence computation for OfflineSpeakerDiarization

### DIFF
--- a/flutter/sherpa_onnx/lib/src/offline_speaker_diarization.dart
+++ b/flutter/sherpa_onnx/lib/src/offline_speaker_diarization.dart
@@ -53,6 +53,8 @@ class OfflineSpeakerDiarization {
 
     c.ref.clustering.numClusters = config.clustering.numClusters;
     c.ref.clustering.threshold = config.clustering.threshold;
+    c.ref.clustering.computeConfidence =
+        config.clustering.computeConfidence ? 1 : 0;
 
     c.ref.minDurationOn = config.minDurationOn;
     c.ref.minDurationOff = config.minDurationOff;
@@ -183,7 +185,10 @@ class OfflineSpeakerDiarization {
       final s = segments + i;
 
       final tmp = OfflineSpeakerDiarizationSegment(
-          start: s.ref.start, end: s.ref.end, speaker: s.ref.speaker);
+          start: s.ref.start,
+          end: s.ref.end,
+          speaker: s.ref.speaker,
+          confidence: s.ref.confidence);
       ans.add(tmp);
     }
 

--- a/flutter/sherpa_onnx/lib/src/offline_speaker_diarization_config.dart
+++ b/flutter/sherpa_onnx/lib/src/offline_speaker_diarization_config.dart
@@ -13,6 +13,7 @@ class OfflineSpeakerDiarizationSegment {
     required this.start,
     required this.end,
     required this.speaker,
+    this.confidence = -2.0,
   });
 
   factory OfflineSpeakerDiarizationSegment.fromJson(Map<String, dynamic> json) {
@@ -20,23 +21,26 @@ class OfflineSpeakerDiarizationSegment {
       start: (json['start'] as num).toDouble(),
       end: (json['end'] as num).toDouble(),
       speaker: json['speaker'] as int,
+      confidence: (json['confidence'] as num?)?.toDouble() ?? -2.0,
     );
   }
 
   @override
   String toString() {
-    return 'OfflineSpeakerDiarizationSegment(start: $start, end: $end, speaker: $speaker)';
+    return 'OfflineSpeakerDiarizationSegment(start: $start, end: $end, speaker: $speaker, confidence: $confidence)';
   }
 
   Map<String, dynamic> toJson() => {
         'start': start,
         'end': end,
         'speaker': speaker,
+        'confidence': confidence,
       };
 
   final double start;
   final double end;
   final int speaker;
+  final double confidence;
 }
 
 /// Pyannote segmentation model path.
@@ -116,27 +120,31 @@ class FastClusteringConfig {
   const FastClusteringConfig({
     this.numClusters = -1,
     this.threshold = 0.5,
+    this.computeConfidence = false,
   });
 
   factory FastClusteringConfig.fromJson(Map<String, dynamic> json) {
     return FastClusteringConfig(
       numClusters: json['numClusters'] as int? ?? -1,
       threshold: (json['threshold'] as num?)?.toDouble() ?? 0.5,
+      computeConfidence: json['computeConfidence'] as bool? ?? false,
     );
   }
 
   @override
   String toString() {
-    return 'FastClusteringConfig(numClusters: $numClusters, threshold: $threshold)';
+    return 'FastClusteringConfig(numClusters: $numClusters, threshold: $threshold, computeConfidence: $computeConfidence)';
   }
 
   Map<String, dynamic> toJson() => {
         'numClusters': numClusters,
         'threshold': threshold,
+        'computeConfidence': computeConfidence,
       };
 
   final int numClusters;
   final double threshold;
+  final bool computeConfidence;
 }
 
 /// Top-level configuration for [OfflineSpeakerDiarization].

--- a/flutter/sherpa_onnx/lib/src/sherpa_onnx_bindings.dart
+++ b/flutter/sherpa_onnx/lib/src/sherpa_onnx_bindings.dart
@@ -66,6 +66,9 @@ final class SherpaOnnxOfflineSpeakerDiarizationSegment extends Struct {
 
   @Int32()
   external int speaker;
+
+  @Float()
+  external double confidence;
 }
 
 final class SherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig
@@ -94,6 +97,9 @@ final class SherpaOnnxFastClusteringConfig extends Struct {
 
   @Float()
   external double threshold;
+
+  @Int32()
+  external int computeConfidence;
 }
 
 final class SherpaOnnxOfflineSpeakerDiarizationConfig extends Struct {

--- a/scripts/dotnet/FastClusteringConfig.cs
+++ b/scripts/dotnet/FastClusteringConfig.cs
@@ -12,9 +12,11 @@ namespace SherpaOnnx
         {
             NumClusters = -1;
             Threshold = 0.5F;
+            ComputeConfidence = 0;
         }
 
         public int NumClusters;
         public float Threshold;
+        public int ComputeConfidence;
     }
 }

--- a/scripts/dotnet/OfflineSpeakerDiarization.cs
+++ b/scripts/dotnet/OfflineSpeakerDiarization.cs
@@ -46,7 +46,7 @@ namespace SherpaOnnx
             OfflineSpeakerDiarizationSegment[] ans = new OfflineSpeakerDiarizationSegment[numSegments];
             unsafe
             {
-              int size = sizeof(float) * 2 + sizeof(int);
+              int size = sizeof(float) * 3 + sizeof(int);
               for (int i = 0; i != numSegments; ++i)
               {
                 IntPtr t = new IntPtr((byte*)p + i * size);

--- a/scripts/dotnet/OfflineSpeakerDiarizationSegment.cs
+++ b/scripts/dotnet/OfflineSpeakerDiarizationSegment.cs
@@ -15,6 +15,7 @@ namespace SherpaOnnx
           Start = impl.Start;
           End = impl.End;
           Speaker = impl.Speaker;
+          Confidence = impl.Confidence;
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -23,11 +24,13 @@ namespace SherpaOnnx
             public float Start;
             public float End;
             public int Speaker;
+            public float Confidence;
         }
 
         public float Start;
         public float End;
         public int Speaker;
+        public float Confidence;
     }
 }
 

--- a/sherpa-onnx/c-api/c-api.cc
+++ b/sherpa-onnx/c-api/c-api.cc
@@ -3178,6 +3178,9 @@ GetOfflineSpeakerDiarizationConfig(
   sd_config.clustering.threshold =
       SHERPA_ONNX_OR(config->clustering.threshold, 0.5);
 
+  sd_config.clustering.compute_confidence =
+      config->clustering.compute_confidence != 0;
+
   sd_config.min_duration_on = SHERPA_ONNX_OR(config->min_duration_on, 0.3);
 
   sd_config.min_duration_off = SHERPA_ONNX_OR(config->min_duration_off, 0.5);
@@ -3234,6 +3237,9 @@ void SherpaOnnxOfflineSpeakerDiarizationSetConfig(
   sd_config.clustering.threshold =
       SHERPA_ONNX_OR(config->clustering.threshold, 0.5);
 
+  sd_config.clustering.compute_confidence =
+      config->clustering.compute_confidence != 0;
+
   sd->impl->SetConfig(sd_config);
 }
 
@@ -3266,6 +3272,7 @@ SherpaOnnxOfflineSpeakerDiarizationResultSortByStartTime(
     ans[i].start = s.Start();
     ans[i].end = s.End();
     ans[i].speaker = s.Speaker();
+    ans[i].confidence = s.Confidence();
   }
 
   return ans;

--- a/sherpa-onnx/c-api/c-api.h
+++ b/sherpa-onnx/c-api/c-api.h
@@ -3875,6 +3875,8 @@ typedef struct SherpaOnnxFastClusteringConfig {
   int32_t num_clusters;
   /** Distance threshold used when the number of speakers is unknown. */
   float threshold;
+  /** When non-zero, per-segment confidence values are computed. */
+  int32_t compute_confidence;
 } SherpaOnnxFastClusteringConfig;
 
 /**
@@ -3965,6 +3967,12 @@ typedef struct SherpaOnnxOfflineSpeakerDiarizationSegment {
   float end;
   /** Speaker label, typically an integer cluster ID. */
   int32_t speaker;
+  /**
+   * Per-segment confidence in [-1, 1] (higher is more confident), or -2 if
+   * unavailable (compute_confidence disabled, or the score could not be
+   * computed for this segment).
+   */
+  float confidence;
 } SherpaOnnxOfflineSpeakerDiarizationSegment;
 
 /**

--- a/sherpa-onnx/c-api/cxx-api.cc
+++ b/sherpa-onnx/c-api/cxx-api.cc
@@ -1475,6 +1475,7 @@ OfflineSpeakerDiarization OfflineSpeakerDiarization::Create(
   c.embedding.provider = config.embedding.provider.c_str();
   c.clustering.num_clusters = config.clustering.num_clusters;
   c.clustering.threshold = config.clustering.threshold;
+  c.clustering.compute_confidence = config.clustering.compute_confidence ? 1 : 0;
   c.min_duration_on = config.min_duration_on;
   c.min_duration_off = config.min_duration_off;
 
@@ -1503,27 +1504,38 @@ void OfflineSpeakerDiarization::SetConfig(
   memset(&c, 0, sizeof(c));
   c.clustering.num_clusters = config.clustering.num_clusters;
   c.clustering.threshold = config.clustering.threshold;
+  c.clustering.compute_confidence = config.clustering.compute_confidence ? 1 : 0;
   SherpaOnnxOfflineSpeakerDiarizationSetConfig(p_, &c);
+}
+
+static std::vector<OfflineSpeakerDiarizationSegment> CollectSegments(
+    const SherpaOnnxOfflineSpeakerDiarizationResult *r) {
+  std::vector<OfflineSpeakerDiarizationSegment> ans;
+  if (!r) {
+    return ans;
+  }
+  int32_t num_segments =
+      SherpaOnnxOfflineSpeakerDiarizationResultGetNumSegments(r);
+  const SherpaOnnxOfflineSpeakerDiarizationSegment *segments =
+      SherpaOnnxOfflineSpeakerDiarizationResultSortByStartTime(r);
+  for (int32_t i = 0; i < num_segments; ++i) {
+    OfflineSpeakerDiarizationSegment seg;
+    seg.start = segments[i].start;
+    seg.end = segments[i].end;
+    seg.speaker = segments[i].speaker;
+    seg.confidence = segments[i].confidence;
+    ans.push_back(seg);
+  }
+  SherpaOnnxOfflineSpeakerDiarizationDestroySegment(segments);
+  return ans;
 }
 
 std::vector<OfflineSpeakerDiarizationSegment>
 OfflineSpeakerDiarization::Process(const float *samples, int32_t n) const {
   const SherpaOnnxOfflineSpeakerDiarizationResult *r =
       SherpaOnnxOfflineSpeakerDiarizationProcess(p_, samples, n);
-  std::vector<OfflineSpeakerDiarizationSegment> ans;
+  auto ans = CollectSegments(r);
   if (r) {
-    int32_t num_segments =
-        SherpaOnnxOfflineSpeakerDiarizationResultGetNumSegments(r);
-    const SherpaOnnxOfflineSpeakerDiarizationSegment *segments =
-        SherpaOnnxOfflineSpeakerDiarizationResultSortByStartTime(r);
-    for (int32_t i = 0; i < num_segments; ++i) {
-      OfflineSpeakerDiarizationSegment seg;
-      seg.start = segments[i].start;
-      seg.end = segments[i].end;
-      seg.speaker = segments[i].speaker;
-      ans.push_back(seg);
-    }
-    SherpaOnnxOfflineSpeakerDiarizationDestroySegment(segments);
     SherpaOnnxOfflineSpeakerDiarizationDestroyResult(r);
   }
   return ans;
@@ -1540,20 +1552,8 @@ OfflineSpeakerDiarization::Process(
   const SherpaOnnxOfflineSpeakerDiarizationResult *r =
       SherpaOnnxOfflineSpeakerDiarizationProcessWithCallback(
           p_, samples, n, DiarizationProgressCallback, &cb);
-  std::vector<OfflineSpeakerDiarizationSegment> ans;
+  auto ans = CollectSegments(r);
   if (r) {
-    int32_t num_segments =
-        SherpaOnnxOfflineSpeakerDiarizationResultGetNumSegments(r);
-    const SherpaOnnxOfflineSpeakerDiarizationSegment *segments =
-        SherpaOnnxOfflineSpeakerDiarizationResultSortByStartTime(r);
-    for (int32_t i = 0; i < num_segments; ++i) {
-      OfflineSpeakerDiarizationSegment seg;
-      seg.start = segments[i].start;
-      seg.end = segments[i].end;
-      seg.speaker = segments[i].speaker;
-      ans.push_back(seg);
-    }
-    SherpaOnnxOfflineSpeakerDiarizationDestroySegment(segments);
     SherpaOnnxOfflineSpeakerDiarizationDestroyResult(r);
   }
   return ans;

--- a/sherpa-onnx/c-api/cxx-api.h
+++ b/sherpa-onnx/c-api/cxx-api.h
@@ -1935,6 +1935,8 @@ struct FastClusteringConfig {
   int32_t num_clusters = 0;
   /** Distance threshold used when the number of speakers is unknown. */
   float threshold = 0.5;
+  /** If true, each returned diarization segment carries a confidence value. */
+  bool compute_confidence = false;
 };
 
 /** @brief Configuration for offline speaker diarization. */
@@ -1953,12 +1955,19 @@ struct OfflineSpeakerDiarizationConfig {
 
 /** @brief One diarization segment. */
 struct OfflineSpeakerDiarizationSegment {
+  /** Sentinel returned in 'confidence' when the value is unavailable */
+  static constexpr float kUnavailableConfidence = -2.0f;
+
   /** Segment start time in seconds. */
   float start;
   /** Segment end time in seconds. */
   float end;
   /** Speaker label, typically an integer cluster ID. */
   int32_t speaker;
+  /** Confidence value in [-1, 1] when clustering.compute_confidence is set on
+   * the config. Otherwise equals kUnavailableConfidence.
+   */
+  float confidence = kUnavailableConfidence;
 };
 
 /** @brief Progress callback for offline speaker diarization. */

--- a/sherpa-onnx/csrc/fast-clustering-config.cc
+++ b/sherpa-onnx/csrc/fast-clustering-config.cc
@@ -15,7 +15,8 @@ std::string FastClusteringConfig::ToString() const {
 
   os << "FastClusteringConfig(";
   os << "num_clusters=" << num_clusters << ", ";
-  os << "threshold=" << threshold << ")";
+  os << "threshold=" << threshold << ", ";
+  os << "compute_confidence=" << (compute_confidence ? "True" : "False") << ")";
 
   return os.str();
 }
@@ -31,6 +32,10 @@ void FastClusteringConfig::Register(ParseOptions *po) {
                "If num_clusters is not specified, then it specifies the "
                "distance threshold for clustering. smaller value -> more "
                "clusters. larger value -> fewer clusters");
+
+  po->Register("compute-confidence", &compute_confidence,
+               "True to compute confidence value for each clustered "
+               "embedding and surface for every diarization segment.");
 }
 
 bool FastClusteringConfig::Validate() const {

--- a/sherpa-onnx/csrc/fast-clustering-config.h
+++ b/sherpa-onnx/csrc/fast-clustering-config.h
@@ -24,10 +24,17 @@ struct FastClusteringConfig {
   // The larger, the fewer clusters it will generate.
   float threshold = 0.5;
 
+  // When true, we compute the confidence value for every clustered
+  // embedding and surface it on each returned diarization segment.
+  bool compute_confidence = false;
+
   FastClusteringConfig() = default;
 
-  FastClusteringConfig(int32_t num_clusters, float threshold)
-      : num_clusters(num_clusters), threshold(threshold) {}
+  FastClusteringConfig(int32_t num_clusters, float threshold,
+                       bool compute_confidence = false)
+      : num_clusters(num_clusters),
+        threshold(threshold),
+        compute_confidence(compute_confidence) {}
 
   std::string ToString() const;
 

--- a/sherpa-onnx/csrc/fast-clustering-test.cc
+++ b/sherpa-onnx/csrc/fast-clustering-test.cc
@@ -4,6 +4,7 @@
 
 #include "sherpa-onnx/csrc/fast-clustering.h"
 
+#include <cmath>
 #include <iostream>
 #include <vector>
 
@@ -67,4 +68,89 @@ TEST(FastClustering, TestClusteringWithThreshold) {
   }
 }
 
+TEST(FastClustering, TestSilhouetteTwoClusters) {
+  std::vector<float> features = {
+      // cluster A
+      1.0, 0.0,
+      0.99, 0.01,
+      0.98, -0.02,
+      // cluster B
+      -1.0, 0.0,
+      -0.99, 0.01,
+      -0.98, -0.02,
+  };
+  const int32_t num_rows = 6;
+  const int32_t num_cols = 2;
+
+  FastClusteringConfig config;
+  config.num_clusters = 2;
+
+  FastClustering clustering(config);
+  std::vector<float> silhouettes;
+  auto labels = clustering.Cluster(features.data(), num_rows, num_cols,
+                                   &silhouettes);
+
+  ASSERT_EQ(labels.size(), static_cast<size_t>(num_rows));
+  ASSERT_EQ(silhouettes.size(), static_cast<size_t>(num_rows));
+
+  double sum = 0;
+  for (float sil : silhouettes) {
+    EXPECT_GE(sil, -1.0f);
+    EXPECT_LE(sil, 1.0f);
+    EXPECT_FALSE(std::isnan(sil));
+    sum += sil;
+  }
+  EXPECT_GT(sum / num_rows, 0.5);
+}
+
+TEST(FastClustering, TestSilhouetteSingletonClusters) {
+  // Two singleton clusters. Silhouette is undefined for
+  // singletons, so we return 0 for those rows.
+  std::vector<float> features = {
+      1.0, 0.0,
+      -1.0, 0.0,
+  };
+  const int32_t num_rows = 2;
+  const int32_t num_cols = 2;
+
+  FastClusteringConfig config;
+  config.num_clusters = 2;
+
+  FastClustering clustering(config);
+  std::vector<float> silhouettes;
+  auto labels = clustering.Cluster(features.data(), num_rows, num_cols,
+                                   &silhouettes);
+
+  ASSERT_EQ(labels.size(), static_cast<size_t>(num_rows));
+  ASSERT_EQ(silhouettes.size(), static_cast<size_t>(num_rows));
+  EXPECT_FLOAT_EQ(silhouettes[0], 0.0f);
+  EXPECT_FLOAT_EQ(silhouettes[1], 0.0f);
+}
+
+TEST(FastClustering, TestSilhouetteSingleCluster) {
+  // When we have only one cluster, we cannot calculate the
+  // silhouette coefficient. So, we expect the unavailable
+  // sentinel.
+  std::vector<float> features = {
+      1.0, 0.0,
+      0.99, 0.01,
+      0.98, -0.02,
+  };
+  const int32_t num_rows = 3;
+  const int32_t num_cols = 2;
+
+  FastClusteringConfig config;
+  config.num_clusters = 1;
+
+  FastClustering clustering(config);
+  std::vector<float> silhouettes;
+  auto labels = clustering.Cluster(features.data(), num_rows, num_cols,
+                                   &silhouettes);
+
+  ASSERT_EQ(labels.size(), static_cast<size_t>(num_rows));
+  ASSERT_EQ(silhouettes.size(), static_cast<size_t>(num_rows));
+  for (float sil : silhouettes) {
+    EXPECT_FLOAT_EQ(sil, kSilhouetteUnavailable);
+  }
+}
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/fast-clustering.cc
+++ b/sherpa-onnx/csrc/fast-clustering.cc
@@ -4,6 +4,11 @@
 
 #include "sherpa-onnx/csrc/fast-clustering.h"
 
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <limits>
 #include <vector>
 
 #include "Eigen/Dense"
@@ -16,12 +21,20 @@ class FastClustering::Impl {
   explicit Impl(const FastClusteringConfig &config) : config_(config) {}
 
   std::vector<int32_t> Cluster(float *features, int32_t num_rows,
-                               int32_t num_cols) const {
+                               int32_t num_cols,
+                               std::vector<float> *silhouettes) const {
+    if (silhouettes) {
+      silhouettes->clear();
+    }
+
     if (num_rows <= 0) {
       return {};
     }
 
     if (num_rows == 1) {
+      if (silhouettes) {
+        silhouettes->assign(1, 0.0f);
+      }
       return {0};
     }
 
@@ -64,10 +77,89 @@ class FastClustering::Impl {
                                    config_.threshold, labels.data());
     }
 
+    if (silhouettes) {
+      ComputeSilhouettes(distance, labels, num_rows, silhouettes);
+    }
+
     return labels;
   }
 
  private:
+  // Compute per-point silhouette coefficients using the already computed
+  // cosine-dissimilarity distance matrix.
+  static void ComputeSilhouettes(const std::vector<double> &distance,
+                                 const std::vector<int32_t> &labels,
+                                 int32_t num_rows,
+                                 std::vector<float> *silhouettes) {
+    assert(silhouettes && "silhouettes output pointer must not be null");
+    assert(!labels.empty() && "labels must not be empty");
+    int32_t num_clusters = *std::max_element(labels.begin(), labels.end()) + 1;
+    assert(num_clusters > 0 && "labels must contain non-negative cluster ids");
+
+    const size_t total_elements = static_cast<size_t>(num_rows) * num_clusters;
+    // Row-major: sum of distances from point i to points in cluster C
+    std::vector<double> sum(total_elements, 0.0);
+    // Row-major: number of points in cluster C contributing to the sum
+    std::vector<int32_t> count(total_elements, 0);
+
+    // We only need to calculate pairs row_index < col_index (no need for
+    // self-pairs). The distance from point X to Y is the same distance from
+    // point Y to X.
+    int32_t distance_matrix_index = 0;
+    for (int32_t row_index = 0; row_index != num_rows; ++row_index) {
+      size_t row_offset_index = static_cast<size_t>(row_index) * num_clusters;
+      for (int32_t col_index = row_index + 1; col_index != num_rows;
+           ++col_index, ++distance_matrix_index) {
+        double pair_distance = distance[distance_matrix_index];
+        int32_t row_point_cluster = labels[row_index];
+        int32_t col_point_cluster = labels[col_index];
+        size_t col_offset_index = static_cast<size_t>(col_index) * num_clusters;
+
+        sum[row_offset_index + col_point_cluster] += pair_distance;
+        count[row_offset_index + col_point_cluster] += 1;
+
+        sum[col_offset_index + row_point_cluster] += pair_distance;
+        count[col_offset_index + row_point_cluster] += 1;
+      }
+    }
+
+    silhouettes->assign(num_rows, 0.0f);
+    for (int32_t row_index = 0; row_index != num_rows; ++row_index) {
+      int32_t row_point_cluster = labels[row_index];
+      size_t base = static_cast<size_t>(row_index) * num_clusters;
+
+      int32_t own_count = count[base + row_point_cluster];
+      if (own_count == 0) {
+        // For singleton clusters, the coefficient is 0.0.
+        continue;
+      }
+
+      double a = sum[base + row_point_cluster] / own_count;
+      double b = std::numeric_limits<double>::infinity();
+
+      for (int32_t cluster_index = 0; cluster_index != num_clusters;
+           ++cluster_index) {
+        if (cluster_index == row_point_cluster) continue;
+        int32_t neighbor_count = count[base + cluster_index];
+        if (neighbor_count == 0) continue;
+        double mean = sum[base + cluster_index] / neighbor_count;
+        if (mean < b) b = mean;
+      }
+
+      if (!std::isfinite(b)) {
+        // We only have one cluster overall. The silhouette coefficient is
+        // undefined, so we set it to kSilhouetteUnavailable (outside the
+        // valid [-1, 1] range) as a the unavailable sentinel.
+        (*silhouettes)[row_index] = kSilhouetteUnavailable;
+        continue;
+      }
+
+      double denom = std::max(a, b);
+      (*silhouettes)[row_index] =
+          denom > 0 ? static_cast<float>((b - a) / denom) : 0.0f;
+    }
+  }
+
   FastClusteringConfig config_;
 };
 
@@ -76,8 +168,9 @@ FastClustering::FastClustering(const FastClusteringConfig &config)
 
 FastClustering::~FastClustering() = default;
 
-std::vector<int32_t> FastClustering::Cluster(float *features, int32_t num_rows,
-                                             int32_t num_cols) const {
-  return impl_->Cluster(features, num_rows, num_cols);
+std::vector<int32_t> FastClustering::Cluster(
+    float *features, int32_t num_rows, int32_t num_cols,
+    std::vector<float> *silhouettes /*= nullptr*/) const {
+  return impl_->Cluster(features, num_rows, num_cols, silhouettes);
 }
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/fast-clustering.h
+++ b/sherpa-onnx/csrc/fast-clustering.h
@@ -12,6 +12,11 @@
 
 namespace sherpa_onnx {
 
+// Sentinel used when the silhouette coefficient cannot be computed
+// (e.g. only one cluster was formed). It is outside the valid silhouette
+// range of [-1, 1].
+inline constexpr float kSilhouetteUnavailable = -2.0f;
+
 class FastClustering {
  public:
   explicit FastClustering(const FastClusteringConfig &config);
@@ -26,13 +31,19 @@ class FastClustering {
    *                 which is 1 - (cosine similarity)
    * @param num_rows Number of feature frames
    * @param num-cols The feature dimension.
+   * @param silhouettes  Optional output. When non-null, on return it holds
+   *                     num_rows silhouette coefficients, one per input row.
+   *                     Valid values are [-1, 1]; singleton clusters and the
+   *                     num_rows <= 1 case yield 0; the single-cluster case
+   *                     yields kSilhouetteUnavailable.
    *
    * @return Return a vector of size num_rows. ans[i] contains the label
    *         for the i-th feature frame, i.e., the i-th row of the feature
    *         matrix.
    */
   std::vector<int32_t> Cluster(float *features, int32_t num_rows,
-                               int32_t num_cols) const;
+                               int32_t num_cols,
+                               std::vector<float> *silhouettes = nullptr) const;
 
  private:
   class Impl;

--- a/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
+++ b/sherpa-onnx/csrc/offline-speaker-diarization-pyannote-impl.h
@@ -54,6 +54,13 @@ using Int32RowVector = Eigen::Matrix<int32_t, 1, Eigen::Dynamic>;
 
 using Int32Pair = std::pair<int32_t, int32_t>;
 
+// One sample interval holding that embedding's silhouette coefficient.
+struct SilhouetteInterval {
+  int32_t start_sample;
+  int32_t end_sample;
+  float silhouette;
+};
+
 class OfflineSpeakerDiarizationPyannoteImpl
     : public OfflineSpeakerDiarizationImpl {
  public:
@@ -185,8 +192,10 @@ class OfflineSpeakerDiarizationPyannoteImpl
     }
 
     Timer clustering_timer(config_.segmentation.debug);
+    std::vector<float> silhouettes;
     std::vector<int32_t> cluster_labels = clustering_->Cluster(
-        &embeddings(0, 0), embeddings.rows(), embeddings.cols());
+        &embeddings(0, 0), embeddings.rows(), embeddings.cols(),
+        config_.clustering.compute_confidence ? &silhouettes : nullptr);
     clustering_timer.Log("OfflineSpeakerDiarization: clustering");
 
     if (cluster_labels.empty()) {
@@ -211,7 +220,17 @@ class OfflineSpeakerDiarizationPyannoteImpl
     Matrix2DInt32 final_labels =
         FinalizeLabels(speaker_count, speakers_per_frame);
 
-    auto result = ComputeResult(final_labels);
+    // For each cluster, we keep the list of sample intervals with their
+    // embedding's silhouette value. When we assign the segments, we calculate
+    // the mean of the intervals's silhouettes that overlap the segment.
+    std::unordered_map<int32_t, std::vector<SilhouetteInterval>>
+        cluster_intervals;
+    if (!silhouettes.empty() && silhouettes.size() == cluster_labels.size()) {
+      cluster_intervals = BuildClusterIntervals(
+          chunk_speaker_samples_list_pair.second, cluster_labels, silhouettes);
+    }
+
+    auto result = ComputeResult(final_labels, cluster_intervals);
 
     if (config_.segmentation.debug) {
       LogTotal(static_cast<float>(total_timer.Elapsed()), n);
@@ -702,7 +721,9 @@ class OfflineSpeakerDiarizationPyannoteImpl
   }
 
   OfflineSpeakerDiarizationResult ComputeResult(
-      const Matrix2DInt32 &final_labels) const {
+      const Matrix2DInt32 &final_labels,
+      const std::unordered_map<int32_t, std::vector<SilhouetteInterval>>
+          &cluster_intervals = {}) const {
     Matrix2DInt32 final_labels_t = final_labels.transpose();
     int32_t num_speakers = final_labels_t.rows();
     int32_t num_frames = final_labels_t.cols();
@@ -756,14 +777,66 @@ class OfflineSpeakerDiarizationPyannoteImpl
       // merge segments if the gap between them is less than min_duration_off
       MergeSegments(&this_speaker);
 
-      for (const auto &seg : this_speaker) {
+      // Add the per-segment confidence (if it was at all computed).
+      auto cluster_it = cluster_intervals.find(speaker_index);
+      bool has_intervals = cluster_it != cluster_intervals.end();
+
+      for (auto &seg : this_speaker) {
         if (seg.Duration() > config_.min_duration_on) {
+          if (has_intervals) {
+            seg.SetConfidence(ComputeSegmentConfidence(cluster_it->second, seg,
+                                                       sample_rate));
+          }
           ans.Add(seg);
         }
       }
     }  // for (int32_t speaker_index = 0; speaker_index != num_speakers;
 
     return ans;
+  }
+
+  // Expand each embedding's (chunk, speaker) pairs into its sample
+  // interval ranges with their respectives silhouette values.
+  static std::unordered_map<int32_t, std::vector<SilhouetteInterval>>
+  BuildClusterIntervals(
+      const std::vector<std::vector<Int32Pair>> &sample_indexes,
+      const std::vector<int32_t> &cluster_labels,
+      const std::vector<float> &silhouettes) {
+    std::unordered_map<int32_t, std::vector<SilhouetteInterval>> flattened;
+    for (size_t i = 0; i < cluster_labels.size(); ++i) {
+      int32_t cluster = cluster_labels[i];
+      float silhouette = silhouettes[i];
+      auto &bucket = flattened[cluster];
+      for (const auto &interval : sample_indexes[i]) {
+        bucket.push_back({interval.first, interval.second, silhouette});
+      }
+    }
+    return flattened;
+  }
+
+  // Returns the mean silhouette of every embedding-interval (in this segment's
+  // cluster) whose sample range overlaps the segment. Returns -2 (outside the
+  // valid [-1, 1] range) as the unavailable sentinel when no interval
+  // overlaps.
+  static float ComputeSegmentConfidence(
+      const std::vector<SilhouetteInterval> &cluster_bucket,
+      const OfflineSpeakerDiarizationSegment &segment, int32_t sample_rate) {
+    int32_t seg_start = static_cast<int32_t>(segment.Start() * sample_rate);
+    int32_t seg_end = static_cast<int32_t>(segment.End() * sample_rate);
+
+    double sum = 0.0;
+    int32_t count = 0;
+    for (const auto &interval : cluster_bucket) {
+      if (interval.end_sample > seg_start && interval.start_sample < seg_end) {
+        sum += interval.silhouette;
+        count += 1;
+      }
+    }
+
+    if (count == 0) {
+      return kUnavailableConfidence;
+    }
+    return static_cast<float>(sum / count);
   }
 
   OfflineSpeakerDiarizationResult HandleOneChunkSpecialCase(

--- a/sherpa-onnx/csrc/offline-speaker-diarization-result.cc
+++ b/sherpa-onnx/csrc/offline-speaker-diarization-result.cc
@@ -13,9 +13,14 @@
 #include <utility>
 #include <vector>
 
+#include "sherpa-onnx/csrc/fast-clustering.h"
 #include "sherpa-onnx/csrc/macros.h"
 
 namespace sherpa_onnx {
+
+static_assert(kUnavailableConfidence == kSilhouetteUnavailable,
+              "kUnavailableConfidence must match the sentinel value used in "
+              "fast-clustering.h.");
 
 OfflineSpeakerDiarizationSegment::OfflineSpeakerDiarizationSegment(
     float start, float end, int32_t speaker, const std::string &text /*= {}*/) {
@@ -50,11 +55,22 @@ OfflineSpeakerDiarizationSegment::Merge(
   }
 }
 
-std::string OfflineSpeakerDiarizationSegment::ToString() const {
-  std::array<char, 128> s{};
+std::string OfflineSpeakerDiarizationSegment::ToString(
+    bool with_confidence /*= false*/) const {
+  std::array<char, 160> s{};
 
-  snprintf(s.data(), s.size(), "%.3f -- %.3f speaker_%02d", start_, end_,
-           speaker_);
+  if (!with_confidence) {
+    snprintf(s.data(), s.size(), "%.3f -- %.3f speaker_%02d", start_, end_,
+             speaker_);
+  } else if (confidence_ == kUnavailableConfidence) {
+    snprintf(s.data(), s.size(),
+             "%.3f -- %.3f speaker_%02d confidence=n/a", start_, end_,
+             speaker_);
+  } else {
+    snprintf(s.data(), s.size(),
+             "%.3f -- %.3f speaker_%02d confidence=%.3f", start_, end_,
+             speaker_, confidence_);
+  }
 
   std::ostringstream os;
   os << s.data();

--- a/sherpa-onnx/csrc/offline-speaker-diarization-result.h
+++ b/sherpa-onnx/csrc/offline-speaker-diarization-result.h
@@ -12,6 +12,12 @@
 
 namespace sherpa_onnx {
 
+// Sentinel used for OfflineSpeakerDiarizationSegment::confidence when the
+// confidence value cannot be determined (e.g. compute_confidence was
+// disabled, only one cluster was formed, or no embedding interval overlapped
+// the segment). Kept outside the valid confidence range of [-1, 1].
+inline constexpr float kUnavailableConfidence = -2.0f;
+
 class OfflineSpeakerDiarizationSegment {
  public:
   OfflineSpeakerDiarizationSegment(float start, float end, int32_t speaker,
@@ -27,10 +33,14 @@ class OfflineSpeakerDiarizationSegment {
   int32_t Speaker() const { return speaker_; }
   const std::string &Text() const { return text_; }
   float Duration() const { return end_ - start_; }
+  float Confidence() const { return confidence_; }
 
   void SetText(const std::string &text) { text_ = text; }
+  void SetConfidence(float confidence) { confidence_ = confidence; }
 
-  std::string ToString() const;
+  // If with_confidence is true, we append the confidence value
+  // (printed as "n/a" when unavailable).
+  std::string ToString(bool with_confidence = false) const;
 
  private:
   float start_;       // in seconds
@@ -38,6 +48,10 @@ class OfflineSpeakerDiarizationSegment {
   int32_t speaker_;   // ID of the speaker, starting from 0
   std::string text_;  // If not empty, it contains the speech recognition result
                       // of this segment
+
+  // Confidence in [-1, 1]. See kUnavailableConfidence for the sentinel used
+  // when the value cannot be computed.
+  float confidence_ = kUnavailableConfidence;
 };
 
 class OfflineSpeakerDiarizationResult {

--- a/sherpa-onnx/csrc/sherpa-onnx-offline-speaker-diarization.cc
+++ b/sherpa-onnx/csrc/sherpa-onnx-offline-speaker-diarization.cc
@@ -119,7 +119,7 @@ a smaller threshold leads to more clusters, i.e., more speakers
           .SortByStartTime();
 
   for (const auto &r : result) {
-    std::cout << r.ToString() << "\n";
+    std::cout << r.ToString(config.clustering.compute_confidence) << "\n";
   }
 
   const auto end = std::chrono::steady_clock::now();

--- a/sherpa-onnx/pascal-api/sherpa_onnx.pas
+++ b/sherpa-onnx/pascal-api/sherpa_onnx.pas
@@ -673,6 +673,7 @@ type
   TSherpaOnnxFastClusteringConfig = record
     NumClusters: Integer;
     Threshold: Single;
+    ComputeConfidence: Integer;
     function ToString: AnsiString;
     class operator Initialize({$IFDEF FPC}var{$ELSE}out{$ENDIF} Dest: TSherpaOnnxFastClusteringConfig);
   end;
@@ -700,6 +701,7 @@ type
     Start: Single;
     Stop: Single;
     Speaker: Integer;
+    Confidence: Single;
     function ToString: AnsiString;
   end;
 
@@ -1275,6 +1277,7 @@ type
   SherpaOnnxFastClusteringConfig = record
     NumClusters: cint32;
     Threshold: cfloat;
+    ComputeConfidence: cint32;
   end;
 
   SherpaOnnxSpeakerEmbeddingExtractorConfig = record
@@ -1296,6 +1299,7 @@ type
     Start: cfloat;
     Stop: cfloat;
     Speaker: cint32;
+    Confidence: cfloat;
   end;
 
   PSherpaOnnxOfflineSpeakerDiarizationSegment = ^SherpaOnnxOfflineSpeakerDiarizationSegment;
@@ -3255,14 +3259,15 @@ end;
 function TSherpaOnnxFastClusteringConfig.ToString: AnsiString;
 begin
   Result := Format('TSherpaOnnxFastClusteringConfig(' +
-    'NumClusters := %d, Threshold := %.3f)',
-    [Self.NumClusters, Self.Threshold]);
+    'NumClusters := %d, Threshold := %.3f, ComputeConfidence := %d)',
+    [Self.NumClusters, Self.Threshold, Self.ComputeConfidence]);
 end;
 
 class operator TSherpaOnnxFastClusteringConfig.Initialize({$IFDEF FPC}var{$ELSE}out{$ENDIF} Dest: TSherpaOnnxFastClusteringConfig);
 begin
   Dest.NumClusters := -1;
   Dest.Threshold := 0.5;
+  Dest.ComputeConfidence := 0;
 end;
 
 function TSherpaOnnxSpeakerEmbeddingExtractorConfig.ToString: AnsiString;
@@ -3305,8 +3310,9 @@ begin
   Result := Format('TSherpaOnnxOfflineSpeakerDiarizationSegment(' +
     'Start := %.3f, '+
     'Stop := %.3f, '+
-    'Speaker := %d)',
-    [Self.Start, Self.Stop, Self.Speaker]);
+    'Speaker := %d, '+
+    'Confidence := %.3f)',
+    [Self.Start, Self.Stop, Self.Speaker, Self.Confidence]);
 end;
 
 constructor TSherpaOnnxOfflineSpeakerDiarization.Create(Config: TSherpaOnnxOfflineSpeakerDiarizationConfig);
@@ -3328,6 +3334,7 @@ begin
 
   C.Clustering.NumClusters := Config.Clustering.NumClusters;
   C.Clustering.Threshold := Config.Clustering.Threshold;
+  C.Clustering.ComputeConfidence := Config.Clustering.ComputeConfidence;
 
   C.MinDurationOn := Config.MinDurationOn;
   C.MinDurationOff := Config.MinDurationOff;
@@ -3356,6 +3363,7 @@ begin
 
   C.Clustering.NumClusters := Config.Clustering.NumClusters;
   C.Clustering.Threshold := Config.Clustering.Threshold;
+  C.Clustering.ComputeConfidence := Config.Clustering.ComputeConfidence;
 
   SherpaOnnxOfflineSpeakerDiarizationSetConfig(Self.Handle, @C);
 end;
@@ -3384,6 +3392,7 @@ begin
       Result[I].Start := Segments[I].Start;
       Result[I].Stop := Segments[I].Stop;
       Result[I].Speaker := Segments[I].Speaker;
+      Result[I].Confidence := Segments[I].Confidence;
     end;
 
   SherpaOnnxOfflineSpeakerDiarizationDestroySegment(Segments);
@@ -3415,6 +3424,7 @@ begin
       Result[I].Start := Segments[I].Start;
       Result[I].Stop := Segments[I].Stop;
       Result[I].Speaker := Segments[I].Speaker;
+      Result[I].Confidence := Segments[I].Confidence;
     end;
 
   SherpaOnnxOfflineSpeakerDiarizationDestroySegment(Segments);

--- a/sherpa-onnx/python/csrc/fast-clustering.cc
+++ b/sherpa-onnx/python/csrc/fast-clustering.cc
@@ -33,10 +33,11 @@ Returns:
 static void PybindFastClusteringConfig(py::module *m) {
   using PyClass = FastClusteringConfig;
   py::class_<PyClass>(*m, "FastClusteringConfig")
-      .def(py::init<int32_t, float>(), py::arg("num_clusters") = -1,
-           py::arg("threshold") = 0.5)
+      .def(py::init<int32_t, float, bool>(), py::arg("num_clusters") = -1,
+           py::arg("threshold") = 0.5, py::arg("compute_confidence") = false)
       .def_readwrite("num_clusters", &PyClass::num_clusters)
       .def_readwrite("threshold", &PyClass::threshold)
+      .def_readwrite("compute_confidence", &PyClass::compute_confidence)
       .def("__str__", &PyClass::ToString)
       .def("validate", &PyClass::Validate);
 }

--- a/sherpa-onnx/python/csrc/offline-speaker-diarization-result.cc
+++ b/sherpa-onnx/python/csrc/offline-speaker-diarization-result.cc
@@ -15,6 +15,7 @@ static void PybindOfflineSpeakerDiarizationSegment(py::module *m) {
       .def_property_readonly("end", &PyClass::End)
       .def_property_readonly("duration", &PyClass::Duration)
       .def_property_readonly("speaker", &PyClass::Speaker)
+      .def_property_readonly("confidence", &PyClass::Confidence)
       .def_property("text", &PyClass::Text, &PyClass::SetText)
       .def("__str__", &PyClass::ToString);
 }

--- a/sherpa-onnx/rust/sherpa-onnx-sys/src/offline_speaker_diarization.rs
+++ b/sherpa-onnx/rust/sherpa-onnx-sys/src/offline_speaker_diarization.rs
@@ -25,6 +25,7 @@ pub struct OfflineSpeakerSegmentationModelConfig {
 pub struct FastClusteringConfig {
     pub num_clusters: i32,
     pub threshold: c_float,
+    pub compute_confidence: i32,
 }
 
 #[repr(C)]
@@ -53,6 +54,7 @@ pub struct OfflineSpeakerDiarizationSegment {
     pub start: c_float,
     pub end: c_float,
     pub speaker: i32,
+    pub confidence: c_float,
 }
 
 extern "C" {

--- a/sherpa-onnx/rust/sherpa-onnx/src/offline_speaker_diarization.rs
+++ b/sherpa-onnx/rust/sherpa-onnx/src/offline_speaker_diarization.rs
@@ -75,6 +75,7 @@ impl OfflineSpeakerSegmentationModelConfig {
 pub struct FastClusteringConfig {
     pub num_clusters: i32,
     pub threshold: f32,
+    pub compute_confidence: bool,
 }
 
 impl Default for FastClusteringConfig {
@@ -82,6 +83,7 @@ impl Default for FastClusteringConfig {
         Self {
             num_clusters: -1,
             threshold: 0.5,
+            compute_confidence: false,
         }
     }
 }
@@ -91,6 +93,7 @@ impl FastClusteringConfig {
         sys::FastClusteringConfig {
             num_clusters: self.num_clusters,
             threshold: self.threshold,
+            compute_confidence: self.compute_confidence as i32,
         }
     }
 }
@@ -141,6 +144,7 @@ pub struct OfflineSpeakerDiarizationSegment {
     pub start: f32,
     pub end: f32,
     pub speaker: i32,
+    pub confidence: f32,
 }
 
 /// Offline speaker diarizer.
@@ -246,6 +250,7 @@ impl OfflineSpeakerDiarizationResult {
                     start: s.start,
                     end: s.end,
                     speaker: s.speaker,
+                    confidence: s.confidence,
                 })
                 .collect::<Vec<_>>();
             sys::SherpaOnnxOfflineSpeakerDiarizationDestroySegment(p);

--- a/swift-api-examples/SherpaOnnx.swift
+++ b/swift-api-examples/SherpaOnnx.swift
@@ -1780,10 +1780,14 @@ public func sherpaOnnxOfflineSpeakerSegmentationModelConfig(
   )
 }
 
-public func sherpaOnnxFastClusteringConfig(numClusters: Int = -1, threshold: Float = 0.5)
+public func sherpaOnnxFastClusteringConfig(
+  numClusters: Int = -1, threshold: Float = 0.5, computeConfidence: Bool = false
+)
   -> SherpaOnnxFastClusteringConfig
 {
-  return SherpaOnnxFastClusteringConfig(num_clusters: Int32(numClusters), threshold: threshold)
+  return SherpaOnnxFastClusteringConfig(
+    num_clusters: Int32(numClusters), threshold: threshold,
+    compute_confidence: computeConfidence ? 1 : 0)
 }
 
 public func sherpaOnnxSpeakerEmbeddingExtractorConfig(

--- a/wasm/speaker-diarization/sherpa-onnx-speaker-diarization.js
+++ b/wasm/speaker-diarization/sherpa-onnx-speaker-diarization.js
@@ -124,7 +124,7 @@ function initSherpaOnnxSpeakerEmbeddingExtractorConfig(config, Module) {
 }
 
 function initSherpaOnnxFastClusteringConfig(config, Module) {
-  const len = 2 * 4;
+  const len = 3 * 4;
   const ptr = Module._malloc(len);
 
   let offset = 0;
@@ -132,6 +132,9 @@ function initSherpaOnnxFastClusteringConfig(config, Module) {
   offset += 4;
 
   Module.setValue(ptr + offset, config.threshold || 0.5, 'float');
+  offset += 4;
+
+  Module.setValue(ptr + offset, config.computeConfidence ? 1 : 0, 'i32');
   offset += 4;
 
   return {
@@ -261,15 +264,16 @@ class OfflineSpeakerDiarization {
 
     let ans = [];
 
-    let sizeOfSegment = 3 * 4;
+    let sizeOfSegment = 4 * 4;
     for (let i = 0; i < numSegments; ++i) {
       let p = segments + i * sizeOfSegment
 
       let start = this.Module.HEAPF32[p / 4 + 0];
       let end = this.Module.HEAPF32[p / 4 + 1];
       let speaker = this.Module.HEAP32[p / 4 + 2];
+      let confidence = this.Module.HEAPF32[p / 4 + 3];
 
-      ans.push({start: start, end: end, speaker: speaker});
+      ans.push({start: start, end: end, speaker: speaker, confidence: confidence});
     }
 
     this.Module._SherpaOnnxOfflineSpeakerDiarizationDestroySegment(segments);

--- a/wasm/speaker-diarization/sherpa-onnx-wasm-main-speaker-diarization.cc
+++ b/wasm/speaker-diarization/sherpa-onnx-wasm-main-speaker-diarization.cc
@@ -22,7 +22,7 @@ static_assert(
         sizeof(SherpaOnnxOfflineSpeakerSegmentationPyannoteModelConfig) + 3 * 4,
     "");
 
-static_assert(sizeof(SherpaOnnxFastClusteringConfig) == 2 * 4, "");
+static_assert(sizeof(SherpaOnnxFastClusteringConfig) == 3 * 4, "");
 
 static_assert(sizeof(SherpaOnnxSpeakerEmbeddingExtractorConfig) == 4 * 4, "");
 
@@ -54,6 +54,7 @@ void MyPrint(const SherpaOnnxOfflineSpeakerDiarizationConfig *sd_config) {
   fprintf(stdout, "----------clustering config----------\n");
   fprintf(stdout, "num_clusters: %d\n", clustering.num_clusters);
   fprintf(stdout, "threshold: %.3f\n", clustering.threshold);
+  fprintf(stdout, "compute_confidence: %d\n", clustering.compute_confidence);
 
   fprintf(stdout, "min_duration_on: %.3f\n", sd_config->min_duration_on);
   fprintf(stdout, "min_duration_off: %.3f\n", sd_config->min_duration_off);


### PR DESCRIPTION
Motivating issue: #3880 

When performing offline speaker diarization, we add an option to toggle the computation of the [silhouette coefficient](https://www.geeksforgeeks.org/machine-learning/what-is-silhouette-score/) against the final cluster assignment as the per-segment confidence value. The added cost is $O(n^2)$, since we can reuse the cosine dissimilarity matrix already calculated in `fast-clustering.cc` (i.e. no asymptotic regression).

The option was added to `SherpaOnnxFastClusteringConfig`. This feature is backwards compatible:
- We toggle this enhancement via `clustering.compute-confidence` (disabled by default). Example:
```bash
./sherpa-onnx-offline-speaker-diarization \
    --segmentation.pyannote-model=SEGMENTATION_MODEL \
    --embedding.model=EMBEDDING_MODEL \
    --clustering.compute-confidence=1 \
    INPUT_WAV
```
(See original [issue](https://github.com/k2-fsa/sherpa-onnx/issues/3880) for an example output).

Confidence values:
- `confidence=[-1,1]`: the mean of the silhouette coefficients of the embedding intervals overlapping a given segment.
- `confidence=-2.0f` (printed as `n/a`):
  - no embedding window for this segment's speaker overaps its time range (e.g. short-overlapping split segments).
  - clustering only produced one cluster (i.e. we are unable to calculate the coefficient).
  - if for some reason `clustering.compute-confidence` is disabled, but a confidence diarization output is requested (via `ToString(with_confidence=true)`.
- `confidence=0.0`: singleton clusters (per convention).

A minimal set of unit tests has been added to `fast-clustering-test.cc`

Supported bindings: 
- C, Python and C++
- Rust, Pascal, Dart, C#, Swift, WASM (just mirrored the struct to keep ABI in layouts synced (higher-level wrapper is deferred to future PRs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional confidence scoring for offline speaker-diarization segments.
  - Confidence values are available through C++ and C APIs and align with start-time-sorted segments.
  - Added controls to enable or disable confidence computation.
  - Diarization output can display confidence values when available; unavailable values are reported as `NaN`.

- **Bug Fixes**
  - Improved consistency by sorting diarization segments by start time before returning results.

- **Tests**
  - Added coverage for cluster-quality scores, including well-separated, singleton, and single-cluster cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->