### PR TITLE
Fix Flutter packages for iOS

### DIFF
--- a/.github/workflows/build-xcframework-shared-sherpa-with-static-onnxruntime.yaml
+++ b/.github/workflows/build-xcframework-shared-sherpa-with-static-onnxruntime.yaml
@@ -133,7 +133,7 @@ jobs:
         shell: bash
         run: |
           ls -lh build-ios-shared-sherpa-with-static-onnxruntime/
-          cd build-ios-shared-sherpa-with-static-onnxruntime/sherpa-onnx.xcframework
+          cd build-ios-shared-sherpa-with-static-onnxruntime/SherpaOnnxC.xcframework
           du -h -d1 .
           tree .
 
@@ -148,10 +148,10 @@ jobs:
           mkdir -p /tmp/test-xcframework
           cd /tmp/test-xcframework
           unzip -o $GITHUB_WORKSPACE/build-ios-shared-sherpa-with-static-onnxruntime/*.xcframework.zip -d .
-          ls -lh sherpa-onnx.xcframework/
+          ls -lh SherpaOnnxC.xcframework/
 
           # Verify xcframework structure (framework bundle)
-          fw_path=$(find sherpa-onnx.xcframework -path "*simulator*" -name "SherpaOnnxC.framework" -type d | head -1)
+          fw_path=$(find SherpaOnnxC.xcframework -path "*simulator*" -name "SherpaOnnxC.framework" -type d | head -1)
           echo "fw_path: $fw_path"
 
           test -f "$fw_path/SherpaOnnxC" || { echo "Binary not found"; exit 1; }

--- a/.github/workflows/release-dart-package.yaml
+++ b/.github/workflows/release-dart-package.yaml
@@ -945,9 +945,9 @@ jobs:
           unzip sherpa-onnx-${SHERPA_ONNX_VERSION}-ios-shared-onnxruntime-static.xcframework.zip
           rm sherpa-onnx-${SHERPA_ONNX_VERSION}-ios-shared-onnxruntime-static.xcframework.zip
 
-          mv sherpa-onnx.xcframework sherpa_onnx_ios/sherpa-onnx.xcframework
+          mv SherpaOnnxC.xcframework sherpa_onnx_ios/SherpaOnnxC.xcframework
 
-          ls -lh sherpa_onnx_ios/sherpa-onnx.xcframework/
+          ls -lh sherpa_onnx_ios/SherpaOnnxC.xcframework/
 
       - name: Prepare for publish
         shell: bash

--- a/.github/workflows/test-flutter-package.yaml
+++ b/.github/workflows/test-flutter-package.yaml
@@ -46,8 +46,8 @@ jobs:
         shell: bash
         run: |
           cd flutter-examples/hello_world
-          flutter pub get
           flutter config --no-enable-swift-package-manager
+          flutter pub get
           flutter build macos
 
           ls -lh build/macos/Build/Products/Release/
@@ -141,8 +141,8 @@ jobs:
         shell: bash
         run: |
           cd flutter-examples/hello_world
-          flutter pub get
           flutter config --no-enable-swift-package-manager
+          flutter pub get
           flutter build ios --no-codesign
 
           ls -lh build/ios/iphoneos/
@@ -209,7 +209,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm]
+        # os: [ubuntu-latest, ubuntu-24.04-arm]
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -309,7 +310,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        abi: [arm64-v8a, armeabi-v7a, x86_64, x86]
+        abi: [arm64, arm, x64]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test-flutter.yaml
+++ b/.github/workflows/test-flutter.yaml
@@ -260,8 +260,8 @@ jobs:
       - name: Copy xcframework
         shell: bash
         run: |
-          cp -av build-ios-shared-sherpa-with-static-onnxruntime/sherpa-onnx.xcframework flutter/sherpa_onnx_ios/ios/sherpa_onnx_ios/sherpa-onnx.xcframework
-          ls -lh flutter/sherpa_onnx_ios/ios/sherpa_onnx_ios/sherpa-onnx.xcframework/
+          cp -av build-ios-shared-sherpa-with-static-onnxruntime/SherpaOnnxC.xcframework flutter/sherpa_onnx_ios/ios/sherpa_onnx_ios/SherpaOnnxC.xcframework
+          ls -lh flutter/sherpa_onnx_ios/ios/sherpa_onnx_ios/SherpaOnnxC.xcframework/
 
       - name: Use local sherpa_onnx_ios
         shell: bash
@@ -336,8 +336,8 @@ jobs:
       - name: Copy xcframework
         shell: bash
         run: |
-          cp -av build-ios-shared-sherpa-with-static-onnxruntime/sherpa-onnx.xcframework flutter/sherpa_onnx_ios/ios/sherpa_onnx_ios/sherpa-onnx.xcframework
-          ls -lh flutter/sherpa_onnx_ios/ios/sherpa_onnx_ios/sherpa-onnx.xcframework/
+          cp -av build-ios-shared-sherpa-with-static-onnxruntime/SherpaOnnxC.xcframework flutter/sherpa_onnx_ios/ios/sherpa_onnx_ios/SherpaOnnxC.xcframework
+          ls -lh flutter/sherpa_onnx_ios/ios/sherpa_onnx_ios/SherpaOnnxC.xcframework/
 
       - name: Use local sherpa_onnx_ios
         shell: bash

--- a/build-ios-shared-sherpa-with-static-onnxruntime.sh
+++ b/build-ios-shared-sherpa-with-static-onnxruntime.sh
@@ -175,7 +175,7 @@ lipo \
   -output \
     ios-arm64_x86_64-simulator/libsherpa-onnx-c-api.dylib
 
-rm -rf sherpa-onnx.xcframework
+rm -rf SherpaOnnxC.xcframework
 
 # Create framework bundles so SPM can resolve the module
 create_framework() {
@@ -238,9 +238,9 @@ create_framework ios-arm64_x86_64-simulator/libsherpa-onnx-c-api.dylib ios-arm64
 xcodebuild -create-xcframework \
   -framework "ios-arm64/SherpaOnnxC.framework" \
   -framework "ios-arm64_x86_64-simulator/SherpaOnnxC.framework" \
-  -output sherpa-onnx.xcframework
+  -output SherpaOnnxC.xcframework
 
-cd sherpa-onnx.xcframework
+cd SherpaOnnxC.xcframework
 echo "PWD: $PWD"
 ls -lh
 echo "---"
@@ -250,7 +250,7 @@ cd ..
 
 SHERPA_ONNX_VERSION=v$(grep "SHERPA_ONNX_VERSION" ../CMakeLists.txt | cut -d " " -f 2 | cut -d '"' -f 2)
 rm -f sherpa-onnx-${SHERPA_ONNX_VERSION}-ios-shared-onnxruntime-static.xcframework.zip
-zip -r -y sherpa-onnx-${SHERPA_ONNX_VERSION}-ios-shared-onnxruntime-static.xcframework.zip sherpa-onnx.xcframework
+zip -r -y sherpa-onnx-${SHERPA_ONNX_VERSION}-ios-shared-onnxruntime-static.xcframework.zip SherpaOnnxC.xcframework
 
 echo "Checksum:"
 swift package compute-checksum sherpa-onnx-${SHERPA_ONNX_VERSION}-ios-shared-onnxruntime-static.xcframework.zip | tee checksum.txt

--- a/flutter/sherpa_onnx/pubspec.yaml
+++ b/flutter/sherpa_onnx/pubspec.yaml
@@ -23,6 +23,7 @@ homepage: https://github.com/k2-fsa/sherpa-onnx
 
 environment:
   sdk: ">=3.2.0 <4.0.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   ffi: ^2.1.0

--- a/flutter/sherpa_onnx_ios/ios/sherpa_onnx_ios.podspec
+++ b/flutter/sherpa_onnx_ios/ios/sherpa_onnx_ios.podspec
@@ -23,7 +23,7 @@ A new Flutter FFI plugin project.
   s.source           = { :path => '.' }
   s.dependency 'Flutter'
   s.platform = :ios, '13.0'
-  s.vendored_frameworks = 'sherpa_onnx_ios/sherpa-onnx.xcframework'
+  s.vendored_frameworks = 'sherpa_onnx_ios/SherpaOnnxC.xcframework'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = {

--- a/flutter/sherpa_onnx_ios/ios/sherpa_onnx_ios/Package.swift
+++ b/flutter/sherpa_onnx_ios/ios/sherpa_onnx_ios/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
   targets: [
     .binaryTarget(
       name: "SherpaOnnxC",
-      path: "sherpa-onnx.xcframework"
+      path: "SherpaOnnxC.xcframework"
     ),
     .target(
       name: "sherpa_onnx_ios",


### PR DESCRIPTION
Fix the error in https://github.com/csukuangfj/sherpa-onnx/actions/runs/32126202562/job/95677209525

```
Xcode build done.                                           56.2s
Failed to build iOS app
Error (Xcode): Framework 'sherpa-onnx' not found
/Users/runner/work/sherpa-onnx/sherpa-onnx/flutter-examples/hello_world/ios/Runner.xcodeproj

Error (Xcode): Linker command failed with exit code 1 (use -v to see invocation)
/Users/runner/work/sherpa-onnx/sherpa-onnx/flutter-examples/hello_world/ios/Runner.xcodeproj

Encountered error while building for device.
Error: Process completed with exit code 1.

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated iOS and Flutter build, release, and package configuration to consistently use the renamed `SherpaOnnxC.xcframework`.
  * Improved Flutter test coverage across supported Android target platforms and disabled Swift Package Manager where CocoaPods builds require it.

* **Compatibility**
  * Flutter package now requires Flutter 3.10.0 or newer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->