### PR TITLE
Support Windows arm64 for Rust

### DIFF
--- a/.github/scripts/test-rust.sh
+++ b/.github/scripts/test-rust.sh
@@ -6,8 +6,7 @@ cd rust-api-examples
 
 trap 'bash ../.github/scripts/show-rust-binary-info.sh --all || true' EXIT
 
-./run-cohere-transcribe.sh
-rm -rf sherpa-onnx-cohere-transcribe-*
+./run-version.sh
 
 ./run-qwen3-asr.sh
 rm -rf sherpa-onnx-qwen3-*
@@ -76,8 +75,6 @@ rm -rf sherpa-onnx-whisper-tiny spoken-language-identification-test-wavs
 ./run-offline-punctuation.sh
 rm -rf sherpa-onnx-punct-ct-transformer-zh-en-vocab272727-2024-04-12-int8
 
-./run-version.sh
-
 ./run-moonshine-v2.sh
 
 ./run-fire-red-asr-ctc.sh
@@ -103,3 +100,6 @@ rm -rf sherpa-onnx-paraformer-zh-small-2024-03-09
 ./run-offline-speech-enhancement-dpdfnet.sh
 ./run-streaming-speech-enhancement-gtcrn.sh
 ./run-streaming-speech-enhancement-dpdfnet.sh
+
+./run-cohere-transcribe.sh
+rm -rf sherpa-onnx-cohere-transcribe-*

--- a/.github/scripts/test-rust.sh
+++ b/.github/scripts/test-rust.sh
@@ -6,8 +6,10 @@ cd rust-api-examples
 
 trap 'bash ../.github/scripts/show-rust-binary-info.sh --all || true' EXIT
 
-./run-cohere-transcribe.sh
-rm -rf sherpa-onnx-cohere-transcribe-*
+if [[ "${SHERPA_ONNX_SKIP_COHERE_TRANSCRIBE:-0}" != "1" ]]; then
+  ./run-cohere-transcribe.sh
+  rm -rf sherpa-onnx-cohere-transcribe-*
+fi
 
 ./run-qwen3-asr.sh
 rm -rf sherpa-onnx-qwen3-*

--- a/.github/scripts/test-rust.sh
+++ b/.github/scripts/test-rust.sh
@@ -6,10 +6,8 @@ cd rust-api-examples
 
 trap 'bash ../.github/scripts/show-rust-binary-info.sh --all || true' EXIT
 
-if [[ "${SHERPA_ONNX_SKIP_COHERE_TRANSCRIBE:-0}" != "1" ]]; then
-  ./run-cohere-transcribe.sh
-  rm -rf sherpa-onnx-cohere-transcribe-*
-fi
+./run-cohere-transcribe.sh
+rm -rf sherpa-onnx-cohere-transcribe-*
 
 ./run-qwen3-asr.sh
 rm -rf sherpa-onnx-qwen3-*

--- a/.github/workflows/test-rust-package-static.yaml
+++ b/.github/workflows/test-rust-package-static.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-15-intel, ubuntu-22.04-arm, windows-latest]
+        os: [ubuntu-latest, macos-latest, macos-15-intel, ubuntu-22.04-arm, windows-latest, windows-11-arm]
         lib_setup: [explicit, auto]
 
     steps:
@@ -26,10 +26,13 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
+          targets: ${{ matrix.os == 'windows-11-arm' && 'aarch64-pc-windows-msvc' || '' }}
 
       - name: Set up MSVC
-        if: matrix.os == 'windows-latest'
+        if: startsWith(matrix.os, 'windows')
         uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.os == 'windows-11-arm' && 'amd64_arm64' || 'x64' }}
 
       - name: Select MSVC linker
         if: matrix.os == 'windows-latest'
@@ -70,6 +73,8 @@ jobs:
             d=sherpa-onnx-v$SHERPA_ONNX_VERSION-linux-aarch64-static-lib
           elif [[ "${{ matrix.os }}" == "windows-latest" ]]; then
             d=sherpa-onnx-v$SHERPA_ONNX_VERSION-win-x64-static-MT-Release-lib
+          elif [[ "${{ matrix.os }}" == "windows-11-arm" ]]; then
+            d=sherpa-onnx-v$SHERPA_ONNX_VERSION-win-arm64-static-MT-Release-lib
           else
             echo "Unknown ${{ matrix.os }}"
             exit 1
@@ -93,6 +98,10 @@ jobs:
 
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
             echo "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER: $CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER"
+          fi
+
+          if [[ "${{ matrix.os }}" == "windows-11-arm" ]]; then
+            echo "CARGO_TARGET_AARCH64_PC_WINDOWS_MSVC_LINKER: $CARGO_TARGET_AARCH64_PC_WINDOWS_MSVC_LINKER"
           fi
 
       - name: Run static tests

--- a/.github/workflows/test-rust-package-static.yaml
+++ b/.github/workflows/test-rust-package-static.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          targets: ${{ matrix.os == 'windows-11-arm' && 'aarch64-pc-windows-msvc' || '' }}
+          target: ${{ matrix.os == 'windows-11-arm' && 'aarch64-pc-windows-msvc' || '' }}
 
       - name: Set up MSVC
         if: startsWith(matrix.os, 'windows')
@@ -35,14 +35,20 @@ jobs:
           arch: ${{ matrix.os == 'windows-11-arm' && 'amd64_arm64' || 'x64' }}
 
       - name: Select MSVC linker
-        if: matrix.os == 'windows-latest'
+        if: startsWith(matrix.os, 'windows')
         shell: pwsh
         run: |
-          $linker = Join-Path $env:VCToolsInstallDir 'bin\HostX64\x64\link.exe'
+          if ("${{ matrix.os }}" -eq "windows-11-arm") {
+            $linker = Join-Path $env:VCToolsInstallDir 'bin\HostX64\ARM64\link.exe'
+            $env_var = "CARGO_TARGET_AARCH64_PC_WINDOWS_MSVC_LINKER"
+          } else {
+            $linker = Join-Path $env:VCToolsInstallDir 'bin\HostX64\x64\link.exe'
+            $env_var = "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER"
+          }
           if (-not (Test-Path $linker)) {
             throw "MSVC linker not found: $linker"
           }
-          "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$linker" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "$env_var=$linker" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Host "Using linker: $linker"
           & where.exe link
 

--- a/.github/workflows/test-rust-package.yaml
+++ b/.github/workflows/test-rust-package.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          targets: ${{ matrix.os == 'windows-11-arm' && 'aarch64-pc-windows-msvc' || '' }}
+          target: ${{ matrix.os == 'windows-11-arm' && 'aarch64-pc-windows-msvc' || '' }}
 
       - name: Set up MSVC
         if: startsWith(matrix.os, 'windows')
@@ -35,14 +35,20 @@ jobs:
           arch: ${{ matrix.os == 'windows-11-arm' && 'amd64_arm64' || 'x64' }}
 
       - name: Select MSVC linker
-        if: matrix.os == 'windows-latest'
+        if: startsWith(matrix.os, 'windows')
         shell: pwsh
         run: |
-          $linker = Join-Path $env:VCToolsInstallDir 'bin\HostX64\x64\link.exe'
+          if ("${{ matrix.os }}" -eq "windows-11-arm") {
+            $linker = Join-Path $env:VCToolsInstallDir 'bin\HostX64\ARM64\link.exe'
+            $env_var = "CARGO_TARGET_AARCH64_PC_WINDOWS_MSVC_LINKER"
+          } else {
+            $linker = Join-Path $env:VCToolsInstallDir 'bin\HostX64\x64\link.exe'
+            $env_var = "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER"
+          }
           if (-not (Test-Path $linker)) {
             throw "MSVC linker not found: $linker"
           }
-          "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$linker" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "$env_var=$linker" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Host "Using linker: $linker"
           & where.exe link
 

--- a/.github/workflows/test-rust-package.yaml
+++ b/.github/workflows/test-rust-package.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-15-intel, ubuntu-22.04-arm, windows-latest]
+        os: [ubuntu-latest, macos-latest, macos-15-intel, ubuntu-22.04-arm, windows-latest, windows-11-arm]
         lib_setup: [explicit, auto]
 
     steps:
@@ -26,10 +26,13 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
+          targets: ${{ matrix.os == 'windows-11-arm' && 'aarch64-pc-windows-msvc' || '' }}
 
       - name: Set up MSVC
-        if: matrix.os == 'windows-latest'
+        if: startsWith(matrix.os, 'windows')
         uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.os == 'windows-11-arm' && 'amd64_arm64' || 'x64' }}
 
       - name: Select MSVC linker
         if: matrix.os == 'windows-latest'
@@ -70,6 +73,8 @@ jobs:
             d=sherpa-onnx-v$SHERPA_ONNX_VERSION-linux-aarch64-shared-cpu-lib
           elif [[ "${{ matrix.os }}" == "windows-latest" ]]; then
             d=sherpa-onnx-v$SHERPA_ONNX_VERSION-win-x64-shared-MT-Release-lib
+          elif [[ "${{ matrix.os }}" == "windows-11-arm" ]]; then
+            d=sherpa-onnx-v$SHERPA_ONNX_VERSION-win-arm64-shared-MT-Release-lib
           else
             echo "Unknown ${{ matrix.os }}"
             exit 1
@@ -106,6 +111,10 @@ jobs:
 
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
             echo "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER: $CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER"
+          fi
+
+          if [[ "${{ matrix.os }}" == "windows-11-arm" ]]; then
+            echo "CARGO_TARGET_AARCH64_PC_WINDOWS_MSVC_LINKER: $CARGO_TARGET_AARCH64_PC_WINDOWS_MSVC_LINKER"
           fi
 
       - name: Run shared tests

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -110,43 +110,6 @@ jobs:
           fi
           ls -lh install/lib
 
-      - name: Check for duplicate symbols in static libs
-        if: matrix.link_mode == 'static' && !startsWith(matrix.os, 'windows')
-        shell: bash
-        run: |
-          lib_dir="$PWD/build/install/lib"
-          echo "=== Checking for duplicate symbols between piper_phonemize and espeak-ng ==="
-
-          # Get defined (T) symbols from each library
-          nm --defined-only -g "$lib_dir/libpiper_phonemize.a" 2>/dev/null | awk '{print $3}' | sort -u > /tmp/piper_syms.txt
-          nm --defined-only -g "$lib_dir/libespeak-ng.a" 2>/dev/null | awk '{print $3}' | sort -u > /tmp/espeak_syms.txt
-
-          echo "piper_phonemize symbols: $(wc -l < /tmp/piper_syms.txt)"
-          echo "espeak-ng symbols: $(wc -l < /tmp/espeak_syms.txt)"
-
-          dups=$(comm -12 /tmp/piper_syms.txt /tmp/espeak_syms.txt)
-          dup_count=$(echo "$dups" | grep -c . || true)
-          echo "Duplicate symbols: $dup_count"
-          if [[ $dup_count -gt 0 ]]; then
-            echo "First 30 duplicates:"
-            echo "$dups" | head -30
-          fi
-
-          echo ""
-          echo "=== Checking all static libs for duplicate symbols ==="
-          for a in "$lib_dir"/*.a; do
-            for b in "$lib_dir"/*.a; do
-              [[ "$a" < "$b" ]] || continue
-              nm --defined-only -g "$a" 2>/dev/null | awk '{print $3}' | sort -u > /tmp/a_syms.txt
-              nm --defined-only -g "$b" 2>/dev/null | awk '{print $3}' | sort -u > /tmp/b_syms.txt
-              count=$(comm -12 /tmp/a_syms.txt /tmp/b_syms.txt | wc -l)
-              if [[ $count -gt 0 ]]; then
-                echo "$(basename "$a") <-> $(basename "$b"): $count duplicates"
-                comm -12 /tmp/a_syms.txt /tmp/b_syms.txt | head -5
-              fi
-            done
-          done
-
       - name: Set library paths
         shell: bash
         run: |

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -110,6 +110,43 @@ jobs:
           fi
           ls -lh install/lib
 
+      - name: Check for duplicate symbols in static libs
+        if: matrix.link_mode == 'static' && !startsWith(matrix.os, 'windows')
+        shell: bash
+        run: |
+          lib_dir="$PWD/build/install/lib"
+          echo "=== Checking for duplicate symbols between piper_phonemize and espeak-ng ==="
+
+          # Get defined (T) symbols from each library
+          nm --defined-only -g "$lib_dir/libpiper_phonemize.a" 2>/dev/null | awk '{print $3}' | sort -u > /tmp/piper_syms.txt
+          nm --defined-only -g "$lib_dir/libespeak-ng.a" 2>/dev/null | awk '{print $3}' | sort -u > /tmp/espeak_syms.txt
+
+          echo "piper_phonemize symbols: $(wc -l < /tmp/piper_syms.txt)"
+          echo "espeak-ng symbols: $(wc -l < /tmp/espeak_syms.txt)"
+
+          dups=$(comm -12 /tmp/piper_syms.txt /tmp/espeak_syms.txt)
+          dup_count=$(echo "$dups" | grep -c . || true)
+          echo "Duplicate symbols: $dup_count"
+          if [[ $dup_count -gt 0 ]]; then
+            echo "First 30 duplicates:"
+            echo "$dups" | head -30
+          fi
+
+          echo ""
+          echo "=== Checking all static libs for duplicate symbols ==="
+          for a in "$lib_dir"/*.a; do
+            for b in "$lib_dir"/*.a; do
+              [[ "$a" < "$b" ]] || continue
+              nm --defined-only -g "$a" 2>/dev/null | awk '{print $3}' | sort -u > /tmp/a_syms.txt
+              nm --defined-only -g "$b" 2>/dev/null | awk '{print $3}' | sort -u > /tmp/b_syms.txt
+              count=$(comm -12 /tmp/a_syms.txt /tmp/b_syms.txt | wc -l)
+              if [[ $count -gt 0 ]]; then
+                echo "$(basename "$a") <-> $(basename "$b"): $count duplicates"
+                comm -12 /tmp/a_syms.txt /tmp/b_syms.txt | head -5
+              fi
+            done
+          done
+
       - name: Set library paths
         shell: bash
         run: |
@@ -197,6 +234,8 @@ jobs:
 
       - name: Run test
         shell: bash
+        env:
+          SHERPA_ONNX_SKIP_COHERE_TRANSCRIBE: ${{ matrix.os == 'ubuntu-latest' && matrix.link_mode == 'static' && '1' || '0' }}
         run: |
           if [[ "${{ matrix.link_mode }}" == "shared" ]]; then
             ./.github/scripts/test-rust-shared.sh

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -30,6 +30,13 @@ jobs:
         with:
           key: ${{ matrix.os }}-rust-${{ matrix.link_mode }}
 
+      - name: Cache installed libs
+        id: cache-libs
+        uses: actions/cache@v4
+        with:
+          path: build/install
+          key: rust-libs-${{ matrix.os }}-${{ matrix.link_mode }}-${{ hashFiles('CMakeLists.txt') }}
+
       - name: Update version
         shell: bash
         run: |
@@ -43,6 +50,7 @@ jobs:
           arch: ${{ matrix.os == 'windows-11-arm' && 'amd64_arm64' || 'x64' }}
 
       - name: Configure sherpa-onnx
+        if: steps.cache-libs.outputs.cache-hit != 'true'
         shell: bash
         run: |
           export CMAKE_CXX_COMPILER_LAUNCHER=ccache
@@ -85,6 +93,7 @@ jobs:
           fi
 
       - name: Build sherpa-onnx
+        if: steps.cache-libs.outputs.cache-hit != 'true'
         shell: bash
         run: |
           export CMAKE_CXX_COMPILER_LAUNCHER=ccache
@@ -101,23 +110,44 @@ jobs:
           fi
           ls -lh install/lib
 
-          echo "SHERPA_ONNX_LIB_DIR=$PWD/install/lib" >> "$GITHUB_ENV"
+      - name: Set library paths
+        shell: bash
+        run: |
+          echo "SHERPA_ONNX_LIB_DIR=$PWD/build/install/lib" >> "$GITHUB_ENV"
 
           if [[ "${{ matrix.link_mode }}" == "shared" ]]; then
             if [[ "${{ matrix.os }}" == ubuntu-* ]]; then
-              echo "LD_LIBRARY_PATH=$PWD/install/lib:\$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+              echo "LD_LIBRARY_PATH=$PWD/build/install/lib:\$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
             elif [[ "${{ matrix.os }}" == macos-* ]]; then
-              echo "DYLD_LIBRARY_PATH=$PWD/install/lib:\$DYLD_LIBRARY_PATH" >> "$GITHUB_ENV"
+              echo "DYLD_LIBRARY_PATH=$PWD/build/install/lib:\$DYLD_LIBRARY_PATH" >> "$GITHUB_ENV"
             elif [[ "${{ matrix.os }}" == windows-* ]]; then
               # Copy DLLs next to the test binary so the linker can find them
-              cp -v install/bin/*.dll install/lib/ 2>/dev/null || true
+              cp -v build/install/bin/*.dll build/install/lib/ 2>/dev/null || true
             fi
           fi
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          targets: ${{ matrix.os == 'windows-11-arm' && 'aarch64-pc-windows-msvc' || '' }}
+          target: ${{ matrix.os == 'windows-11-arm' && 'aarch64-pc-windows-msvc' || '' }}
+
+      - name: Select MSVC linker
+        if: startsWith(matrix.os, 'windows')
+        shell: pwsh
+        run: |
+          if ("${{ matrix.os }}" -eq "windows-11-arm") {
+            $linker = Join-Path $env:VCToolsInstallDir 'bin\HostX64\ARM64\link.exe'
+            $env_var = "CARGO_TARGET_AARCH64_PC_WINDOWS_MSVC_LINKER"
+          } else {
+            $linker = Join-Path $env:VCToolsInstallDir 'bin\HostX64\x64\link.exe'
+            $env_var = "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER"
+          }
+          if (-not (Test-Path $linker)) {
+            throw "MSVC linker not found: $linker"
+          }
+          "$env_var=$linker" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Host "Using linker: $linker"
+          & where.exe link
 
       - name: Show libs
         shell: bash

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -19,13 +19,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-15-intel, ubuntu-22.04-arm]
+        os: [ubuntu-latest, macos-latest, macos-15-intel, ubuntu-22.04-arm, windows-latest, windows-11-arm]
         link_mode: [shared, static]
-        exclude:
-          - os: ubuntu-latest
-            link_mode: static
-          - os: ubuntu-22.04-arm
-            link_mode: static
 
     steps:
       - uses: actions/checkout@v4
@@ -40,6 +35,12 @@ jobs:
         run: |
           ./new-release.sh
           git diff .
+
+      - name: Set up MSVC
+        if: startsWith(matrix.os, 'windows')
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.os == 'windows-11-arm' && 'amd64_arm64' || 'x64' }}
 
       - name: Configure sherpa-onnx
         shell: bash
@@ -57,11 +58,31 @@ jobs:
             build_shared_libs=OFF
           fi
 
-          cmake \
-            -D SHERPA_ONNX_ENABLE_BINARY=OFF \
-            -D BUILD_SHARED_LIBS=$build_shared_libs \
-            -D CMAKE_INSTALL_PREFIX=./install \
-            ..
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            cmake \
+              -A x64 \
+              -D SHERPA_ONNX_ENABLE_BINARY=OFF \
+              -D BUILD_SHARED_LIBS=$build_shared_libs \
+              -D SHERPA_ONNX_USE_STATIC_CRT=ON \
+              -D SHERPA_ONNX_ENABLE_PORTAUDIO=OFF \
+              -D CMAKE_INSTALL_PREFIX=./install \
+              ..
+          elif [[ "${{ matrix.os }}" == "windows-11-arm" ]]; then
+            cmake \
+              -A ARM64 \
+              -D SHERPA_ONNX_ENABLE_BINARY=OFF \
+              -D BUILD_SHARED_LIBS=$build_shared_libs \
+              -D SHERPA_ONNX_USE_STATIC_CRT=ON \
+              -D SHERPA_ONNX_ENABLE_PORTAUDIO=OFF \
+              -D CMAKE_INSTALL_PREFIX=./install \
+              ..
+          else
+            cmake \
+              -D SHERPA_ONNX_ENABLE_BINARY=OFF \
+              -D BUILD_SHARED_LIBS=$build_shared_libs \
+              -D CMAKE_INSTALL_PREFIX=./install \
+              ..
+          fi
 
       - name: Build sherpa-onnx
         shell: bash
@@ -71,8 +92,13 @@ jobs:
           cmake --version
 
           cd build
-          make -j2
-          make install
+          if [[ "${{ matrix.os }}" == windows-* ]]; then
+            cmake --build . --config Release -- -m:2
+            cmake --build . --config Release --target install -- -m:2
+          else
+            make -j2
+            make install
+          fi
           ls -lh install/lib
 
           echo "SHERPA_ONNX_LIB_DIR=$PWD/install/lib" >> "$GITHUB_ENV"
@@ -82,12 +108,16 @@ jobs:
               echo "LD_LIBRARY_PATH=$PWD/install/lib:\$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
             elif [[ "${{ matrix.os }}" == macos-* ]]; then
               echo "DYLD_LIBRARY_PATH=$PWD/install/lib:\$DYLD_LIBRARY_PATH" >> "$GITHUB_ENV"
+            elif [[ "${{ matrix.os }}" == windows-* ]]; then
+              # Copy DLLs next to the test binary so the linker can find them
+              cp -v install/bin/*.dll install/lib/ 2>/dev/null || true
             fi
           fi
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
+          targets: ${{ matrix.os == 'windows-11-arm' && 'aarch64-pc-windows-msvc' || '' }}
 
       - name: Show libs
         shell: bash

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -21,6 +21,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, macos-15-intel, ubuntu-22.04-arm, windows-latest, windows-11-arm]
         link_mode: [shared, static]
+        exclude:
+          # Static linking on x86_64 Linux crashes with "free(): invalid pointer"
+          - os: ubuntu-latest
+            link_mode: static
 
     steps:
       - uses: actions/checkout@v4
@@ -197,8 +201,6 @@ jobs:
 
       - name: Run test
         shell: bash
-        env:
-          SHERPA_ONNX_SKIP_COHERE_TRANSCRIBE: ${{ matrix.os == 'ubuntu-latest' && matrix.link_mode == 'static' && '1' || '0' }}
         run: |
           if [[ "${{ matrix.link_mode }}" == "shared" ]]; then
             ./.github/scripts/test-rust-shared.sh

--- a/rust-api-examples/Cargo.lock
+++ b/rust-api-examples/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "rust-api-examples"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -1010,9 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "sherpa-onnx"
-version = "1.13.5"
+version = "1.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "352a5dbbd9623e800be27e77de514e87fcfe2120256acc4434e6ea87a56bc885"
+checksum = "93440301c4240bd5d83496ab9adeee889be48d9428f9c01c37e5ae4ef33ba9e2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1021,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "sherpa-onnx-sys"
-version = "1.13.5"
+version = "1.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1541926ecf70b3d806467a2f100d3d879eef7fd34f8b307028bb074871d7493"
+checksum = "4d627abc4624c845e628ad87cca4ff9ac265fc643021d155f2721ac589eeb324"
 dependencies = [
  "bzip2",
  "tar",

--- a/rust-api-examples/for-advanced-users.md
+++ b/rust-api-examples/for-advanced-users.md
@@ -47,6 +47,7 @@ Most users just get this behavior automatically.
 | macOS | x86_64 | `sherpa-onnx-v1.13.6-osx-x64-static-lib.tar.bz2` |
 | macOS | arm64 | `sherpa-onnx-v1.13.6-osx-arm64-static-lib.tar.bz2` |
 | Windows | x86_64 | `sherpa-onnx-v1.13.6-win-x64-static-MT-Release-lib.tar.bz2` |
+| Windows | arm64 | `sherpa-onnx-v1.13.6-win-arm64-static-MT-Release-lib.tar.bz2` |
 
 ### Shared mode
 
@@ -60,6 +61,7 @@ archives instead:
 | macOS | x86_64 | `sherpa-onnx-v1.13.6-osx-x64-shared-lib.tar.bz2` |
 | macOS | arm64 | `sherpa-onnx-v1.13.6-osx-arm64-shared-lib.tar.bz2` |
 | Windows | x86_64 | `sherpa-onnx-v1.13.6-win-x64-shared-MT-Release-lib.tar.bz2` |
+| Windows | arm64 | `sherpa-onnx-v1.13.6-win-arm64-shared-MT-Release-lib.tar.bz2` |
 
 In practice, use the latest release tag instead of the example version above.
 

--- a/sherpa-onnx/rust/sherpa-onnx-sys/build.rs
+++ b/sherpa-onnx/rust/sherpa-onnx-sys/build.rs
@@ -244,6 +244,9 @@ fn archive_name(
         (LinkMode::Static, "windows", "x86_64") => {
             format!("sherpa-onnx-v{version}-win-x64-static-MT-Release-lib.tar.bz2")
         }
+        (LinkMode::Static, "windows", "aarch64") => {
+            format!("sherpa-onnx-v{version}-win-arm64-static-MT-Release-lib.tar.bz2")
+        }
         (LinkMode::Shared, "linux", "x86_64") => {
             format!("sherpa-onnx-v{version}-linux-x64-shared-lib.tar.bz2")
         }
@@ -258,6 +261,9 @@ fn archive_name(
         }
         (LinkMode::Shared, "windows", "x86_64") => {
             format!("sherpa-onnx-v{version}-win-x64-shared-MT-Release-lib.tar.bz2")
+        }
+        (LinkMode::Shared, "windows", "aarch64") => {
+            format!("sherpa-onnx-v{version}-win-arm64-shared-MT-Release-lib.tar.bz2")
         }
         // Android: one archive with all ABIs under jniLibs/{abi}/.
         (LinkMode::Shared, "android", "aarch64" | "arm" | "x86" | "x86_64") => {

--- a/sherpa-onnx/rust/sherpa-onnx/src/lib.rs
+++ b/sherpa-onnx/rust/sherpa-onnx/src/lib.rs
@@ -67,6 +67,8 @@
 //!   [sherpa-onnx-v1.13.6-osx-arm64-static-lib.tar.bz2](https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.13.6/sherpa-onnx-v1.13.6-osx-arm64-static-lib.tar.bz2)
 //! - Windows x64:
 //!   [sherpa-onnx-v1.13.6-win-x64-static-MT-Release-lib.tar.bz2](https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.13.6/sherpa-onnx-v1.13.6-win-x64-static-MT-Release-lib.tar.bz2)
+//! - Windows arm64:
+//!   [sherpa-onnx-v1.13.6-win-arm64-static-MT-Release-lib.tar.bz2](https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.13.6/sherpa-onnx-v1.13.6-win-arm64-static-MT-Release-lib.tar.bz2)
 //!
 //! Optional shared archives:
 //!
@@ -80,6 +82,8 @@
 //!   [sherpa-onnx-v1.13.6-osx-arm64-shared-lib.tar.bz2](https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.13.6/sherpa-onnx-v1.13.6-osx-arm64-shared-lib.tar.bz2)
 //! - Windows x64:
 //!   [sherpa-onnx-v1.13.6-win-x64-shared-MT-Release-lib.tar.bz2](https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.13.6/sherpa-onnx-v1.13.6-win-x64-shared-MT-Release-lib.tar.bz2)
+//! - Windows arm64:
+//!   [sherpa-onnx-v1.13.6-win-arm64-shared-MT-Release-lib.tar.bz2](https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.13.6/sherpa-onnx-v1.13.6-win-arm64-shared-MT-Release-lib.tar.bz2)
 //!
 //! # How the Rust API is organized
 //!
@@ -97,19 +101,70 @@
 //!
 //! The repository contains end-to-end Rust examples under
 //! [`rust-api-examples/examples/`](https://github.com/k2-fsa/sherpa-onnx/tree/master/rust-api-examples/examples).
-//! Good entry points are:
 //!
-//! - [`sense_voice.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/sense_voice.rs)
+//! ## ASR
+//!
+//! - [`cohere_transcribe.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/cohere_transcribe.rs)
+//! - [`fire_red_asr_ctc.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/fire_red_asr_ctc.rs)
+//! - [`funasr_nano.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/funasr_nano.rs)
+//! - [`moonshine_v2.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/moonshine_v2.rs)
 //! - [`nemo_parakeet.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/nemo_parakeet.rs)
+//! - [`paraformer.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/paraformer.rs)
+//! - [`qwen3_asr.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/qwen3_asr.rs)
+//! - [`sense_voice.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/sense_voice.rs)
+//! - [`whisper.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/whisper.rs)
+//! - [`zipformer.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/zipformer.rs)
 //! - [`streaming_zipformer.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/streaming_zipformer.rs)
+//! - [`fire_red_asr_ctc_simulate_streaming_microphone.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/fire_red_asr_ctc_simulate_streaming_microphone.rs)
+//! - [`parakeet_tdt_ctc_simulate_streaming_microphone.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/parakeet_tdt_ctc_simulate_streaming_microphone.rs)
+//! - [`parakeet_tdt_simulate_streaming_microphone.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/parakeet_tdt_simulate_streaming_microphone.rs)
+//! - [`qwen3_asr_simulate_streaming_microphone.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/qwen3_asr_simulate_streaming_microphone.rs)
+//! - [`sense_voice_simulate_streaming_microphone.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/sense_voice_simulate_streaming_microphone.rs)
+//! - [`streaming_zipformer_microphone.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/streaming_zipformer_microphone.rs)
+//! - [`wenet_ctc_simulate_streaming_microphone.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/wenet_ctc_simulate_streaming_microphone.rs)
+//! - [`zipformer_ctc_simulate_streaming_microphone.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/zipformer_ctc_simulate_streaming_microphone.rs)
+//! - [`zipformer_transducer_simulate_streaming_microphone.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/zipformer_transducer_simulate_streaming_microphone.rs)
+//!
+//! ## TTS
+//!
+//! - [`kitten_tts_en.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/kitten_tts_en.rs)
+//! - [`kokoro_tts_en.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/kokoro_tts_en.rs)
+//! - [`kokoro_tts_zh_en.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/kokoro_tts_zh_en.rs)
+//! - [`matcha_tts_en.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/matcha_tts_en.rs)
+//! - [`matcha_tts_zh.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/matcha_tts_zh.rs)
 //! - [`pocket_tts.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/pocket_tts.rs)
+//! - [`supertonic_tts.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/supertonic_tts.rs)
+//! - [`vits_tts.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/vits_tts.rs)
+//! - [`zipvoice_tts.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/zipvoice_tts.rs)
+//!
+//! ## Audio tagging
+//!
+//! - [`audio_tagging_ced.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/audio_tagging_ced.rs)
+//! - [`audio_tagging_zipformer.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/audio_tagging_zipformer.rs)
+//!
+//! ## Speaker / diarization
+//!
+//! - [`speaker_embedding_cosine_similarity.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/speaker_embedding_cosine_similarity.rs)
+//! - [`speaker_embedding_extractor.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/speaker_embedding_extractor.rs)
+//! - [`speaker_embedding_manager.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/speaker_embedding_manager.rs)
+//! - [`offline_speaker_diarization.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/offline_speaker_diarization.rs)
+//! - [`spoken_language_identification.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/spoken_language_identification.rs)
+//!
+//! ## VAD / punctuation / enhancement / keyword spotting
+//!
 //! - [`silero_vad_remove_silence.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/silero_vad_remove_silence.rs)
+//! - [`ten_vad_remove_silence.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/ten_vad_remove_silence.rs)
 //! - [`online_punctuation.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/online_punctuation.rs)
 //! - [`offline_punctuation.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/offline_punctuation.rs)
+//! - [`offline_speech_enhancement_gtcrn.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/offline_speech_enhancement_gtcrn.rs)
+//! - [`offline_speech_enhancement_dpdfnet.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/offline_speech_enhancement_dpdfnet.rs)
+//! - [`streaming_speech_enhancement_gtcrn.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/streaming_speech_enhancement_gtcrn.rs)
+//! - [`streaming_speech_enhancement_dpdfnet.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/streaming_speech_enhancement_dpdfnet.rs)
 //! - [`keyword_spotter.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/keyword_spotter.rs)
-//! - [`spoken_language_identification.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/spoken_language_identification.rs)
-//! - [`offline_speaker_diarization.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/offline_speaker_diarization.rs)
-//! - [`speaker_embedding_manager.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/speaker_embedding_manager.rs)
+//!
+//! ## Misc
+//!
+//! - [`version.rs`](https://github.com/k2-fsa/sherpa-onnx/blob/master/rust-api-examples/examples/version.rs)
 //!
 //! # Offline recognition example
 //!


### PR DESCRIPTION
Fixes https://github.com/cislunarspace/altgo/issues/131

cc @cislunarspace


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for building and testing on Windows 11 ARM64.
  * Added Windows ARM64 prebuilt libraries for static and shared linking.
  * Expanded platform coverage to include macOS Intel.

* **Bug Fixes**
  * Improved architecture-specific build configuration, linker selection, library discovery, and caching.

* **Documentation**
  * Added Windows ARM64 archive examples and expanded categorized Rust API example guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->