### PR TITLE
Support per-stream runtime options (setOption/getOption/hasOption) in the JavaScript (node-addon) API for streaming ASR

### DIFF
--- a/.github/scripts/test-nodejs-addon-npm.sh
+++ b/.github/scripts/test-nodejs-addon-npm.sh
@@ -486,6 +486,16 @@ rm sherpa-onnx-streaming-paraformer-bilingual-zh-en.tar.bz2
 node ./test_asr_streaming_paraformer.js
 rm -rf sherpa-onnx-streaming-paraformer-bilingual-zh-en
 
+echo "----------streaming ASR Nemotron multilingual----------"
+
+curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-1120ms-int8-2026-06-11.tar.bz2
+tar xvf sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-1120ms-int8-2026-06-11.tar.bz2
+rm sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-1120ms-int8-2026-06-11.tar.bz2
+
+node ./test_asr_streaming_nemotron.js
+
+rm -rf sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-1120ms-int8-2026-06-11
+
 echo "----------non-streaming asr----------"
 
 curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-zipformer-en-2023-04-01.tar.bz2

--- a/harmony-os/SherpaOnnxHar/sherpa_onnx/src/main/cpp/streaming-asr.cc
+++ b/harmony-os/SherpaOnnxHar/sherpa_onnx/src/main/cpp/streaming-asr.cc
@@ -439,6 +439,116 @@ static void AcceptWaveformWrapper(const Napi::CallbackInfo &info) {
 #endif
 }
 
+static void OnlineStreamSetOptionWrapper(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+
+  if (info.Length() != 3) {
+    std::ostringstream os;
+    os << "Expect 3 arguments. Given: " << info.Length();
+
+    Napi::TypeError::New(env, os.str()).ThrowAsJavaScriptException();
+
+    return;
+  }
+
+  if (!info[0].IsExternal()) {
+    Napi::TypeError::New(env, "Argument 0 should be an online stream pointer.")
+        .ThrowAsJavaScriptException();
+
+    return;
+  }
+
+  if (!info[1].IsString() || !info[2].IsString()) {
+    Napi::TypeError::New(env, "Arguments 1 and 2 should be strings.")
+        .ThrowAsJavaScriptException();
+
+    return;
+  }
+
+  const SherpaOnnxOnlineStream *stream =
+      info[0].As<Napi::External<SherpaOnnxOnlineStream>>().Data();
+
+  std::string key = info[1].As<Napi::String>().Utf8Value();
+  std::string value = info[2].As<Napi::String>().Utf8Value();
+  SherpaOnnxOnlineStreamSetOption(stream, key.c_str(), value.c_str());
+}
+
+static Napi::String OnlineStreamGetOptionWrapper(
+    const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+
+  if (info.Length() != 2) {
+    std::ostringstream os;
+    os << "Expect only 2 arguments. Given: " << info.Length();
+
+    Napi::TypeError::New(env, os.str()).ThrowAsJavaScriptException();
+
+    return {};
+  }
+
+  if (!info[0].IsExternal()) {
+    Napi::TypeError::New(env, "Argument 0 should be an online stream pointer.")
+        .ThrowAsJavaScriptException();
+
+    return {};
+  }
+
+  if (!info[1].IsString()) {
+    Napi::TypeError::New(env, "Argument 1 should be a string.")
+        .ThrowAsJavaScriptException();
+
+    return {};
+  }
+
+  const SherpaOnnxOnlineStream *stream =
+      info[0].As<Napi::External<SherpaOnnxOnlineStream>>().Data();
+
+  std::string key = info[1].As<Napi::String>().Utf8Value();
+
+  // The returned pointer is owned by the stream and is an empty string if the
+  // option has not been set, so copy it into a JS string right away.
+  const char *value = SherpaOnnxOnlineStreamGetOption(stream, key.c_str());
+
+  return Napi::String::New(env, value ? value : "");
+}
+
+static Napi::Boolean OnlineStreamHasOptionWrapper(
+    const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+
+  if (info.Length() != 2) {
+    std::ostringstream os;
+    os << "Expect only 2 arguments. Given: " << info.Length();
+
+    Napi::TypeError::New(env, os.str()).ThrowAsJavaScriptException();
+
+    return {};
+  }
+
+  if (!info[0].IsExternal()) {
+    Napi::TypeError::New(env, "Argument 0 should be an online stream pointer.")
+        .ThrowAsJavaScriptException();
+
+    return {};
+  }
+
+  if (!info[1].IsString()) {
+    Napi::TypeError::New(env, "Argument 1 should be a string.")
+        .ThrowAsJavaScriptException();
+
+    return {};
+  }
+
+  const SherpaOnnxOnlineStream *stream =
+      info[0].As<Napi::External<SherpaOnnxOnlineStream>>().Data();
+
+  std::string key = info[1].As<Napi::String>().Utf8Value();
+
+  int32_t has_option = SherpaOnnxOnlineStreamHasOption(stream, key.c_str());
+
+  return Napi::Boolean::New(env, has_option);
+}
+
 static Napi::Boolean IsOnlineStreamReadyWrapper(
     const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
@@ -731,6 +841,15 @@ void InitStreamingAsr(Napi::Env env, Napi::Object exports) {
 
   exports.Set(Napi::String::New(env, "acceptWaveformOnline"),
               Napi::Function::New(env, AcceptWaveformWrapper));
+
+  exports.Set(Napi::String::New(env, "onlineStreamSetOption"),
+              Napi::Function::New(env, OnlineStreamSetOptionWrapper));
+
+  exports.Set(Napi::String::New(env, "onlineStreamGetOption"),
+              Napi::Function::New(env, OnlineStreamGetOptionWrapper));
+
+  exports.Set(Napi::String::New(env, "onlineStreamHasOption"),
+              Napi::Function::New(env, OnlineStreamHasOptionWrapper));
 
   exports.Set(Napi::String::New(env, "isOnlineStreamReady"),
               Napi::Function::New(env, IsOnlineStreamReadyWrapper));

--- a/nodejs-addon-examples/README.md
+++ b/nodejs-addon-examples/README.md
@@ -109,6 +109,7 @@ The following tables list the examples in this folder.
 |[./test_asr_streaming_ctc.js](./test_asr_streaming_ctc.js)| Streaming speech recognition from a file using a Zipformer CTC model with greedy search|
 |[./test_asr_streaming_ctc_hlg.js](./test_asr_streaming_ctc_hlg.js)| Streaming speech recognition from a file using a Zipformer CTC model with HLG decoding|
 |[./test_asr_streaming_paraformer.js](./test_asr_streaming_paraformer.js)|Streaming speech recognition from a file using a [Paraformer](https://github.com/alibaba-damo-academy/FunASR) model|
+|[./test_asr_streaming_nemotron.js](./test_asr_streaming_nemotron.js)|Streaming speech recognition from a file using a multilingual [NeMo](https://github.com/NVIDIA/NeMo) Nemotron transducer model with per-stream language pinning|
 
 ## Streaming speech-to-text from a microphone
 
@@ -293,6 +294,16 @@ node ./test_asr_streaming_transducer.js
 npm install node-cpal
 
 node ./test_asr_streaming_transducer_microphone.js
+```
+
+### Streaming speech recognition with multilingual Nemotron
+
+```bash
+wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-1120ms-int8-2026-06-11.tar.bz2
+tar xvf sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-1120ms-int8-2026-06-11.tar.bz2
+rm sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-1120ms-int8-2026-06-11.tar.bz2
+
+node ./test_asr_streaming_nemotron.js
 ```
 
 ### Streaming speech recognition with Zipformer CTC

--- a/nodejs-addon-examples/test_asr_streaming_nemotron.js
+++ b/nodejs-addon-examples/test_asr_streaming_nemotron.js
@@ -1,0 +1,66 @@
+// Copyright (c)  2026  Xiaomi Corporation
+const sherpa_onnx = require('sherpa-onnx-node');
+
+// This example shows streaming speech recognition with a multilingual
+// Nemotron transducer model and per-stream language pinning.
+//
+// Multilingual Nemotron models read the option 'language' from each stream
+// on every decode call, so streams of the same recognizer can be pinned to
+// different languages, and a stream can even switch language mid-session.
+// Leaving the option unset selects automatic language detection.
+// English-only Nemotron models ignore the option.
+//
+// Please download test files from
+// https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models
+
+const modelDir =
+    './sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-1120ms-int8-2026-06-11';
+
+const config = {
+  'featConfig': {
+    'sampleRate': 16000,
+    'featureDim': 128,
+  },
+  'modelConfig': {
+    'transducer': {
+      'encoder': `${modelDir}/encoder.int8.onnx`,
+      'decoder': `${modelDir}/decoder.int8.onnx`,
+      'joiner': `${modelDir}/joiner.int8.onnx`,
+    },
+    'tokens': `${modelDir}/tokens.txt`,
+    'numThreads': 2,
+    'provider': 'cpu',
+    'debug': 1,
+  }
+};
+
+const recognizer = new sherpa_onnx.OnlineRecognizer(config);
+
+function decode(waveFilename, language) {
+  const stream = recognizer.createStream();
+  if (language !== undefined) {
+    stream.setOption('language', language);
+  }
+  console.log(
+      `hasOption('language'): ${stream.hasOption('language')},`,
+      `getOption('language'): '${stream.getOption('language')}'`);
+
+  const wave = sherpa_onnx.readWave(waveFilename);
+  stream.acceptWaveform({sampleRate: wave.sampleRate, samples: wave.samples});
+
+  const tailPadding = new Float32Array(wave.sampleRate * 0.4);
+  stream.acceptWaveform({samples: tailPadding, sampleRate: wave.sampleRate});
+  stream.inputFinished();
+
+  while (recognizer.isReady(stream)) {
+    recognizer.decode(stream);
+  }
+  return recognizer.getResult(stream).text;
+}
+
+// Streams of the same recognizer, each pinned to its own language.
+console.log('de pinned:', decode(`${modelDir}/test_wavs/de.wav`, 'de'));
+console.log('es pinned:', decode(`${modelDir}/test_wavs/es.wav`, 'es'));
+
+// Leaving the option unset selects automatic language detection.
+console.log('auto:', decode(`${modelDir}/test_wavs/de.wav`));

--- a/scripts/node-addon-api/lib/streaming-asr.js
+++ b/scripts/node-addon-api/lib/streaming-asr.js
@@ -53,6 +53,40 @@ class OnlineStream {
   inputFinished() {
     addon.inputFinished(this.handle)
   }
+
+  /**
+   * Set a string option on the underlying online stream.
+   *
+   * For example, multilingual streaming Nemotron models read the option
+   * 'language' (e.g. 'en', 'de') from each stream on every decode call;
+   * leaving it unset selects automatic language detection.
+   * @param {string} key
+   * @param {string} value
+   */
+  setOption(key, value) {
+    addon.onlineStreamSetOption(this.handle, key, value);
+  }
+
+  /**
+   * Get a string option of the underlying online stream.
+   *
+   * Returns an empty string if the option has not been set; use hasOption()
+   * to distinguish an unset option from an empty value.
+   * @param {string} key
+   * @returns {string}
+   */
+  getOption(key) {
+    return addon.onlineStreamGetOption(this.handle, key);
+  }
+
+  /**
+   * Check whether an option has been set on the underlying online stream.
+   * @param {string} key
+   * @returns {boolean}
+   */
+  hasOption(key) {
+    return addon.onlineStreamHasOption(this.handle, key);
+  }
 }
 
 /**


### PR DESCRIPTION
## What this PR does

The C API has exported `SherpaOnnxOnlineStreamSetOption` / `GetOption` / `HasOption` since the SetOption series (#3307–#3315), and the streaming NeMo (Nemotron) recognizer reads the per-stream option `"language"` on every decode call (`GetLanguagePromptIds` in `online-recognizer-transducer-nemo-impl.h`). #3458 exposed the offline twin (`offlineStreamSetOption`) to JavaScript, but the node addon's `OnlineStream` was skipped — and `SherpaOnnxOnlineModelConfig` has no language field, so `sherpa-onnx-node` users of the multilingual streaming Nemotron models currently cannot select a language at all.

This PR binds the three online-stream option functions in the node addon and surfaces them on `OnlineStream`:

```js
const stream = recognizer.createStream();
stream.setOption('language', 'de');  // pin this stream to German
stream.hasOption('language');        // true
stream.getOption('language');        // 'de'
```

Because the option is re-read on each decode call, a stream can switch language mid-session without recreating the recognizer, and different streams of the same recognizer can be pinned to different languages.

Downstream context: FreeShow, an open-source church presentation app with an AI scripture feature under review (ChurchApps/FreeShow#3579), ships this exact multilingual Nemotron export via sherpa-onnx-node and needs to pin the congregation's language per stream.

## Changes

- `harmony-os/SherpaOnnxHar/sherpa_onnx/src/main/cpp/streaming-asr.cc` (shared with `scripts/node-addon-api/src/` via the existing symlink): add `OnlineStreamSetOptionWrapper` / `OnlineStreamGetOptionWrapper` / `OnlineStreamHasOptionWrapper`, mirroring `OfflineStreamSetOptionWrapper` in `non-streaming-asr.cc`, registered as `onlineStreamSetOption` / `onlineStreamGetOption` / `onlineStreamHasOption`.
- `scripts/node-addon-api/lib/streaming-asr.js`: add `OnlineStream.setOption()` / `getOption()` / `hasOption()`.
- `nodejs-addon-examples/test_asr_streaming_nemotron.js`: new example decoding the multilingual streaming Nemotron model with per-stream language pinning (German and Spanish streams of one recognizer, plus automatic detection).
- `nodejs-addon-examples/README.md`: table entry and run instructions for the new example.
- `.github/scripts/test-nodejs-addon-npm.sh`: run the new example. The tarball is ~453 MB — the same order as the parakeet/canary blocks already in this script — happy to drop this block if you prefer to keep CI lighter.

## Example output

From `node ./test_asr_streaming_nemotron.js` with `sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-1120ms-int8-2026-06-11`:

```
hasOption('language'): true, getOption('language'): 'de'
de pinned: hat ein Ende, nur die Wurst
hasOption('language'): true, getOption('language'): 'es'
es pinned: preguntas que puede hacer tu país por ti.  Pregunta qué puedes hacer tú por tu país
hasOption('language'): false, getOption('language'): ''
auto: hat ein Ende, nur die Wurst
```

## Notes

- Backward compatible: only adds new exports and methods.
- `getOption` returns `''` for an option that has not been set, matching the C/C++ semantics (`OnlineStream::GetOption`); `hasOption` disambiguates. The binding copies the stream-owned pointer into a JS string immediately.
- English-only Nemotron models ignore the `language` option (`IsMultilingual` guard) and unknown keys are decoding no-ops, so the new API is safe on all models.
- The C API example `c-api-examples/streaming-nemotron-c-api.c` already demonstrates the same option in C; this brings the node addon to parity with the Flutter/WASM/.NET/Go/Swift/Rust bindings, which all expose it.
- Tested by building the macOS arm64 addon from this branch (cmake flags from `test-nodejs-addon-api.yaml`, then `cmake-js compile`) and running the new example against the released 1120ms int8 tarball (output above). Additionally verified: per-stream isolation (two interleaved streams of one recognizer pinned to different languages match their single-stream results exactly) and mid-stream language switching. `npm run typecheck` passes. Note the node-addon CI workflows do not run on pull requests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for setting, retrieving, and checking streaming recognition options.
  * Added multilingual Nemotron streaming speech recognition support, including optional language selection and automatic language detection.
  * Added a runnable example for German and Spanish transcription.

* **Documentation**
  * Updated usage examples with setup and execution instructions for the multilingual Nemotron model.

* **Tests**
  * Added automated coverage for Nemotron streaming speech recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->