### PR TITLE
Expose num_trailing_blanks in the online recognizer result JSON

### DIFF
--- a/scripts/node-addon-api/lib/types.js
+++ b/scripts/node-addon-api/lib/types.js
@@ -739,6 +739,7 @@
  * @property {number[]} context_scores
  * @property {number} segment
  * @property {number[]} words
+ * @property {number} num_trailing_blanks
  * @property {number} start_time
  * @property {boolean} is_final
  * @property {boolean} is_eof

--- a/sherpa-onnx/csrc/online-recognizer-ctc-impl.h
+++ b/sherpa-onnx/csrc/online-recognizer-ctc-impl.h
@@ -66,6 +66,7 @@ static OnlineRecognizerResult ConvertCtc(const OnlineCtcDecoderResult &src,
     r.timestamps.push_back(time);
   }
 
+  r.num_trailing_blanks = src.num_trailing_blanks;
   r.segment = segment;
   r.words = std::move(src.words);
   r.start_time = frames_since_start * frame_shift_ms / 1000.;

--- a/sherpa-onnx/csrc/online-recognizer-transducer-impl.h
+++ b/sherpa-onnx/csrc/online-recognizer-transducer-impl.h
@@ -79,6 +79,7 @@ OnlineRecognizerResult Convert(const OnlineTransducerDecoderResult &src,
   r.ys_probs = std::move(src.ys_probs);
   r.lm_probs = std::move(src.lm_probs);
   r.context_scores = std::move(src.context_scores);
+  r.num_trailing_blanks = src.num_trailing_blanks;
 
   r.segment = segment;
   r.start_time = frames_since_start * frame_shift_ms / 1000.;

--- a/sherpa-onnx/csrc/online-recognizer.cc
+++ b/sherpa-onnx/csrc/online-recognizer.cc
@@ -76,6 +76,7 @@ std::string OnlineRecognizerResult::AsJsonString() const {
   os << "\"context_scores\": " << VecToString(context_scores, 6) << ", ";
   os << "\"segment\": " << segment << ", ";
   os << "\"words\": " << VecToString(words, 0) << ", ";
+  os << "\"num_trailing_blanks\": " << num_trailing_blanks << ", ";
   os << "\"start_time\": " << std::fixed << std::setprecision(2) << start_time
      << ", ";
   os << "\"is_final\": " << (is_final ? "true" : "false") << ", ";

--- a/sherpa-onnx/csrc/online-recognizer.h
+++ b/sherpa-onnx/csrc/online-recognizer.h
@@ -45,13 +45,6 @@ struct OnlineRecognizerResult {
 
   std::vector<int32_t> words;
 
-  /// Number of trailing blank frames the decoder has seen after the last
-  /// non-blank token, measured at the model's output frame rate (i.e., after
-  /// subsampling). It is reset to 0 whenever a non-blank token is emitted.
-  /// It stays 0 for decoders that do not track it (e.g., streaming
-  /// Paraformer).
-  int32_t num_trailing_blanks = 0;
-
   /// ID of this segment
   /// When an endpoint is detected, it is incremented
   int32_t segment = 0;
@@ -67,6 +60,15 @@ struct OnlineRecognizerResult {
   /// used only in ./online-websocket-server-impl.cc
   /// If it is true, it means the server has processed all received samples
   bool is_eof = false;
+
+  /// Number of trailing blank frames the decoder has seen after the last
+  /// non-blank token, measured at the model's output frame rate (i.e., after
+  /// subsampling). It is reset to 0 whenever a non-blank token is emitted.
+  /// It stays 0 for decoders that do not track it (e.g., streaming
+  /// Paraformer).
+  /// Note: appended after the existing members so that positional aggregate
+  /// initialization of this struct keeps working.
+  int32_t num_trailing_blanks = 0;
 
   /** Return a json string.
    *

--- a/sherpa-onnx/csrc/online-recognizer.h
+++ b/sherpa-onnx/csrc/online-recognizer.h
@@ -45,6 +45,13 @@ struct OnlineRecognizerResult {
 
   std::vector<int32_t> words;
 
+  /// Number of trailing blank frames the decoder has seen after the last
+  /// non-blank token, measured at the model's output frame rate (i.e., after
+  /// subsampling). It is reset to 0 whenever a non-blank token is emitted.
+  /// It stays 0 for decoders that do not track it (e.g., streaming
+  /// Paraformer).
+  int32_t num_trailing_blanks = 0;
+
   /// ID of this segment
   /// When an endpoint is detected, it is incremented
   int32_t segment = 0;
@@ -72,6 +79,8 @@ struct OnlineRecognizerResult {
    *     "lm_probs": [x, x, x],
    *     "context_scores": [x, x, x],
    *     "segment": x,
+   *     "words": [x, x, x],
+   *     "num_trailing_blanks": x,
    *     "start_time": x,
    *     "is_final": true|false
    *     "is_eof": true|false

--- a/sherpa-onnx/csrc/qnn/online-recognizer-nemo-transducer-qnn-impl.h
+++ b/sherpa-onnx/csrc/qnn/online-recognizer-nemo-transducer-qnn-impl.h
@@ -68,6 +68,7 @@ inline OnlineRecognizerResult ConvertResult(
     r.timestamps.push_back(frame_shift_s * t);
   }
 
+  r.num_trailing_blanks = src.num_trailing_blanks;
   r.segment = segment;
   r.start_time = frames_since_start * frame_shift_ms / 1000.f;
 

--- a/sherpa-onnx/csrc/qnn/online-recognizer-zipformer-transducer-qnn-impl.h
+++ b/sherpa-onnx/csrc/qnn/online-recognizer-zipformer-transducer-qnn-impl.h
@@ -93,6 +93,7 @@ inline OnlineRecognizerResult ConvertQnnResult(
     r.timestamps.push_back(frame_shift_s * t);
   }
 
+  r.num_trailing_blanks = src.num_trailing_blanks;
   r.segment = segment;
   r.start_time = frames_since_start * frame_shift_ms / 1000.f;
 
@@ -235,7 +236,8 @@ class OnlineRecognizerZipformerTransducerQnnImpl
         blank_id_(0),
         greedy_decoder_(blank_id_),
         modified_beam_search_decoder_(
-            blank_id_, model_->VocabSize(), std::max(1, config.max_active_paths)) {
+            blank_id_, model_->VocabSize(),
+            std::max(1, config.max_active_paths)) {
     if (!config.model_config.tokens_buf.empty()) {
       sym_ = SymbolTable(config.model_config.tokens_buf, false);
     } else {
@@ -256,7 +258,8 @@ class OnlineRecognizerZipformerTransducerQnnImpl
         blank_id_(0),
         greedy_decoder_(blank_id_),
         modified_beam_search_decoder_(
-            blank_id_, model_->VocabSize(), std::max(1, config.max_active_paths)) {
+            blank_id_, model_->VocabSize(),
+            std::max(1, config.max_active_paths)) {
     if (!config.model_config.tokens_buf.empty()) {
       sym_ = SymbolTable(config.model_config.tokens_buf, false);
     } else {
@@ -390,8 +393,8 @@ class OnlineRecognizerZipformerTransducerQnnImpl
       SHERPA_ONNX_EXIT(-1);
     }
 
-    r.decoder_out =
-        model_->RunDecoder(qnn_impl::GetQnnContext(r.tokens, model_->ContextSize()));
+    r.decoder_out = model_->RunDecoder(
+        qnn_impl::GetQnnContext(r.tokens, model_->ContextSize()));
     return r;
   }
 

--- a/sherpa-onnx/csrc/rknn/online-recognizer-transducer-rknn-impl.h
+++ b/sherpa-onnx/csrc/rknn/online-recognizer-transducer-rknn-impl.h
@@ -63,6 +63,7 @@ OnlineRecognizerResult Convert(const OnlineTransducerDecoderResultRknn &src,
     r.timestamps.push_back(time);
   }
 
+  r.num_trailing_blanks = src.num_trailing_blanks;
   r.segment = segment;
   r.start_time = frames_since_start * frame_shift_ms / 1000.;
 


### PR DESCRIPTION

## What this PR does

The online decoders already track the number of trailing blank frames emitted after the last token — endpointing consumes it internally — but the value never crosses into `OnlineRecognizerResult`, so consumers of the result JSON cannot see it.

This PR adds `num_trailing_blanks` to `OnlineRecognizerResult`, populates it in the result converters, and emits it in `AsJsonString()`.

Streaming clients that handle segmentation themselves (endpoint rules disabled, e.g. driven by an app-side VAD) can then close utterances and gate output on trailing silence directly from the result, instead of re-implementing silence tracking outside the decoder.

Downstream context: FreeShow, an open-source church presentation app with an AI scripture feature under review (ChurchApps/FreeShow#3579), runs streaming Nemotron via sherpa-onnx-node with endpointing disabled and uses this counter to close utterances on live transcripts.

## Changes

- `sherpa-onnx/csrc/online-recognizer.h`: new documented field — units are model output frames (after subsampling), reset whenever a non-blank token is emitted, stays 0 for decoders that do not track it (e.g. streaming Paraformer). Also added the missing `words` entry to the `AsJsonString()` schema comment while touching it.
- `sherpa-onnx/csrc/online-recognizer.cc`: emit the field in `AsJsonString()` (between `words` and `start_time`).
- `sherpa-onnx/csrc/online-recognizer-transducer-impl.h`: copy from the decoder result in `Convert()` — shared by the standard transducer, NeMo, and NeMo parakeet-unified impls.
- `sherpa-onnx/csrc/online-recognizer-ctc-impl.h`: same in `ConvertCtc()` — covers Zipformer2 CTC, T-one CTC, and the rknn CTC impl (which shares this definition).
- `sherpa-onnx/csrc/rknn/online-recognizer-transducer-rknn-impl.h`, `sherpa-onnx/csrc/qnn/online-recognizer-zipformer-transducer-qnn-impl.h`, `sherpa-onnx/csrc/qnn/online-recognizer-nemo-transducer-qnn-impl.h`: the same one-line copy in their converters.
- qnn zipformer impl: wrapped three pre-existing over-80-column lines so `./scripts/check_style_cpplint.sh` passes on the touched file.
- `scripts/node-addon-api/lib/types.js`: `@property {number} num_trailing_blanks` on the `OnlineRecognizerResult` typedef.

## Verification output

Streaming Nemotron 3.5 1120 ms int8 on macOS arm64, endpointing disabled, 1 s chunks:

```
--- speech (1 s chunks) ---        num_trailing_blanks: 0, 2, 1, 3, 2, 2, 2
--- 4 s silence ---                num_trailing_blanks: 7, 21, 35, 49   (monotonic)
--- speech resumes ---             num_trailing_blanks: 63, 1, 6        (reset on new tokens)
```

Result keys: `text, tokens, timestamps, ys_probs, lm_probs, context_scores, segment, words, num_trailing_blanks, start_time, is_final, is_eof`.

## Notes

- Backward compatible: one new struct field, one new JSON key; existing consumers unaffected.
- `./scripts/check_style_cpplint.sh 1` passes; `npm run typecheck` (node-addon `lib/**` gate) passes.
- The rknn/qnn backends are not enabled in the default build, so those converters are not compiled locally — the changes there are one-line field copies mirroring the main impls, and both source structs already carry the field.
- The style/node CI workflows do not run on pull requests; verification above is local (built with the `test-nodejs-addon-api.yaml` cmake flags and exercised through the node addon against the released Nemotron export).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Online recognition results now report the number of trailing blank frames after the last recognized token.
  * The value is included in JSON output and documented for JavaScript integrations.
  * Trailing-blank information is consistently preserved across supported recognition engines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->