### PR TITLE
Populate ys_probs in the online NeMo transducer greedy search decoders

### DIFF
--- a/sherpa-onnx/csrc/online-transducer-greedy-search-nemo-decoder.cc
+++ b/sherpa-onnx/csrc/online-transducer-greedy-search-nemo-decoder.cc
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/macros.h"
+#include "sherpa-onnx/csrc/math.h"
 #include "sherpa-onnx/csrc/online-stream.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"
 
@@ -80,10 +81,15 @@ static void DecodeOne(const float *encoder_out, int32_t num_rows,
 
       int32_t y = MaxElementIndex(p_logit, vocab_size);
 
+      // Apply LogSoftmax and get log probability for selected token
+      LogSoftmax(p_logit, vocab_size);
+      float log_prob = p_logit[y];
+
       if (y != blank_id) {
         emitted = true;
         r.tokens.push_back(y);
         r.timestamps.push_back(t + r.frame_offset);
+        r.ys_probs.push_back(log_prob);
         r.num_trailing_blanks = 0;
 
         decoder_input = BuildDecoderInput(y, model->Allocator());

--- a/sherpa-onnx/csrc/online-transducer-greedy-search-nemo-parakeet-unified-decoder.cc
+++ b/sherpa-onnx/csrc/online-transducer-greedy-search-nemo-parakeet-unified-decoder.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "sherpa-onnx/csrc/macros.h"
+#include "sherpa-onnx/csrc/math.h"
 #include "sherpa-onnx/csrc/online-stream.h"
 #include "sherpa-onnx/csrc/onnx-utils.h"
 
@@ -74,10 +75,15 @@ static void DecodeOne(const float *encoder_out, int32_t num_rows,
 
       int32_t y = MaxElementIndex(p_logit, vocab_size);
 
+      // Apply LogSoftmax and get log probability for selected token
+      LogSoftmax(p_logit, vocab_size);
+      float log_prob = p_logit[y];
+
       if (y != blank_id) {
         emitted = true;
         r.tokens.push_back(y);
         r.timestamps.push_back(t + r.frame_offset);
+        r.ys_probs.push_back(log_prob);
         r.num_trailing_blanks = 0;
 
         decoder_input = BuildDecoderInput(y, model->Allocator());


### PR DESCRIPTION

Fixes #3181

## What this PR does

The online NeMo transducer greedy search decoder never fills `ys_probs`, so streaming NeMo results always report `"ys_probs": []` and applications cannot access per-token confidence. The offline path was fixed in #3105; this applies the same approach to the online decoders:

- after the argmax, apply `LogSoftmax` to the joiner output and push the selected token's log-probability alongside the token (only when a non-blank is emitted, so `ys_probs.size() == tokens.size()`).

`LogSoftmax` runs after the token has been selected, so decoding output is unchanged.

The same gap existed in the parakeet-unified online decoder; it gets the identical fix. The multilingual language-tag filter (`FilterLanguageTags` in `online-recognizer-transducer-nemo-impl.h`) already filters `ys_probs` index-aligned with tokens whenever the sizes match, so tag-filtered results stay aligned with no further changes.

Downstream context: FreeShow, an open-source church presentation app with an AI scripture feature under review (ChurchApps/FreeShow#3579), runs streaming Nemotron via sherpa-onnx-node and uses these per-token log-probs for confidence gating on live transcripts.

## Changes

- `sherpa-onnx/csrc/online-transducer-greedy-search-nemo-decoder.cc`: `LogSoftmax` + `r.ys_probs.push_back(log_prob)` (mirrors the offline #3105 fix; +1 include of `math.h`).
- `sherpa-onnx/csrc/online-transducer-greedy-search-nemo-parakeet-unified-decoder.cc`: identical fix.

## Verification output

Streaming Nemotron 3.5 1120 ms int8 on macOS arm64, greedy_search, exercised through the node addon:

```
tokens: 48, ys_probs: 48        (lengths match; was ys_probs: 0 before)
all <= 0: true
min: -0.6439, max: -0.0001, mean: -0.1096
text unchanged vs pre-patch baseline: true
sample token/logprob pairs:
  " A"   -0.1219
  "ft"   -0.0010
  "er"   -0.1261
```

## Notes

- Backward compatible: `ys_probs` already exists in the result struct and JSON — it just goes from always-empty to populated for these decoders.
- No temperature scaling, matching #3105 (these decoders take no `temperature_scale`, unlike the standard online greedy decoder).
- `./scripts/check_style_cpplint.sh 1` passes. Built with the `test-nodejs-addon-api.yaml` cmake flags. The related CI workflows do not run on pull requests; verification above is local.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added log-probability scores for tokens emitted during online speech recognition.
  * Improved decoding output by associating each recognized token with its confidence-related score.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->