### PR TITLE
Support batched decoding of multiple online streams in the JavaScript (node-addon) API

### DIFF
--- a/harmony-os/SherpaOnnxHar/sherpa_onnx/src/main/cpp/streaming-asr.cc
+++ b/harmony-os/SherpaOnnxHar/sherpa_onnx/src/main/cpp/streaming-asr.cc
@@ -4,6 +4,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "macros.h"  // NOLINT
 #include "napi.h"    // NOLINT
@@ -512,6 +513,64 @@ static void DecodeOnlineStreamWrapper(const Napi::CallbackInfo &info) {
   SherpaOnnxDecodeOnlineStream(recognizer, stream);
 }
 
+static void DecodeMultipleOnlineStreamsWrapper(
+    const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (info.Length() != 2) {
+    std::ostringstream os;
+    os << "Expect only 2 arguments. Given: " << info.Length();
+
+    Napi::TypeError::New(env, os.str()).ThrowAsJavaScriptException();
+
+    return;
+  }
+
+  if (!info[0].IsExternal()) {
+    Napi::TypeError::New(env,
+                         "Argument 0 should be an online recognizer pointer.")
+        .ThrowAsJavaScriptException();
+
+    return;
+  }
+
+  if (!info[1].IsArray()) {
+    Napi::TypeError::New(
+        env, "Argument 1 should be an array of online stream pointers.")
+        .ThrowAsJavaScriptException();
+
+    return;
+  }
+
+  const SherpaOnnxOnlineRecognizer *recognizer =
+      info[0].As<Napi::External<SherpaOnnxOnlineRecognizer>>().Data();
+
+  Napi::Array arr = info[1].As<Napi::Array>();
+
+  std::vector<const SherpaOnnxOnlineStream *> streams;
+  streams.reserve(arr.Length());
+
+  for (uint32_t i = 0; i != arr.Length(); ++i) {
+    Napi::Value v = arr.Get(i);
+    if (!v.IsExternal()) {
+      std::ostringstream os;
+      os << "Element " << i << " should be an online stream pointer.";
+
+      Napi::TypeError::New(env, os.str()).ThrowAsJavaScriptException();
+
+      return;
+    }
+
+    streams.push_back(v.As<Napi::External<SherpaOnnxOnlineStream>>().Data());
+  }
+
+  if (streams.empty()) {
+    return;
+  }
+
+  SherpaOnnxDecodeMultipleOnlineStreams(recognizer, streams.data(),
+                                        static_cast<int32_t>(streams.size()));
+}
+
 static Napi::String GetOnlineStreamResultAsJsonWrapper(
     const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
@@ -737,6 +796,9 @@ void InitStreamingAsr(Napi::Env env, Napi::Object exports) {
 
   exports.Set(Napi::String::New(env, "decodeOnlineStream"),
               Napi::Function::New(env, DecodeOnlineStreamWrapper));
+
+  exports.Set(Napi::String::New(env, "decodeMultipleOnlineStreams"),
+              Napi::Function::New(env, DecodeMultipleOnlineStreamsWrapper));
 
   exports.Set(Napi::String::New(env, "getOnlineStreamResultAsJson"),
               Napi::Function::New(env, GetOnlineStreamResultAsJsonWrapper));

--- a/scripts/node-addon-api/lib/streaming-asr.js
+++ b/scripts/node-addon-api/lib/streaming-asr.js
@@ -101,8 +101,13 @@ class OnlineRecognizer {
    * @param {OnlineStream[]} streams
    */
   decodeStreams(streams) {
-    addon.decodeMultipleOnlineStreams(
-        this.handle, streams.map((stream) => stream.handle));
+    const handles = streams.map((stream) => {
+      if (!(stream instanceof OnlineStream)) {
+        throw new TypeError('Every element should be an OnlineStream');
+      }
+      return stream.handle;
+    });
+    addon.decodeMultipleOnlineStreams(this.handle, handles);
   }
 
   /**

--- a/scripts/node-addon-api/lib/streaming-asr.js
+++ b/scripts/node-addon-api/lib/streaming-asr.js
@@ -94,6 +94,18 @@ class OnlineRecognizer {
   }
 
   /**
+   * Decode multiple streams of this recognizer in parallel.
+   *
+   * The caller must ensure every stream in the array is ready for decoding,
+   * i.e. isReady() returns true for each of them.
+   * @param {OnlineStream[]} streams
+   */
+  decodeStreams(streams) {
+    addon.decodeMultipleOnlineStreams(
+        this.handle, streams.map((stream) => stream.handle));
+  }
+
+  /**
    * Check endpoint condition for a stream.
    * @param {OnlineStream} stream
    * @returns {boolean}


### PR DESCRIPTION

## What this PR does

The C API exports `SherpaOnnxDecodeMultipleOnlineStreams` (`c-api.h`, with a usage example in its doc comment) and the Python API exposes it as `OnlineRecognizer.decode_streams`, but the node addon binds only the single-stream `decodeOnlineStream`. This PR adds the batched binding and surfaces it as `OnlineRecognizer.decodeStreams()`:

```js
while (recognizer.isReady(s1) && recognizer.isReady(s2)) {
  recognizer.decodeStreams([s1, s2]);
}
```

Downstream context: FreeShow, an open-source church presentation app with an AI scripture feature under review (ChurchApps/FreeShow#3579), runs streaming Nemotron via sherpa-onnx-node and wants to decode several language-pinned streams of one recognizer in parallel for interpreted services.

## Changes

- `harmony-os/SherpaOnnxHar/sherpa_onnx/src/main/cpp/streaming-asr.cc` (shared with `scripts/node-addon-api/src/` via the existing symlink): add `DecodeMultipleOnlineStreamsWrapper` — validates a recognizer pointer plus an array of online stream pointers (with a per-element error message), treats an empty array as a no-op — registered as `decodeMultipleOnlineStreams`.
- `scripts/node-addon-api/lib/streaming-asr.js`: add `OnlineRecognizer.decodeStreams(streams)`; its JSDoc carries the C header's contract (the caller must ensure every stream in the array is ready).

## Verification output

macOS arm64, addon built from this branch (`test-nodejs-addon-api.yaml` cmake flags + `cmake-js compile`):

- **Streaming Zipformer transducer**: batched `n=2` transcripts are **byte-identical** to the individually decoded references (26 batched calls); `n=1` identical; empty array is a safe no-op.
- **Streaming Nemotron 3.5 multilingual 1120 ms int8**: word content identical between batched and single-stream decoding; punctuation can flip marginally (e.g. one comma) — batch-padding numerics of that model's int8 encoder, not introduced by this binding (single-stream `decode` routes through the same C++ `DecodeStreams` with `n=1`).
- `npm run typecheck` passes. The node-addon CI workflows do not run on pull requests; verification above is local.

## Notes

- Naming follows the Python API's `decode_streams`.
- Backward compatible: adds one export and one method.
- No new example added to keep the PR focused — happy to add one (the streaming transducer example extends naturally) if you'd like.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for decoding multiple online speech-recognition streams in parallel.
  * Introduced an API for submitting multiple ready-to-decode streams at once.
  * Empty stream lists are handled safely without starting a decode operation.

* **Bug Fixes**
  * Added validation to reject invalid stream inputs with a clear type error before processing begins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->