### PR TITLE
Add Nabra-82M Arabic TTS conversion scripts for Kokoro runtime

### DIFF
--- a/scripts/kokoro/nabra/README.md
+++ b/scripts/kokoro/nabra/README.md
@@ -1,0 +1,42 @@
+# Nabra-82M (Arabic, MSA) — sherpa-onnx packaging
+
+This directory contains scripts to convert [Nabra-82M](https://huggingface.co/oddadmix/Nabra-82M-v0.1)
+ONNX exports for use with sherpa-onnx's Kokoro runtime.
+
+Nabra-82M is a Kokoro/StyleTTS2-architecture model fine-tuned for Modern
+Standard Arabic. Its ONNX export shares the Kokoro v1.0 input signature
+(`tokens`, `style[1,256]`, `speed`), so it runs on the existing Kokoro runtime
+without code changes.
+
+Pre-packaged models: https://huggingface.co/marwanelamami/nabra-82m-sherpa-onnx
+
+## Usage
+
+```bash
+./run.sh /path/to/nabra_int4qat.onnx
+```
+
+Produces:
+- `model.int4.onnx` — metadata-stamped + iSTFT notch FIR baked in
+- `tokens.txt` — phoneme vocabulary from the model's `vocab.json`
+- `voices.bin` — style vectors `[510, 1, 256]`
+
+## Test
+
+```python
+import sherpa_onnx
+
+tts = sherpa_onnx.OfflineTts(
+    sherpa_onnx.OfflineTtsConfig(
+        model=sherpa_onnx.OfflineTtsModelConfig(
+            kokoro=sherpa_onnx.OfflineTtsKokoroModelConfig(
+                model="model.int4.onnx",
+                voices="voices.bin",
+                tokens="tokens.txt",
+                data_dir="espeak-ng-data",
+            ),
+        ),
+    )
+)
+audio = tts.generate("السلام عليكم", sid=0, speed=1.0)
+```

--- a/scripts/kokoro/nabra/add_meta_data.py
+++ b/scripts/kokoro/nabra/add_meta_data.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+"""Stamp sherpa-onnx Kokoro metadata onto a Nabra-82M ONNX model.
+
+Also bakes an FIR notch (4800/9600 Hz) into the graph tail to remove
+iSTFT image tones, so no player-side post-processing is needed."""
 # Stamp sherpa-onnx Kokoro metadata onto a Nabra-82M ONNX model and bake in
 # the iSTFT image-tone notch FIR.
 #
@@ -11,6 +15,7 @@ from onnx import TensorProto, helper, numpy_helper
 
 
 def main():
+    """Stamp metadata and bake the notch FIR into the given Nabra ONNX file."""
     src, dst = sys.argv[1], sys.argv[2]
 
     meta = {

--- a/scripts/kokoro/nabra/add_meta_data.py
+++ b/scripts/kokoro/nabra/add_meta_data.py
@@ -11,7 +11,7 @@ import sys
 
 import numpy as np
 import onnx
-from onnx import TensorProto, helper, numpy_helper
+from onnx import helper, numpy_helper
 
 
 def main():
@@ -70,10 +70,36 @@ def main():
     g.initializer.append(
         numpy_helper.from_array(h.reshape(1, 1, -1).astype(np.float32),
                                 "notch_fir_w"))
+    idx = list(g.node).index(squeeze)
     for i, inp in enumerate(squeeze.input):
         if inp == src_tensor:
             squeeze.input[i] = "audio_notched"
-    g.node.append(conv)
+    g.node.insert(idx, conv)
+
+    # ONNX requires nodes in topological order; appending the Conv at the
+    # end left it after its consumer. Re-sort the node list so every
+    # producer precedes its consumers.
+    nodes = list(g.node)
+    produced = {t.name for t in g.initializer}
+    for inp in g.input:
+        produced.add(inp.name)
+    sorted_nodes = []
+    pending = nodes[:]
+    while pending:
+        progressed = False
+        for n in list(pending):
+            if all((inp in produced or inp == "") for inp in n.input):
+                sorted_nodes.append(n)
+                produced.update(n.output)
+                pending.remove(n)
+                progressed = True
+        if not progressed:
+            break  # cyclic or external refs; leave remaining as-is
+    del g.node[:]
+    g.node.extend(sorted_nodes)
+
+    # ONNX requires nodes in topological order; re-sort defensively.
+
 
     onnx.save(m, dst)
     print(f"saved {dst}")

--- a/scripts/kokoro/nabra/add_meta_data.py
+++ b/scripts/kokoro/nabra/add_meta_data.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# Stamp sherpa-onnx Kokoro metadata onto a Nabra-82M ONNX model and bake in
+# the iSTFT image-tone notch FIR.
+#
+# Usage: python3 add_meta_data.py <nabra.onnx> <output.onnx>
+import sys
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+
+
+def main():
+    src, dst = sys.argv[1], sys.argv[2]
+
+    meta = {
+        "model_type": "kokoro",
+        "language": "Arabic (Modern Standard)",
+        "has_espeak": 1,
+        "sample_rate": 24000,
+        "version": 1,
+        "voice": "ar",
+        "style_dim": "510,1,256",
+        "n_speakers": 1,
+        "id2speaker": "0->af_msa",
+        "speaker2id": "af_msa->0",
+        "speaker_names": "af_msa",
+        "max_token_len": 510,
+        "comment": "Nabra-82M Arabic TTS (Kokoro architecture), base: oddadmix/Nabra-82M-v0.1",
+    }
+
+    m = onnx.load(src)
+    while len(m.metadata_props):
+        m.metadata_props.pop()
+    for k, v in meta.items():
+        e = m.metadata_props.add()
+        e.key, e.value = k, str(v)
+
+    # Bake iSTFT image-tone notch (4800 + 9600 Hz) as a final FIR Conv1d so
+    # no player-side post-processing is required.
+    g = m.graph
+    out_name = g.output[0].name
+    prod = {}
+    for n in g.node:
+        for o in n.output:
+            prod[o] = n
+    squeeze = prod[out_name]
+    assert squeeze.op_type == "Squeeze", f"unexpected producer {squeeze.op_type}"
+    src_tensor = squeeze.input[0]
+
+    sr, ntaps = 24000, 129
+    edges = [0, 4400, 4650, 4950, 5200, 9200, 9450, 9750, 10000, sr // 2]
+    gains = [1, 1, 0, 0, 1, 1, 0, 0, 1, 0]
+    from scipy.signal import firwin2
+    h = firwin2(ntaps, np.array(edges) / (sr / 2), gains)
+
+    conv = helper.make_node(
+        "Conv",
+        inputs=[src_tensor, "notch_fir_w"],
+        outputs=["audio_notched"],
+        kernel_shape=[ntaps],
+        pads=[ntaps // 2] * 2,
+        name="notch_fir",
+    )
+    g.initializer.append(
+        numpy_helper.from_array(h.reshape(1, 1, -1).astype(np.float32),
+                                "notch_fir_w"))
+    for i, inp in enumerate(squeeze.input):
+        if inp == src_tensor:
+            squeeze.input[i] = "audio_notched"
+    g.node.append(conv)
+
+    onnx.save(m, dst)
+    print(f"saved {dst}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follows issue #3897.

[oddadmix](https://huggingface.co/oddadmix) trained Nabra-82M ([oddadmix/Nabra-82M-v0.1](https://huggingface.co/oddadmix/Nabra-82M-v0.1)), a Kokoro/StyleTTS2 model fine-tuned for Modern Standard Arabic. I quantized and packaged it. Its ONNX export shares the Kokoro v1.0 input signature (`tokens` int64[1,T], `style` float32[1,256], `speed` float32[1]), so it runs on the existing kokoro runtime with no code changes. I verified sherpa's espeak-ng token output matches the training pipeline's symbol-for-symbol on several sentences.

This PR adds conversion scripts under `scripts/kokoro/nabra/`:

- `add_meta_data.py`: stamps sherpa metadata (`model_type=kokoro`, `voice=ar`, `style_dim=510,1,256`, etc.) and bakes an FIR notch (Conv1d, 129 taps) at 4800/9600 Hz into the graph tail to remove iSTFT image tones
- `run.sh`: end-to-end conversion (metadata + tokens.txt + voices.bin)
- `README.md`: usage example with `OfflineTtsKokoroModelConfig`

Pre-packaged models (int4/int8/fp16) are at https://huggingface.co/marwanelamami/nabra-82m-sherpa-onnx if you'd rather link than host.

Tested with sherpa-onnx 1.13.6 Python API; RTF ~0.66-0.68 @ 4 threads on Snapdragon 865/870.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added documentation for converting Nabra-82M Arabic speech models for use with the Kokoro runtime.
  * Added a tool to prepare Nabra-82M ONNX models with the required Arabic voice metadata and audio filtering.
  * Documented how to generate optimized model assets, configure Arabic text-to-speech, and test speech generation with sherpa-onnx.
  * Improved support for producing high-quality Arabic speech output at supported audio sample rates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->