### PR TITLE
Remove caret prefix from sherpa_onnx flutter dependencies

### DIFF
--- a/.github/workflows/test-flutter-punct.yaml
+++ b/.github/workflows/test-flutter-punct.yaml
@@ -644,7 +644,6 @@ jobs:
         run: |
           cd flutter/sherpa_onnx
           sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: 1.13.6\n  sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
-          sed -i.bak 's|sherpa_onnx_web: 1.13.6$|sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
       - name: Build Flutter web app
@@ -652,7 +651,6 @@ jobs:
         run: |
           cd flutter-examples/${{ matrix.demo }}
 
-          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 

--- a/.github/workflows/test-flutter-punct.yaml
+++ b/.github/workflows/test-flutter-punct.yaml
@@ -79,7 +79,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_macos: ^1.13.6|  # sherpa_onnx_macos: ^1.13.6\n  sherpa_onnx_macos:\n    path: ../sherpa_onnx_macos|' pubspec.yaml
+          sed -i.bak 's|  sherpa_onnx_macos: 1.13.6|  # sherpa_onnx_macos: 1.13.6\n  sherpa_onnx_macos:\n    path: ../sherpa_onnx_macos|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -87,7 +87,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: ^1.13.6|' pubspec.yaml
+          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: 1.13.6|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
 
@@ -119,7 +119,7 @@ jobs:
         run: |
           cd flutter-examples/${{ matrix.demo }}
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter config --no-enable-swift-package-manager
@@ -237,7 +237,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_linux: ^1.13.6|  # sherpa_onnx_linux: ^1.13.6\n  sherpa_onnx_linux:\n    path: ../sherpa_onnx_linux|' pubspec.yaml
+          sed -i.bak 's|  sherpa_onnx_linux: 1.13.6|  # sherpa_onnx_linux: 1.13.6\n  sherpa_onnx_linux:\n    path: ../sherpa_onnx_linux|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -245,7 +245,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: ^1.13.6|' pubspec.yaml
+          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: 1.13.6|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
 
@@ -272,7 +272,7 @@ jobs:
         run: |
           cd flutter-examples/${{ matrix.demo }}
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter pub get
@@ -362,7 +362,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_windows: ^1.13.6|  # sherpa_onnx_windows: ^1.13.6\n  sherpa_onnx_windows:\n    path: ../sherpa_onnx_windows|' pubspec.yaml
+          sed -i.bak 's|  sherpa_onnx_windows: 1.13.6|  # sherpa_onnx_windows: 1.13.6\n  sherpa_onnx_windows:\n    path: ../sherpa_onnx_windows|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -370,7 +370,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: ^1.13.6|' pubspec.yaml
+          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: 1.13.6|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
       - name: Download model
@@ -396,7 +396,7 @@ jobs:
         run: |
           cd flutter-examples/${{ matrix.demo }}
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter pub get
@@ -512,7 +512,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  ${{ matrix.plugin_key }}: ^1.13.6|  # ${{ matrix.plugin_key }}: ^1.13.6\n  ${{ matrix.plugin_key }}:\n    path: ../${{ matrix.plugin }}|' pubspec.yaml
+          sed -i.bak 's|  ${{ matrix.plugin_key }}: 1.13.6|  # ${{ matrix.plugin_key }}: 1.13.6\n  ${{ matrix.plugin_key }}:\n    path: ../${{ matrix.plugin }}|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -540,7 +540,7 @@ jobs:
         run: |
           cd flutter-examples/${{ matrix.demo }}
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter pub get
@@ -643,7 +643,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: ^1.13.6\n  sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
+          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: 1.13.6\n  sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
           sed -i.bak 's|sherpa_onnx_web: 1.13.6$|sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
@@ -652,7 +652,7 @@ jobs:
         run: |
           cd flutter-examples/${{ matrix.demo }}
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 

--- a/.github/workflows/test-flutter-vad-asr.yaml
+++ b/.github/workflows/test-flutter-vad-asr.yaml
@@ -148,7 +148,6 @@ jobs:
           cd flutter-examples/${{ matrix.demo }}
 
           sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
-          sed -i.bak 's|sherpa_onnx: 1.13.6$|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter config --no-enable-swift-package-manager
@@ -337,7 +336,6 @@ jobs:
           cd flutter-examples/${{ matrix.demo }}
 
           sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
-          sed -i.bak 's|sherpa_onnx: 1.13.6$|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter pub get
@@ -476,7 +474,6 @@ jobs:
           cd flutter-examples/${{ matrix.demo }}
 
           sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
-          sed -i.bak 's|sherpa_onnx: 1.13.6$|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter pub get
@@ -614,7 +611,6 @@ jobs:
           cd flutter-examples/${{ matrix.demo }}
 
           sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
-          sed -i.bak 's|sherpa_onnx: 1.13.6$|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter pub get
@@ -731,7 +727,6 @@ jobs:
         run: |
           cd flutter/sherpa_onnx
           sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: 1.13.6\n  sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
-          sed -i.bak 's|sherpa_onnx_web: 1.13.6$|sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
       - name: Build Flutter web app
@@ -740,7 +735,6 @@ jobs:
           cd flutter-examples/${{ matrix.demo }}
 
           sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
-          sed -i.bak 's|sherpa_onnx: 1.13.6$|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter pub get

--- a/.github/workflows/test-flutter-vad-asr.yaml
+++ b/.github/workflows/test-flutter-vad-asr.yaml
@@ -94,7 +94,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_macos: ^1.13.6|  # sherpa_onnx_macos: ^1.13.6\n  sherpa_onnx_macos:\n    path: ../sherpa_onnx_macos|' pubspec.yaml
+          sed -i.bak 's|  sherpa_onnx_macos: 1.13.6|  # sherpa_onnx_macos: 1.13.6\n  sherpa_onnx_macos:\n    path: ../sherpa_onnx_macos|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -102,7 +102,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: ^1.13.6|' pubspec.yaml
+          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: 1.13.6|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
       - name: Copy LICENSE for sherpa_onnx_macos podspec
@@ -147,7 +147,7 @@ jobs:
         run: |
           cd flutter-examples/${{ matrix.demo }}
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           sed -i.bak 's|sherpa_onnx: 1.13.6$|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
@@ -282,7 +282,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_linux: ^1.13.6|  # sherpa_onnx_linux: ^1.13.6\n  sherpa_onnx_linux:\n    path: ../sherpa_onnx_linux|' pubspec.yaml
+          sed -i.bak 's|  sherpa_onnx_linux: 1.13.6|  # sherpa_onnx_linux: 1.13.6\n  sherpa_onnx_linux:\n    path: ../sherpa_onnx_linux|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -290,7 +290,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: ^1.13.6|' pubspec.yaml
+          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: 1.13.6|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
       - name: Download model
@@ -336,7 +336,7 @@ jobs:
         run: |
           cd flutter-examples/${{ matrix.demo }}
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           sed -i.bak 's|sherpa_onnx: 1.13.6$|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
@@ -427,7 +427,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_windows: ^1.13.6|  # sherpa_onnx_windows: ^1.13.6\n  sherpa_onnx_windows:\n    path: ../sherpa_onnx_windows|' pubspec.yaml
+          sed -i.bak 's|  sherpa_onnx_windows: 1.13.6|  # sherpa_onnx_windows: 1.13.6\n  sherpa_onnx_windows:\n    path: ../sherpa_onnx_windows|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -435,7 +435,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: ^1.13.6|' pubspec.yaml
+          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: 1.13.6|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
       - name: Download model
@@ -475,7 +475,7 @@ jobs:
         run: |
           cd flutter-examples/${{ matrix.demo }}
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           sed -i.bak 's|sherpa_onnx: 1.13.6$|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
@@ -572,7 +572,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  ${{ matrix.plugin_key }}: ^1.13.6|  # ${{ matrix.plugin_key }}: ^1.13.6\n  ${{ matrix.plugin_key }}:\n    path: ../${{ matrix.plugin }}|' pubspec.yaml
+          sed -i.bak 's|  ${{ matrix.plugin_key }}: 1.13.6|  # ${{ matrix.plugin_key }}: 1.13.6\n  ${{ matrix.plugin_key }}:\n    path: ../${{ matrix.plugin }}|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -613,7 +613,7 @@ jobs:
         run: |
           cd flutter-examples/${{ matrix.demo }}
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           sed -i.bak 's|sherpa_onnx: 1.13.6$|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
@@ -730,7 +730,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: ^1.13.6\n  sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
+          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: 1.13.6\n  sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
           sed -i.bak 's|sherpa_onnx_web: 1.13.6$|sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
@@ -739,7 +739,7 @@ jobs:
         run: |
           cd flutter-examples/${{ matrix.demo }}
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           sed -i.bak 's|sherpa_onnx: 1.13.6$|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 

--- a/.github/workflows/test-flutter-vad.yaml
+++ b/.github/workflows/test-flutter-vad.yaml
@@ -110,7 +110,6 @@ jobs:
           cd flutter-examples/${{ matrix.demo }}
 
           sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
-          sed -i.bak 's|sherpa_onnx: 1.13.6$|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter config --no-enable-swift-package-manager
@@ -278,7 +277,6 @@ jobs:
           cd flutter-examples/${{ matrix.demo }}
 
           sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
-          sed -i.bak 's|sherpa_onnx: 1.13.6$|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter pub get
@@ -395,7 +393,6 @@ jobs:
           cd flutter-examples/${{ matrix.demo }}
 
           sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
-          sed -i.bak 's|sherpa_onnx: 1.13.6$|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter pub get
@@ -531,7 +528,6 @@ jobs:
           cd flutter-examples/${{ matrix.demo }}
 
           sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
-          sed -i.bak 's|sherpa_onnx: 1.13.6$|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter pub get
@@ -626,7 +622,6 @@ jobs:
         run: |
           cd flutter/sherpa_onnx
           sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: 1.13.6\n  sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
-          sed -i.bak 's|sherpa_onnx_web: 1.13.6$|sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
       - name: Build Flutter web app
@@ -635,7 +630,6 @@ jobs:
           cd flutter-examples/${{ matrix.demo }}
 
           sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
-          sed -i.bak 's|sherpa_onnx: 1.13.6$|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter pub get

--- a/.github/workflows/test-flutter-vad.yaml
+++ b/.github/workflows/test-flutter-vad.yaml
@@ -78,7 +78,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_macos: ^1.13.6|  # sherpa_onnx_macos: ^1.13.6\n  sherpa_onnx_macos:\n    path: ../sherpa_onnx_macos|' pubspec.yaml
+          sed -i.bak 's|  sherpa_onnx_macos: 1.13.6|  # sherpa_onnx_macos: 1.13.6\n  sherpa_onnx_macos:\n    path: ../sherpa_onnx_macos|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -86,7 +86,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: ^1.13.6|' pubspec.yaml
+          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: 1.13.6|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
       - name: Copy LICENSE for sherpa_onnx_macos podspec
@@ -109,7 +109,7 @@ jobs:
         run: |
           cd flutter-examples/${{ matrix.demo }}
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           sed -i.bak 's|sherpa_onnx: 1.13.6$|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
@@ -245,7 +245,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_linux: ^1.13.6|  # sherpa_onnx_linux: ^1.13.6\n  sherpa_onnx_linux:\n    path: ../sherpa_onnx_linux|' pubspec.yaml
+          sed -i.bak 's|  sherpa_onnx_linux: 1.13.6|  # sherpa_onnx_linux: 1.13.6\n  sherpa_onnx_linux:\n    path: ../sherpa_onnx_linux|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -253,7 +253,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: ^1.13.6|' pubspec.yaml
+          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: 1.13.6|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
       - name: Download model
@@ -277,7 +277,7 @@ jobs:
         run: |
           cd flutter-examples/${{ matrix.demo }}
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           sed -i.bak 's|sherpa_onnx: 1.13.6$|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
@@ -368,7 +368,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_windows: ^1.13.6|  # sherpa_onnx_windows: ^1.13.6\n  sherpa_onnx_windows:\n    path: ../sherpa_onnx_windows|' pubspec.yaml
+          sed -i.bak 's|  sherpa_onnx_windows: 1.13.6|  # sherpa_onnx_windows: 1.13.6\n  sherpa_onnx_windows:\n    path: ../sherpa_onnx_windows|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -376,7 +376,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: ^1.13.6|' pubspec.yaml
+          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: 1.13.6|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
       - name: Download model
@@ -394,7 +394,7 @@ jobs:
         run: |
           cd flutter-examples/${{ matrix.demo }}
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           sed -i.bak 's|sherpa_onnx: 1.13.6$|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
@@ -511,7 +511,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  ${{ matrix.plugin_key }}: ^1.13.6|  # ${{ matrix.plugin_key }}: ^1.13.6\n  ${{ matrix.plugin_key }}:\n    path: ../${{ matrix.plugin }}|' pubspec.yaml
+          sed -i.bak 's|  ${{ matrix.plugin_key }}: 1.13.6|  # ${{ matrix.plugin_key }}: 1.13.6\n  ${{ matrix.plugin_key }}:\n    path: ../${{ matrix.plugin }}|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -530,7 +530,7 @@ jobs:
         run: |
           cd flutter-examples/${{ matrix.demo }}
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           sed -i.bak 's|sherpa_onnx: 1.13.6$|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
@@ -625,7 +625,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: ^1.13.6\n  sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
+          sed -i.bak 's|^  sherpa_onnx_web:.*|  # sherpa_onnx_web: 1.13.6\n  sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
           sed -i.bak 's|sherpa_onnx_web: 1.13.6$|sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
@@ -634,7 +634,7 @@ jobs:
         run: |
           cd flutter-examples/${{ matrix.demo }}
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           sed -i.bak 's|sherpa_onnx: 1.13.6$|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 

--- a/.github/workflows/test-flutter.yaml
+++ b/.github/workflows/test-flutter.yaml
@@ -73,7 +73,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_macos: ^1.13.6|  # sherpa_onnx_macos: ^1.13.6\n  sherpa_onnx_macos:\n    path: ../sherpa_onnx_macos|' pubspec.yaml
+          sed -i.bak 's|  sherpa_onnx_macos: 1.13.6|  # sherpa_onnx_macos: 1.13.6\n  sherpa_onnx_macos:\n    path: ../sherpa_onnx_macos|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -82,7 +82,7 @@ jobs:
         run: |
           cd flutter-examples/hello_world
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter config --no-enable-swift-package-manager
@@ -174,7 +174,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_macos: ^1.13.6|  # sherpa_onnx_macos: ^1.13.6\n  sherpa_onnx_macos:\n    path: ../sherpa_onnx_macos|' pubspec.yaml
+          sed -i.bak 's|  sherpa_onnx_macos: 1.13.6|  # sherpa_onnx_macos: 1.13.6\n  sherpa_onnx_macos:\n    path: ../sherpa_onnx_macos|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -183,7 +183,7 @@ jobs:
         run: |
           cd flutter-examples/hello_world
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter config --enable-swift-package-manager
@@ -267,7 +267,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_ios: ^1.13.6|  # sherpa_onnx_ios: ^1.13.6\n  sherpa_onnx_ios:\n    path: ../sherpa_onnx_ios|' pubspec.yaml
+          sed -i.bak 's|  sherpa_onnx_ios: 1.13.6|  # sherpa_onnx_ios: 1.13.6\n  sherpa_onnx_ios:\n    path: ../sherpa_onnx_ios|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -276,7 +276,7 @@ jobs:
         run: |
           cd flutter-examples/hello_world
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter config --no-enable-swift-package-manager
@@ -343,7 +343,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_ios: ^1.13.6|  # sherpa_onnx_ios: ^1.13.6\n  sherpa_onnx_ios:\n    path: ../sherpa_onnx_ios|' pubspec.yaml
+          sed -i.bak 's|  sherpa_onnx_ios: 1.13.6|  # sherpa_onnx_ios: 1.13.6\n  sherpa_onnx_ios:\n    path: ../sherpa_onnx_ios|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -352,7 +352,7 @@ jobs:
         run: |
           cd flutter-examples/hello_world
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter config --enable-swift-package-manager
@@ -447,7 +447,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_linux: ^1.13.6|  # sherpa_onnx_linux: ^1.13.6\n  sherpa_onnx_linux:\n    path: ../sherpa_onnx_linux|' pubspec.yaml
+          sed -i.bak 's|  sherpa_onnx_linux: 1.13.6|  # sherpa_onnx_linux: 1.13.6\n  sherpa_onnx_linux:\n    path: ../sherpa_onnx_linux|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -456,7 +456,7 @@ jobs:
         run: |
           cd flutter-examples/hello_world
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter pub get
@@ -524,7 +524,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_windows: ^1.13.6|  # sherpa_onnx_windows: ^1.13.6\n  sherpa_onnx_windows:\n    path: ../sherpa_onnx_windows|' pubspec.yaml
+          sed -i.bak 's|  sherpa_onnx_windows: 1.13.6|  # sherpa_onnx_windows: 1.13.6\n  sherpa_onnx_windows:\n    path: ../sherpa_onnx_windows|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -533,7 +533,7 @@ jobs:
         run: |
           cd flutter-examples/hello_world
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter pub get
@@ -629,7 +629,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  ${{ matrix.plugin_key }}: ^1.13.6|  # ${{ matrix.plugin_key }}: ^1.13.6\n  ${{ matrix.plugin_key }}:\n    path: ../${{ matrix.plugin }}|' pubspec.yaml
+          sed -i.bak 's|  ${{ matrix.plugin_key }}: 1.13.6|  # ${{ matrix.plugin_key }}: 1.13.6\n  ${{ matrix.plugin_key }}:\n    path: ../${{ matrix.plugin }}|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -638,7 +638,7 @@ jobs:
         run: |
           cd flutter-examples/hello_world
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter pub get
@@ -707,7 +707,7 @@ jobs:
         shell: bash
         run: |
           cd flutter/sherpa_onnx
-          sed -i.bak 's|  sherpa_onnx_web: ^1.13.6|  # sherpa_onnx_web: ^1.13.6\n  sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
+          sed -i.bak 's|  sherpa_onnx_web: 1.13.6|  # sherpa_onnx_web: 1.13.6\n  sherpa_onnx_web:\n    path: ../sherpa_onnx_web|' pubspec.yaml
           rm -f pubspec.yaml.bak
           cat pubspec.yaml
 
@@ -716,7 +716,7 @@ jobs:
         run: |
           cd flutter-examples/hello_world
 
-          sed -i.bak 's|sherpa_onnx: ^1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
+          sed -i.bak 's|sherpa_onnx: 1.13.6|sherpa_onnx:\n    path: ../../flutter/sherpa_onnx|' pubspec.yaml
           rm -f pubspec.yaml.bak
 
           flutter pub get

--- a/dart-api-examples/add-punctuations/pubspec.yaml
+++ b/dart-api-examples/add-punctuations/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/audio-tagging/pubspec.yaml
+++ b/dart-api-examples/audio-tagging/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/keyword-spotter/pubspec.yaml
+++ b/dart-api-examples/keyword-spotter/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   path: ^1.9.0

--- a/dart-api-examples/non-streaming-asr/pubspec.yaml
+++ b/dart-api-examples/non-streaming-asr/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/speaker-diarization/pubspec.yaml
+++ b/dart-api-examples/speaker-diarization/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   path: ^1.9.0

--- a/dart-api-examples/speaker-identification/pubspec.yaml
+++ b/dart-api-examples/speaker-identification/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/speech-enhancement-dpdfnet/pubspec.yaml
+++ b/dart-api-examples/speech-enhancement-dpdfnet/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   path: ^1.9.0

--- a/dart-api-examples/speech-enhancement-gtcrn/pubspec.yaml
+++ b/dart-api-examples/speech-enhancement-gtcrn/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   path: ^1.9.0

--- a/dart-api-examples/spoken-language-identification/pubspec.yaml
+++ b/dart-api-examples/spoken-language-identification/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   path: ^1.9.0

--- a/dart-api-examples/streaming-asr/pubspec.yaml
+++ b/dart-api-examples/streaming-asr/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/streaming-speech-enhancement-dpdfnet/pubspec.yaml
+++ b/dart-api-examples/streaming-speech-enhancement-dpdfnet/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   path: ^1.9.0

--- a/dart-api-examples/streaming-speech-enhancement-gtcrn/pubspec.yaml
+++ b/dart-api-examples/streaming-speech-enhancement-gtcrn/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   path: ^1.9.0

--- a/dart-api-examples/tts/pubspec.yaml
+++ b/dart-api-examples/tts/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/vad-with-non-streaming-asr/pubspec.yaml
+++ b/dart-api-examples/vad-with-non-streaming-asr/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/vad/pubspec.yaml
+++ b/dart-api-examples/vad/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   path: ^1.9.0
   args: ^2.5.0
 

--- a/dart-api-examples/version/pubspec.yaml
+++ b/dart-api-examples/version/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   path: ^1.9.0
 
 dev_dependencies:

--- a/flutter-examples/hello_world/pubspec.yaml
+++ b/flutter-examples/hello_world/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
 

--- a/flutter-examples/non_streaming_vad_asr/pubspec.yaml
+++ b/flutter-examples/non_streaming_vad_asr/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   record: 6.0.0
   url_launcher: ^6.2.6
 
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
 

--- a/flutter-examples/offline-punctuation/pubspec.yaml
+++ b/flutter-examples/offline-punctuation/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   cupertino_icons: ^1.0.6
   path_provider: ^2.1.3
   path: ^1.9.0
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   url_launcher: 6.2.6

--- a/flutter-examples/online-punctuation/pubspec.yaml
+++ b/flutter-examples/online-punctuation/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   cupertino_icons: ^1.0.6
   path_provider: ^2.1.3
   path: ^1.9.0
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   url_launcher: 6.2.6

--- a/flutter-examples/streaming_asr/pubspec.yaml
+++ b/flutter-examples/streaming_asr/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   record: ^6.1.2
   url_launcher: ^6.2.6
 
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
 

--- a/flutter-examples/tts/pubspec.yaml
+++ b/flutter-examples/tts/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   file_picker: ^8.0.0
   path_provider: ^2.1.3
   path: ^1.9.0
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   url_launcher: 6.2.6

--- a/flutter-examples/vad-from-file/pubspec.yaml
+++ b/flutter-examples/vad-from-file/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   file_picker: ^8.0.0
   path_provider: ^2.1.3
   path: ^1.9.0
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   media_kit: ^1.1.11

--- a/flutter-examples/vad-from-microphone/pubspec.yaml
+++ b/flutter-examples/vad-from-microphone/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   file_picker: ^8.0.0
   path_provider: ^2.1.3
   path: ^1.9.0
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   record: ^6.2.0

--- a/flutter-examples/vad-non-streaming-asr-from-file/pubspec.yaml
+++ b/flutter-examples/vad-non-streaming-asr-from-file/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   file_picker: ^8.0.0
   path_provider: ^2.1.3
   path: ^1.9.0
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   media_kit: ^1.1.11

--- a/flutter-examples/vad-non-streaming-asr-from-microphone/pubspec.yaml
+++ b/flutter-examples/vad-non-streaming-asr-from-microphone/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   file_picker: ^8.0.0
   path_provider: ^2.1.3
   path: ^1.9.0
-  sherpa_onnx: ^1.13.6
+  sherpa_onnx: 1.13.6
   # sherpa_onnx:
   #   path: ../../flutter/sherpa_onnx
   record: ^6.2.0

--- a/flutter/sherpa_onnx/pubspec.yaml
+++ b/flutter/sherpa_onnx/pubspec.yaml
@@ -27,39 +27,39 @@ environment:
 
 dependencies:
   ffi: ^2.1.0
-  sherpa_onnx_android_arm64: ^1.13.6
+  sherpa_onnx_android_arm64: 1.13.6
   # sherpa_onnx_android_arm64:
   #   path: ../sherpa_onnx_android_arm64
 
-  sherpa_onnx_android_armeabi: ^1.13.6
+  sherpa_onnx_android_armeabi: 1.13.6
   # sherpa_onnx_android_armeabi:
   #   path: ../sherpa_onnx_android_armeabi
 
-  sherpa_onnx_android_x86: ^1.13.6
+  sherpa_onnx_android_x86: 1.13.6
   # sherpa_onnx_android_x86:
   #   path: ../sherpa_onnx_android_x86
 
-  sherpa_onnx_android_x86_64: ^1.13.6
+  sherpa_onnx_android_x86_64: 1.13.6
   # sherpa_onnx_android_x86_64:
   #   path: ../sherpa_onnx_android_x86_64
 
-  sherpa_onnx_ios: ^1.13.6
+  sherpa_onnx_ios: 1.13.6
   # sherpa_onnx_ios:
   #   path: ../sherpa_onnx_ios
 
-  sherpa_onnx_linux: ^1.13.6
+  sherpa_onnx_linux: 1.13.6
   # sherpa_onnx_linux:
   #   path: ../sherpa_onnx_linux
 
-  sherpa_onnx_macos: ^1.13.6
+  sherpa_onnx_macos: 1.13.6
   # sherpa_onnx_macos:
   #   path: ../sherpa_onnx_macos
 
-  sherpa_onnx_web: ^1.13.6
+  sherpa_onnx_web: 1.13.6
   # sherpa_onnx_web:
   #   path: ../sherpa_onnx_web
 
-  sherpa_onnx_windows: ^1.13.6
+  sherpa_onnx_windows: 1.13.6
   # sherpa_onnx_windows:
   #   path: ../sherpa_onnx_windows
 


### PR DESCRIPTION
Changed all sherpa_onnx flutter dependencies in pubspec.yaml files from caret version (^1.13.6) to exact version (1.13.6) matching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned Flutter and Dart example dependencies to the exact `sherpa_onnx` version `1.13.6`.
  * Updated platform-specific packages to consistently use the same exact version.
  * Aligned automated build and release checks across macOS, Linux, Windows, Android, iOS, and web.
  * Removed redundant dependency replacement steps to provide more consistent builds across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->