### PR TITLE
Fix online punctuation model initialization when the vocabulary path contains non-ASCII characters on Windows.

### DIFF
--- a/sherpa-onnx/csrc/online-punctuation-cnn-bilstm-impl.h
+++ b/sherpa-onnx/csrc/online-punctuation-cnn-bilstm-impl.h
@@ -34,8 +34,9 @@ class OnlinePunctuationCNNBiLSTMImpl : public OnlinePunctuationImpl {
   explicit OnlinePunctuationCNNBiLSTMImpl(const OnlinePunctuationConfig &config)
       : config_(config), model_(config.model) {
     if (!config_.model.bpe_vocab.empty()) {
-      bpe_encoder_ = std::make_unique<ssentencepiece::Ssentencepiece>(
-          config_.model.bpe_vocab);
+      auto buf = ReadFile(config_.model.bpe_vocab);
+      std::istringstream iss(std::string(buf.begin(), buf.end()));
+      bpe_encoder_ = std::make_unique<ssentencepiece::Ssentencepiece>(iss);
     }
   }
 


### PR DESCRIPTION
## Problem

The regular `OnlinePunctuationCNNBiLSTMImpl` constructor passes the BPE vocabulary path directly to `Ssentencepiece`.

On Windows, the path-based `Ssentencepiece` constructor ultimately opens the file using a narrow `std::ifstream`. As a result, valid UTF-8 paths containing characters such as Japanese or Chinese directory names cannot be opened.

The dependency also terminates the process when the vocabulary file cannot be opened, so applications using the C API may exit instead of receiving a recoverable error.

The manager-based constructor does not have this problem because it already loads the vocabulary through `ReadFile()` and constructs `Ssentencepiece` from an input stream.

## Solution

Use the same approach in the regular constructor:

1. Read the vocabulary with `ReadFile()`.
2. Create an `std::istringstream` from the returned buffer.
3. Construct `Ssentencepiece` from the stream.

On Windows, `ReadFile()` uses Sherpa ONNX's UTF-8-to-wide-path handling. On POSIX platforms, it continues to use the normal file APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved punctuation model initialization when loading BPE vocabulary files directly.
  * Ensured consistent vocabulary handling across supported loading paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->