### PR TITLE
Fix Qwen3-ASR hallucinating text on silent audio when hotwords/language are set

### DIFF
--- a/sherpa-onnx/csrc/CMakeLists.txt
+++ b/sherpa-onnx/csrc/CMakeLists.txt
@@ -830,6 +830,7 @@ if(SHERPA_ONNX_ENABLE_TESTS)
     context-graph-test.cc
     lfr-test.cc
     math-test.cc
+    offline-recognizer-qwen3-asr-impl-test.cc
     offline-whisper-timestamp-rules-test.cc
     packed-sequence-test.cc
     pad-sequence-test.cc

--- a/sherpa-onnx/csrc/offline-recognizer-qwen3-asr-impl-test.cc
+++ b/sherpa-onnx/csrc/offline-recognizer-qwen3-asr-impl-test.cc
@@ -1,0 +1,98 @@
+// sherpa-onnx/csrc/offline-recognizer-qwen3-asr-impl-test.cc
+//
+// Copyright (c)  2026  fra-shipper
+
+#include "sherpa-onnx/csrc/offline-recognizer-qwen3-asr-impl.h"
+
+#include <array>
+#include <cstring>
+
+#include "gtest/gtest.h"
+#include "sherpa-onnx/csrc/onnx-utils.h"
+
+namespace sherpa_onnx {
+
+// Regression test for https://github.com/k2-fsa/sherpa-onnx/issues/3509
+//
+// When every frame of audio_features is silence, TrimAudioFeatures() must
+// report that via |all_silent| so that GenerateText() can short-circuit to
+// an empty result before any hotwords/language prompt tokens are built.
+// Previously the all-silent case was indistinguishable from "nothing needed
+// trimming", so decoding proceeded and the hotwords/language prompt could
+// bias the LLM decoder into hallucinating text for silent audio.
+TEST(TrimAudioFeatures, AllSilentSetsFlag) {
+  Ort::AllocatorWithDefaultOptions allocator;
+
+  constexpr int32_t kFrames = 5;
+  constexpr int32_t kDim = 4;
+  std::array<int64_t, 3> shape{1, kFrames, kDim};
+  Ort::Value audio_features =
+      Ort::Value::CreateTensor<float>(allocator, shape.data(), shape.size());
+
+  float *p = audio_features.GetTensorMutableData<float>();
+  std::memset(p, 0, sizeof(float) * kFrames * kDim);
+
+  bool all_silent = false;
+  Ort::Value trimmed =
+      TrimAudioFeatures(std::move(audio_features), allocator, &all_silent);
+
+  EXPECT_TRUE(all_silent);
+
+  auto trimmed_shape = trimmed.GetTensorTypeAndShapeInfo().GetShape();
+  ASSERT_EQ(trimmed_shape.size(), 3u);
+  EXPECT_EQ(trimmed_shape[1], kFrames);
+}
+
+TEST(TrimAudioFeatures, TrailingSilenceIsTrimmedAndFlagStaysFalse) {
+  Ort::AllocatorWithDefaultOptions allocator;
+
+  constexpr int32_t kFrames = 5;
+  constexpr int32_t kValidFrames = 3;
+  constexpr int32_t kDim = 4;
+  std::array<int64_t, 3> shape{1, kFrames, kDim};
+  Ort::Value audio_features =
+      Ort::Value::CreateTensor<float>(allocator, shape.data(), shape.size());
+
+  float *p = audio_features.GetTensorMutableData<float>();
+  std::memset(p, 0, sizeof(float) * kFrames * kDim);
+  for (int32_t a = 0; a < kValidFrames; ++a) {
+    p[a * kDim] = 1.0f;
+  }
+
+  bool all_silent = false;
+  Ort::Value trimmed =
+      TrimAudioFeatures(std::move(audio_features), allocator, &all_silent);
+
+  EXPECT_FALSE(all_silent);
+
+  auto trimmed_shape = trimmed.GetTensorTypeAndShapeInfo().GetShape();
+  ASSERT_EQ(trimmed_shape.size(), 3u);
+  EXPECT_EQ(trimmed_shape[1], kValidFrames);
+}
+
+TEST(TrimAudioFeatures, NoTrailingSilenceFlagStaysFalse) {
+  Ort::AllocatorWithDefaultOptions allocator;
+
+  constexpr int32_t kFrames = 3;
+  constexpr int32_t kDim = 4;
+  std::array<int64_t, 3> shape{1, kFrames, kDim};
+  Ort::Value audio_features =
+      Ort::Value::CreateTensor<float>(allocator, shape.data(), shape.size());
+
+  float *p = audio_features.GetTensorMutableData<float>();
+  for (int32_t i = 0; i < kFrames * kDim; ++i) {
+    p[i] = 1.0f;
+  }
+
+  bool all_silent = false;
+  Ort::Value trimmed =
+      TrimAudioFeatures(std::move(audio_features), allocator, &all_silent);
+
+  EXPECT_FALSE(all_silent);
+
+  auto trimmed_shape = trimmed.GetTensorTypeAndShapeInfo().GetShape();
+  ASSERT_EQ(trimmed_shape.size(), 3u);
+  EXPECT_EQ(trimmed_shape[1], kFrames);
+}
+
+}  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/offline-recognizer-qwen3-asr-impl.cc
+++ b/sherpa-onnx/csrc/offline-recognizer-qwen3-asr-impl.cc
@@ -124,8 +124,10 @@ inline float ReadFloatOrHalfBitsValue(const float *data_f32,
   return HalfBitsToFloat(data_f16_bits[index]);
 }
 
-Ort::Value TrimAudioFeatures(Ort::Value audio_features,
-                             OrtAllocator *allocator) {
+}  // namespace
+
+Ort::Value TrimAudioFeatures(Ort::Value audio_features, OrtAllocator *allocator,
+                             bool *all_silent) {
   auto info = audio_features.GetTensorTypeAndShapeInfo();
   auto shape = info.GetShape();
   if (shape.size() != 3 || shape[0] != 1 || shape[1] <= 0 || shape[2] <= 0) {
@@ -170,6 +172,12 @@ Ort::Value TrimAudioFeatures(Ort::Value audio_features,
   }
 
   if (A_valid <= 0) {
+    // The whole clip is silence. Report it so the caller can short-circuit
+    // before building any hotwords/language prompt tokens, instead of
+    // silently falling through to decoding on an all-silence input.
+    if (all_silent != nullptr) {
+      *all_silent = true;
+    }
     return audio_features;
   }
 
@@ -197,6 +205,8 @@ Ort::Value TrimAudioFeatures(Ort::Value audio_features,
 
   return trimmed;
 }
+
+namespace {
 
 Ort::Value TruncateAudioFeatures(Ort::Value audio_features, int32_t keep_frames,
                                  OrtAllocator *allocator) {
@@ -680,14 +690,22 @@ OfflineRecognitionResult OfflineRecognizerQwen3ASRImpl::GenerateText(
       stream->GetOptionFloat("temperature", qwen3_config.temperature);
   const float top_p = stream->GetOptionFloat("top_p", qwen3_config.top_p);
 
-  Ort::Value trimmed_audio_features =
-      TrimAudioFeatures(std::move(audio_features), model_->Allocator());
+  bool all_silent = false;
+  Ort::Value trimmed_audio_features = TrimAudioFeatures(
+      std::move(audio_features), model_->Allocator(), &all_silent);
 
   auto trimmed_shape =
       trimmed_audio_features.GetTensorTypeAndShapeInfo().GetShape();
   if (trimmed_shape.size() == 3 && trimmed_shape[1] > 0) {
     audio_token_len = std::min<int32_t>(audio_token_len,
                                         static_cast<int32_t>(trimmed_shape[1]));
+  }
+
+  if (all_silent) {
+    // The whole clip is silence. Force an empty result now, before any
+    // hotwords/language prompt tokens are built, so they cannot bias the
+    // decoder into hallucinating text for silent audio.
+    audio_token_len = 0;
   }
 
   if (config_.model_config.debug) {

--- a/sherpa-onnx/csrc/offline-recognizer-qwen3-asr-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-qwen3-asr-impl.h
@@ -20,6 +20,14 @@
 
 namespace sherpa_onnx {
 
+// Trims trailing near-silent frames from audio_features (shape [1, A, H]).
+// If every frame's energy stays below the silence threshold, the tensor is
+// returned unmodified and, when |all_silent| is not null, |*all_silent| is
+// set to true so the caller can treat the clip as having no speech content.
+// Exposed here (rather than kept file-local) so it can be unit tested.
+Ort::Value TrimAudioFeatures(Ort::Value audio_features, OrtAllocator *allocator,
+                             bool *all_silent = nullptr);
+
 class OfflineRecognizerQwen3ASRImpl : public OfflineRecognizerImpl {
  public:
   explicit OfflineRecognizerQwen3ASRImpl(const OfflineRecognizerConfig &config);


### PR DESCRIPTION
Fixes #3509

### Root cause

`TrimAudioFeatures()` walks `audio_features` (shape `[1, A, H]`) back-to-front
looking for the last frame whose energy exceeds `eps`. When every frame is
below `eps` (`A_valid <= 0`, i.e. the whole clip is silence), it returns the
original, untrimmed tensor -- the same thing it does when nothing needed
trimming. The caller in `GenerateText()` has no way to tell those two cases
apart: it only shrinks `audio_token_len` when the trimmed tensor is shorter
than the original, so for a nonzero-duration all-silent clip `audio_token_len`
stays at its original nonzero value and the existing `audio_token_len <= 0`
early return never fires.

As a result, decoding proceeds on all-silent audio and the hotwords/language
prompt tokens get built and fed to the LLM decoder. As reported in the issue,
an empty prompt (no hotwords, no language) still happens to produce an empty
result because the decoder naturally emits EOS, but adding `--hotwords` or
`--language` biases it away from that and it hallucinates text (e.g.
`"system"`).

### Fix

`TrimAudioFeatures()` now takes an optional `bool *all_silent` out-parameter
and sets it to `true` when every frame is below the silence threshold.
`GenerateText()` uses that flag to force `audio_token_len` to `0` and return
an empty result before any hotwords/language prompt tokens are built, so
silence is handled the same way regardless of what options are set.

`TrimAudioFeatures()` is moved out of the file-local anonymous namespace and
declared in `offline-recognizer-qwen3-asr-impl.h` so it can be exercised
directly by a unit test.

### Testing

Added `offline-recognizer-qwen3-asr-impl-test.cc` with three gtest cases
against `TrimAudioFeatures()` directly:
- an all-zero (silent) tensor sets `all_silent = true`
- a tensor with real signal in the leading frames and silence in the trailing
  frames trims correctly and leaves `all_silent = false`
- a tensor with no trailing silence is returned unmodified and leaves
  `all_silent = false`

Registered the new test file in `sherpa-onnx/csrc/CMakeLists.txt`'s
`sherpa_onnx_test_srcs` list.

Built and ran the new test against a real CMake configuration
(`-DSHERPA_ONNX_ENABLE_TESTS=ON`, all other optional components off, ONNX
Runtime v1.27.1 fetched by the build):

```
cmake --build . --target offline-recognizer-qwen3-asr-impl-test -j 12
-- [100%] Built target offline-recognizer-qwen3-asr-impl-test

./bin/offline-recognizer-qwen3-asr-impl-test
[==========] Running 3 tests from 1 test suite.
[ OK ] TrimAudioFeatures.AllSilentSetsFlag (0 ms)
[ OK ] TrimAudioFeatures.TrailingSilenceIsTrimmedAndFlagStaysFalse (0 ms)
[ OK ] TrimAudioFeatures.NoTrailingSilenceFlagStaysFalse (0 ms)
[PASSED] 3 tests.

ctest -R offline-recognizer-qwen3-asr-impl-test --output-on-failure
1/1 Test #6: offline-recognizer-qwen3-asr-impl-test ... Passed 0.01 sec
100% tests passed out of 1
```

Also confirmed the test fails to build against the pre-fix code (checked out
`offline-recognizer-qwen3-asr-impl.{cc,h}` from the parent commit): the
build fails with `use of undeclared identifier 'TrimAudioFeatures'` because
the old signature isn't visible outside the anonymous namespace, then passes
again once the fix is restored.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline speech recognition handling for audio containing only silence.
  * Trailing silent audio frames are now trimmed while preserving valid speech features.
  * Prevented unnecessary prompt and token processing when an entire audio clip is silent.

* **Tests**
  * Added coverage for all-silent, trailing-silence, and no-silence audio scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->