### PR TITLE
Fix data race on shared PRNG in FunASR-Nano and Qwen3-ASR offline recognizers

### DIFF
--- a/sherpa-onnx/csrc/CMakeLists.txt
+++ b/sherpa-onnx/csrc/CMakeLists.txt
@@ -831,6 +831,7 @@ if(SHERPA_ONNX_ENABLE_TESTS)
     lfr-test.cc
     math-test.cc
     offline-recognizer-qwen3-asr-impl-test.cc
+    offline-recognizer-shared-rng-test.cc
     offline-whisper-timestamp-rules-test.cc
     packed-sequence-test.cc
     pad-sequence-test.cc

--- a/sherpa-onnx/csrc/offline-recognizer-funasr-nano-impl.cc
+++ b/sherpa-onnx/csrc/offline-recognizer-funasr-nano-impl.cc
@@ -372,7 +372,11 @@ int64_t OfflineRecognizerFunASRNanoImpl::SampleTokenWithTemperatureAndTopP(
 
   if (top_p >= 1.0f) {
     std::uniform_real_distribution<float> dist(0.0f, 1.0f);
-    float sample = dist(rng_);
+    float sample;
+    {
+      std::lock_guard<std::mutex> lock(rng_mutex_);
+      sample = dist(rng_);
+    }
     float cumsum = 0.0f;
     for (int32_t i = 0; i < vocab_size; ++i) {
       cumsum += probs[i];
@@ -413,7 +417,11 @@ int64_t OfflineRecognizerFunASRNanoImpl::SampleTokenWithTemperatureAndTopP(
   if (renorm_sum <= 0.0f) return 0;
 
   std::uniform_real_distribution<float> dist(0.0f, renorm_sum);
-  float sample = dist(rng_);
+  float sample;
+  {
+    std::lock_guard<std::mutex> lock(rng_mutex_);
+    sample = dist(rng_);
+  }
   float cumsum_sample = 0.0f;
   for (int32_t i = 0; i < cutoff; ++i) {
     cumsum_sample += probs[idx[i]];

--- a/sherpa-onnx/csrc/offline-recognizer-funasr-nano-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-funasr-nano-impl.h
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <mutex>
 #include <random>
 #include <string>
 #include <utility>
@@ -64,6 +65,12 @@ class OfflineRecognizerFunASRNanoImpl : public OfflineRecognizerImpl {
   std::unique_ptr<OfflineFunASRNanoModel> model_;
   std::unique_ptr<FunASRNanoTokenizer> tokenizer_;
   mutable std::mt19937 rng_;
+  // Protects rng_, which is shared and drawn from by
+  // SampleTokenWithTemperatureAndTopP(). DecodeStreams() may be called
+  // concurrently from multiple threads on the same recognizer instance (see
+  // sherpa-onnx-offline-parallel.cc), so draws from rng_ must be serialized to
+  // avoid a data race.
+  mutable std::mutex rng_mutex_;
 };
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/offline-recognizer-qwen3-asr-impl.cc
+++ b/sherpa-onnx/csrc/offline-recognizer-qwen3-asr-impl.cc
@@ -730,7 +730,11 @@ int64_t OfflineRecognizerQwen3ASRImpl::SampleTokenWithTemperatureAndTopP(
       return prob_idx[0].first;
     }
 
-    float r = std::uniform_real_distribution<float>(0.0f, kept_sum)(rng_);
+    float r;
+    {
+      std::lock_guard<std::mutex> lock(rng_mutex_);
+      r = std::uniform_real_distribution<float>(0.0f, kept_sum)(rng_);
+    }
     float cumsum = 0.0f;
     for (int32_t i = 0; i < cutoff; ++i) {
       cumsum += prob_idx[i].second;
@@ -742,7 +746,11 @@ int64_t OfflineRecognizerQwen3ASRImpl::SampleTokenWithTemperatureAndTopP(
     return prob_idx[cutoff - 1].first;
   }
 
-  float r = std::uniform_real_distribution<float>(0.0f, sum)(rng_);
+  float r;
+  {
+    std::lock_guard<std::mutex> lock(rng_mutex_);
+    r = std::uniform_real_distribution<float>(0.0f, sum)(rng_);
+  }
   float cumsum = 0.0f;
   for (int32_t i = 0; i < vocab_size; ++i) {
     cumsum += probs[i];

--- a/sherpa-onnx/csrc/offline-recognizer-qwen3-asr-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-qwen3-asr-impl.h
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <random>
 #include <string>
 #include <utility>
@@ -73,6 +74,12 @@ class OfflineRecognizerQwen3ASRImpl : public OfflineRecognizerImpl {
   std::vector<int64_t> prompt_ids_after_;
   int64_t asr_text_token_id_ = -1;
   mutable std::mt19937 rng_;
+  // Protects rng_, which is shared and drawn from by
+  // SampleTokenWithTemperatureAndTopP(). DecodeStreams() may be called
+  // concurrently from multiple threads on the same recognizer instance (see
+  // sherpa-onnx-offline-parallel.cc), so draws from rng_ must be serialized to
+  // avoid a data race.
+  mutable std::mutex rng_mutex_;
 };
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/offline-recognizer-shared-rng-test.cc
+++ b/sherpa-onnx/csrc/offline-recognizer-shared-rng-test.cc
@@ -1,0 +1,105 @@
+// sherpa-onnx/csrc/offline-recognizer-shared-rng-test.cc
+//
+// Copyright (c)  2026  fra-shipper
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <random>
+#include <thread>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace sherpa_onnx {
+
+namespace {
+
+// OfflineRecognizerFunASRNanoImpl (offline-recognizer-funasr-nano-impl.h)
+// and OfflineRecognizerQwen3ASRImpl (offline-recognizer-qwen3-asr-impl.h)
+// each hold a single `mutable std::mt19937 rng_` that is drawn from inside
+// SampleTokenWithTemperatureAndTopP(), a const method reachable from
+// DecodeStreams(). sherpa-onnx-offline-parallel.cc builds exactly ONE
+// OfflineRecognizer and spawns `nj` std::threads that all call
+// DecodeStreams() on that same instance concurrently, so with temperature
+// sampling enabled every thread used to draw from the same rng_ with no
+// synchronization -- a data race. The fix adds a
+// `mutable std::mutex rng_mutex_` next to rng_ and a
+// `std::lock_guard<std::mutex> lock(rng_mutex_)` around every draw.
+//
+// OfflineRecognizerFunASRNanoImpl/OfflineRecognizerQwen3ASRImpl cannot be
+// constructed in a unit test without loading real ONNX model weights (their
+// constructors eagerly open the model files), so this test isolates the
+// exact rng_/rng_mutex_ synchronization pattern those two fixes now share
+// and exercises it under the same one-instance/nj-threads usage pattern as
+// sherpa-onnx-offline-parallel.cc. A small delay is injected inside the
+// "critical section" to widen the race window so an unguarded run reliably
+// shows overlapping access instead of only occasionally.
+class SharedRngSampler {
+ public:
+  explicit SharedRngSampler(uint32_t seed) : rng_(seed) {}
+
+  // Mirrors the shape of the fixed draw sites, e.g.
+  //   std::lock_guard<std::mutex> lock(rng_mutex_);
+  //   float sample = dist(rng_);
+  float Sample() {
+    std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+    std::lock_guard<std::mutex> lock(rng_mutex_);
+    return DrawLocked(&dist);
+  }
+
+  int32_t MaxConcurrentEntries() const {
+    return max_active_in_critical_section_.load();
+  }
+
+ private:
+  float DrawLocked(std::uniform_real_distribution<float> *dist) {
+    int32_t active = active_in_critical_section_.fetch_add(1) + 1;
+    RecordMax(active);
+    std::this_thread::sleep_for(std::chrono::microseconds(200));
+    float sample = (*dist)(rng_);
+    active_in_critical_section_.fetch_sub(1);
+    return sample;
+  }
+
+  void RecordMax(int32_t active) {
+    int32_t prev =
+        max_active_in_critical_section_.load(std::memory_order_relaxed);
+    while (
+        active > prev &&
+        !max_active_in_critical_section_.compare_exchange_weak(prev, active)) {
+    }
+  }
+
+  mutable std::mt19937 rng_;
+  mutable std::mutex rng_mutex_;
+  std::atomic<int32_t> active_in_critical_section_{0};
+  std::atomic<int32_t> max_active_in_critical_section_{0};
+};
+
+}  // namespace
+
+// Regression test: with rng_mutex_ guarding every draw from the shared
+// rng_, no two of the nj decode threads may ever be inside the critical
+// section at the same time.
+TEST(SharedRngThreadSafety, ConcurrentSamplingIsSerialized) {
+  constexpr int32_t kNumThreads = 8;  // mirrors a --nj=8 decode run
+  constexpr int32_t kDrawsPerThread = 50;
+
+  SharedRngSampler sampler(/*seed=*/42);
+
+  std::vector<std::thread> threads;
+  threads.reserve(kNumThreads);
+  for (int32_t t = 0; t < kNumThreads; ++t) {
+    threads.emplace_back([&sampler]() {
+      for (int32_t i = 0; i < kDrawsPerThread; ++i) {
+        sampler.Sample();
+      }
+    });
+  }
+  for (auto &th : threads) th.join();
+
+  EXPECT_EQ(sampler.MaxConcurrentEntries(), 1);
+}
+
+}  // namespace sherpa_onnx


### PR DESCRIPTION
## Root cause

`OfflineRecognizerFunASRNanoImpl` and `OfflineRecognizerQwen3ASRImpl` each hold a single
`mutable std::mt19937 rng_`, seeded once in the constructor
(`offline-recognizer-funasr-nano-impl.h:66`, `offline-recognizer-qwen3-asr-impl.h:75`)
and drawn from inside `SampleTokenWithTemperatureAndTopP()` -- a `const` method reachable
from `DecodeStreams()` via `GenerateText()` -- whenever temperature sampling is enabled
(`temperature > 1e-6`; the default is greedy decoding at `1e-6`, so the bug is dormant
unless the caller opts into sampling via `--funasr-nano-temperature` /
`--qwen3-asr-temperature`, wired in through `OfflineModelConfig::Register`).

`sherpa-onnx-offline-parallel.cc`, the project's own documented way to batch-decode
concurrently with a single loaded model instead of `nj` copies, constructs exactly ONE
`sherpa_onnx::OfflineRecognizer recognizer(config)` and spawns `nj` `std::thread`s that
each call `recognizer->DecodeStreams(...)` on that same shared instance. `DecodeStreams()`
just forwards to `impl_->DecodeStreams()` with no synchronization
(`offline-recognizer.cc`, around line 172). So with temperature sampling on, every decode
thread draws from the same `rng_` with no locking: a data race on the shared `mt19937`
state array (UB), and it silently defeats the documented `seed=<N>` reproducibility knob
under concurrency -- the same audio can decode to different text run-to-run depending on
thread interleaving.

## Fix

Add a `mutable std::mutex rng_mutex_` next to `rng_` in both impl classes, and take a
`std::lock_guard<std::mutex> lock(rng_mutex_)` around each draw from `rng_`
(`SampleTokenWithTemperatureAndTopP()` in both `.cc` files, at the two draw sites in
each). Greedy decoding (the default) never reaches these draw sites and is unaffected;
existing single-threaded callers see no behavior change.

## Testing

`OfflineRecognizerFunASRNanoImpl`/`OfflineRecognizerQwen3ASRImpl` can't be constructed in
a unit test without loading real ONNX model weights (their constructors eagerly open the
model files), so the added test, `offline-recognizer-shared-rng-test.cc`, isolates the
exact `rng_`/`rng_mutex_` synchronization pattern both fixes now share and exercises it
under the same one-instance/`nj`-threads usage pattern as
`sherpa-onnx-offline-parallel.cc` (8 threads, 50 draws each, with an injected delay inside
the critical section to widen the race window), asserting via an atomic
overlap-detector that no two threads are ever inside the critical section at once.

Built and ran locally (macOS arm64, Release):

- With the mutex removed (reproducing the pre-fix unguarded `dist(rng_)` call):
  ```
  [ RUN      ] SharedRngThreadSafety.ConcurrentSamplingIsSerialized
  offline-recognizer-shared-rng-test.cc:103: Failure
  Expected equality of these values:
    sampler.MaxConcurrentEntries()
      Which is: 8
    1
  [  FAILED  ] SharedRngThreadSafety.ConcurrentSamplingIsSerialized (12 ms)
  ```
  (reproduced consistently across 3 runs)

- With the mutex in place (as committed):
  ```
  [ RUN      ] SharedRngThreadSafety.ConcurrentSamplingIsSerialized
  [       OK ] SharedRngThreadSafety.ConcurrentSamplingIsSerialized (106 ms)
  [  PASSED  ] 1 test.
  ```
  (reproduced consistently across 3 runs)

Also ran the existing `offline-recognizer-qwen3-asr-impl-test` (3 tests, all pass,
unaffected by this change) and built `sherpa-onnx-core` in full with no new warnings or
errors on the four touched files.

`clang-format --style=file` reports no diff on any line this PR added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of random sampling during concurrent speech recognition decoding.
  - Prevented simultaneous access to shared sampling state when multiple decoding operations run in parallel.

- **Tests**
  - Added coverage verifying that concurrent random sampling is properly serialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->