### PR TITLE
Fix Cohere Transcribe hallucinating sentences on silent audio

### DIFF
--- a/sherpa-onnx/csrc/CMakeLists.txt
+++ b/sherpa-onnx/csrc/CMakeLists.txt
@@ -830,6 +830,7 @@ if(SHERPA_ONNX_ENABLE_TESTS)
     context-graph-test.cc
     lfr-test.cc
     math-test.cc
+    offline-recognizer-cohere-transcribe-impl-test.cc
     offline-recognizer-qwen3-asr-impl-test.cc
     offline-recognizer-shared-rng-test.cc
     offline-whisper-timestamp-rules-test.cc

--- a/sherpa-onnx/csrc/offline-recognizer-cohere-transcribe-impl-test.cc
+++ b/sherpa-onnx/csrc/offline-recognizer-cohere-transcribe-impl-test.cc
@@ -32,6 +32,19 @@ TEST(CohereHasSignal, EmptyFeaturesAreNotSignal) {
   EXPECT_FALSE(CohereHasSignal(&unused, 0));
 }
 
+TEST(CohereHasSignal, ThresholdIsStrict) {
+  // the comparison is strictly greater-than, so a value equal to
+  // kCohereSilenceFeatureAbsMax still counts as silent
+  std::vector<float> below = {0.999f};
+  EXPECT_FALSE(CohereHasSignal(below.data(), below.size()));
+
+  std::vector<float> exact = {1.0f};
+  EXPECT_FALSE(CohereHasSignal(exact.data(), exact.size()));
+
+  std::vector<float> above = {1.001f};
+  EXPECT_TRUE(CohereHasSignal(above.data(), above.size()));
+}
+
 TEST(CohereHasSignal, LoudSingleSampleIsSignal) {
   std::vector<float> features(1024, 0.001f);
   features[512] = 3.0f;

--- a/sherpa-onnx/csrc/offline-recognizer-cohere-transcribe-impl-test.cc
+++ b/sherpa-onnx/csrc/offline-recognizer-cohere-transcribe-impl-test.cc
@@ -1,0 +1,41 @@
+// sherpa-onnx/csrc/offline-recognizer-cohere-transcribe-impl-test.cc
+//
+// Copyright (c)  2026  kyo-zzz
+
+#include "sherpa-onnx/csrc/offline-recognizer-cohere-transcribe-impl.h"
+
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace sherpa_onnx {
+
+// DecodeStreams() returns an empty transcript for digitally silent audio so
+// that the decoder cannot hallucinate sentences for it (measured: 7 of 8
+// supported languages hallucinate, e.g. "Herr Präsident, meine Damen und
+// Herren!" for de). These tests cover the silence detector.
+TEST(CohereHasSignal, SilenceVsSignal) {
+  float unused = 0;
+  EXPECT_FALSE(CohereHasSignal(&unused, 0));
+
+  // digital silence: normalized features stay far below the threshold
+  std::vector<float> silence = {0.0f, 0.05f, -0.087f, 0.02f};
+  EXPECT_FALSE(CohereHasSignal(silence.data(), silence.size()));
+
+  // any audio with content is well above it
+  std::vector<float> signal = {0.0f, 0.05f, -1.5f, 0.02f};
+  EXPECT_TRUE(CohereHasSignal(signal.data(), signal.size()));
+}
+
+TEST(CohereHasSignal, EmptyFeaturesAreNotSignal) {
+  float unused = 0;
+  EXPECT_FALSE(CohereHasSignal(&unused, 0));
+}
+
+TEST(CohereHasSignal, LoudSingleSampleIsSignal) {
+  std::vector<float> features(1024, 0.001f);
+  features[512] = 3.0f;
+  EXPECT_TRUE(CohereHasSignal(features.data(), features.size()));
+}
+
+}  // namespace sherpa_onnx

--- a/sherpa-onnx/csrc/offline-recognizer-cohere-transcribe-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-cohere-transcribe-impl.h
@@ -173,7 +173,6 @@ class OfflineRecognizerCohereTranscribeImpl : public OfflineRecognizerImpl {
       // encoder/decoder run, so they cannot hallucinate text for silent
       // audio.
       OfflineRecognitionResult r;
-      r.text = "";
       s->SetResult(r);
       return;
     }

--- a/sherpa-onnx/csrc/offline-recognizer-cohere-transcribe-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-cohere-transcribe-impl.h
@@ -24,6 +24,31 @@
 
 namespace sherpa_onnx {
 
+// The decoder in this file happily transcribes silence into hallucinated
+// sentences for most languages (measured with
+// sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01: e.g. "Herr
+// Präsident, meine Damen und Herren!" for de, "Sous-titrage Société
+// Radio-Canada" for fr, "谢谢" for zh; only en returns an empty string), so
+// digitally silent clips must be detected and short-circuited before the
+// decoder runs.
+//
+// Silence is detected on the normalized fbank features returned by
+// OfflineStream::GetFrames(). Those features are scale invariant, so the
+// recording level does not matter. The fbank configuration is the same as
+// for Canary (see offline-recognizer-canary-impl.h), where digital silence
+// measures a max |feature| of about 0.09 while audio with content stays
+// above 4 regardless of its level.
+inline constexpr float kCohereSilenceFeatureAbsMax = 1.0f;
+
+inline bool CohereHasSignal(const float *features, int32_t n) {
+  float abs_max = 0;
+  for (int32_t i = 0; i != n; ++i) {
+    abs_max = std::max(abs_max, std::abs(features[i]));
+  }
+
+  return abs_max > kCohereSilenceFeatureAbsMax;
+}
+
 class OfflineRecognizerCohereTranscribeImpl : public OfflineRecognizerImpl {
  public:
   explicit OfflineRecognizerCohereTranscribeImpl(
@@ -142,6 +167,16 @@ class OfflineRecognizerCohereTranscribeImpl : public OfflineRecognizerImpl {
     int32_t feat_dim = s->FeatureDim();
     std::vector<float> f = s->GetFrames();
     int32_t num_frames = f.size() / feat_dim;
+
+    if (!CohereHasSignal(f.data(), static_cast<int32_t>(f.size()))) {
+      // The whole clip is silence. Return an empty result before the
+      // encoder/decoder run, so they cannot hallucinate text for silent
+      // audio.
+      OfflineRecognitionResult r;
+      r.text = "";
+      s->SetResult(r);
+      return;
+    }
 
     f = Transpose(f.data(), num_frames, feat_dim);
     // now f is (1, feat_dim, num_frames)


### PR DESCRIPTION
### Root cause

`OfflineRecognizerCohereTranscribeImpl::DecodeStreams()` runs the encoder and the decoder regardless of the input content. For a clip of digital silence, most supported languages decode to a hallucinated sentence (deterministically, measured with the 14-language int8 model):

| language | output for 4 s of digital silence |
|---|---|
| en | `""` (the only correct one) |
| de | `"Herr Präsident, meine Damen und Herren!"` |
| fr | `"Sous-titrage Société Radio-Canada"` |
| zh | `"谢谢"` |
| ko | `"으음."` |
| vi | `"ạ"` |
| ar | `"نهايه الدرس"` |
| es | `"El juego se queda en la pista."` |

The Qwen3-ASR recognizer in this repo already short-circuits this case: an all-silent clip returns an empty result before any decoding happens (#3907). Cohere Transcribe has no equivalent check.

### Fix

`CohereHasSignal()` decides whether the clip contains any signal, and `DecodeStreams()` returns an empty transcript when it does not, before the encoder and the decoder run.

The features returned by `GetFrames()` are per-feature normalized fbank values, which are scale invariant — the recording level does not matter. Measured in this model's own feature domain: digital silence gives a max |feature| of about 0.09, while the official test wavs for all 8 supported languages stay between 3.3 and 4.5 regardless of their level; the threshold sits at 1.0.

As with the Qwen3-ASR fix, audio with a noise floor is still decoded; this change only covers clips that are exactly silent.

### Verification

`sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01`, CPU, Windows:

| input | before | after |
|---|---|---|
| 4 s digital silence, de/fr/zh/ko/vi/ar/es | hallucinated sentences (table above) | `""` |
| 4 s digital silence, en | `""` | `""` (unchanged) |
| 8 official test_wavs (one per language) | full transcript | full transcript (unchanged) |
| 4 s speech with 50/200/500 ms leading silence, en/de/zh | full transcript | full transcript (unchanged) |

The new `offline-recognizer-cohere-transcribe-impl-test` covers the silence detector (thresholds on both sides, a single loud sample, empty input).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline transcription handling for digitally silent audio.
  * Silent clips now return an empty transcript instead of potentially generating hallucinated text.
  * Improved handling of empty and very quiet audio to avoid unintended transcription results.

* **Tests**
  * Added coverage for silence, empty input, quiet audio, and audio containing a detectable signal to help ensure consistent transcription behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->