### PR TITLE
Add Kokoro v1.0 em_santa voice

### DIFF
--- a/scripts/kokoro/v1.0/README.md
+++ b/scripts/kokoro/v1.0/README.md
@@ -1,3 +1,20 @@
 # Introduction
 
 This directory is for kokoro v1.0
+
+`generate_voices_bin.py` generates the Sherpa-ONNX voice table from the
+official `Kokoro-82M/voices` directory. The generated v1.0 table contains 54
+voices, including the Spanish `em_santa` voice at speaker ID 53. Existing
+speaker IDs 0 through 52 remain unchanged.
+
+The generator validates the style embedding shape (`510 x 1 x 256`) and
+`float32` dtype before writing the binary file. Run it from this directory
+after downloading the Kokoro-82M repository:
+
+```bash
+python3 generate_voices_bin.py
+```
+
+The corresponding model metadata must be generated with `add_meta_data.py`,
+which derives `n_speakers`, `speaker_names`, `id2speaker`, and `speaker2id`
+from the same mapping.

--- a/scripts/kokoro/v1.0/generate_voices_bin.py
+++ b/scripts/kokoro/v1.0/generate_voices_bin.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 # Copyright    2025  Xiaomi Corp.        (authors: Fangjun Kuang)
-import torch
+import os
 from pathlib import Path
+
+import torch
 
 
 id2speaker = {
@@ -58,26 +60,42 @@ id2speaker = {
     50: "zm_yunxi",
     51: "zm_yunxia",
     52: "zm_yunyang",
+    53: "em_santa",
 }
 
 speaker2id = {speaker: idx for idx, speaker in id2speaker.items()}
 
+EXPECTED_STYLE_SHAPE = (510, 1, 256)
+
 
 def main():
-    if Path("./voices.bin").is_file():
-        print("./voices.bin exists - skip")
-        return
+    output_path = Path("voices.bin")
+    temp_path = output_path.with_name(f".{output_path.name}.tmp")
+    try:
+        with temp_path.open("wb") as f:
+            for _, speaker in id2speaker.items():
+                m = torch.load(
+                    f"Kokoro-82M/voices/{speaker}.pt",
+                    weights_only=True,
+                    map_location="cpu",
+                ).numpy()
+                if m.shape != EXPECTED_STYLE_SHAPE:
+                    raise ValueError(
+                        f"Unexpected style shape for {speaker}: {m.shape}; "
+                        f"expected {EXPECTED_STYLE_SHAPE}"
+                    )
+                if str(m.dtype) != "float32":
+                    raise TypeError(
+                        f"Unexpected style dtype for {speaker}: {m.dtype}; "
+                        "expected float32"
+                    )
 
-    with open("voices.bin", "wb") as f:
-        for _, speaker in id2speaker.items():
-            m = torch.load(
-                f"Kokoro-82M/voices/{speaker}.pt",
-                weights_only=True,
-                map_location="cpu",
-            ).numpy()
-            # m.shape (510, 1, 256)
-
-            f.write(m.tobytes())
+                f.write(m.tobytes())
+            f.flush()
+            os.fsync(f.fileno())
+        temp_path.replace(output_path)
+    finally:
+        temp_path.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The voice generator now includes em_santa as speaker ID 53 while preserving all existing IDs. It also validates the expected style embedding shape and float32 dtype before generating voices.bin. Metadata generation automatically reflects the expanded 54-voice catalog.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `em_santa` voice as speaker ID 53 while preserving existing speaker IDs.
  * Voice generation now validates voice data dimensions and data type, with clear errors for invalid data.
  * Voice tables can be regenerated reliably, including when an output file already exists.

* **Documentation**
  * Added instructions for generating the Kokoro v1.0 voice table.
  * Documented voice mapping consistency and the steps for generating corresponding model metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->