### PR TITLE
Add Go API for Windows arm64

### DIFF
--- a/.github/workflows/test-go-package.yaml
+++ b/.github/workflows/test-go-package.yaml
@@ -202,6 +202,35 @@ jobs:
             arch: x86
             index: 6
             tests: "add-punctuation-online non-streaming-speaker-diarization streaming-hlg-decoding speaker-identification"
+          # Windows arm64
+          - os: windows-11-arm
+            arch: arm64
+            index: 0
+            tests: "hello-world non-streaming-decode-files"
+          - os: windows-11-arm
+            arch: arm64
+            index: 1
+            tests: "non-streaming-cohere-transcribe-decode-files supertonic-tts non-streaming-moonshine-v2-decode-files"
+          - os: windows-11-arm
+            arch: arm64
+            index: 2
+            tests: "non-streaming-fire-red-asr-ctc-decode-files zero-shot-pocket-tts zero-shot-zipvoice-tts non-streaming-funasr-nano-decode-files"
+          - os: windows-11-arm
+            arch: arm64
+            index: 3
+            tests: "non-streaming-medasr-ctc-decode-files non-streaming-omnilingual-asr-ctc-decode-files non-streaming-tts streaming-decode-files"
+          - os: windows-11-arm
+            arch: arm64
+            index: 4
+            tests: "non-streaming-canary-decode-files speech-enhancement-gtcrn speech-enhancement-dpdfnet streaming-speech-enhancement-gtcrn"
+          - os: windows-11-arm
+            arch: arm64
+            index: 5
+            tests: "streaming-speech-enhancement-dpdfnet audio-tagging keyword-spotting-from-file add-punctuation"
+          - os: windows-11-arm
+            arch: arm64
+            index: 6
+            tests: "add-punctuation-online non-streaming-speaker-diarization streaming-hlg-decoding speaker-identification"
 
     steps:
       - uses: actions/checkout@v4
@@ -232,6 +261,12 @@ jobs:
           go env -w GOARCH=386
           go env -w CGO_ENABLED=1
 
+      - name: Set up MSVC for ARM64
+        if: matrix.os == 'windows-11-arm' && matrix.arch == 'arm64'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: arm64
+
       - name: Update version
         shell: bash
         run: |
@@ -239,11 +274,16 @@ jobs:
           git diff .
 
       - name: Copy DLLs to example directories (Windows)
-        if: matrix.os == 'windows-2022'
+        if: matrix.os == 'windows-2022' || matrix.os == 'windows-11-arm'
         shell: bash
+        env:
+          CC: ${{ matrix.os == 'windows-11-arm' && 'clang' || '' }}
+          CXX: ${{ matrix.os == 'windows-11-arm' && 'clang++' || '' }}
         run: |
           if [[ "${{ matrix.arch }}" == "x86" ]]; then
             win_lib_dir=i686-pc-windows-gnu
+          elif [[ "${{ matrix.arch }}" == "arm64" ]]; then
+            win_lib_dir=aarch64-pc-windows-gnu
           else
             win_lib_dir=x86_64-pc-windows-gnu
           fi
@@ -261,6 +301,9 @@ jobs:
 
       - name: Run tests
         shell: bash
+        env:
+          CC: ${{ matrix.os == 'windows-11-arm' && 'clang' || '' }}
+          CXX: ${{ matrix.os == 'windows-11-arm' && 'clang++' || '' }}
         run: |
           for test in ${{ matrix.tests }}; do
             echo "=== Running ${test} ==="

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - go-win-arm64
 
   workflow_dispatch:
 
@@ -31,6 +32,8 @@ jobs:
             arch: x64
           - os: windows-2022
             arch: x86
+          - os: windows-11-arm
+            arch: arm64
 
     steps:
       - uses: actions/checkout@v4
@@ -61,6 +64,12 @@ jobs:
           platform: x86
           version: '12.2.0'
 
+      - name: Set up MSVC for ARM64
+        if: matrix.os == 'windows-11-arm' && matrix.arch == 'arm64'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: arm64
+
       - uses: actions/setup-go@v5
         with:
           go-version: '>=1.17'
@@ -88,7 +97,7 @@ jobs:
           upload_dir=$PWD/to-upload
           mkdir -p $upload_dir
 
-          if [[ "${{ matrix.os }}" != "windows-2022" ]]; then
+          if [[ "${{ matrix.os }}" != "windows-2022" && "${{ matrix.os }}" != "windows-11-arm" ]]; then
             export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           fi
           mkdir build
@@ -97,6 +106,8 @@ jobs:
           cmake_extra_args=""
           if [[ "${{ matrix.os }}" == "windows-2022" && "${{ matrix.arch }}" == "x86" ]]; then
             cmake_extra_args="-A Win32"
+          elif [[ "${{ matrix.os }}" == "windows-11-arm" ]]; then
+            cmake_extra_args="-A ARM64"
           fi
 
           cmake \
@@ -110,7 +121,7 @@ jobs:
             $cmake_extra_args \
             ..
 
-          if [[ "${{ matrix.os }}" == "windows-2022" ]]; then
+          if [[ "${{ matrix.os }}" == "windows-2022" || "${{ matrix.os }}" == "windows-11-arm" ]]; then
             cmake --build . --target install --config Release -- -m:2
           else
             make -j2 install
@@ -129,10 +140,12 @@ jobs:
             go_lib_dir=../scripts/go/_internal/lib/i686-pc-windows-gnu
           elif [[ "${{ matrix.os }}" == windows-2022 ]]; then
             go_lib_dir=../scripts/go/_internal/lib/x86_64-pc-windows-gnu
+          elif [[ "${{ matrix.os }}" == windows-11-arm ]]; then
+            go_lib_dir=../scripts/go/_internal/lib/aarch64-pc-windows-gnu
           fi
           mkdir -p "$go_lib_dir"
 
-          if [[ ${{ matrix.os }} == windows-2022 ]]; then
+          if [[ "${{ matrix.os }}" == windows-2022 || "${{ matrix.os }}" == windows-11-arm ]]; then
             cp -v ./install/lib/sherpa-onnx-c-api.dll "$go_lib_dir/"
             cp -v ./install/lib/onnxruntime.dll "$go_lib_dir/"
             cp -v ./install/lib/sherpa-onnx-c-api.lib "$go_lib_dir/"
@@ -149,14 +162,20 @@ jobs:
 
           cd ../scripts/go/_internal/
           go mod tidy
-          go build
+          if [[ "${{ matrix.os }}" == "windows-11-arm" ]]; then
+            CC=clang CXX=clang++ CGO_ENABLED=1 go build
+          else
+            go build
+          fi
 
       - name: Copy DLLs to example directories (Windows)
-        if: matrix.os == 'windows-2022'
+        if: matrix.os == 'windows-2022' || matrix.os == 'windows-11-arm'
         shell: bash
         run: |
-          if [[ ${{ matrix.arch }} == x86 ]]; then
+          if [[ "${{ matrix.arch }}" == "x86" ]]; then
             win_lib_dir=i686-pc-windows-gnu
+          elif [[ "${{ matrix.arch }}" == "arm64" ]]; then
+            win_lib_dir=aarch64-pc-windows-gnu
           else
             win_lib_dir=x86_64-pc-windows-gnu
           fi
@@ -172,14 +191,14 @@ jobs:
           done
 
       - name: Remove non-Windows lib dirs before upload
-        if: matrix.os == 'windows-2022'
+        if: matrix.os == 'windows-2022' || matrix.os == 'windows-11-arm'
         shell: bash
         run: |
           # On Windows, remove non-Windows lib dirs and broken symlinks.
           # The upload-artifact action can't stat() broken symlinks.
           cd scripts/go/_internal/lib
           for d in *; do
-            if [[ "$d" != "i686-pc-windows-gnu" && "$d" != "x86_64-pc-windows-gnu" ]]; then
+            if [[ "$d" != "i686-pc-windows-gnu" && "$d" != "x86_64-pc-windows-gnu" && "$d" != "aarch64-pc-windows-gnu" ]]; then
               echo "Removing: $d"
               rm -rf "$d"
             fi
@@ -425,6 +444,43 @@ jobs:
             arch: x86
             index: 8
             tests: "non-streaming-speaker-diarization"
+          # Windows arm64
+          - os: windows-11-arm
+            arch: arm64
+            index: 0
+            tests: "hello-world non-streaming-decode-files speaker-identification source-separation"
+          - os: windows-11-arm
+            arch: arm64
+            index: 1
+            tests: "non-streaming-cohere-transcribe-decode-files non-streaming-qwen3-asr-decode-files supertonic-tts non-streaming-moonshine-v2-decode-files"
+          - os: windows-11-arm
+            arch: arm64
+            index: 2
+            tests: "non-streaming-fire-red-asr-ctc-decode-files zero-shot-pocket-tts zero-shot-zipvoice-tts non-streaming-funasr-nano-decode-files"
+          - os: windows-11-arm
+            arch: arm64
+            index: 3
+            tests: "non-streaming-medasr-ctc-decode-files non-streaming-omnilingual-asr-ctc-decode-files non-streaming-tts streaming-decode-files"
+          - os: windows-11-arm
+            arch: arm64
+            index: 4
+            tests: "non-streaming-canary-decode-files speech-enhancement-gtcrn speech-enhancement-dpdfnet streaming-speech-enhancement-gtcrn"
+          - os: windows-11-arm
+            arch: arm64
+            index: 5
+            tests: "streaming-speech-enhancement-dpdfnet audio-tagging keyword-spotting-from-file add-punctuation"
+          - os: windows-11-arm
+            arch: arm64
+            index: 6
+            tests: "add-punctuation-online non-streaming-speaker-diarization streaming-hlg-decoding"
+          - os: windows-11-arm
+            arch: arm64
+            index: 7
+            tests: "non-streaming-speaker-diarization"
+          - os: windows-11-arm
+            arch: arm64
+            index: 8
+            tests: "non-streaming-speaker-diarization"
 
     steps:
       - uses: actions/checkout@v4
@@ -447,6 +503,12 @@ jobs:
           go env -w GOARCH=386
           go env -w CGO_ENABLED=1
 
+      - name: Set up MSVC for ARM64
+        if: matrix.os == 'windows-11-arm' && matrix.arch == 'arm64'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: arm64
+
       - name: Download built libraries
         uses: actions/download-artifact@v4
         with:
@@ -465,6 +527,9 @@ jobs:
 
       - name: Run tests
         shell: bash
+        env:
+          CC: ${{ matrix.os == 'windows-11-arm' && 'clang' || '' }}
+          CXX: ${{ matrix.os == 'windows-11-arm' && 'clang++' || '' }}
         run: |
           for test in ${{ matrix.tests }}; do
             echo "=== Running ${test} ==="

--- a/scripts/go/_internal/build_windows_arm64.go
+++ b/scripts/go/_internal/build_windows_arm64.go
@@ -1,0 +1,6 @@
+//go:build windows && arm64
+
+package sherpa_onnx
+
+// #cgo LDFLAGS: -L ${SRCDIR}/lib/aarch64-pc-windows-gnu -lsherpa-onnx-c-api -lonnxruntime
+import "C"

--- a/scripts/go/generate.py
+++ b/scripts/go/generate.py
@@ -56,7 +56,7 @@ def parse_golang(target):
 def render(output, defines, platform):
     build_info = ""
     if platform == "windows":
-        build_info = "//go:build (windows && amd64) || (windows && 386)"
+        build_info = "//go:build (windows && amd64) || (windows && 386) || (windows && arm64)"
     elif platform == "linux":
         build_info = "//go:build (!android && linux && arm64) || (!android && linux && amd64 && !musl) || (!android && linux && arm && !arm7) || (!android && arm7) || (!android && linux && 386 && !musl) || (!android && musl) || (!android && linux && mips) || (!android && linux && mips64) || (!android && linux && mips64le) || (!android && linux && mipsle)"
     elif platform == "macos":

--- a/scripts/go/release.sh
+++ b/scripts/go/release.sh
@@ -215,6 +215,19 @@ function windows() {
 
   cd ..
   rm -rf t
+
+  mkdir -p sherpa-onnx-go-windows/lib/aarch64-pc-windows-gnu
+  rm -fv sherpa-onnx-go-windows/lib/aarch64-pc-windows-gnu/*
+  dst=$(realpath sherpa-onnx-go-windows/lib/aarch64-pc-windows-gnu)
+  mkdir t
+  cd t
+  wget -q https://huggingface.co/csukuangfj2/sherpa-onnx-wheels/resolve/main/cpu/$SHERPA_ONNX_VERSION/sherpa_onnx_core-${SHERPA_ONNX_VERSION}-py3-none-win_arm64.whl
+  unzip ./sherpa_onnx_core-${SHERPA_ONNX_VERSION}-py3-none-win_arm64.whl
+
+  cp -v sherpa_onnx/lib/*.dll $dst
+
+  cd ..
+  rm -rf t
   echo "------------------------------"
   cd sherpa-onnx-go-windows
   git status

--- a/scripts/go/sherpa_onnx.go
+++ b/scripts/go/sherpa_onnx.go
@@ -9,7 +9,7 @@ It does not need to access the network during recognition and everything
 runs locally.
 
 It supports a variety of platforms, such as Linux (x86_64, aarch64, arm),
-Windows (x86_64, x86), macOS (x86_64, arm64), etc.
+Windows (x86_64, x86, arm64), macOS (x86_64, arm64), etc.
 
 Usage examples:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Windows ARM64 support for the Go package.
  - Enabled building and testing on Windows ARM64 environments.
  - Added ARM64 Windows runtime library packaging for releases.

- **Documentation**
  - Updated supported-platform documentation to include Windows ARM64.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->