### PR TITLE
Add Go bindings for OfflineSpeakerDiarization confidence computation

### DIFF
--- a/go-api-examples/non-streaming-speaker-diarization/main.go
+++ b/go-api-examples/non-streaming-speaker-diarization/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	sherpa "github.com/k2-fsa/sherpa-onnx-go/sherpa_onnx"
 	"log"
 )
@@ -53,6 +54,9 @@ func initSpeakerDiarization() *sherpa.OfflineSpeakerDiarization {
 	// A larger Threshold leads to fewer clusters
 	// A smaller Threshold leads to more clusters
 
+	// Set ComputeConfidence to 1 to enable per-segment confidence computation
+	// config.Clustering.ComputeConfidence = 1
+
 	sd := sherpa.NewOfflineSpeakerDiarization(&config)
 	return sd
 }
@@ -82,7 +86,13 @@ func main() {
 	segments := sd.Process(wave.Samples)
 	n := len(segments)
 
+	const confidenceUnavailable = -2.0
 	for i := 0; i < n; i++ {
-		log.Printf("%.3f -- %.3f speaker_%02d\n", segments[i].Start, segments[i].End, segments[i].Speaker)
+		suffix := ""
+		if float64(segments[i].Confidence) != confidenceUnavailable {
+			suffix = fmt.Sprintf(" confidence=%.3f", segments[i].Confidence)
+		}
+		log.Printf("%.3f -- %.3f speaker_%02d%s\n",
+			segments[i].Start, segments[i].End, segments[i].Speaker, suffix)
 	}
 }

--- a/scripts/go/sherpa_onnx.go
+++ b/scripts/go/sherpa_onnx.go
@@ -2092,8 +2092,9 @@ type OfflineSpeakerSegmentationModelConfig struct {
 }
 
 type FastClusteringConfig struct {
-	NumClusters int
-	Threshold   float32
+	NumClusters       int
+	Threshold         float32
+	ComputeConfidence int // 1 to enable per-segment confidence computation
 }
 
 type OfflineSpeakerDiarizationConfig struct {
@@ -2138,6 +2139,7 @@ func NewOfflineSpeakerDiarization(config *OfflineSpeakerDiarizationConfig) *Offl
 
 	c.clustering.num_clusters = C.int(config.Clustering.NumClusters)
 	c.clustering.threshold = C.float(config.Clustering.Threshold)
+	c.clustering.compute_confidence = C.int(config.Clustering.ComputeConfidence)
 	c.min_duration_on = C.float(config.MinDurationOn)
 	c.min_duration_off = C.float(config.MinDurationOff)
 
@@ -2163,14 +2165,16 @@ func (sd *OfflineSpeakerDiarization) SetConfig(config *OfflineSpeakerDiarization
 
 	c.clustering.num_clusters = C.int(config.Clustering.NumClusters)
 	c.clustering.threshold = C.float(config.Clustering.Threshold)
+	c.clustering.compute_confidence = C.int(config.Clustering.ComputeConfidence)
 
 	C.SherpaOnnxOfflineSpeakerDiarizationSetConfig(sd.impl, &c)
 }
 
 type OfflineSpeakerDiarizationSegment struct {
-	Start   float32
-	End     float32
-	Speaker int
+	Start      float32
+	End        float32
+	Speaker    int
+	Confidence float32 // range between [-1, 1], -2 if unavailable
 }
 
 func (sd *OfflineSpeakerDiarization) Process(samples []float32) []OfflineSpeakerDiarizationSegment {
@@ -2194,6 +2198,7 @@ func (sd *OfflineSpeakerDiarization) Process(samples []float32) []OfflineSpeaker
 		ans[i].Start = float32(p[i].start)
 		ans[i].End = float32(p[i].end)
 		ans[i].Speaker = int(p[i].speaker)
+		ans[i].Confidence = float32(p[i].confidence)
 	}
 
 	return ans


### PR DESCRIPTION
The main motivator can be found in #3880.

In #3881, we merged the compute confidence feature for `C` and `C++` bindings. In this PR, we extend the support to the `Go` bindings. See an example of how it's used in `go-api-examples/non-streaming-speaker-diarization/main.go`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional per-segment confidence scores to speaker diarization results.
  - Added configuration support for enabling confidence computation.
  - Updated the non-streaming speaker diarization example to display confidence scores when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->