### PR TITLE
fix(nemo/qnn/parakeet-ctc): wrapper.py raises NameError on undefined `feat_dim`

### DIFF
--- a/scripts/nemo/qnn/parakeet-ctc/wrapper.py
+++ b/scripts/nemo/qnn/parakeet-ctc/wrapper.py
@@ -64,6 +64,8 @@ def main():
     m = ModelWrapper(asr_model)
     m.eval()
 
+    feat_dim = asr_model.cfg.preprocessor.features
+
     print("feat_dim", feat_dim)
     x = torch.rand(1, feat_dim, args.max_len, dtype=torch.float32)
 


### PR DESCRIPTION
`scripts/nemo/qnn/parakeet-ctc/wrapper.py` uses `feat_dim` without ever binding it:

```python
    m = ModelWrapper(asr_model)
    m.eval()

    print("feat_dim", feat_dim)                                    # NameError
    x = torch.rand(1, feat_dim, args.max_len, dtype=torch.float32)
```

```
$ pyflakes scripts/nemo/qnn/parakeet-ctc/wrapper.py
scripts/nemo/qnn/parakeet-ctc/wrapper.py:67:23: undefined name 'feat_dim'
scripts/nemo/qnn/parakeet-ctc/wrapper.py:68:23: undefined name 'feat_dim'
```

Those are the only two undefined names in the file, and they sit on the straight-line path of
`main()`, so `python wrapper.py --max-len ... --model-id ...` always dies right after downloading
and printing the model — before it exports anything.

The sibling script one directory over,
`scripts/nemo/qnn/nemotron-3.5-asr-streaming-0.6b/wrapper.py:370`, has the line this one is
missing:

```python
    feat_dim = asr_model.cfg.preprocessor.features
    ...
    x = torch.rand(1, feat_dim, window_size, dtype=torch.float32)
```

(`scripts/nemo/nemotron-3.5-asr-streaming-0.6b/export_onnx.py:186` does the same.)

### Reproduction

NeMo is not needed to show it — `main` is lifted out of the file with `ast` and run against a
stub whose `cfg` behaves like the OmegaConf config NeMo returns
(`preprocessor.features = 128`), with `torch.onnx.export` captured:

```
### python wrapper.py --max-len 200 --model-id nvidia/parakeet-ctc-0.6b
  [before] NameError: name 'feat_dim' is not defined
  [after]  feat_dim 128
           exported input shape (1, 128, 200)
```

`(1, 128, 200)` is `(N, C, T)` as documented in `ModelWrapper.forward`.

### Fix

Add the missing `feat_dim = asr_model.cfg.preprocessor.features`, matching the sibling wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ONNX export compatibility by matching the generated input tensor to the model’s configured feature dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->