### PR TITLE
Add confidence computation support for speaker diarization to JNI.

### DIFF
--- a/.github/workflows/run-java-test.yaml
+++ b/.github/workflows/run-java-test.yaml
@@ -154,6 +154,13 @@ jobs:
           cd ./java-api-examples
           ./run-version-test.sh
 
+      - name:  Run java test (speaker diarization)
+        shell: bash
+        run: |
+          cd ./java-api-examples
+          ./run-offline-speaker-diarization.sh
+          rm -rfv *.onnx *.wav sherpa-onnx-pyannote-*
+
       - name:  Run java test (Cohere Transcribe)
         if: runner.os != 'Windows'
         shell: bash
@@ -304,13 +311,6 @@ jobs:
           ./run-offline-add-diacritics.sh
           # Delete model files to save space
           rm -rf catt_eo_model_onnx
-
-      - name:  Run java test (speaker diarization)
-        shell: bash
-        run: |
-          cd ./java-api-examples
-          ./run-offline-speaker-diarization.sh
-          rm -rfv *.onnx *.wav sherpa-onnx-pyannote-*
 
       - name:  Run java test (kws)
         shell: bash

--- a/java-api-examples/OfflineSpeakerDiarizationDemo.java
+++ b/java-api-examples/OfflineSpeakerDiarizationDemo.java
@@ -61,6 +61,7 @@ public class OfflineSpeakerDiarizationDemo {
         FastClusteringConfig.builder()
             .setNumClusters(4) // set it to -1 if you don't know the actual number
             .setThreshold(0.5f)
+            .setComputeConfidence(true) // enable confidence computation
             .build();
 
     OfflineSpeakerDiarizationConfig config =
@@ -95,7 +96,7 @@ public class OfflineSpeakerDiarizationDemo {
             });
 
     for (OfflineSpeakerDiarizationSegment s : segments) {
-      System.out.printf("%.3f -- %.3f speaker_%02d\n", s.getStart(), s.getEnd(), s.getSpeaker());
+      System.out.printf("%.3f -- %.3f speaker_%02d confidence=%.3f\n", s.getStart(), s.getEnd(), s.getSpeaker(), s.getConfidence());
     }
 
     sd.release();

--- a/kotlin-api-examples/run.sh
+++ b/kotlin-api-examples/run.sh
@@ -784,6 +784,7 @@ function testOfflineWenetCtc() {
 }
 
 testVersion
+testOfflineSpeakerDiarization
 testOfflineCohereTranscribe
 testOfflineQwen3Asr
 testOfflineMoonshineAsrV2
@@ -799,7 +800,6 @@ testOfflineNeMoCanary
 testOfflineSenseVoiceWithHr
 testOfflineSpeechDenoiser
 testOnlineSpeechDenoiser
-testOfflineSpeakerDiarization
 testSpeakerEmbeddingExtractor
 testOnlineAsr
 testTts

--- a/kotlin-api-examples/test_offline_speaker_diarization.kt
+++ b/kotlin-api-examples/test_offline_speaker_diarization.kt
@@ -34,7 +34,7 @@ fun testOfflineSpeakerDiarization() {
     // A larger threshold leads to fewer clusters, i.e., few speakers.
     // A smaller threshold leads to more clusters, i.e., more speakers.
     //
-    clustering=FastClusteringConfig(numClusters=4),
+    clustering=FastClusteringConfig(numClusters=4, computeConfidence=true),
   )
 
   val sd = OfflineSpeakerDiarization(config=config)
@@ -51,6 +51,6 @@ fun testOfflineSpeakerDiarization() {
   // val segments = sd.process(waveData.samples) // this one is also ok
   val segments = sd.processWithCallback(waveData.samples, callback=::callback)
   for (segment in segments) {
-    println("${segment.start} -- ${segment.end} speaker_${segment.speaker}")
+    println("${segment.start} -- ${segment.end} speaker_${segment.speaker} confidence=${segment.confidence}")
   }
 }

--- a/sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/FastClusteringConfig.java
+++ b/sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/FastClusteringConfig.java
@@ -5,10 +5,12 @@ package com.k2fsa.sherpa.onnx;
 public class FastClusteringConfig {
     private final int numClusters;
     private final float threshold;
+    private final boolean computeConfidence;
 
     private FastClusteringConfig(Builder builder) {
         this.numClusters = builder.numClusters;
         this.threshold = builder.threshold;
+        this.computeConfidence = builder.computeConfidence;
     }
 
     public static Builder builder() {
@@ -23,9 +25,14 @@ public class FastClusteringConfig {
         return threshold;
     }
 
+    public boolean getComputeConfidence() {
+        return computeConfidence;
+    }
+
     public static class Builder {
         private int numClusters = -1;
         private float threshold = 0.5f;
+        private boolean computeConfidence = false;
 
         public FastClusteringConfig build() {
             return new FastClusteringConfig(this);
@@ -38,6 +45,11 @@ public class FastClusteringConfig {
 
         public Builder setThreshold(float threshold) {
             this.threshold = threshold;
+            return this;
+        }
+
+        public Builder setComputeConfidence(boolean computeConfidence) {
+            this.computeConfidence = computeConfidence;
             return this;
         }
     }

--- a/sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/OfflineSpeakerDiarizationSegment.java
+++ b/sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/OfflineSpeakerDiarizationSegment.java
@@ -6,11 +6,13 @@ public class OfflineSpeakerDiarizationSegment {
     private final float start;
     private final float end;
     private final int speaker;
+    private final float confidence;
 
-    public OfflineSpeakerDiarizationSegment(float start, float end, int speaker) {
+    public OfflineSpeakerDiarizationSegment(float start, float end, int speaker, float confidence) {
         this.start = start;
         this.end = end;
         this.speaker = speaker;
+        this.confidence = confidence;
     }
 
     public float getStart() {
@@ -23,5 +25,9 @@ public class OfflineSpeakerDiarizationSegment {
 
     public int getSpeaker() {
         return speaker;
+    }
+
+    public float getConfidence() {
+        return confidence;
     }
 }

--- a/sherpa-onnx/jni/offline-speaker-diarization.cc
+++ b/sherpa-onnx/jni/offline-speaker-diarization.cc
@@ -76,6 +76,9 @@ static OfflineSpeakerDiarizationConfig GetOfflineSpeakerDiarizationConfig(
   SHERPA_ONNX_JNI_READ_FLOAT(ans.clustering.threshold, threshold,
                              clustering_config_cls, clustering_config);
 
+  SHERPA_ONNX_JNI_READ_BOOL(ans.clustering.compute_confidence, computeConfidence,
+                            clustering_config_cls, clustering_config);
+
   SHERPA_ONNX_JNI_READ_FLOAT(ans.min_duration_on, minDurationOn, cls, config);
 
   SHERPA_ONNX_JNI_READ_FLOAT(ans.min_duration_off, minDurationOff, cls, config);
@@ -185,7 +188,7 @@ static jobjectArray ProcessImpl(
   jobjectArray obj_arr =
       (jobjectArray)env->NewObjectArray(segments.size(), cls, nullptr);
 
-  jmethodID constructor = env->GetMethodID(cls, "<init>", "(FFI)V");
+  jmethodID constructor = env->GetMethodID(cls, "<init>", "(FFIF)V");
   if (constructor == nullptr) {
     SHERPA_ONNX_LOGE(
         "Failed to get OfflineSpeakerDiarizationSegment constructor");
@@ -196,7 +199,7 @@ static jobjectArray ProcessImpl(
   for (int32_t i = 0; i != static_cast<int32_t>(segments.size()); ++i) {
     const auto &s = segments[i];
     jobject segment =
-        env->NewObject(cls, constructor, s.Start(), s.End(), s.Speaker());
+        env->NewObject(cls, constructor, s.Start(), s.End(), s.Speaker(), s.Confidence());
     env->SetObjectArrayElement(obj_arr, i, segment);
     env->DeleteLocalRef(segment);
   }

--- a/sherpa-onnx/kotlin-api/OfflineSpeakerDiarization.kt
+++ b/sherpa-onnx/kotlin-api/OfflineSpeakerDiarization.kt
@@ -17,6 +17,7 @@ data class OfflineSpeakerSegmentationModelConfig(
 data class FastClusteringConfig(
     var numClusters: Int = -1,
     var threshold: Float = 0.5f,
+    var computeConfidence: Boolean = false,
 )
 
 data class OfflineSpeakerDiarizationConfig(
@@ -31,6 +32,7 @@ data class OfflineSpeakerDiarizationSegment(
     val start: Float, // in seconds
     val end: Float, // in seconds
     val speaker: Int, // ID of the speaker; count from 0
+    val confidence: Float, // confidence score in [-1, 1], or -2 if unavailable
 )
 
 class OfflineSpeakerDiarization(


### PR DESCRIPTION
See #3881 and #3936

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional confidence computation for offline speaker diarization.
  - Diarization segments now expose confidence scores, including confidence values in Java and Kotlin example output.
  - Added configuration support for enabling or disabling confidence calculation in Java and Kotlin APIs.

- **Tests**
  - Updated automated and example test execution for offline speaker diarization.
  - Added cleanup of downloaded test models and audio files after test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->