### PR TITLE
fix(python-tests): UnboundLocalError instead of the intended ValueError in test_fast_clustering

### DIFF
--- a/sherpa-onnx/python/tests/test_fast_clustering.py
+++ b/sherpa-onnx/python/tests/test_fast_clustering.py
@@ -128,7 +128,7 @@ class TestFastClustering(unittest.TestCase):
             debug=0,
         )
         if not extractor_config.validate():
-            raise ValueError(f"Invalid extractor config. {config}")
+            raise ValueError(f"Invalid extractor config. {extractor_config}")
 
         extractor = sherpa_onnx.SpeakerEmbeddingExtractor(extractor_config)
 


### PR DESCRIPTION
### The bug

`TestFastClustering.test_cluster_speaker_embeddings` names its extractor config `extractor_config`, because plain `config` is reused ~20 lines further down for the `FastClusteringConfig`. The validation error, however, still interpolates `{config}`:

```python
extractor_config = sherpa_onnx.SpeakerEmbeddingExtractorConfig(
    model=str(model_file), num_threads=1, debug=0,
)
if not extractor_config.validate():
    raise ValueError(f"Invalid extractor config. {config}")   # line 131
...
config = sherpa_onnx.FastClusteringConfig(num_clusters=3)     # line 150 -- first binding
```

`config` is a local of this method (bound at line 150), so at line 131 it is unbound. When the extractor config fails to validate — a corrupt or incompatible `.onnx`, which is exactly what this branch exists to report — the test dies with

```
UnboundLocalError: cannot access local variable 'config' where it is not associated with a value
```

instead of the intended message, and the actual config never gets printed. `python -m pyflakes` on master flags it:

```
sherpa-onnx/python/tests/test_fast_clustering.py:131:59: undefined name 'config'
```

### The fix

Interpolate `extractor_config`. This is the only place in the Python tree where the validated local and the interpolated name disagree — the six sibling call sites all name the local `config` and print that same local:

| file | line |
|---|---|
| `sherpa-onnx/python/tests/test_speaker_recognition.py` | 54 |
| `python-api-examples/speaker-identification.py` | 122 |
| `python-api-examples/speaker-identification-with-vad.py` | 137 |
| `python-api-examples/speaker-identification-with-vad-dynamic.py` | 106 |
| `python-api-examples/speaker-identification-with-vad-non-streaming-asr.py` | 350 |
| `python-api-examples/speaker-identification-with-vad-non-streaming-asr-alsa.py` | 350 |

So this looks like the copy that renamed the local but not the message.

### Verification

The test's real method was extracted with `ast` and run against a stub whose `SpeakerEmbeddingExtractorConfig.validate()` returns `False` (no `sherpa_onnx` build needed), with the wave/model fixture files created so the early-return guards don't fire:

```
condition: extractor_config.validate() returns False

upstream  -> UnboundLocalError: cannot access local variable 'config' where it is not associated with a value
patched   -> ValueError: Invalid extractor config. SpeakerEmbeddingExtractorConfig({'model': '...3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx', 'num_threads': 1, 'debug': 0})
```

The happy path is untouched — this only changes which name the error message reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the invalid extractor configuration error message to reference the appropriate configuration setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->