### PR TITLE
Add OfflineDiacritization to kotlin-api

### DIFF
--- a/kotlin-api-examples/OfflineDiacritization.kt
+++ b/kotlin-api-examples/OfflineDiacritization.kt
@@ -1,0 +1,1 @@
+../sherpa-onnx/kotlin-api/OfflineDiacritization.kt

--- a/kotlin-api-examples/run.sh
+++ b/kotlin-api-examples/run.sh
@@ -430,6 +430,25 @@ function testOfflinePunctuation() {
   java -Djava.library.path=../build/lib -jar $out_filename
 }
 
+function testOfflineDiacritization() {
+  if [[ ! -f ./catt_eo_model_onnx/encoder.onnx || ! -f ./catt_eo_model_onnx/decoder.onnx ]]; then
+    curl -SL -O https://github.com/abjadai/catt/releases/download/v2/eo_model_onnx.zip
+    unzip eo_model_onnx.zip -d catt_eo_model_onnx
+    rm eo_model_onnx.zip
+  fi
+
+  out_filename=test_offline_diacritization.jar
+  kotlinc-jvm -include-runtime -d $out_filename \
+    ./test_offline_diacritization.kt \
+    ./OfflineDiacritization.kt \
+    faked-asset-manager.kt \
+    faked-log.kt
+
+  ls -lh $out_filename
+
+  java -Djava.library.path=../build/lib -jar $out_filename
+}
+
 function testOnlinePunctuation() {
   if [ ! -f ./sherpa-onnx-online-punct-en-2024-08-06/model.int8.onnx ]; then
     curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/punctuation-models/sherpa-onnx-online-punct-en-2024-08-06.tar.bz2
@@ -807,6 +826,7 @@ testAudioTagging
 testSpokenLanguageIdentification
 testOfflineAsr
 testOfflinePunctuation
+testOfflineDiacritization
 testOnlinePunctuation
 testInverseTextNormalizationOfflineAsr
 testInverseTextNormalizationOnlineAsr

--- a/kotlin-api-examples/run.sh
+++ b/kotlin-api-examples/run.sh
@@ -433,7 +433,8 @@ function testOfflinePunctuation() {
 function testOfflineDiacritization() {
   if [[ ! -f ./catt_eo_model_onnx/encoder.onnx || ! -f ./catt_eo_model_onnx/decoder.onnx ]]; then
     curl -SL -O https://github.com/abjadai/catt/releases/download/v2/eo_model_onnx.zip
-    unzip eo_model_onnx.zip -d catt_eo_model_onnx
+    rm -rf catt_eo_model_onnx
+    unzip -o eo_model_onnx.zip -d catt_eo_model_onnx
     rm eo_model_onnx.zip
   fi
 

--- a/kotlin-api-examples/test_offline_diacritization.kt
+++ b/kotlin-api-examples/test_offline_diacritization.kt
@@ -1,0 +1,33 @@
+package com.k2fsa.sherpa.onnx
+
+fun main() {
+  testDiacritization()
+}
+
+fun testDiacritization() {
+  // please download the model from
+  // https://github.com/abjadai/catt/releases/download/v2/eo_model_onnx.zip
+  val config = OfflineDiacritizationConfig(
+      model = OfflineDiacritizationModelConfig(
+          cattEncoder = "./catt_eo_model_onnx/encoder.onnx",
+          cattDecoder = "./catt_eo_model_onnx/decoder.onnx",
+          numThreads = 1,
+          debug = true,
+          provider = "cpu",
+      )
+  )
+  val diacrt = OfflineDiacritization(config = config)
+  val sentences = arrayOf(
+      "وقالت مجلة نيوزويك الأمريكية التحديث الجديد ل إنستجرام يمكن أن يساهم في إيقاف وكشف الحسابات المزورة بسهولة شديدة",
+      "اللغة العربية من أقدم اللغات السامية",
+  )
+  println("---")
+  for (text in sentences) {
+    val out = diacrt.addDiacritics(text)
+    println("Input: $text")
+    println("Output: $out")
+    println("---")
+  }
+
+  diacrt.release()
+}

--- a/sherpa-onnx/kotlin-api/OfflineDiacritization.kt
+++ b/sherpa-onnx/kotlin-api/OfflineDiacritization.kt
@@ -1,0 +1,64 @@
+package com.k2fsa.sherpa.onnx
+
+import android.content.res.AssetManager
+
+data class OfflineDiacritizationModelConfig(
+    var cattEncoder: String = "",
+    var cattDecoder: String = "",
+    var numThreads: Int = 1,
+    var debug: Boolean = false,
+    var provider: String = "cpu",
+)
+
+
+data class OfflineDiacritizationConfig(
+    var model: OfflineDiacritizationModelConfig,
+)
+
+class OfflineDiacritization(
+    assetManager: AssetManager? = null,
+    config: OfflineDiacritizationConfig,
+) {
+    private var ptr: Long
+
+    init {
+        ptr = if (assetManager != null) {
+            newFromAsset(assetManager, config)
+        } else {
+            newFromFile(config)
+        }
+        require(ptr != 0L) {
+            "Invalid OfflineDiacritizationConfig: failed to create native OfflineDiacritization"
+        }
+    }
+
+    protected fun finalize() {
+        if (ptr != 0L) {
+            delete(ptr)
+            ptr = 0
+        }
+    }
+
+    fun release() = finalize()
+
+    fun addDiacritics(text: String) = addDiacritics(ptr, text)
+
+    private external fun delete(ptr: Long)
+
+    private external fun addDiacritics(ptr: Long, text: String): String
+
+    private external fun newFromAsset(
+        assetManager: AssetManager,
+        config: OfflineDiacritizationConfig,
+    ): Long
+
+    private external fun newFromFile(
+        config: OfflineDiacritizationConfig,
+    ): Long
+
+    companion object {
+        init {
+            System.loadLibrary("sherpa-onnx-jni")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `OfflineDiacritization` to `sherpa-onnx/kotlin-api`, mirroring `OfflinePunctuation` lifecycle (`newFromAsset` / `newFromFile` / `addDiacritics` / `release`) and the existing JNI field names (`cattEncoder`, `cattDecoder`, …).
- Add `kotlin-api-examples/test_offline_diacritization.kt`, symlink, and `run.sh` hook `testOfflineDiacritization` (CATT EO model download).
- Kotlin-only binding PR (per maintainer guidance on #3647: one PR per language). Complements Java bindings from #3669; no C++/C/JNI/Java changes.

## How to test

```bash
cd kotlin-api-examples
./run.sh
# or only the new function after JNI is built:
# testOfflineDiacritization
```

Model: https://github.com/abjadai/catt/releases/download/v2/eo_model_onnx.zip

## Sample output (local smoke)

```
---
Input: وقالت مجلة نيوزويك الأمريكية التحديث الجديد ل إنستجرام يمكن أن يساهم في إيقاف وكشف الحسابات المزورة بسهولة شديدة
Output: وَقَالَتْ مَجَلَّةُ نِيُوزْوِيكَ الْأَمْرِيكِيَّةُ التَّحْدِيثَ الْجَدِيدُ لِ إِنسِتِجْرَامٍ يُمْكِنُ أنْ يُسَاهِمَ فِي إِيقَافِ وَكَشْفِ الْحِسَابَاتِ الْمُزَوَّرَةِ بِسُهُولَةٍ شَدِيدَةٍ
---
Input: اللغة العربية من أقدم اللغات السامية
Output: اللُّغَةُ الْعَرَبِيَّةُ مِنْ أقْدَمِ اللُّغَاتِ السَّامِيَةِ
---
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added offline diacritization support for Kotlin and Android applications.
  * Added configuration options for model files, threading, debugging, and execution providers.
  * Added an API to apply diacritics to text and release processing resources.
  * Added a runnable Kotlin example demonstrating Arabic text diacritization.
  * Added support for loading models from application assets or local files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->