### PR TITLE
Support HLG decoding for offline CTC models in the C, CXX, JNI/Kotlin/Java and WASM APIs

### DIFF
--- a/.github/workflows/c-api.yaml
+++ b/.github/workflows/c-api.yaml
@@ -298,6 +298,34 @@ jobs:
           rm $name
           rm -rf sherpa-onnx-wenetspeech-*
 
+      - name: Test Zipformer CTC with an HLG graph
+        shell: bash
+        run: |
+          name=zipformer-ctc-hlg-c-api
+          gcc -o $name ./c-api-examples/$name.c \
+            -I ./build/install/include \
+            -L ./build/install/lib/ \
+            -l sherpa-onnx-c-api \
+            -l onnxruntime
+
+          ls -lh $name
+
+          curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-zipformer-ctc-en-2023-10-02.tar.bz2
+          tar xvf sherpa-onnx-zipformer-ctc-en-2023-10-02.tar.bz2
+          rm sherpa-onnx-zipformer-ctc-en-2023-10-02.tar.bz2
+
+          export LD_LIBRARY_PATH=$PWD/build/install/lib:$LD_LIBRARY_PATH
+          export DYLD_LIBRARY_PATH=$PWD/build/install/lib:$DYLD_LIBRARY_PATH
+
+          # A clean exit proves nothing here: without a graph the decoder
+          # still succeeds, it just decodes freely. The word ids show up only
+          # when the FST decoder ran.
+          ./$name 2>&1 | tee /tmp/hlg.txt
+          grep -q '"words": \[[0-9]' /tmp/hlg.txt
+
+          rm $name
+          rm -rf sherpa-onnx-zipformer-ctc-en-*
+
       - name: Test Dolphin CTC
         shell: bash
         run: |

--- a/.github/workflows/cxx-api.yaml
+++ b/.github/workflows/cxx-api.yaml
@@ -214,6 +214,34 @@ jobs:
           rm -rf sherpa-onnx-fire-red-*
           rm -v ./$name
 
+      - name: Test Zipformer CTC with an HLG graph
+        shell: bash
+        run: |
+          name=zipformer-ctc-hlg-cxx-api
+          g++ -std=c++17 -o $name ./cxx-api-examples/$name.cc \
+            -I ./build/install/include \
+            -L ./build/install/lib/ \
+            -l sherpa-onnx-cxx-api \
+            -l sherpa-onnx-c-api \
+            -l onnxruntime
+
+          ls -lh $name
+
+          curl -SL -O https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-zipformer-ctc-en-2023-10-02.tar.bz2
+          tar xvf sherpa-onnx-zipformer-ctc-en-2023-10-02.tar.bz2
+          rm sherpa-onnx-zipformer-ctc-en-2023-10-02.tar.bz2
+
+          echo "---"
+
+          # A clean exit proves nothing here: without a graph the decoder
+          # still succeeds, it just decodes freely. The word ids show up only
+          # when the FST decoder ran.
+          ./$name 2>&1 | tee /tmp/hlg.txt
+          grep -q '"words": \[[0-9]' /tmp/hlg.txt
+
+          rm -rf sherpa-onnx-zipformer-ctc-en-*
+          rm -v ./$name
+
       - name: Test FunASR Nano
         shell: bash
         run: |

--- a/c-api-examples/CMakeLists.txt
+++ b/c-api-examples/CMakeLists.txt
@@ -130,6 +130,9 @@ target_link_libraries(moonshine-v2-c-api sherpa-onnx-c-api)
 add_executable(zipformer-c-api zipformer-c-api.c)
 target_link_libraries(zipformer-c-api sherpa-onnx-c-api)
 
+add_executable(zipformer-ctc-hlg-c-api zipformer-ctc-hlg-c-api.c)
+target_link_libraries(zipformer-ctc-hlg-c-api sherpa-onnx-c-api)
+
 add_executable(wenet-ctc-c-api wenet-ctc-c-api.c)
 target_link_libraries(wenet-ctc-c-api sherpa-onnx-c-api)
 

--- a/c-api-examples/zipformer-ctc-hlg-c-api.c
+++ b/c-api-examples/zipformer-ctc-hlg-c-api.c
@@ -1,0 +1,84 @@
+// c-api-examples/zipformer-ctc-hlg-c-api.c
+//
+// Copyright (c)  2026  Marcin Baszczewski
+
+//
+// This file demonstrates how to decode a non-streaming CTC model with an
+// HLG decoding graph using sherpa-onnx's C API.
+//
+// clang-format off
+//
+// wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-zipformer-ctc-en-2023-10-02.tar.bz2
+// tar xvf sherpa-onnx-zipformer-ctc-en-2023-10-02.tar.bz2
+// rm sherpa-onnx-zipformer-ctc-en-2023-10-02.tar.bz2
+//
+// clang-format on
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "sherpa-onnx/c-api/c-api.h"
+
+int32_t main() {
+  const char *dir = "./sherpa-onnx-zipformer-ctc-en-2023-10-02";
+  char wav_filename[256];
+  char model_filename[256];
+  char tokens_filename[256];
+  char graph_filename[256];
+
+  snprintf(wav_filename, sizeof(wav_filename), "%s/test_wavs/0.wav", dir);
+  snprintf(model_filename, sizeof(model_filename), "%s/model.onnx", dir);
+  snprintf(tokens_filename, sizeof(tokens_filename), "%s/tokens.txt", dir);
+
+  // The model above also ships H.fst and HL.fst; any of the three works.
+  snprintf(graph_filename, sizeof(graph_filename), "%s/HLG.fst", dir);
+
+  const SherpaOnnxWave *wave = SherpaOnnxReadWave(wav_filename);
+  if (wave == NULL) {
+    fprintf(stderr, "Failed to read %s\n", wav_filename);
+    return -1;
+  }
+
+  SherpaOnnxOfflineRecognizerConfig recognizer_config;
+  memset(&recognizer_config, 0, sizeof(recognizer_config));
+  recognizer_config.decoding_method = "greedy_search";
+  recognizer_config.model_config.debug = 1;
+  recognizer_config.model_config.num_threads = 1;
+  recognizer_config.model_config.provider = "cpu";
+  recognizer_config.model_config.tokens = tokens_filename;
+  recognizer_config.model_config.zipformer_ctc.model = model_filename;
+
+  recognizer_config.ctc_fst_decoder_config.graph = graph_filename;
+  recognizer_config.ctc_fst_decoder_config.max_active = 3000;
+
+  const SherpaOnnxOfflineRecognizer *recognizer =
+      SherpaOnnxCreateOfflineRecognizer(&recognizer_config);
+
+  if (recognizer == NULL) {
+    fprintf(stderr, "Please check your config!\n");
+    SherpaOnnxFreeWave(wave);
+    return -1;
+  }
+
+  const SherpaOnnxOfflineStream *stream =
+      SherpaOnnxCreateOfflineStream(recognizer);
+
+  SherpaOnnxAcceptWaveformOffline(stream, wave->sample_rate, wave->samples,
+                                  wave->num_samples);
+  SherpaOnnxDecodeOfflineStream(recognizer, stream);
+  const SherpaOnnxOfflineRecognizerResult *result =
+      SherpaOnnxGetOfflineStreamResult(stream);
+
+  fprintf(stderr, "Decoded text: %s\n", result->text);
+
+  // The graph's output labels are in the json field, under "words".
+  fprintf(stderr, "Result as json: %s\n", result->json);
+
+  SherpaOnnxDestroyOfflineRecognizerResult(result);
+  SherpaOnnxDestroyOfflineStream(stream);
+  SherpaOnnxDestroyOfflineRecognizer(recognizer);
+  SherpaOnnxFreeWave(wave);
+
+  return 0;
+}

--- a/cxx-api-examples/CMakeLists.txt
+++ b/cxx-api-examples/CMakeLists.txt
@@ -12,6 +12,9 @@ target_link_libraries(streaming-nemotron-cxx-api sherpa-onnx-cxx-api)
 add_executable(streaming-zipformer-with-hr-cxx-api ./streaming-zipformer-with-hr-cxx-api.cc)
 target_link_libraries(streaming-zipformer-with-hr-cxx-api sherpa-onnx-cxx-api)
 
+add_executable(zipformer-ctc-hlg-cxx-api ./zipformer-ctc-hlg-cxx-api.cc)
+target_link_libraries(zipformer-ctc-hlg-cxx-api sherpa-onnx-cxx-api)
+
 add_executable(speech-enhancement-gtcrn-cxx-api ./speech-enhancement-gtcrn-cxx-api.cc)
 target_link_libraries(speech-enhancement-gtcrn-cxx-api sherpa-onnx-cxx-api)
 

--- a/cxx-api-examples/zipformer-ctc-hlg-cxx-api.cc
+++ b/cxx-api-examples/zipformer-ctc-hlg-cxx-api.cc
@@ -1,0 +1,85 @@
+// cxx-api-examples/zipformer-ctc-hlg-cxx-api.cc
+//
+// Copyright (c)  2026  Marcin Baszczewski
+
+//
+// This file demonstrates how to decode a non-streaming CTC model with an
+// HLG decoding graph using sherpa-onnx's C++ API.
+//
+// clang-format off
+//
+// wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-zipformer-ctc-en-2023-10-02.tar.bz2
+// tar xvf sherpa-onnx-zipformer-ctc-en-2023-10-02.tar.bz2
+// rm sherpa-onnx-zipformer-ctc-en-2023-10-02.tar.bz2
+//
+// clang-format on
+
+#include <chrono>  // NOLINT
+#include <cstdio>
+#include <iostream>
+#include <string>
+
+#include "sherpa-onnx/c-api/cxx-api.h"
+
+int32_t main() {
+  using namespace sherpa_onnx::cxx;  // NOLINT
+  OfflineRecognizerConfig config;
+
+  std::string dir = "./sherpa-onnx-zipformer-ctc-en-2023-10-02";
+
+  config.model_config.zipformer_ctc.model = dir + "/model.onnx";
+  config.model_config.tokens = dir + "/tokens.txt";
+  config.model_config.num_threads = 1;
+
+  // The model above also ships H.fst and HL.fst; any of the three works.
+  config.ctc_fst_decoder_config.graph = dir + "/HLG.fst";
+  config.ctc_fst_decoder_config.max_active = 3000;
+
+  std::cout << "Loading model\n";
+  OfflineRecognizer recognizer = OfflineRecognizer::Create(config);
+  if (!recognizer.Get()) {
+    std::cerr << "Please check your config\n";
+    return -1;
+  }
+  std::cout << "Loading model done\n";
+
+  std::string wave_filename = dir + "/test_wavs/0.wav";
+
+  Wave wave = ReadWave(wave_filename);
+  if (wave.samples.empty()) {
+    std::cerr << "Failed to read: '" << wave_filename << "'\n";
+    return -1;
+  }
+
+  std::cout << "Start recognition\n";
+  const auto begin = std::chrono::steady_clock::now();
+
+  OfflineStream stream = recognizer.CreateStream();
+  stream.AcceptWaveform(wave.sample_rate, wave.samples.data(),
+                        wave.samples.size());
+
+  recognizer.Decode(&stream);
+
+  OfflineRecognizerResult result = recognizer.GetResult(&stream);
+
+  const auto end = std::chrono::steady_clock::now();
+  const float elapsed_seconds =
+      std::chrono::duration_cast<std::chrono::milliseconds>(end - begin)
+          .count() /
+      1000.;
+  float duration = wave.samples.size() / static_cast<float>(wave.sample_rate);
+  float rtf = elapsed_seconds / duration;
+
+  std::cout << "text: " << result.text << "\n";
+
+  // The graph's output labels are in the json field, under "words".
+  std::cout << "json: " << result.json << "\n";
+
+  printf("Number of threads: %d\n", config.model_config.num_threads);
+  printf("Duration: %.3fs\n", duration);
+  printf("Elapsed seconds: %.3fs\n", elapsed_seconds);
+  printf("(Real time factor) RTF = %.3f / %.3f = %.3f\n", elapsed_seconds,
+         duration, rtf);
+
+  return 0;
+}

--- a/sherpa-onnx/c-api/c-api.cc
+++ b/sherpa-onnx/c-api/c-api.cc
@@ -674,6 +674,11 @@ static sherpa_onnx::OfflineRecognizerConfig GetOfflineRecognizerConfig(
   recognizer_config.hr.lexicon = SHERPA_ONNX_OR(config->hr.lexicon, "");
   recognizer_config.hr.rule_fsts = SHERPA_ONNX_OR(config->hr.rule_fsts, "");
 
+  recognizer_config.ctc_fst_decoder_config.graph =
+      SHERPA_ONNX_OR(config->ctc_fst_decoder_config.graph, "");
+  recognizer_config.ctc_fst_decoder_config.max_active =
+      SHERPA_ONNX_OR(config->ctc_fst_decoder_config.max_active, 3000);
+
   if (config->model_config.debug) {
 #if __OHOS__
     auto str_vec = sherpa_onnx::SplitString(recognizer_config.ToString(), 128);

--- a/sherpa-onnx/c-api/c-api.h
+++ b/sherpa-onnx/c-api/c-api.h
@@ -300,6 +300,14 @@ typedef struct SherpaOnnxOnlineCtcFstDecoderConfig {
   int32_t max_active;
 } SherpaOnnxOnlineCtcFstDecoderConfig;
 
+/** @brief Configuration for HLG/FST-based offline CTC decoding. */
+typedef struct SherpaOnnxOfflineCtcFstDecoderConfig {
+  /** Path to the decoding graph. */
+  const char *graph;
+  /** Decoder max-active setting. 0 means 3000. */
+  int32_t max_active;
+} SherpaOnnxOfflineCtcFstDecoderConfig;
+
 /** @brief Configuration for homophone replacement. */
 typedef struct SherpaOnnxHomophoneReplacerConfig {
   /** Unused legacy field kept for ABI compatibility. */
@@ -1200,6 +1208,9 @@ typedef struct SherpaOnnxOfflineRecognizerConfig {
 
   /** Optional homophone replacement configuration. */
   SherpaOnnxHomophoneReplacerConfig hr;
+
+  /** Optional CTC+FST decoder configuration. */
+  SherpaOnnxOfflineCtcFstDecoderConfig ctc_fst_decoder_config;
 } SherpaOnnxOfflineRecognizerConfig;
 
 /** @brief Non-streaming recognizer handle. */

--- a/sherpa-onnx/c-api/cxx-api.cc
+++ b/sherpa-onnx/c-api/cxx-api.cc
@@ -394,6 +394,10 @@ static SherpaOnnxOfflineRecognizerConfig Convert(
   c.hr.lexicon = config.hr.lexicon.c_str();
   c.hr.rule_fsts = config.hr.rule_fsts.c_str();
 
+  c.ctc_fst_decoder_config.graph = config.ctc_fst_decoder_config.graph.c_str();
+  c.ctc_fst_decoder_config.max_active =
+      config.ctc_fst_decoder_config.max_active;
+
   return c;
 }
 

--- a/sherpa-onnx/c-api/cxx-api.h
+++ b/sherpa-onnx/c-api/cxx-api.h
@@ -689,6 +689,14 @@ struct OfflineLMConfig {
   float scale = 1.0;
 };
 
+/** @brief Decoder graph configuration for offline CTC + FST decoding. */
+struct OfflineCtcFstDecoderConfig {
+  /** FST graph file. */
+  std::string graph;
+  /** Maximum number of active states during search. */
+  int32_t max_active = 3000;
+};
+
 /**
  * @brief Configuration for offline ASR.
  *
@@ -747,6 +755,8 @@ struct OfflineRecognizerConfig {
   float blank_penalty = 0;
   /** Optional homophone replacement configuration. */
   HomophoneReplacerConfig hr;
+  /** Optional CTC+FST decoder configuration. */
+  OfflineCtcFstDecoderConfig ctc_fst_decoder_config;
 };
 
 /** @brief Offline ASR result copied into C++ containers. */

--- a/sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/OfflineCtcFstDecoderConfig.java
+++ b/sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/OfflineCtcFstDecoderConfig.java
@@ -1,0 +1,44 @@
+// Copyright 2026 Marcin Baszczewski
+
+package com.k2fsa.sherpa.onnx;
+
+public class OfflineCtcFstDecoderConfig {
+    private final String graph;
+    private final int maxActive;
+
+    private OfflineCtcFstDecoderConfig(Builder builder) {
+        this.graph = builder.graph;
+        this.maxActive = builder.maxActive;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getGraph() {
+        return graph;
+    }
+
+    public int getMaxActive() {
+        return maxActive;
+    }
+
+    public static class Builder {
+        private String graph = "";
+        private int maxActive = 3000;
+
+        public OfflineCtcFstDecoderConfig build() {
+            return new OfflineCtcFstDecoderConfig(this);
+        }
+
+        public Builder setGraph(String graph) {
+            this.graph = graph;
+            return this;
+        }
+
+        public Builder setMaxActive(int maxActive) {
+            this.maxActive = maxActive;
+            return this;
+        }
+    }
+}

--- a/sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/OfflineRecognizerConfig.java
+++ b/sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/OfflineRecognizerConfig.java
@@ -6,6 +6,7 @@ public class OfflineRecognizerConfig {
     private final FeatureConfig featConfig;
     private final OfflineModelConfig modelConfig;
     private final HomophoneReplacerConfig hr;
+    private final OfflineCtcFstDecoderConfig ctcFstDecoderConfig;
     private final String decodingMethod;
     private final int maxActivePaths;
     private final String hotwordsFile;
@@ -18,6 +19,7 @@ public class OfflineRecognizerConfig {
         this.featConfig = builder.featConfig;
         this.modelConfig = builder.modelConfig;
         this.hr = builder.hr;
+        this.ctcFstDecoderConfig = builder.ctcFstDecoderConfig;
         this.decodingMethod = builder.decodingMethod;
         this.maxActivePaths = builder.maxActivePaths;
         this.hotwordsFile = builder.hotwordsFile;
@@ -39,6 +41,7 @@ public class OfflineRecognizerConfig {
         private FeatureConfig featConfig = FeatureConfig.builder().build();
         private OfflineModelConfig modelConfig = OfflineModelConfig.builder().build();
         private HomophoneReplacerConfig hr = HomophoneReplacerConfig.builder().build();
+        private OfflineCtcFstDecoderConfig ctcFstDecoderConfig = OfflineCtcFstDecoderConfig.builder().build();
         private String decodingMethod = "greedy_search";
         private int maxActivePaths = 4;
         private String hotwordsFile = "";
@@ -63,6 +66,11 @@ public class OfflineRecognizerConfig {
 
         public Builder setHr(HomophoneReplacerConfig hr) {
             this.hr = hr;
+            return this;
+        }
+
+        public Builder setCtcFstDecoderConfig(OfflineCtcFstDecoderConfig ctcFstDecoderConfig) {
+            this.ctcFstDecoderConfig = ctcFstDecoderConfig;
             return this;
         }
 

--- a/sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/OfflineRecognizerResult.java
+++ b/sherpa-onnx/java-api/src/main/java/com/k2fsa/sherpa/onnx/OfflineRecognizerResult.java
@@ -10,8 +10,9 @@ public class OfflineRecognizerResult {
     private final String emotion;
     private final String event;
     private final float[] durations;
+    private final int[] words;
 
-    public OfflineRecognizerResult(String text, String[] tokens, float[] timestamps, String lang, String emotion, String event, float[] durations) {
+    public OfflineRecognizerResult(String text, String[] tokens, float[] timestamps, String lang, String emotion, String event, float[] durations, int[] words) {
         this.text = text;
         this.tokens = tokens;
         this.timestamps = timestamps;
@@ -19,6 +20,7 @@ public class OfflineRecognizerResult {
         this.emotion = emotion;
         this.event = event;
         this.durations = durations;
+        this.words = words;
     }
 
     public String getText() {
@@ -47,5 +49,9 @@ public class OfflineRecognizerResult {
 
     public float[] getDurations() {
         return durations;
+    }
+
+    public int[] getWords() {
+        return words;
     }
 }

--- a/sherpa-onnx/jni/offline-recognizer.cc
+++ b/sherpa-onnx/jni/offline-recognizer.cc
@@ -35,6 +35,17 @@ static OfflineRecognizerConfig GetOfflineConfig(JNIEnv *env, jobject config,
 
   SHERPA_ONNX_JNI_READ_FLOAT(ans.blank_penalty, blankPenalty, cls, config);
 
+  fid = env->GetFieldID(cls, "ctcFstDecoderConfig",
+                        "Lcom/k2fsa/sherpa/onnx/OfflineCtcFstDecoderConfig;");
+  jobject fst_decoder_config = env->GetObjectField(config, fid);
+  jclass fst_decoder_config_cls = env->GetObjectClass(fst_decoder_config);
+
+  SHERPA_ONNX_JNI_READ_STRING(ans.ctc_fst_decoder_config.graph, graph,
+                              fst_decoder_config_cls, fst_decoder_config);
+
+  SHERPA_ONNX_JNI_READ_INT(ans.ctc_fst_decoder_config.max_active, maxActive,
+                           fst_decoder_config_cls, fst_decoder_config);
+
   fid = env->GetFieldID(cls, "featConfig",
                         "Lcom/k2fsa/sherpa/onnx/FeatureConfig;");
   jobject feat_config = env->GetObjectField(config, fid);
@@ -661,7 +672,7 @@ Java_com_k2fsa_sherpa_onnx_OfflineRecognizer_getResult(JNIEnv *env,
   jmethodID ctor =
       env->GetMethodID(cls, "<init>",
                        "(Ljava/lang/String;[Ljava/lang/String;[FLjava/lang/"
-                       "String;Ljava/lang/String;Ljava/lang/String;[F)V");
+                       "String;Ljava/lang/String;Ljava/lang/String;[F[I)V");
   jstring jtext = SafeNewStringUTF(env, result.text);
 
   jclass string_cls = env->FindClass("java/lang/String");
@@ -687,8 +698,14 @@ Java_com_k2fsa_sherpa_onnx_OfflineRecognizer_getResult(JNIEnv *env,
   env->SetFloatArrayRegion(jdurations, 0, result.durations.size(),
                            result.durations.data());
 
+  jintArray jwords = env->NewIntArray(result.words.size());
+  if (!result.words.empty()) {
+    env->SetIntArrayRegion(jwords, 0, result.words.size(),
+                           result.words.data());
+  }
+
   jobject jresult = env->NewObject(cls, ctor, jtext, jtokens, jtimestamps,
-                                   jlang, jemotion, jevent, jdurations);
+                                   jlang, jemotion, jevent, jdurations, jwords);
 
   env->DeleteLocalRef(jtext);
   env->DeleteLocalRef(jtokens);
@@ -697,6 +714,7 @@ Java_com_k2fsa_sherpa_onnx_OfflineRecognizer_getResult(JNIEnv *env,
   env->DeleteLocalRef(jemotion);
   env->DeleteLocalRef(jevent);
   env->DeleteLocalRef(jdurations);
+  env->DeleteLocalRef(jwords);
   env->DeleteLocalRef(cls);
 
   return jresult;  // returned object is safe

--- a/sherpa-onnx/kotlin-api/OfflineRecognizer.kt
+++ b/sherpa-onnx/kotlin-api/OfflineRecognizer.kt
@@ -12,6 +12,9 @@ data class OfflineRecognizerResult(
 
     // valid only for TDT models
     val durations: FloatArray,
+
+    // valid only when ctcFstDecoderConfig.graph is set
+    val words: IntArray = IntArray(0),
 )
 
 data class OfflineTransducerModelConfig(
@@ -163,6 +166,11 @@ data class OfflineModelConfig(
     var bpeVocab: String = "",
 )
 
+data class OfflineCtcFstDecoderConfig(
+    var graph: String = "",
+    var maxActive: Int = 3000,
+)
+
 data class OfflineRecognizerConfig(
     var featConfig: FeatureConfig = FeatureConfig(),
     var modelConfig: OfflineModelConfig = OfflineModelConfig(),
@@ -175,6 +183,7 @@ data class OfflineRecognizerConfig(
     var ruleFsts: String = "",
     var ruleFars: String = "",
     var blankPenalty: Float = 0.0f,
+    var ctcFstDecoderConfig: OfflineCtcFstDecoderConfig = OfflineCtcFstDecoderConfig(),
 )
 
 class OfflineRecognizer(

--- a/wasm/asr/sherpa-onnx-asr.js
+++ b/wasm/asr/sherpa-onnx-asr.js
@@ -442,6 +442,19 @@ function initSherpaOnnxOnlineCtcFstDecoderConfig(config, Module) {
   return {ptr: ptr, len: len, buffer: buffer};
 }
 
+function initSherpaOnnxOfflineCtcFstDecoderConfig(config, Module) {
+  const len = 2 * 4;
+  const ptr = Module._malloc(len);
+
+  const graphLen = Module.lengthBytesUTF8(config.graph || '') + 1;
+  const buffer = Module._malloc(graphLen);
+  Module.stringToUTF8(config.graph || '', buffer, graphLen);
+
+  Module.setValue(ptr, buffer, 'i8*');
+  Module.setValue(ptr + 4, config.maxActive || 3000, 'i32');
+  return {ptr: ptr, len: len, buffer: buffer};
+}
+
 function initSherpaOnnxOnlineRecognizerConfig(config, Module) {
   if (!('featConfig' in config)) {
     config.featConfig = {
@@ -1697,12 +1710,21 @@ function initSherpaOnnxOfflineRecognizerConfig(config, Module) {
     };
   }
 
+  if (!('ctcFstDecoderConfig' in config)) {
+    config.ctcFstDecoderConfig = {
+      graph: '',
+      maxActive: 3000,
+    };
+  }
+
   const feat = initSherpaOnnxFeatureConfig(config.featConfig, Module);
   const model = initSherpaOnnxOfflineModelConfig(config.modelConfig, Module);
   const lm = initSherpaOnnxOfflineLMConfig(config.lmConfig, Module);
   const hr = initSherpaOnnxHomophoneReplacerConfig(config.hr, Module);
+  const ctcFstDecoder = initSherpaOnnxOfflineCtcFstDecoderConfig(
+      config.ctcFstDecoderConfig, Module);
 
-  const len = feat.len + model.len + lm.len + 7 * 4 + hr.len;
+  const len = feat.len + model.len + lm.len + 7 * 4 + hr.len + ctcFstDecoder.len;
   const ptr = Module._malloc(len);
 
   let offset = 0;
@@ -1768,6 +1790,9 @@ function initSherpaOnnxOfflineRecognizerConfig(config, Module) {
   Module._CopyHeap(hr.ptr, hr.len, ptr + offset);
   offset += hr.len;
 
+  Module._CopyHeap(ctcFstDecoder.ptr, ctcFstDecoder.len, ptr + offset);
+  offset += ctcFstDecoder.len;
+
   return {
     buffer: buffer,
     ptr: ptr,
@@ -1776,6 +1801,7 @@ function initSherpaOnnxOfflineRecognizerConfig(config, Module) {
     model: model,
     lm: lm,
     hr: hr,
+    ctcFstDecoder: ctcFstDecoder,
   };
 }
 

--- a/wasm/nodejs/sherpa-onnx-wasm-nodejs.cc
+++ b/wasm/nodejs/sherpa-onnx-wasm-nodejs.cc
@@ -58,7 +58,8 @@ static_assert(sizeof(SherpaOnnxOfflineRecognizerConfig) ==
                   sizeof(SherpaOnnxFeatureConfig) +
                       sizeof(SherpaOnnxOfflineLMConfig) +
                       sizeof(SherpaOnnxOfflineModelConfig) + 7 * 4 +
-                      sizeof(SherpaOnnxHomophoneReplacerConfig),
+                      sizeof(SherpaOnnxHomophoneReplacerConfig) +
+                      sizeof(SherpaOnnxOfflineCtcFstDecoderConfig),
               "");
 
 void PrintOfflineTtsConfig(SherpaOnnxOfflineTtsConfig *tts_config) {


### PR DESCRIPTION
`sherpa_onnx::OfflineCtcFstDecoderConfig` has always existed in C++ and is
exposed by the Python bindings, but it is not reachable through the C API, so
HLG decoding for non-streaming CTC models is Python-only today. The streaming
counterpart, `SherpaOnnxOnlineCtcFstDecoderConfig`, has been in the C API, the
JNI and the WASM layer all along.

With a graph attached the decoder can only return paths the graph contains,
which is what a closed-grammar recognizer needs on a phone or in a browser.

### Commits

1. **C and CXX API** - adds `SherpaOnnxOfflineCtcFstDecoderConfig` and a
   `ctc_fst_decoder_config` field on `SherpaOnnxOfflineRecognizerConfig`, the
   same pair in `cxx-api`, plus a C and a C++ example and a CI step for each.
   This follows the shape of #2156, which added the last field to this struct.
2. **JNI, Kotlin and Java API** - reads the new config, and returns the graph's
   output labels as `words`.
3. **WebAssembly** - serialises the new field in `wasm/asr/sherpa-onnx-asr.js`
   and extends the struct-layout `static_assert`.

### Reading the graph's output labels

Only the JNI needed a result-side change. The C API, the CXX API and the WASM
layer all return the result as json, and `OfflineRecognitionResult::words` is
already serialised into it, so a caller reads the labels with no new API. The
JNI builds the Kotlin/Java object field by field, so there `words` had to be
added explicitly or it would be dropped.

`OfflineRecognizerResult` is declared twice, in `kotlin-api` and in `java-api`,
and the JNI looks its constructor up by descriptor. Both declarations are
updated, so the Java API keeps working too. In Kotlin the field defaults to an
empty array, which keeps existing callers compiling.

### ABI

`ctc_fst_decoder_config` goes at the end of
`SherpaOnnxOfflineRecognizerConfig`, so the offset of every existing field is
unchanged. A caller that zero-initialises the struct gets an empty graph, which
means no graph, so nothing changes for existing code.

Bindings that mirror the struct by hand rather than reading the C header
(Dart/Flutter, C#, Pascal, Rust, node-addon) are unchanged here and keep
working; they cannot set the new field yet. This follows how the last
field added to this struct was handled: #2156 for the C and CXX API, then
#2167 for Dart. I am happy to send the same follow-ups, either as one sweep
across the remaining bindings or one PR per binding - whichever you prefer.

The Go binding needs nothing: cgo generates the struct from `c-api.h`.

### Testing

- Both examples decode with the `HLG.fst` that ships with
  `sherpa-onnx-zipformer-ctc-en-2023-10-02`, the model
  `.github/scripts/test-offline-ctc.sh` already downloads for graph decoding,
  so no new asset is involved. A step in `c-api.yaml` and one in `cxx-api.yaml`
  build and run them, following the neighbouring steps.
- Both examples are also built by the ordinary CMake build
  (`SHERPA_ONNX_BUILD_C_API_EXAMPLES` and `SHERPA_ONNX_ENABLE_BINARY` are both
  on by default for a top-level build), so `linux.yaml` and `macos.yaml`
  compile them on this PR.
- Both were run locally against that model. The config reaches the core
  (`ctc_fst_decoder_config=OfflineCtcFstDecoderConfig(graph="./sherpa-onnx-zipformer-ctc-en-2023-10-02/HLG.fst", max_active=3000)`
  in the debug dump) and the result json carries the graph's labels:

  ```
  text: AFTER EARLY NIGHTFALL THE YELLOW LAMPS WOULD LIGHT UP HERE AND THERE THE SQUALID QUARTER OF THE BROTHELS
  "words": [2191, 52770, 121894, 175861, 198295, 98505, 197114, 101964, 186768, 80190, 5411, 176144, 175861, 166824, 142471, 124782, 175861, 22700]
  ```

  Eighteen labels for eighteen words, with 175861 in each of the three places
  the sentence says "THE".
- `./scripts/check_style_cpplint.sh`: the series adds no new cpplint findings;
  every file it touches reports exactly what it reports on master.
- The JNI translation unit compiles with the Android NDK clang (aarch64), and
  the whole `java-api` source set compiles with `javac -Xlint:all`, so the
  descriptor the JNI looks up matches both declarations of
  `OfflineRecognizerResult`.
- `wasm/nodejs/sherpa-onnx-wasm-nodejs.cc` compiles under `emcc`. That is the
  target where its `static_assert` means something: it fails the build if the
  JavaScript layout and the C header disagree.
- The three commits have been running in a closed-grammar voice-command
  project on desktop (Python), Android (Kotlin) and in the browser (WASM),
  against NeMo FastConformer CTC models with HLG graphs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added offline CTC decoding with HLG/FST graphs across the C, C++, Java, Kotlin, and WebAssembly APIs.
  * Added configuration for decoding graphs and maximum active paths.
  * Recognition results now expose decoded word information where supported.
  * Added C and C++ examples demonstrating Zipformer CTC recognition with HLG graphs.

* **Tests**
  * Added automated coverage for Zipformer CTC HLG recognition in the C and C++ API workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->