### PR TITLE
Support NeMo transducers in offline Python examples

### DIFF
--- a/python-api-examples/README.md
+++ b/python-api-examples/README.md
@@ -4,6 +4,9 @@
   Files are saved in [./web](./web).
 - [non_streaming_server.py](./non_streaming_server.py) WebSocket server for
   non-streaming models.
+- [Orukeet](./orukeet.md) Download and serve the multilingual Orukeet model
+  using the existing NeMo transducer runtime. The same server options support
+  Parakeet TDT v3.
 - [vad-remove-non-speech-segments.py](./vad-remove-non-speech-segments.py) It uses
   [silero-vad](https://github.com/snakers4/silero-vad) to remove non-speech
   segments and concatenate all speech segments into a single one.

--- a/python-api-examples/non_streaming_server.py
+++ b/python-api-examples/non_streaming_server.py
@@ -213,6 +213,13 @@ def setup_logger(
 
 def add_transducer_model_args(parser: argparse.ArgumentParser):
     parser.add_argument(
+        "--model-type",
+        default="transducer",
+        choices=["transducer", "nemo_transducer"],
+        help="Transducer family. Use nemo_transducer for Parakeet TDT and Orukeet.",
+    )
+
+    parser.add_argument(
         "--encoder",
         default="",
         type=str,
@@ -963,6 +970,7 @@ def create_recognizer(args) -> sherpa_onnx.OfflineRecognizer:
             decoder=args.decoder,
             joiner=args.joiner,
             tokens=args.tokens,
+            model_type=args.model_type,
             num_threads=args.num_threads,
             sample_rate=args.sample_rate,
             feature_dim=args.feat_dim,

--- a/python-api-examples/orukeet.md
+++ b/python-api-examples/orukeet.md
@@ -1,0 +1,100 @@
+# Orukeet with the offline WebSocket server
+
+[Orukeet](https://huggingface.co/oruk/orukeet) is a 25-language fine-tune of
+Parakeet TDT 0.6B v3. Its ONNX export uses sherpa-onnx's existing NeMo transducer
+implementation. The fitted Gabor filters are stored as convolution weights;
+inference requires no custom operators.
+
+## Download
+
+The following commands download the release's manifest and INT8 model archive
+from an immutable Hugging Face revision. The manifest supplies the archive's
+size, checksum, and extraction directory.
+
+```bash
+set -e
+base=https://huggingface.co/oruk/orukeet/resolve/55a984d46f68323301837194ce647c702f55facc/onnx
+curl -fL "$base/manifest.json" -o orukeet-manifest.json
+curl -fL "$base/sherpa-onnx-orukeet-v0.1.0-int8.tar.bz2" \
+  -o sherpa-onnx-orukeet-v0.1.0-int8.tar.bz2
+
+python3 - <<'PY'
+import hashlib
+import json
+from pathlib import Path
+
+manifest_path = Path("orukeet-manifest.json")
+expected = "7e80f93f0e9b923c392424b0f85d28a717feee0a4d2a6aa9bfa723693868e727"
+assert hashlib.sha256(manifest_path.read_bytes()).hexdigest() == expected
+manifest = json.loads(manifest_path.read_text())
+archive = Path(manifest["archive"])
+assert archive.stat().st_size == manifest["archive_bytes"]
+digest = hashlib.sha256()
+with archive.open("rb") as stream:
+    for block in iter(lambda: stream.read(1024 * 1024), b""):
+        digest.update(block)
+assert digest.hexdigest() == manifest["archive_sha256"]
+print("Verified:", archive)
+PY
+
+tar xf sherpa-onnx-orukeet-v0.1.0-int8.tar.bz2
+```
+
+The archive contains `encoder.int8.onnx`, `decoder.int8.onnx`,
+`joiner.int8.onnx`, `tokens.txt`, and the weight license and attribution.
+Keep these files together. Downloads occupy approximately 487 MB; the extracted
+model occupies approximately 672 MB. Existing model files can be reused offline.
+
+## Serve
+
+From the sherpa-onnx repository root, install the example's dependencies. This
+example uses the legacy WebSocket server API:
+
+```bash
+python3 -m pip install sherpa-onnx numpy 'websockets<14'
+```
+
+Start the server:
+
+```bash
+model=./sherpa-onnx-orukeet-v0.1.0-int8
+python3 python-api-examples/non_streaming_server.py \
+  --model-type nemo_transducer \
+  --encoder "$model/encoder.int8.onnx" \
+  --decoder "$model/decoder.int8.onnx" \
+  --joiner "$model/joiner.int8.onnx" \
+  --tokens "$model/tokens.txt" \
+  --feat-dim 128 \
+  --num-threads 2 \
+  --provider cpu \
+  --port 6006
+```
+
+Transcribe files with the existing client:
+
+```bash
+python3 python-api-examples/offline-websocket-client-decode-files-sequential.py \
+  --server-addr localhost --server-port 6006 recording.wav
+```
+
+Audio is decoded locally. The model uses a 16 kHz frontend and the existing
+greedy TDT decoder. This is utterance-based recognition: the client sends each
+recording for a final transcript.
+
+For microphone input, download `silero_vad.onnx` as described in
+[vad-with-non-streaming-asr.py](./vad-with-non-streaming-asr.py), then run:
+
+```bash
+python3 -m pip install sounddevice
+python3 python-api-examples/vad-with-non-streaming-asr.py \
+  --silero-vad-model ./silero_vad.onnx \
+  --model-type nemo_transducer \
+  --encoder "$model/encoder.int8.onnx" \
+  --decoder "$model/decoder.int8.onnx" \
+  --joiner "$model/joiner.int8.onnx" \
+  --tokens "$model/tokens.txt" \
+  --feature-dim 128 --num-threads 2
+```
+
+Stock Parakeet TDT v3 uses the same server options with its own model directory.
+Other transducer examples retain the default `--model-type transducer`.

--- a/python-api-examples/orukeet.md
+++ b/python-api-examples/orukeet.md
@@ -86,6 +86,7 @@ For microphone input, download `silero_vad.onnx` as described in
 
 ```bash
 python3 -m pip install sounddevice
+model=./sherpa-onnx-orukeet-v0.1.0-int8
 python3 python-api-examples/vad-with-non-streaming-asr.py \
   --silero-vad-model ./silero_vad.onnx \
   --model-type nemo_transducer \

--- a/python-api-examples/vad-with-non-streaming-asr.py
+++ b/python-api-examples/vad-with-non-streaming-asr.py
@@ -116,6 +116,13 @@ def get_args():
     )
 
     parser.add_argument(
+        "--model-type",
+        default="transducer",
+        choices=["transducer", "nemo_transducer"],
+        help="Transducer family. Use nemo_transducer for Parakeet TDT and Orukeet.",
+    )
+
+    parser.add_argument(
         "--encoder",
         default="",
         type=str,
@@ -321,6 +328,7 @@ def create_recognizer(args) -> sherpa_onnx.OfflineRecognizer:
             decoder=args.decoder,
             joiner=args.joiner,
             tokens=args.tokens,
+            model_type=args.model_type,
             num_threads=args.num_threads,
             sample_rate=args.sample_rate,
             feature_dim=args.feature_dim,


### PR DESCRIPTION
The offline WebSocket and microphone/VAD examples currently send every encoder/decoder/joiner triple to the generic transducer loader. A valid Orukeet export exits during loading with `'vocab_size' does not exist in the metadata`.

This exposes the existing `model_type` option as `--model-type nemo_transducer`, enabling Parakeet TDT and Orukeet in both examples. The default remains `transducer`. The linked Orukeet recipe downloads an immutable, checksum-verified INT8 export from Hugging Face and uses the existing NeMo runtime. No new inference dependencies or operators.

Validation on macOS arm64 with sherpa-onnx 1.13.8:

- Reproduced the pre-change load failure; the patched WebSocket server transcribes English, German, Spanish and French through the existing clients.
- Exercised sequential requests, 12 concurrent clients, short and long silence, disconnect/reconnect, and the actual VAD example loop with a fixture microphone. Concurrent batches preserve the normalized words; punctuation can vary with padding shape.
- Verified the existing default, compiled both Python files, and ran `git diff --check`.

Paired model comparison: first 20 FLEURS validation clips in each of six languages (120 clips, 2,433 reference words), CPU / two threads on an M5 Max, greedy decoding. Each clip warmed once, then three timed passes; timing excludes loading and file decoding.

| WER (%) | Parakeet TDT v3 INT8 | Orukeet INT8 |
|---|---:|---:|
| English | 4.19 | 3.66 |
| German | 11.20 | 6.87 |
| Spanish | 14.83 | 2.40 |
| French | 6.21 | 7.49 |
| Russian | 9.65 | 6.97 |
| Ukrainian | 15.99 | 15.36 |
| Pooled | 10.28 | 6.70 |

Median latency: **325 → 276 ms**; p95: **586 → 507 ms**. These are measurements of the two exports on this machine, not a runtime optimization in this patch.

Model: [oruk/orukeet](https://huggingface.co/oruk/orukeet). AI-assisted implementation and validation using Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added model-type selection to non-streaming server and microphone transcription examples, supporting standard and NeMo transducer models.
  - Added support guidance for serving and transcribing the multilingual Orukeet model.

- **Documentation**
  - Documented Orukeet setup, including model download, integrity verification, file transcription, and microphone input.
  - Documented compatibility with existing NeMo transducer server options and multilingual usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->