### PR TITLE
feat(offline-transducer): expose n-best hypotheses from modified beam search

### DIFF
--- a/python-api-examples/offline-transducer-nbest-decode-files.py
+++ b/python-api-examples/offline-transducer-nbest-decode-files.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+"""
+This file shows how to get the n-best hypotheses from a non-streaming
+transducer model decoded with modified_beam_search.
+
+Set num_return_paths to a value greater than 1 and read result.hypotheses.
+It is ordered from best to worst, and hypotheses[0] matches the top-level
+result.text / result.tokens / result.timestamps.
+
+Please download model files from
+https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models
+
+For instance,
+
+wget https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-zipformer-small-en-2023-06-26.tar.bz2
+tar xvf sherpa-onnx-zipformer-small-en-2023-06-26.tar.bz2
+rm sherpa-onnx-zipformer-small-en-2023-06-26.tar.bz2
+"""
+
+from pathlib import Path
+
+import sherpa_onnx
+import soundfile as sf
+
+
+def create_recognizer():
+    d = "./sherpa-onnx-zipformer-small-en-2023-06-26"
+
+    encoder = f"{d}/encoder-epoch-99-avg-1.onnx"
+    decoder = f"{d}/decoder-epoch-99-avg-1.onnx"
+    joiner = f"{d}/joiner-epoch-99-avg-1.onnx"
+    tokens = f"{d}/tokens.txt"
+    test_wav = f"{d}/test_wavs/0.wav"
+
+    for f in [encoder, decoder, joiner, tokens, test_wav]:
+        if not Path(f).is_file():
+            raise ValueError(f"{f} does not exist. Please read the comments.")
+
+    recognizer = sherpa_onnx.OfflineRecognizer.from_transducer(
+        encoder=encoder,
+        decoder=decoder,
+        joiner=joiner,
+        tokens=tokens,
+        decoding_method="modified_beam_search",
+        # the search width
+        max_active_paths=8,
+        # how many of those paths to return; clamped to max_active_paths
+        num_return_paths=5,
+    )
+
+    return recognizer, test_wav
+
+
+def main():
+    recognizer, wave_filename = create_recognizer()
+
+    audio, sample_rate = sf.read(wave_filename, dtype="float32", always_2d=True)
+    audio = audio[:, 0]  # only use the first channel
+
+    stream = recognizer.create_stream()
+    stream.accept_waveform(sample_rate, audio)
+    recognizer.decode_stream(stream)
+
+    result = stream.result
+
+    print("1-best:")
+    print(f"  {result.text}")
+
+    print(f"\nn-best ({len(result.hypotheses)} hypotheses):")
+    for i, hyp in enumerate(result.hypotheses):
+        print(f"  [{i}] score={hyp.score:.4f}")
+        print(f"      {hyp.text}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sherpa-onnx/csrc/offline-recognizer-transducer-impl.h
+++ b/sherpa-onnx/csrc/offline-recognizer-transducer-impl.h
@@ -5,6 +5,7 @@
 #ifndef SHERPA_ONNX_CSRC_OFFLINE_RECOGNIZER_TRANSDUCER_IMPL_H_
 #define SHERPA_ONNX_CSRC_OFFLINE_RECOGNIZER_TRANSDUCER_IMPL_H_
 
+#include <algorithm>
 #include <fstream>
 #include <ios>
 #include <memory>
@@ -31,18 +32,18 @@
 
 namespace sherpa_onnx {
 
-static OfflineRecognitionResult Convert(
-    const OfflineTransducerDecoderResult &src, const SymbolTable &sym_table,
-    int32_t frame_shift_ms, int32_t subsampling_factor) {
-  OfflineRecognitionResult r;
-  r.tokens.reserve(src.tokens.size());
-  r.timestamps.reserve(src.timestamps.size());
-  r.durations.reserve(src.durations.size());
+// Converts token IDs to their symbols, appending the detokenized text to
+// *text. Shared by the 1-best result and every entry of the n-best list.
+static std::vector<std::string> ConvertTokens(
+    const std::vector<int64_t> &token_ids, const SymbolTable &sym_table,
+    std::string *text) {
+  std::vector<std::string> tokens;
+  tokens.reserve(token_ids.size());
 
-  std::string text;
-  for (auto i : src.tokens) {
+  std::string t;
+  for (auto i : token_ids) {
     auto sym = sym_table[i];
-    text.append(sym);
+    t.append(sym);
 
     if (sym.size() == 1 && (sym[0] < 0x20 || sym[0] > 0x7e)) {
       // for bpe models with byte_fallback,
@@ -54,21 +55,38 @@ static OfflineRecognitionResult Convert(
       sym = os.str();
     }
 
-    r.tokens.push_back(std::move(sym));
+    tokens.push_back(std::move(sym));
   }
+
   if (sym_table.IsByteBpe()) {
-    text = sym_table.DecodeByteBpe(text);
+    t = sym_table.DecodeByteBpe(t);
   }
 
-  text = RemoveSpaceBetweenCjk(text);
+  *text = RemoveSpaceBetweenCjk(t);
 
-  r.text = std::move(text);
+  return tokens;
+}
+
+static std::vector<float> ConvertTimestamps(
+    const std::vector<int32_t> &timestamps, float frame_shift_s) {
+  std::vector<float> ans;
+  ans.reserve(timestamps.size());
+  for (auto t : timestamps) {
+    ans.push_back(frame_shift_s * t);
+  }
+  return ans;
+}
+
+static OfflineRecognitionResult Convert(
+    const OfflineTransducerDecoderResult &src, const SymbolTable &sym_table,
+    int32_t frame_shift_ms, int32_t subsampling_factor) {
+  OfflineRecognitionResult r;
+  r.durations.reserve(src.durations.size());
+
+  r.tokens = ConvertTokens(src.tokens, sym_table, &r.text);
 
   float frame_shift_s = frame_shift_ms / 1000. * subsampling_factor;
-  for (auto t : src.timestamps) {
-    float time = frame_shift_s * t;
-    r.timestamps.push_back(time);
-  }
+  r.timestamps = ConvertTimestamps(src.timestamps, frame_shift_s);
 
   // Copy durations (if present)
   for (auto d : src.durations) {
@@ -77,6 +95,18 @@ static OfflineRecognitionResult Convert(
 
   // Copy token log probabilities (confidence scores)
   r.ys_log_probs = src.ys_log_probs;
+
+  // n-best list, present only for modified_beam_search with
+  // num_return_paths > 1
+  r.hypotheses.reserve(src.hypotheses.size());
+  for (const auto &h : src.hypotheses) {
+    OfflineRecognitionHypothesis hyp;
+    hyp.tokens = ConvertTokens(h.tokens, sym_table, &hyp.text);
+    hyp.timestamps = ConvertTimestamps(h.timestamps, frame_shift_s);
+    hyp.ys_log_probs = h.ys_log_probs;
+    hyp.score = h.score;
+    r.hypotheses.push_back(std::move(hyp));
+  }
 
   return r;
 }
@@ -112,7 +142,8 @@ class OfflineRecognizerTransducerImpl : public OfflineRecognizerImpl {
 
       decoder_ = std::make_unique<OfflineTransducerModifiedBeamSearchDecoder>(
           model_.get(), lm_.get(), config_.max_active_paths,
-          config_.lm_config.scale, unk_id_, config_.blank_penalty);
+          config_.lm_config.scale, unk_id_, config_.blank_penalty,
+          std::min(config_.num_return_paths, config_.max_active_paths));
     } else {
       SHERPA_ONNX_LOGE("Unsupported decoding method: %s",
                        config_.decoding_method.c_str());
@@ -152,7 +183,8 @@ class OfflineRecognizerTransducerImpl : public OfflineRecognizerImpl {
 
       decoder_ = std::make_unique<OfflineTransducerModifiedBeamSearchDecoder>(
           model_.get(), lm_.get(), config_.max_active_paths,
-          config_.lm_config.scale, unk_id_, config_.blank_penalty);
+          config_.lm_config.scale, unk_id_, config_.blank_penalty,
+          std::min(config_.num_return_paths, config_.max_active_paths));
     } else {
       SHERPA_ONNX_LOGE("Unsupported decoding method: %s",
                        config_.decoding_method.c_str());
@@ -252,6 +284,13 @@ class OfflineRecognizerTransducerImpl : public OfflineRecognizerImpl {
                        model_->SubsamplingFactor());
       r.text = ApplyInverseTextNormalization(std::move(r.text));
       r.text = ApplyHomophoneReplacer(std::move(r.text));
+
+      // Apply the same text post-processing to every hypothesis, so that
+      // hypotheses[0].text stays consistent with the 1-best text above.
+      for (auto &hyp : r.hypotheses) {
+        hyp.text = ApplyInverseTextNormalization(std::move(hyp.text));
+        hyp.text = ApplyHomophoneReplacer(std::move(hyp.text));
+      }
 
       ss[i]->SetResult(r);
     }

--- a/sherpa-onnx/csrc/offline-recognizer.cc
+++ b/sherpa-onnx/csrc/offline-recognizer.cc
@@ -41,6 +41,11 @@ void OfflineRecognizerConfig::Register(ParseOptions *po) {
   po->Register("max-active-paths", &max_active_paths,
                "Used only when decoding_method is modified_beam_search");
 
+  po->Register("num-return-paths", &num_return_paths,
+               "Number of hypotheses to return per utterance. Used only for "
+               "transducer models when decoding_method is "
+               "modified_beam_search. It is clamped to max_active_paths.");
+
   po->Register("blank-penalty", &blank_penalty,
                "The penalty applied on blank symbol during decoding. "
                "Note: It is a positive value. "
@@ -70,6 +75,20 @@ void OfflineRecognizerConfig::Register(ParseOptions *po) {
 }
 
 bool OfflineRecognizerConfig::Validate() const {
+  if (num_return_paths < 1) {
+    SHERPA_ONNX_LOGE("num_return_paths must be >= 1! Given: %d",
+                     num_return_paths);
+    return false;
+  }
+
+  if (num_return_paths > 1 && decoding_method != "modified_beam_search") {
+    SHERPA_ONNX_LOGE(
+        "num_return_paths > 1 requires --decoding-method=modified_beam_search."
+        " Given --decoding-method='%s', --num-return-paths=%d",
+        decoding_method.c_str(), num_return_paths);
+    return false;
+  }
+
   if (decoding_method == "modified_beam_search" && !lm_config.model.empty()) {
     if (max_active_paths <= 0) {
       SHERPA_ONNX_LOGE("max_active_paths is less than 0! Given: %d",
@@ -141,6 +160,7 @@ std::string OfflineRecognizerConfig::ToString() const {
 
   os << "decoding_method=\"" << decoding_method << "\", ";
   os << "max_active_paths=" << max_active_paths << ", ";
+  os << "num_return_paths=" << num_return_paths << ", ";
   os << "hotwords_file=\"" << hotwords_file << "\", ";
   os << "hotwords_score=" << hotwords_score << ", ";
   os << "blank_penalty=" << blank_penalty << ", ";
@@ -176,6 +196,12 @@ void OfflineRecognizer::DecodeStreams(OfflineStream **ss, int32_t n) const {
   for (int32_t i = 0; i < n; ++i) {
     auto r = ss[i]->GetResult();
     r.text = RemoveLeadingSpaces(r.text);
+
+    // Keep every hypothesis in the n-best list formatted like r.text
+    for (auto &hyp : r.hypotheses) {
+      hyp.text = RemoveLeadingSpaces(hyp.text);
+    }
+
     ss[i]->SetResult(r);
   }
 }

--- a/sherpa-onnx/csrc/offline-recognizer.h
+++ b/sherpa-onnx/csrc/offline-recognizer.h
@@ -31,6 +31,13 @@ struct OfflineRecognizerConfig {
   std::string decoding_method = "greedy_search";
   int32_t max_active_paths = 4;
 
+  // Number of hypotheses to return per utterance.
+  //
+  // Used only by offline transducer models with
+  // decoding_method == "modified_beam_search". When > 1, each result carries
+  // an n-best list; the top-level fields always describe the 1-best.
+  int32_t num_return_paths = 1;
+
   std::string hotwords_file;
   float hotwords_score = 1.5;
 
@@ -54,13 +61,15 @@ struct OfflineRecognizerConfig {
       const std::string &decoding_method, int32_t max_active_paths,
       const std::string &hotwords_file, float hotwords_score,
       float blank_penalty, const std::string &rule_fsts,
-      const std::string &rule_fars, const HomophoneReplacerConfig &hr)
+      const std::string &rule_fars, const HomophoneReplacerConfig &hr,
+      int32_t num_return_paths = 1)
       : feat_config(feat_config),
         model_config(model_config),
         lm_config(lm_config),
         ctc_fst_decoder_config(ctc_fst_decoder_config),
         decoding_method(decoding_method),
         max_active_paths(max_active_paths),
+        num_return_paths(num_return_paths),
         hotwords_file(hotwords_file),
         hotwords_score(hotwords_score),
         blank_penalty(blank_penalty),

--- a/sherpa-onnx/csrc/offline-stream.h
+++ b/sherpa-onnx/csrc/offline-stream.h
@@ -16,6 +16,27 @@
 
 namespace sherpa_onnx {
 
+/// One entry of an n-best list. Produced only by offline transducer models
+/// decoded with modified_beam_search and num_return_paths > 1.
+struct OfflineRecognitionHypothesis {
+  /// Recognition result for this hypothesis.
+  std::string text;
+
+  /// Decoded result at the token level.
+  std::vector<std::string> tokens;
+
+  /// timestamps.size() == tokens.size()
+  /// timestamps[i] records the time in seconds when tokens[i] is decoded.
+  std::vector<float> timestamps;
+
+  /// ys_log_probs[i] contains the log probability (confidence) for tokens[i].
+  std::vector<float> ys_log_probs;
+
+  /// Total score of this hypothesis in log space (acoustic + LM, if an LM is
+  /// used). Not length-normalized.
+  float score = 0;
+};
+
 struct OfflineRecognitionResult {
   // Recognition results.
   // For English, it consists of space separated words.
@@ -54,6 +75,13 @@ struct OfflineRecognitionResult {
   std::vector<float> segment_timestamps;   // start time of each segment
   std::vector<float> segment_durations;    // duration of each segment
   std::vector<std::string> segment_texts;  // text of each segment
+
+  /// The n-best list, ordered from best to worst, where hypotheses[0]
+  /// matches the fields above.
+  ///
+  /// Empty unless this is a transducer model decoded with
+  /// modified_beam_search and num_return_paths > 1.
+  std::vector<OfflineRecognitionHypothesis> hypotheses;
 
   std::string AsJsonString() const;
 };

--- a/sherpa-onnx/csrc/offline-transducer-decoder.h
+++ b/sherpa-onnx/csrc/offline-transducer-decoder.h
@@ -12,6 +12,24 @@
 
 namespace sherpa_onnx {
 
+/// One hypothesis from the beam. Populated only by
+/// modified_beam_search when num_return_paths > 1.
+struct OfflineTransducerHypothesis {
+  /// The decoded token IDs (leading blanks already stripped)
+  std::vector<int64_t> tokens;
+
+  /// timestamps[i] contains the output frame index where tokens[i] is decoded.
+  /// Note: The index is after subsampling
+  std::vector<int32_t> timestamps;
+
+  /// ys_log_probs[i] contains the log probability (confidence) for tokens[i].
+  std::vector<float> ys_log_probs;
+
+  /// Total score of this hypothesis in log space (acoustic + LM, if an LM is
+  /// used). Not length-normalized.
+  float score = 0;
+};
+
 struct OfflineTransducerDecoderResult {
   /// The decoded token IDs
   std::vector<int64_t> tokens;
@@ -27,6 +45,13 @@ struct OfflineTransducerDecoderResult {
 
   /// ys_log_probs[i] contains the log probability (confidence) for tokens[i].
   std::vector<float> ys_log_probs;
+
+  /// The n-best list, ordered from best to worst, where hypotheses[0]
+  /// corresponds to the fields above.
+  ///
+  /// Empty unless the decoding method is modified_beam_search and
+  /// num_return_paths > 1.
+  std::vector<OfflineTransducerHypothesis> hypotheses;
 };
 
 class OfflineTransducerDecoder {

--- a/sherpa-onnx/csrc/offline-transducer-modified-beam-search-decoder.cc
+++ b/sherpa-onnx/csrc/offline-transducer-modified-beam-search-decoder.cc
@@ -183,14 +183,40 @@ OfflineTransducerModifiedBeamSearchDecoder::Decode(
 
   std::vector<OfflineTransducerDecoderResult> unsorted_ans(batch_size);
   for (int32_t i = 0; i != batch_size; ++i) {
-    Hypothesis hyp = cur[i].GetMostProbable(true);
-
     auto &r = unsorted_ans[packed_encoder_out.sorted_indexes[i]];
 
-    // strip leading blanks
-    r.tokens = {hyp.ys.begin() + context_size, hyp.ys.end()};
-    r.timestamps = std::move(hyp.timestamps);
-    r.ys_log_probs = std::move(hyp.ys_probs);
+    if (num_return_paths_ <= 1) {
+      Hypothesis hyp = cur[i].GetMostProbable(true);
+
+      // strip leading blanks
+      r.tokens = {hyp.ys.begin() + context_size, hyp.ys.end()};
+      r.timestamps = std::move(hyp.timestamps);
+      r.ys_log_probs = std::move(hyp.ys_probs);
+      continue;
+    }
+
+    // GetTopK() ranks by the same length-normalized score as
+    // GetMostProbable(true), so top_k[0] is the 1-best hypothesis and the
+    // legacy fields below keep their existing meaning. (The two differ only
+    // in how they break an exact score tie, since partial_sort is not
+    // stable.) GetTopK() also clamps k to [1, Size()], so fewer than
+    // num_return_paths hypotheses come back when the beam holds fewer.
+    auto top_k = cur[i].GetTopK(num_return_paths_, true);
+
+    r.hypotheses.reserve(top_k.size());
+    for (auto &hyp : top_k) {
+      OfflineTransducerHypothesis h;
+      // strip leading blanks
+      h.tokens = {hyp.ys.begin() + context_size, hyp.ys.end()};
+      h.timestamps = std::move(hyp.timestamps);
+      h.ys_log_probs = std::move(hyp.ys_probs);
+      h.score = static_cast<float>(hyp.TotalLogProb());
+      r.hypotheses.push_back(std::move(h));
+    }
+
+    r.tokens = r.hypotheses[0].tokens;
+    r.timestamps = r.hypotheses[0].timestamps;
+    r.ys_log_probs = r.hypotheses[0].ys_log_probs;
   }
 
   return unsorted_ans;

--- a/sherpa-onnx/csrc/offline-transducer-modified-beam-search-decoder.h
+++ b/sherpa-onnx/csrc/offline-transducer-modified-beam-search-decoder.h
@@ -20,13 +20,15 @@ class OfflineTransducerModifiedBeamSearchDecoder
                                              OfflineLM *lm,
                                              int32_t max_active_paths,
                                              float lm_scale, int32_t unk_id,
-                                             float blank_penalty)
+                                             float blank_penalty,
+                                             int32_t num_return_paths = 1)
       : model_(model),
         lm_(lm),
         max_active_paths_(max_active_paths),
         lm_scale_(lm_scale),
         unk_id_(unk_id),
-        blank_penalty_(blank_penalty) {}
+        blank_penalty_(blank_penalty),
+        num_return_paths_(num_return_paths) {}
 
   std::vector<OfflineTransducerDecoderResult> Decode(
       Ort::Value encoder_out, Ort::Value encoder_out_length,
@@ -40,6 +42,10 @@ class OfflineTransducerModifiedBeamSearchDecoder
   float lm_scale_;  // used only when lm_ is not nullptr
   int32_t unk_id_;
   float blank_penalty_;
+
+  // Number of hypotheses to return per utterance. When > 1, the decoding
+  // result carries an n-best list in its `hypotheses` field.
+  int32_t num_return_paths_;
 };
 
 }  // namespace sherpa_onnx

--- a/sherpa-onnx/python/csrc/offline-recognizer.cc
+++ b/sherpa-onnx/python/csrc/offline-recognizer.cc
@@ -33,6 +33,12 @@ Args:
   max_active_paths:
     Number of active paths for beam search decoding. Only effective when
     ``decoding_method`` is ``modified_beam_search``.
+  num_return_paths:
+    Number of hypotheses to return per utterance. Only effective for
+    transducer models when ``decoding_method`` is ``modified_beam_search``.
+    It is clamped to ``max_active_paths``. When greater than 1, each result
+    exposes an n-best list via ``result.hypotheses``; the top-level fields
+    always describe the 1-best.
   hotwords_file:
     Path to a file containing hotwords, one per line.
   hotwords_score:
@@ -113,7 +119,7 @@ static void PybindOfflineRecognizerConfig(py::module *m) {
                     const OfflineLMConfig &, const OfflineCtcFstDecoderConfig &,
                     const std::string &, int32_t, const std::string &, float,
                     float, const std::string &, const std::string &,
-                    const HomophoneReplacerConfig &>(),
+                    const HomophoneReplacerConfig &, int32_t>(),
            py::arg("feat_config") = FeatureExtractorConfig(),
            py::arg("model_config") = OfflineModelConfig(),
            py::arg("lm_config") = OfflineLMConfig(),
@@ -123,13 +129,14 @@ static void PybindOfflineRecognizerConfig(py::module *m) {
            py::arg("hotwords_score") = 1.5, py::arg("blank_penalty") = 0.0,
            py::arg("rule_fsts") = "", py::arg("rule_fars") = "",
            py::arg("hr") = HomophoneReplacerConfig{},
-           kOfflineRecognizerConfigInitDoc)
+           py::arg("num_return_paths") = 1, kOfflineRecognizerConfigInitDoc)
       .def_readwrite("feat_config", &PyClass::feat_config)
       .def_readwrite("model_config", &PyClass::model_config)
       .def_readwrite("lm_config", &PyClass::lm_config)
       .def_readwrite("ctc_fst_decoder_config", &PyClass::ctc_fst_decoder_config)
       .def_readwrite("decoding_method", &PyClass::decoding_method)
       .def_readwrite("max_active_paths", &PyClass::max_active_paths)
+      .def_readwrite("num_return_paths", &PyClass::num_return_paths)
       .def_readwrite("hotwords_file", &PyClass::hotwords_file)
       .def_readwrite("hotwords_score", &PyClass::hotwords_score)
       .def_readwrite("blank_penalty", &PyClass::blank_penalty)

--- a/sherpa-onnx/python/csrc/offline-stream.cc
+++ b/sherpa-onnx/python/csrc/offline-stream.cc
@@ -68,6 +68,33 @@ Return:
   does not exist.
 )doc";
 
+static constexpr const char *kOfflineRecognitionHypothesisDoc = R"doc(
+One entry of an n-best list.
+
+Produced only by transducer models decoded with ``modified_beam_search``
+and ``num_return_paths`` greater than 1.
+)doc";
+
+static void PybindOfflineRecognitionHypothesis(py::module *m) {  // NOLINT
+  using PyClass = OfflineRecognitionHypothesis;
+  py::class_<PyClass>(*m, "OfflineRecognitionHypothesis",
+                      kOfflineRecognitionHypothesisDoc)
+      .def_property_readonly(
+          "text",
+          [](const PyClass &self) -> py::str {
+            return py::str(PyUnicode_DecodeUTF8(self.text.c_str(),
+                                                self.text.size(), "ignore"));
+          })
+      .def_property_readonly("tokens",
+        [](const PyClass &self) { return self.tokens; })
+      .def_property_readonly("timestamps",
+        [](const PyClass &self) { return self.timestamps; })
+      .def_property_readonly("ys_log_probs",
+        [](const PyClass &self) { return self.ys_log_probs; })
+      .def_property_readonly("score",
+        [](const PyClass &self) { return self.score; });
+}
+
 static void PybindOfflineRecognitionResult(py::module *m) {  // NOLINT
   using PyClass = OfflineRecognitionResult;
   py::class_<PyClass>(*m, "OfflineRecognitionResult",
@@ -100,10 +127,13 @@ static void PybindOfflineRecognitionResult(py::module *m) {  // NOLINT
       .def_property_readonly("segment_durations",
         [](const PyClass &self) { return self.segment_durations; })
       .def_property_readonly("segment_texts",
-        [](const PyClass &self) { return self.segment_texts; });
+        [](const PyClass &self) { return self.segment_texts; })
+      .def_property_readonly("hypotheses",
+        [](const PyClass &self) { return self.hypotheses; });
 }
 
 void PybindOfflineStream(py::module *m) {
+  PybindOfflineRecognitionHypothesis(m);
   PybindOfflineRecognitionResult(m);
 
   using PyClass = OfflineStream;

--- a/sherpa-onnx/python/sherpa_onnx/offline_recognizer.py
+++ b/sherpa-onnx/python/sherpa_onnx/offline_recognizer.py
@@ -113,6 +113,7 @@ class OfflineRecognizer(object):
         dither: float = 0.0,
         decoding_method: str = "greedy_search",
         max_active_paths: int = 4,
+        num_return_paths: int = 1,
         hotwords_file: str = "",
         hotwords_score: float = 1.5,
         blank_penalty: float = 0.0,
@@ -166,6 +167,13 @@ class OfflineRecognizer(object):
           max_active_paths:
             Maximum number of active paths to keep. Used only when
             decoding_method is modified_beam_search.
+          num_return_paths:
+            Number of hypotheses to return per utterance. Used only when
+            decoding_method is modified_beam_search. It is clamped to
+            max_active_paths. When greater than 1, each result exposes an
+            n-best list via result.hypotheses, ordered best first; the
+            top-level fields (text, tokens, timestamps) always describe the
+            1-best.
           hotwords_file:
             The file containing hotwords, one words/phrases per line, and for each
             phrase the bpe/cjkchar are separated by a space.
@@ -248,6 +256,7 @@ class OfflineRecognizer(object):
             lm_config=lm_config,
             decoding_method=decoding_method,
             max_active_paths=max_active_paths,
+            num_return_paths=num_return_paths,
             hotwords_file=hotwords_file,
             hotwords_score=hotwords_score,
             blank_penalty=blank_penalty,


### PR DESCRIPTION
Closes #3858.

`modified_beam_search` already keeps `max_active_paths` hypotheses internally but throws all but the best one away. This adds a `num_return_paths` option so callers can read the whole n-best list.

Scope is what the issue proposed: offline recognition, transducer models, `modified_beam_search`. No new decoding algorithm.

### API

```python
recognizer = sherpa_onnx.OfflineRecognizer.from_transducer(
    ...,
    decoding_method="modified_beam_search",
    max_active_paths=8,   # search width
    num_return_paths=5,   # how many to return
)

result = stream.result
result.text          # 1-best, unchanged
for hyp in result.hypotheses:   # ordered best first
    hyp.text, hyp.tokens, hyp.timestamps, hyp.ys_log_probs, hyp.score
```

### Behavior

- `num_return_paths` defaults to `1`, which keeps the current behavior exactly and leaves `hypotheses` empty. Nothing changes for existing users.
- When `> 1`, `hypotheses[0]` is the 1-best and matches the top-level `text` / `tokens` / `timestamps`.
- It is clamped to `max_active_paths`, and `GetTopK()` clamps again to how many hypotheses the beam actually holds, so a small beam simply returns fewer.
- `Validate()` rejects `num_return_paths < 1`, and `num_return_paths > 1` with any decoding method other than `modified_beam_search`.
- Each hypothesis gets the same text post-processing as the 1-best (inverse text normalization, homophone replacer, leading-space removal), so `hypotheses[0].text == result.text` holds.
- `score` is the total log-prob (acoustic + LM when an LM is used), not length-normalized. Ranking uses the same length-normalized comparison as `GetMostProbable(true)`, so the 1-best is unchanged.

### Implementation

`Hypotheses::GetTopK()` already existed, so the decoder change is small: when `num_return_paths_ > 1`, take the top-k instead of just the most probable. The token→text conversion in `Convert()` was factored into a helper (`ConvertTokens` / `ConvertTimestamps`) and reused for each hypothesis rather than duplicated.

### Verified

Built `sherpa-onnx-core` and `_sherpa_onnx` cleanly (gcc 13.3, Release), then ran `sherpa-onnx-zipformer-small-en-2023-06-26` over `test_wavs/0.wav` and `1.wav`:

```
1-best:
  AFTER EARLY NIGHTFALL THE YELLOW LAMPS WOULD LIGHT UP HERE AND THERE THE SQUALID QUARTER OF THE BROTHELS

n-best (5 hypotheses):
  [0] score=-1.0923   ... OF THE BROTHELS
  [1] score=-2.3082   ... OF THE BROTHALS
  [2] score=-2.5559   ... OF THE BROFFLES
  [3] score=-2.9750   ... OF THE BRIFFLES
  [4] score=-12.2809  ... OF THE BROFFLES'
```

Checked on both wavs: 1-best text is byte-identical between `num_return_paths=1` and `=5`; `hypotheses[0]` matches the top-level text, tokens and timestamps; scores are non-increasing; `len(timestamps) == len(tokens) == len(ys_log_probs)` per hypothesis; `num_return_paths=50` with `max_active_paths=4` returns 4; `greedy_search` is unaffected and returns an empty list.

### Notes / open questions

- Only the Python bindings are wired up here. Happy to add C / Go / Kotlin / Swift / C# in this PR or a follow-up — let me know which you want and how you would prefer the n-best represented in the C API.
- `AsJsonString()` does not include `hypotheses` yet. I left it out to avoid changing existing JSON output; glad to add it behind the same flag if you would like it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added n-best decoding for offline transducer recognition using modified beam search.
  - Configure the number of returned hypotheses, with results including text, tokens, timestamps, log probabilities, and scores.
  - Added Python API support through `num_return_paths` and `result.hypotheses`.
  - Hypotheses receive the same text normalization and formatting as the top result.
- **Documentation**
  - Added a Python example demonstrating offline n-best decoding and displaying ranked hypotheses with scores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->